### PR TITLE
[LOOP-2] Workflow YAML schema v1

### DIFF
--- a/config/workflows/README.md
+++ b/config/workflows/README.md
@@ -104,7 +104,7 @@ override any of them via the `labels:` map in `config/projects.yaml`.
 | `done` | Terminal: PR merged and issue closed |
 
 **Terminal labels** (valid transition targets, never trigger a stage):
-`done`, `blocked`, `needs-clarification`
+`done`, `blocked`, `needs-clarification`, `qa-fail`
 
 ## Per-project overrides
 

--- a/config/workflows/README.md
+++ b/config/workflows/README.md
@@ -14,6 +14,7 @@ This dir contains starter workflows. Operators can author their own.
 | `default.yaml` | Recommended for new repos. Clean canonical labels: `plan` / `needs-review` / `needs-qa` / `qa-pass` / `qa-fail`. |
 | `current.yaml` | Legacy-vocabulary mirror. Uses `dev` instead of `plan`; matches the label set in svv2014 projects at v0.1.0 migration. |
 | `minimal.yaml` | Two-stage pipeline (`plan → merge`). No review, no QA. Solo prototypes only. |
+| `docs-only.yaml` | Three-stage pipeline (`plan → review → merge`). No QA. For documentation and content-only PRs. |
 
 ## Schema (v1)
 
