### PR TITLE
[LOOP-3] projects.yaml v1 schema — workflow ref + label overrides

### DIFF
--- a/config/projects.example.yaml
+++ b/config/projects.example.yaml
@@ -29,6 +29,11 @@ projects:
     #   plan: dev                      # this repo uses 'dev' instead of 'plan'
     #   qa-pass: approved
     #   qa-fail: qa-failed
+    #
+    # Example with overrides enabled (remove the '#' to activate):
+    # labels:
+    #   plan: ready                    # trigger dev agent with 'ready' instead of 'plan'
+    #   needs-review: review           # shorter label name already in use on this repo
 
     # Backend adapter — controls which VCS/issue-tracker integration is used.
     # Default: github. See docs/backends.md for how to add a new backend.

--- a/install.sh
+++ b/install.sh
@@ -500,6 +500,15 @@ PY
 fi
 
 # ─────────────────────────────────────────────────────────────────────────────
+# 2b. Validate projects.yaml
+# ─────────────────────────────────────────────────────────────────────────────
+
+if [ -x "$LOOP_ROOT/scripts/validate-config.sh" ]; then
+    "$LOOP_ROOT/scripts/validate-config.sh" "$PROJECTS_YAML" \
+        || { echo "ERROR: projects.yaml validation failed — fix the errors above before continuing." >&2; exit 2; }
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
 # 3. Create canonical labels (idempotent)
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -10,8 +10,10 @@ LOOP_CONFIG="${LOOP_CONFIG:-$LOOP_ROOT/config/projects.yaml}"
 # loop_load_project <slug>
 # Exports: REPO ROOT DEFAULT_BRANCH COMMIT_PREFIX MERGE_STRATEGY AUTO_REBASE
 #          DEV_VALIDATION_CMD QA_VALIDATION_CMD QA_BROWSER_URL NAME BACKEND
-#          MAX_CONCURRENT_PRS
+#          MAX_CONCURRENT_PRS WORKFLOW LOOP_LABEL_OVERRIDES
 # BACKEND defaults to 'github' when not specified in projects.yaml.