@@ -70,9 +71,40 @@ source lib/workflow.sh
 loop_workflow_validate config/workflows/default.yaml
 ```
 
-The validator checks: schema version, name presence, stage required
-fields, no duplicate `trigger_label` within a workflow, at least one
-stage exists.
+The validator checks: schema version, `name` matches filename, stage
+required fields, no duplicate `trigger_label` within a workflow, at
+least one stage exists, and all transition targets reference known
+labels (trigger labels declared in the file or terminal labels below).
+Missing handler scripts produce a warning but do not cause validation
+to fail.
+
+## Canonical label set
+
+These are the canonical label names used in `default.yaml`. Projects may
+override any of them via the `labels:` map in `config/projects.yaml`.
+
+**Issue labels** (drive `issue_stages`):
+
+| Label | Role |
+|---|---|
+| `po-review` | PO expansion stage — turns a rough idea into a spec |
+| `plan` | Dev implementation stage |
+| `blocked` | Terminal: issue cannot proceed; human attention required |
+| `needs-clarification` | Terminal: issue body is ambiguous; awaiting author reply |
+
+**PR labels** (drive `pr_stages`):
+
+| Label | Role |
+|---|---|
+| `needs-review` | Code review stage |
+| `needs-rework` | Sent back to dev after review rejection |
+| `needs-qa` | QA / automated test stage |
+| `qa-pass` | QA passed; triggers merge |
+| `qa-fail` | QA failed; triggers rework or close |
+| `done` | Terminal: PR merged and issue closed |
+
+**Terminal labels** (valid transition targets, never trigger a stage):
+`done`, `blocked`, `needs-clarification`
 
 ## Per-project overrides
 

--- a/config/workflows/docs-only.yaml
+++ b/config/workflows/docs-only.yaml
@@ -11,7 +11,7 @@
 version: 1
 name: docs-only
 description: |
-  Two-stage pipeline: plan → review → merge. No QA gate. For documentation
+  Three-stage pipeline: plan → review → merge. No QA gate. For documentation
   and content-only changes where human review is sufficient before merge.
 
 issue_stages:

--- a/config/workflows/docs-only.yaml
+++ b/config/workflows/docs-only.yaml
@@ -1,0 +1,41 @@
+# Loop docs-only workflow — documentation and content change pipeline.
+#
+# Stages:
+#   plan (issue) → needs-review (PR) → done
+#
+# Skips QA. Use for documentation PRs, README updates, and other changes
+# where automated testing adds no value and human review is sufficient.
+#
+# To use: in config/projects.yaml, set `workflow: docs-only`.
+
+version: 1
+name: docs-only
+description: |
+  Two-stage pipeline: plan → review → merge. No QA gate. For documentation
+  and content-only changes where human review is sufficient before merge.
+
+issue_stages:
+  - id: plan
+    trigger_label: plan
+    handler: dev-handler
+    on_done: needs-review
+    on_failed_after_max: blocked
+
+pr_stages:
+  - id: review
+    trigger_label: needs-review
+    handler: review-handler
+    decisions:
+      approve: merge-ready
+      reject: needs-rework
+
+  - id: rework
+    trigger_label: needs-rework
+    handler: dev-rework-handler
+    on_done: needs-review
+    on_failed_after_max: blocked
+
+  - id: merge
+    trigger_label: merge-ready
+    handler: merge-handler
+    on_done: done

--- a/lib/workflow.sh
+++ b/lib/workflow.sh
@@ -138,12 +138,20 @@ PY
 
 # loop_workflow_validate <path>
 # Exit 0 if schema-v1 valid; non-zero with stderr message otherwise.
+# Warns (does not fail) for handler scripts not found on disk.
 loop_workflow_validate() {
     local path="$1"
     [ -f "$path" ] || { echo "[workflow] not a file: $path" >&2; return 2; }
-    PTH="$path" python3 - <<'PY'
+    PTH="$path" SCRIPTS_DIR="${LOOP_ROOT:-.}/scripts" python3 - <<'PY'
 import os, sys, yaml
+
 path = os.environ['PTH']
+scripts_dir = os.environ.get('SCRIPTS_DIR', 'scripts')
+
+# Labels valid as transition targets without needing to be trigger_labels.
+# Includes terminal states and outcome labels that don't launch a handler.
+TERMINAL_LABELS = {'done', 'blocked', 'needs-clarification', 'qa-fail'}
+
 try:
     with open(path) as f:
         wf = yaml.safe_load(f) or {}
@@ -151,12 +159,24 @@ except Exception as e:
     print(f"[workflow] {path}: parse error: {e}", file=sys.stderr); sys.exit(2)
 
 errors = []
+warnings = []
+
 if wf.get('version') != 1:
     errors.append("missing or non-1 'version' field")
-if not wf.get('name'):
+
+name = wf.get('name')
+if not name:
     errors.append("missing 'name'")
+else:
+    expected = os.path.splitext(os.path.basename(path))[0]
+    if name != expected:
+        errors.append(f"'name' field '{name}' does not match filename '{expected}'")
+
 stages_total = 0
 seen_labels = set()
+all_handlers = []
+all_transitions = []  # (field_name, value)
+
 for section in ('issue_stages', 'pr_stages'):
     for s in wf.get(section, []) or []:
         stages_total += 1
@@ -166,13 +186,45 @@ for section in ('issue_stages', 'pr_stages'):
             errors.append(f"{section}/{s.get('id','?')} missing 'trigger_label'")
         if 'handler' not in s:
             errors.append(f"{section}/{s.get('id','?')} missing 'handler'")
+
         lbl = s.get('trigger_label')
         if lbl and lbl in seen_labels:
             errors.append(f"duplicate trigger_label '{lbl}' in workflow")
         elif lbl:
             seen_labels.add(lbl)
+
+        handler = s.get('handler')
+        if handler:
+            all_handlers.append(handler)
+
+        # Collect transition targets
+        for field in ('on_done', 'on_blocked', 'on_clarification',
+                      'on_failed_after_max', 'on_pass', 'on_fail'):
+            val = s.get(field)
+            if val:
+                all_transitions.append((field, val))
+        decisions = s.get('decisions') or {}
+        for decision_val in decisions.values():
+            all_transitions.append(('decisions', decision_val))
+
 if stages_total == 0:
     errors.append("workflow has zero stages")
+
+# Validate transition targets: must be a trigger_label in the file or a terminal label.
+known_labels = seen_labels | TERMINAL_LABELS
+for field, target in all_transitions:
+    if target not in known_labels:
+        errors.append(f"transition target '{target}' (in '{field}') is not a known label or terminal label")
+
+# Warn (do not fail) for missing handler scripts.
+for handler in all_handlers:
+    script = os.path.join(scripts_dir, handler + '.sh')
+    if not os.path.isfile(script):
+        warnings.append(f"handler script not found (non-fatal): {script}")
+
+for w in warnings:
+    print(f"[workflow] WARN {path}: {w}", file=sys.stderr)
+
 if errors:
     for e in errors:
         print(f"[workflow] {path}: {e}", file=sys.stderr)

--- a/tests/workflow.bats
+++ b/tests/workflow.bats
@@ -1,0 +1,255 @@
+#!/usr/bin/env bats
+# tests/workflow.bats — unit tests for loop_workflow_validate in lib/workflow.sh.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    # shellcheck source=../lib/workflow.sh
+    source "$REPO_ROOT/lib/workflow.sh"
+    # Temp dir for test fixture files
+    TEST_TMP="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$TEST_TMP"
+}
+
+# Write a minimal valid workflow YAML for a given name.
+write_valid_workflow() {
+    local name="$1"
+    cat > "$TEST_TMP/${name}.yaml" <<YAML
+version: 1
+name: ${name}
+description: test workflow
+
+issue_stages:
+  - id: plan
+    trigger_label: plan
+    handler: dev-handler
+    on_done: done
+YAML
+}
+
+# ---------------------------------------------------------------------------
+# Valid file passes
+# ---------------------------------------------------------------------------
+
+@test "validate: valid minimal workflow passes" {
+    write_valid_workflow "test-wf"
+    run loop_workflow_validate "$TEST_TMP/test-wf.yaml"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate: all three starter workflows pass validation" {
+    run loop_workflow_validate "$REPO_ROOT/config/workflows/default.yaml"
+    [ "$status" -eq 0 ]
+    run loop_workflow_validate "$REPO_ROOT/config/workflows/minimal.yaml"
+    [ "$status" -eq 0 ]
+    run loop_workflow_validate "$REPO_ROOT/config/workflows/docs-only.yaml"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Missing version fails
+# ---------------------------------------------------------------------------
+
+@test "validate: missing version field fails" {
+    cat > "$TEST_TMP/no-version.yaml" <<YAML
+name: no-version
+issue_stages:
+  - id: plan
+    trigger_label: plan
+    handler: dev-handler
+YAML
+    run loop_workflow_validate "$TEST_TMP/no-version.yaml"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"version"* ]]
+}
+
+@test "validate: version=2 fails" {
+    cat > "$TEST_TMP/v2.yaml" <<YAML
+version: 2
+name: v2
+issue_stages:
+  - id: plan
+    trigger_label: plan
+    handler: dev-handler
+YAML
+    run loop_workflow_validate "$TEST_TMP/v2.yaml"
+    [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# name must match filename
+# ---------------------------------------------------------------------------
+
+@test "validate: name mismatch with filename fails" {
+    cat > "$TEST_TMP/mywf.yaml" <<YAML
+version: 1
+name: otherwf
+issue_stages:
+  - id: plan
+    trigger_label: plan
+    handler: dev-handler
+YAML
+    run loop_workflow_validate "$TEST_TMP/mywf.yaml"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"name"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Duplicate trigger_label fails
+# ---------------------------------------------------------------------------
+
+@test "validate: duplicate trigger_label within issue_stages fails" {
+    cat > "$TEST_TMP/dup.yaml" <<YAML
+version: 1
+name: dup
+issue_stages:
+  - id: stage1
+    trigger_label: plan
+    handler: dev-handler
+    on_done: done
+  - id: stage2
+    trigger_label: plan
+    handler: dev-handler
+    on_done: done
+YAML
+    run loop_workflow_validate "$TEST_TMP/dup.yaml"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"duplicate"* ]]
+}
+
+@test "validate: duplicate trigger_label across issue_stages and pr_stages fails" {
+    cat > "$TEST_TMP/xdup.yaml" <<YAML
+version: 1
+name: xdup
+issue_stages:
+  - id: plan
+    trigger_label: shared-label
+    handler: dev-handler
+    on_done: done
+pr_stages:
+  - id: merge
+    trigger_label: shared-label
+    handler: merge-handler
+    on_done: done
+YAML
+    run loop_workflow_validate "$TEST_TMP/xdup.yaml"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"duplicate"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Unknown transition target fails
+# ---------------------------------------------------------------------------
+
+@test "validate: unknown transition target fails" {
+    cat > "$TEST_TMP/badtrans.yaml" <<YAML
+version: 1
+name: badtrans
+issue_stages:
+  - id: plan
+    trigger_label: plan
+    handler: dev-handler
+    on_done: nonexistent-label
+YAML
+    run loop_workflow_validate "$TEST_TMP/badtrans.yaml"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"nonexistent-label"* ]]
+}
+
+@test "validate: transition to terminal label 'done' passes" {
+    cat > "$TEST_TMP/term.yaml" <<YAML
+version: 1
+name: term
+issue_stages:
+  - id: plan
+    trigger_label: plan
+    handler: dev-handler
+    on_done: done
+    on_failed_after_max: blocked
+YAML
+    run loop_workflow_validate "$TEST_TMP/term.yaml"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate: decisions approve/reject referencing unknown labels fails" {
+    cat > "$TEST_TMP/baddec.yaml" <<YAML
+version: 1
+name: baddec
+pr_stages:
+  - id: review
+    trigger_label: needs-review
+    handler: review-handler
+    decisions:
+      approve: unknown-target
+      reject: needs-rework
+YAML
+    run loop_workflow_validate "$TEST_TMP/baddec.yaml"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"unknown-target"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Zero stages fails
+# ---------------------------------------------------------------------------
+
+@test "validate: empty workflow with no stages fails" {
+    cat > "$TEST_TMP/empty.yaml" <<YAML
+version: 1
+name: empty
+YAML
+    run loop_workflow_validate "$TEST_TMP/empty.yaml"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"zero stages"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Missing required stage fields fail
+# ---------------------------------------------------------------------------
+
+@test "validate: stage missing trigger_label fails" {
+    cat > "$TEST_TMP/notrig.yaml" <<YAML
+version: 1
+name: notrig
+issue_stages:
+  - id: plan
+    handler: dev-handler
+    on_done: done
+YAML
+    run loop_workflow_validate "$TEST_TMP/notrig.yaml"
+    [ "$status" -ne 0 ]
+}
+
+@test "validate: stage missing handler fails" {
+    cat > "$TEST_TMP/nohandler.yaml" <<YAML
+version: 1
+name: nohandler
+issue_stages:
+  - id: plan
+    trigger_label: plan
+    on_done: done
+YAML
+    run loop_workflow_validate "$TEST_TMP/nohandler.yaml"
+    [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Missing handler script warns but does not fail
+# ---------------------------------------------------------------------------
+
+@test "validate: missing handler script produces warning but passes" {
+    cat > "$TEST_TMP/missinghandler.yaml" <<YAML
+version: 1
+name: missinghandler
+issue_stages:
+  - id: plan
+    trigger_label: plan
+    handler: nonexistent-handler-xyz
+    on_done: done
+YAML
+    run loop_workflow_validate "$TEST_TMP/missinghandler.yaml"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"WARN"* ]]
+}

--- a/tests/workflow.bats
+++ b/tests/workflow.bats
@@ -40,12 +40,14 @@ YAML
     [ "$status" -eq 0 ]
 }
 
-@test "validate: all three starter workflows pass validation" {
+@test "validate: all four starter workflows pass validation" {
     run loop_workflow_validate "$REPO_ROOT/config/workflows/default.yaml"
     [ "$status" -eq 0 ]
     run loop_workflow_validate "$REPO_ROOT/config/workflows/minimal.yaml"
     [ "$status" -eq 0 ]
     run loop_workflow_validate "$REPO_ROOT/config/workflows/docs-only.yaml"
+    [ "$status" -eq 0 ]
+    run loop_workflow_validate "$REPO_ROOT/config/workflows/current.yaml"
     [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
Closes #2

## Changes

- **`config/workflows/docs-only.yaml`** — new starter workflow: `plan → review → merge`, skipping QA. For documentation and content-only PRs where human review is sufficient.
- **`lib/workflow.sh`** — enhanced `loop_workflow_validate` with three additional checks:
  1. `name` field must match the filename (catches copy-paste mistakes)
  2. All transition targets (`on_done`, `on_blocked`, `decisions.approve`, etc.) must reference a trigger_label defined in the file or a canonical terminal label (`done`, `blocked`, `needs-clarification`, `qa-fail`)
  3. Missing handler scripts emit a `WARN` line to stderr but do not cause validation to fail (consistent with CLAUDE.md guidance)
- **`config/workflows/README.md`** — adds `docs-only.yaml` to the file table, documents the canonical label set (issue labels, PR labels, terminal labels), and updates the validator description.
- **`tests/workflow.bats`** — 12 BATS unit tests covering: valid workflows pass, all starter files pass, duplicate `trigger_label` fails, missing `version` fails, `name` mismatch fails, unknown transition target fails, `decisions` referencing unknown label fails, zero stages fails, missing required stage fields fail, missing handler script warns but passes.

## Test Plan

- [x] `bash -n lib/workflow.sh scripts/validate-workflow.sh` — clean
- [x] `shellcheck -S warning lib/workflow.sh scripts/validate-workflow.sh` — clean
- [x] No personal identifiers in diff
- [x] `loop_workflow_validate` tested manually against all four starter workflows (default, minimal, docs-only, current) — all pass
- [x] All failure cases verified: duplicate label, bad transition target, missing version, name mismatch, zero stages

🤖 Generated with [Claude Code](https://claude.ai/claude-code)