+# WORKFLOW defaults to 'default' when not specified.
+# LOOP_LABEL_OVERRIDES is a pipe-separated list of canonical=override pairs.
 # Returns non-zero if the slug is not found.
 loop_load_project() {
     local slug="$1"
@@ -21,19 +23,40 @@ loop_load_project() {
 
     local out
     out=$(python3 - "$config" "$slug" <<'PY'
-import sys, yaml
+import sys, yaml, os
 cfg_path, slug = sys.argv[1], sys.argv[2]
 with open(cfg_path) as f:
     data = yaml.safe_load(f) or {}
+
+# v0 legacy fallback: warn when version field is absent
+version = data.get("version")
+if version is None:
+    print("WARNING: projects.yaml has no 'version' field — assuming v0 (legacy). Add 'version: 1' to suppress this warning.", file=sys.stderr)
+
 for p in data.get("projects", []) or []:
     if p.get("slug") == slug:
         dev = p.get("dev") or {}
         qa  = p.get("qa") or {}
         mg  = p.get("merge") or {}
         def sh(v): return "" if v is None else str(v).replace("'", "'\\''")
+
+        # v1: workflow ref (defaults to "default")
+        workflow = p.get("workflow") or "default"
+
+        # v1: sparse label overrides — serialized as "canonical=override|..." pairs
+        label_map = p.get("labels") or {}
+        home = os.environ.get("HOME", "")
+        label_overrides = "|".join(
+            f"{k}={v}" for k, v in label_map.items()
+        )
+
+        # root: substitute ${HOME} and $HOME placeholders
+        root_raw = p.get("root") or ""
+        root_val = root_raw.replace("${HOME}", home).replace("$HOME", home)
+
         print(f"NAME='{sh(p.get('name',''))}'")
         print(f"REPO='{sh(p.get('repo',''))}'")
-        print(f"ROOT='{sh(p.get('root',''))}'")
+        print(f"ROOT='{sh(root_val)}'")
         print(f"DEFAULT_BRANCH='{sh(p.get('default_branch','main'))}'")
         print(f"COMMIT_PREFIX='{sh(dev.get('commit_prefix', slug.upper()))}'")
         print(f"DEV_VALIDATION_CMD='{sh(dev.get('validation_cmd',''))}'")
@@ -54,6 +77,9 @@ for p in data.get("projects", []) or []:
         project_authors = p.get("allowed_authors") or global_authors
         authors_str = ",".join(str(a) for a in project_authors)
         print(f"ALLOWED_AUTHORS='{sh(authors_str)}'")
+        # v1 fields
+        print(f"WORKFLOW='{sh(workflow)}'")
+        print(f"LOOP_LABEL_OVERRIDES='{sh(label_overrides)}'")
         sys.exit(0)
 sys.exit(1)
 PY
@@ -64,7 +90,7 @@ PY
         return 1
     fi
     eval "$out"
-    export NAME REPO ROOT DEFAULT_BRANCH COMMIT_PREFIX DEV_VALIDATION_CMD QA_VALIDATION_CMD QA_BROWSER_URL QA_TIMEOUT_SECONDS HANDLER_TIMEOUT_SECONDS MERGE_STRATEGY AUTO_REBASE BACKEND MAX_CONCURRENT_PRS LOOP_AGENT_MODEL ALLOWED_AUTHORS
+    export NAME REPO ROOT DEFAULT_BRANCH COMMIT_PREFIX DEV_VALIDATION_CMD QA_VALIDATION_CMD QA_BROWSER_URL QA_TIMEOUT_SECONDS HANDLER_TIMEOUT_SECONDS MERGE_STRATEGY AUTO_REBASE BACKEND MAX_CONCURRENT_PRS LOOP_AGENT_MODEL ALLOWED_AUTHORS WORKFLOW LOOP_LABEL_OVERRIDES
 }
 
 # loop_list_slugs — print each project slug on its own line

--- a/scripts/validate-config.sh
+++ b/scripts/validate-config.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# scripts/validate-config.sh — validate config/projects.yaml (v1 schema).
+#
+# Usage:
+#   ./scripts/validate-config.sh [path-to-config]
+#
+# Checks:
+#   1. File exists and parses as valid YAML
+#   2. Slug uniqueness across all projects
+#   3. Repo uniqueness across all projects
+#   4. Workflow file existence (config/workflows/<name>.yaml)
+#   5. Label override key validity (non-empty strings)
+#   6. ${HOME} substitution in root paths
+#
+# Exits 0 on success, 1 on validation failures.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+CONFIG_PATH="${1:-$LOOP_ROOT/config/projects.yaml}"
+
+if [ ! -f "$CONFIG_PATH" ]; then
+    echo "[validate] ERROR: config not found: $CONFIG_PATH" >&2
+    exit 1
+fi
+
+python3 - "$CONFIG_PATH" "$LOOP_ROOT" "$HOME" <<'PY'
+import sys, yaml, os
+
+cfg_path, loop_root, home = sys.argv[1], sys.argv[2], sys.argv[3]
+workflows_dir = os.path.join(loop_root, "config", "workflows")
+
+errors = []
+warnings = []
+
+# Parse YAML
+try:
+    with open(cfg_path) as f:
+        data = yaml.safe_load(f) or {}
+except yaml.YAMLError as e:
+    print(f"[validate] ERROR: YAML parse error in {cfg_path}: {e}", file=sys.stderr)
+    sys.exit(1)
+
+# v0 legacy warning
+version = data.get("version")
+if version is None:
+    warnings.append("no 'version' field — add 'version: 1' to adopt the v1 schema")
+elif version != 1:
+    warnings.append(f"unexpected version '{version}' — only version 1 is supported")
+
+projects = data.get("projects") or []
+
+seen_slugs = {}
+seen_repos = {}
+
+for idx, p in enumerate(projects):
+    loc = f"projects[{idx}]"
+    slug = p.get("slug") or ""
+    repo = p.get("repo") or ""
+
+    if not slug:
+        errors.append(f"{loc}: missing required field 'slug'")
+    elif slug in seen_slugs:
+        errors.append(f"{loc}: duplicate slug '{slug}' (first seen at {seen_slugs[slug]})")
+    else:
+        seen_slugs[slug] = loc
+
+    if not repo:
+        errors.append(f"{loc} (slug={slug!r}): missing required field 'repo'")
+    elif repo in seen_repos:
+        errors.append(f"{loc} (slug={slug!r}): duplicate repo '{repo}' (first seen at {seen_repos[repo]})")
+    else:
+        seen_repos[repo] = loc
+
+    # Workflow file existence
+    workflow = p.get("workflow") or "default"
+    wf_file = os.path.join(workflows_dir, f"{workflow}.yaml")
+    if not os.path.isfile(wf_file):
+        errors.append(
+            f"{loc} (slug={slug!r}): workflow '{workflow}' not found at "
+            f"config/workflows/{workflow}.yaml"
+        )
+
+    # Label override key validity
+    label_map = p.get("labels") or {}
+    if not isinstance(label_map, dict):
+        errors.append(f"{loc} (slug={slug!r}): 'labels' must be a mapping")
+    else:
+        for k, v in label_map.items():
+            if not k or not isinstance(k, str) or not k.strip():
+                errors.append(f"{loc} (slug={slug!r}): invalid label key: {k!r}")
+            if not v or not isinstance(v, str) or not v.strip():
+                errors.append(f"{loc} (slug={slug!r}): invalid label override value for '{k}': {v!r}")
+
+    # ${HOME} substitution in root path
+    root_raw = p.get("root") or ""
+    if "${HOME}" in root_raw or "$HOME" in root_raw:
+        substituted = root_raw.replace("${HOME}", home).replace("$HOME", home)
+        warnings.append(
+            f"{loc} (slug={slug!r}): 'root' contains $HOME placeholder — "
+            f"resolved to: {substituted}"
+        )
+
+# Print results
+for w in warnings:
+    print(f"[validate] WARN:  {w}", file=sys.stderr)
+
+if errors:
+    for e in errors:
+        print(f"[validate] ERROR: {e}", file=sys.stderr)
+    sys.exit(1)
+
+print(f"[validate] OK: {cfg_path} ({len(projects)} project(s))")
+PY

--- a/scripts/validate-config.sh
+++ b/scripts/validate-config.sh
@@ -83,7 +83,7 @@ for idx, p in enumerate(projects):
             f"config/workflows/{workflow}.yaml"
         )
 
-    # Label override key validity
+    # Label override key validity + cross-check against workflow canonical labels
     label_map = p.get("labels") or {}
     if not isinstance(label_map, dict):
         errors.append(f"{loc} (slug={slug!r}): 'labels' must be a mapping")
@@ -93,6 +93,46 @@ for idx, p in enumerate(projects):
                 errors.append(f"{loc} (slug={slug!r}): invalid label key: {k!r}")
             if not v or not isinstance(v, str) or not v.strip():
                 errors.append(f"{loc} (slug={slug!r}): invalid label override value for '{k}': {v!r}")
+
+        # Cross-check label keys against canonical labels in the referenced workflow
+        if label_map and os.path.isfile(wf_file):
+            try:
+                with open(wf_file) as wf:
+                    wf_data = yaml.safe_load(wf) or {}
+            except yaml.YAMLError as e:
+                warnings.append(
+                    f"{loc} (slug={slug!r}): could not parse workflow file for label cross-check: {e}"
+                )
+                wf_data = None
+
+            if wf_data is not None:
+                canonical_labels = set()
+                stage_fields = ("trigger_label", "on_done", "on_blocked",
+                                "on_clarification", "on_failed_after_max")
+                for stage in (wf_data.get("issue_stages") or []):
+                    for field in stage_fields:
+                        v = stage.get(field)
+                        if v:
+                            canonical_labels.add(v)
+                pr_fields = ("trigger_label", "on_done", "on_pass", "on_fail")
+                for stage in (wf_data.get("pr_stages") or []):
+                    for field in pr_fields:
+                        v = stage.get(field)
+                        if v:
+                            canonical_labels.add(v)
+                    decisions = stage.get("decisions") or {}
+                    if isinstance(decisions, dict):
+                        for dv in decisions.values():
+                            if dv:
+                                canonical_labels.add(dv)
+
+                for k in label_map:
+                    if k and isinstance(k, str) and k.strip() and k not in canonical_labels:
+                        errors.append(
+                            f"{loc} (slug={slug!r}): label override key '{k}' is not a "
+                            f"canonical label in workflow '{workflow}' — "
+                            f"valid keys: {sorted(canonical_labels)}"
+                        )
 
     # ${HOME} substitution in root path
     root_raw = p.get("root") or ""

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -1,0 +1,261 @@
+#!/usr/bin/env bats
+# tests/config.bats — unit tests for lib/config.sh (v1 schema parsing).
+# Uses temporary YAML fixtures; does not touch config/projects.yaml.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    FIXTURES_DIR="$BATS_TMPDIR/fixtures"
+    mkdir -p "$FIXTURES_DIR"
+
+    # Point loop_load_project at the temp config.
+    export LOOP_CONFIG="$FIXTURES_DIR/projects.yaml"
+
+    # shellcheck source=../lib/config.sh
+    source "$REPO_ROOT/lib/config.sh"
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/fixtures" 2>/dev/null || true
+    unset LOOP_CONFIG NAME REPO ROOT DEFAULT_BRANCH COMMIT_PREFIX
+    unset DEV_VALIDATION_CMD QA_VALIDATION_CMD MERGE_STRATEGY AUTO_REBASE
+    unset BACKEND MAX_CONCURRENT_PRS LOOP_AGENT_MODEL ALLOWED_AUTHORS
+    unset WORKFLOW LOOP_LABEL_OVERRIDES
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helper: write a minimal v1 projects.yaml fixture
+# ─────────────────────────────────────────────────────────────────────────────
+
+write_fixture() {
+    cat > "$LOOP_CONFIG"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# v1 — default workflow (no workflow key → WORKFLOW=default)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "v1: WORKFLOW defaults to 'default' when workflow key is absent" {
+    write_fixture <<'YAML'
+version: 1
+projects:
+  - name: Test Project
+    slug: testproj
+    repo: owner/test-project
+    root: /tmp/testproj
+    default_branch: main
+    dev:
+      commit_prefix: TEST
+YAML
+
+    loop_load_project "testproj"
+    [ "$WORKFLOW" = "default" ]
+}
+
+@test "v1: basic fields are parsed correctly with default workflow" {
+    write_fixture <<'YAML'
+version: 1
+projects:
+  - name: Test Project
+    slug: testproj
+    repo: owner/test-project
+    root: /tmp/testproj
+    default_branch: main
+    dev:
+      commit_prefix: TEST
+YAML
+
+    loop_load_project "testproj"
+    [ "$REPO" = "owner/test-project" ]
+    [ "$DEFAULT_BRANCH" = "main" ]
+    [ "$COMMIT_PREFIX" = "TEST" ]
+    [ "$BACKEND" = "github" ]
+}
+
+@test "v1: LOOP_LABEL_OVERRIDES is empty string when no labels key" {
+    write_fixture <<'YAML'
+version: 1
+projects:
+  - name: Test Project
+    slug: testproj
+    repo: owner/test-project
+    root: /tmp/testproj
+    default_branch: main
+YAML
+
+    loop_load_project "testproj"
+    [ "$LOOP_LABEL_OVERRIDES" = "" ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# v1 — custom workflow ref
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "v1: WORKFLOW is set to the value of the workflow key" {
+    write_fixture <<'YAML'
+version: 1
+projects:
+  - name: Minimal Project
+    slug: minproj
+    repo: owner/min-project
+    root: /tmp/minproj
+    default_branch: main
+    workflow: minimal
+YAML
+
+    loop_load_project "minproj"
+    [ "$WORKFLOW" = "minimal" ]
+}
+
+@test "v1: WORKFLOW accepts 'current' as a valid workflow name" {
+    write_fixture <<'YAML'
+version: 1
+projects:
+  - name: Legacy Project
+    slug: legproj
+    repo: owner/leg-project
+    root: /tmp/legproj
+    default_branch: main
+    workflow: current
+YAML
+
+    loop_load_project "legproj"
+    [ "$WORKFLOW" = "current" ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# v1 — label overrides
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "v1: single label override is exported in LOOP_LABEL_OVERRIDES" {
+    write_fixture <<'YAML'
+version: 1
+projects:
+  - name: Override Project
+    slug: ovproj
+    repo: owner/ov-project
+    root: /tmp/ovproj
+    default_branch: main
+    labels:
+      plan: dev
+YAML
+
+    loop_load_project "ovproj"
+    [[ "$LOOP_LABEL_OVERRIDES" == *"plan=dev"* ]]
+}
+
+@test "v1: multiple label overrides are all present in LOOP_LABEL_OVERRIDES" {
+    write_fixture <<'YAML'
+version: 1
+projects:
+  - name: Override Project
+    slug: ovproj
+    repo: owner/ov-project
+    root: /tmp/ovproj
+    default_branch: main
+    labels:
+      plan: dev
+      qa-pass: approved
+      qa-fail: qa-failed
+YAML
+
+    loop_load_project "ovproj"
+    [[ "$LOOP_LABEL_OVERRIDES" == *"plan=dev"* ]]
+    [[ "$LOOP_LABEL_OVERRIDES" == *"qa-pass=approved"* ]]
+    [[ "$LOOP_LABEL_OVERRIDES" == *"qa-fail=qa-failed"* ]]
+}
+
+@test "v1: label overrides use pipe as separator" {
+    write_fixture <<'YAML'
+version: 1
+projects:
+  - name: Override Project
+    slug: ovproj
+    repo: owner/ov-project
+    root: /tmp/ovproj
+    default_branch: main
+    labels:
+      plan: dev
+      needs-review: review
+YAML
+
+    loop_load_project "ovproj"
+    # At least one pipe separator must be present for two overrides
+    [[ "$LOOP_LABEL_OVERRIDES" == *"|"* ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# v0 legacy fallback — no version field
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "v0: loads project successfully even when version field is absent" {
+    write_fixture <<'YAML'
+projects:
+  - name: Legacy Project
+    slug: legacyproj
+    repo: owner/legacy-project
+    root: /tmp/legacyproj
+    default_branch: main
+    dev:
+      commit_prefix: LEG
+YAML
+
+    loop_load_project "legacyproj"
+    [ "$REPO" = "owner/legacy-project" ]
+    [ "$COMMIT_PREFIX" = "LEG" ]
+}
+
+@test "v0: WORKFLOW defaults to 'default' when version field is absent" {
+    write_fixture <<'YAML'
+projects:
+  - name: Legacy Project
+    slug: legacyproj
+    repo: owner/legacy-project
+    root: /tmp/legacyproj
+    default_branch: main
+YAML
+
+    loop_load_project "legacyproj"
+    [ "$WORKFLOW" = "default" ]
+}
+
+@test "v0: emits deprecation warning to stderr when version field is absent" {
+    write_fixture <<'YAML'
+projects:
+  - name: Legacy Project
+    slug: legacyproj
+    repo: owner/legacy-project
+    root: /tmp/legacyproj
+    default_branch: main
+YAML
+
+    run loop_load_project "legacyproj"
+    # Exit should still be 0 (project found)
+    [ "$status" -eq 0 ]
+    # Warning must appear somewhere in combined output
+    [[ "$output" == *"v0"* ]] || [[ "$output" == *"legacy"* ]] || [[ "$output" == *"version"* ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Error cases
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "loop_load_project: returns non-zero for unknown slug" {
+    write_fixture <<'YAML'
+version: 1
+projects:
+  - name: Test
+    slug: known
+    repo: owner/test
+    root: /tmp/test
+    default_branch: main
+YAML
+
+    run loop_load_project "unknown-slug"
+    [ "$status" -ne 0 ]
+}
+
+@test "loop_load_project: returns 2 when config file is missing" {
+    export LOOP_CONFIG="/tmp/nonexistent-config-$$.yaml"
+    run loop_load_project "anything"
+    [ "$status" -eq 2 ]
+}


### PR DESCRIPTION
## Summary

- **`lib/config.sh`**: parse v1 schema fields — `version` (emit deprecation warning when absent), `workflow` ref (default: `"default"`), sparse `labels` map; substitute `${HOME}` in `root`; export `WORKFLOW` and `LOOP_LABEL_OVERRIDES` (pipe-separated `canonical=override` pairs)
- **`scripts/validate-config.sh`**: new validator script — checks slug/repo uniqueness, workflow file existence, label key validity, warns on `${HOME}` placeholders in root paths; wired into `install.sh` as step 2b
- **`config/projects.example.yaml`**: added annotated label-override example block
- **`tests/config.bats`**: 13 unit tests covering v1 default workflow, custom workflow refs, multiple label overrides, v0 legacy fallback, and error cases (all passing)

## Test plan

- [x] `bash -n` passes on all `lib/*.sh scripts/*.sh scanner/*.sh install.sh`
- [x] `shellcheck -S warning` passes on changed files
- [x] `bats tests/config.bats` — 13/13 tests pass
- [ ] Manually run `./scripts/validate-config.sh config/projects.example.yaml` and confirm OK output
- [ ] Confirm `loop_load_project` exports `WORKFLOW` and `LOOP_LABEL_OVERRIDES` correctly for a v1 config

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)