### PR TITLE
[LOOP-4] Bounty event API v1.0 payload contract

### DIFF
--- a/docs/api/bounty-events.md
+++ b/docs/api/bounty-events.md
@@ -1,0 +1,55 @@
+# Bounty event API v1.0
+
+Documents the versioned HTTP contract between loop's handlers and the
+`loop-monitor` `/api/report` endpoint.
+
+## Endpoint
+
+```
+POST /api/report
+Content-Type: application/json
+```
+
+## Canonical payload example
+
+```json
+{
+  "api": "1.0",
+  "core_version": "0.1.0",
+  "event": "dev_done",
+  "role": "dev",
+  "agent": "claude",
+  "model": "sonnet",
+  "project": "ppl",
+  "issue_num": 42,
+  "pr_num": 100,
+  "detail": "optional human-readable note",
+  "timestamp": "2026-04-27T04:00:00Z"
+}
+```
+
+## Field semantics
+
+| Field | Required | Type | Notes |
+|---|---|---|---|
+| `api` | yes | string `"<MAJOR>.<MINOR>"` | API version. Loop emits `1.0`. Monitor accepts `1.x`, rejects `2.x` with HTTP 426. |
+| `core_version` | yes | string semver | Sender's loop core version, for telemetry. |
+| `event` | yes | string | One of: `dev_start`, `dev_done`, `dev_failed`, `review_start`, `review_done`, `review_request_changes`, `qa_start`, `qa_pass`, `qa_fail`, `merge_start`, `merge_done`, `merge_conflict`, `merge_failed`, `po_start`, `po_done`, `po_failed`, `rework_start`, `rework_done`, `rework_failed` |
+| `role` | optional | string | Free-form (e.g. `dev`, `reviewer`, `merger`, or future specialist names like `frontend`) |
+| `agent` | optional | string | The agent CLI name (`claude`, `codex`, `gemini`, `aider`) |
+| `model` | optional | string | Model id (`sonnet`, `opus`, `o4-mini`) |
+| `project` | yes | string | Project slug from `projects.yaml` |
+| `issue_num` | optional | integer | At least one of `issue_num` / `pr_num` required |
+| `pr_num` | optional | integer | At least one of `issue_num` / `pr_num` required |
+| `detail` | optional | string | Human-readable context (e.g. `attempt 2/3`, `merge conflict`) |
+| `timestamp` | yes | string ISO 8601 UTC | e.g. `2026-04-27T04:00:00Z` |
+
+## Versioning rules
+
+- **Loop core** sends `api: "1.x"` always (`x` is bumped when adding optional fields; never breaking).
+- **Loop-monitor** parses any `1.x` payload; unknown fields are ignored gracefully.
+- **Loop-monitor** rejects `2.x` with HTTP 426 and body:
+  ```json
+  {"error":"version_unsupported","supported":["1.x"]}
+  ```
+- **Legacy clients** (no `api` field) are treated as `1.0` for v0.x compatibility; a deprecation warning is emitted in monitor logs.

--- a/lib/bounty.sh
+++ b/lib/bounty.sh
@@ -44,15 +44,21 @@ bounty_report() {
         esac
     done
 
+    local api_ver="$BOUNTY_API_VERSION"
+    if [ -z "$api_ver" ]; then
+        echo "bounty: api version not set, defaulting to 1.0 (deprecated)" >&2
+        api_ver="1.0"
+    fi
+
     local payload
     payload=$(
-        _API="$BOUNTY_API_VERSION" _CV="$(_bounty_core_version)" \
+        _API="$api_ver" _CV="$(_bounty_core_version)" \
         _BE="$event" _BA="$agent" _BM="$model" _BR="$role" \
         _BP="$project" _BD="$detail" _BI="$issue_num" _BPN="$pr_num" \
         python3 - <<'PY'
 import json, os, datetime
 d = {
-    "api":          os.environ.get("_API", "1.0"),
+    "api":          os.environ.get("_API") or "1.0",
     "core_version": os.environ.get("_CV") or "unknown",
     "event":        os.environ.get("_BE", "unknown"),
     "agent":        os.environ.get("_BA") or None,

--- a/lib/bounty.sh
+++ b/lib/bounty.sh
@@ -10,6 +10,20 @@ BOUNTY_URL="${BOUNTY_URL:-http://127.0.0.1:18792}"
 BOUNTY_TIMEOUT="${BOUNTY_TIMEOUT:-3}"
 BOUNTY_API_VERSION="1.0"
 
+# Resolve core version from LOOP_VERSION env var, then VERSION file, then 'unknown'.
+_bounty_core_version() {
+    if [ -n "${LOOP_VERSION:-}" ]; then
+        printf '%s' "$LOOP_VERSION"
+        return
+    fi
+    local vfile="${LOOP_ROOT:-}/VERSION"
+    if [ -f "$vfile" ]; then
+        tr -d '[:space:]' < "$vfile"
+        return
+    fi
+    printf 'unknown'
+}
+
 # bounty_report <event> [key=value ...]
 # Keys: agent model role project issue_num pr_num detail
 # Example: bounty_report "dev_start" role=dev model=sonnet project=myapp issue_num=42
@@ -32,7 +46,7 @@ bounty_report() {
 
     local payload
     payload=$(
-        _API="$BOUNTY_API_VERSION" _CV="${LOOP_VERSION:-unknown}" \
+        _API="$BOUNTY_API_VERSION" _CV="$(_bounty_core_version)" \
         _BE="$event" _BA="$agent" _BM="$model" _BR="$role" \
         _BP="$project" _BD="$detail" _BI="$issue_num" _BPN="$pr_num" \
         python3 - <<'PY'

--- a/scripts/judge.sh
+++ b/scripts/judge.sh
@@ -9,9 +9,6 @@ LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$LOOP_ROOT/lib/env.sh"
 source "$LOOP_ROOT/lib/bounty.sh"
 
-BOUNTY_URL="${BOUNTY_URL:-http://127.0.0.1:18792}"
-BOUNTY_TIMEOUT="${BOUNTY_TIMEOUT:-3}"
-
 PR_NUM="${1:-}"
 REPO="${2:-}"
 MODEL="${3:-}"

--- a/scripts/po-handler.sh
+++ b/scripts/po-handler.sh
@@ -21,6 +21,8 @@ source "$LOOP_ROOT/lib/runner.sh"
 source "$LOOP_ROOT/lib/config.sh"
 # shellcheck source=../lib/backends/backend.sh
 source "$LOOP_ROOT/lib/backends/backend.sh"
+# shellcheck source=../lib/bounty.sh
+source "$LOOP_ROOT/lib/bounty.sh"
 # shellcheck source=../lib/notify.sh
 source "$LOOP_ROOT/lib/notify.sh"
 

--- a/tests/bounty.bats
+++ b/tests/bounty.bats
@@ -154,3 +154,47 @@ PY
     run bounty_report "dev_start" project=myapp
     [ "$status" -eq 0 ]
 }
+
+# ---------------------------------------------------------------------------
+# _bounty_core_version() — three resolution paths
+# ---------------------------------------------------------------------------
+
+@test "_bounty_core_version: returns LOOP_VERSION when env var is set" {
+    LOOP_VERSION="9.9.9" run _bounty_core_version
+    [ "$status" -eq 0 ]
+    [ "$output" = "9.9.9" ]
+}
+
+@test "_bounty_core_version: reads VERSION file when LOOP_VERSION is unset" {
+    local vfile="$BATS_TMPDIR/VERSION"
+    printf '1.2.3' > "$vfile"
+    unset LOOP_VERSION
+    LOOP_ROOT="$BATS_TMPDIR" run _bounty_core_version
+    [ "$status" -eq 0 ]
+    [ "$output" = "1.2.3" ]
+}
+
+@test "_bounty_core_version: returns unknown when neither env var nor VERSION file is present" {
+    unset LOOP_VERSION
+    LOOP_ROOT="$BATS_TMPDIR/nonexistent" run _bounty_core_version
+    [ "$status" -eq 0 ]
+    [ "$output" = "unknown" ]
+}
+
+@test "bounty_report: payload core_version is non-empty" {
+    BOUNTY_API_VERSION="1.0"
+    LOOP_VERSION="0.1.0"
+    bounty_report "dev_start" project=myapp
+
+    [ -f "$PAYLOAD_FILE" ]
+    run python3 - "$PAYLOAD_FILE" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    d = json.load(f)
+cv = d.get("core_version", "")
+if not cv:
+    print("core_version is empty or missing")
+    sys.exit(1)
+PY
+    [ "$status" -eq 0 ]
+}

--- a/tests/bounty.bats
+++ b/tests/bounty.bats
@@ -1,0 +1,156 @@
+#!/usr/bin/env bats
+# tests/bounty.bats — unit tests for lib/bounty.sh payload helper.
+# curl calls are intercepted by the mock binary in test_helper/.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    # Expose mock-curl.sh as the curl binary via a per-test temp bin directory.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-curl.sh" "$BATS_TMPDIR/bin/curl"
+    chmod +x "$BATS_TMPDIR/bin/curl"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    # shellcheck source=../lib/bounty.sh
+    source "$REPO_ROOT/lib/bounty.sh"
+
+    # Point at the mock so tests don't need a real loop-monitor.
+    export BOUNTY_URL="http://127.0.0.1:18792"
+    export BOUNTY_TIMEOUT="1"
+
+    PAYLOAD_FILE="$BATS_TMPDIR/payload.json"
+    export CURL_PAYLOAD_FILE="$PAYLOAD_FILE"
+    unset CURL_MOCK_EXIT CURL_MOCK_LOG
+}
+
+teardown() {
+    rm -rf "${BATS_TMPDIR:?}/bin" "${BATS_TMPDIR:?}/payload.json" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# (a) valid v1.0 payload accepted
+# ---------------------------------------------------------------------------
+
+@test "bounty_report: valid v1.0 payload has correct api field" {
+    BOUNTY_API_VERSION="1.0"
+    bounty_report "dev_start" project=myapp issue_num=42
+
+    [ -f "$PAYLOAD_FILE" ]
+    run python3 -c "import json,sys; d=json.load(sys.stdin); print(d['api'])" < "$PAYLOAD_FILE"
+    [ "$status" -eq 0 ]
+    [ "$output" = "1.0" ]
+}
+
+@test "bounty_report: valid v1.0 payload contains required fields" {
+    BOUNTY_API_VERSION="1.0"
+    bounty_report "dev_done" project=loop issue_num=7
+
+    [ -f "$PAYLOAD_FILE" ]
+    run python3 - "$PAYLOAD_FILE" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    d = json.load(f)
+required = ["api", "core_version", "event", "timestamp"]
+missing = [k for k in required if k not in d]
+if missing:
+    print("missing:", missing)
+    sys.exit(1)
+PY
+    [ "$status" -eq 0 ]
+}
+
+@test "bounty_report: returns 0 when monitor accepts v1.0 payload" {
+    BOUNTY_API_VERSION="1.0"
+    export CURL_MOCK_EXIT=0
+    run bounty_report "dev_start" project=myapp
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# (b) future v1.x payload — extra unknown key=value args are ignored
+# ---------------------------------------------------------------------------
+
+@test "bounty_report: extra unknown key=value args are not included in payload" {
+    BOUNTY_API_VERSION="1.0"
+    bounty_report "dev_start" project=myapp unknown_field=foo another_extra=bar
+
+    [ -f "$PAYLOAD_FILE" ]
+    run python3 - "$PAYLOAD_FILE" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    d = json.load(f)
+for key in ("unknown_field", "another_extra"):
+    if key in d:
+        print("unexpected key in payload:", key)
+        sys.exit(1)
+PY
+    [ "$status" -eq 0 ]
+}
+
+@test "bounty_report: known fields are still present when extra args are passed" {
+    BOUNTY_API_VERSION="1.0"
+    bounty_report "qa_pass" project=loop issue_num=3 pr_num=10 extra_future_field=ignored
+
+    [ -f "$PAYLOAD_FILE" ]
+    run python3 - "$PAYLOAD_FILE" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    d = json.load(f)
+assert d["api"] == "1.0", "api mismatch"
+assert d["event"] == "qa_pass", "event mismatch"
+assert d["project"] == "loop", "project mismatch"
+assert d["issue_num"] == 3, "issue_num mismatch"
+assert d["pr_num"] == 10, "pr_num mismatch"
+PY
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# (c) v2.0 payload rejected with HTTP 426 — client handles it gracefully
+# ---------------------------------------------------------------------------
+
+@test "bounty_report: returns 0 when monitor responds with 426 (fire-and-forget)" {
+    BOUNTY_API_VERSION="1.0"
+    # curl -f exits 22 for HTTP 4xx/5xx errors (simulates 426 from monitor)
+    export CURL_MOCK_EXIT=22
+    run bounty_report "dev_start" project=myapp
+    [ "$status" -eq 0 ]
+}
+
+@test "bounty_report: returns 0 when curl times out (monitor unreachable)" {
+    BOUNTY_API_VERSION="1.0"
+    # curl exits 28 on timeout
+    export CURL_MOCK_EXIT=28
+    run bounty_report "dev_start" project=myapp
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# (d) missing api field — treated as 1.0 with deprecation warning
+# ---------------------------------------------------------------------------
+
+@test "bounty_report: empty BOUNTY_API_VERSION defaults payload api to 1.0" {
+    BOUNTY_API_VERSION=""
+    bounty_report "dev_start" project=myapp
+
+    [ -f "$PAYLOAD_FILE" ]
+    run python3 -c "import json,sys; d=json.load(sys.stdin); print(d['api'])" < "$PAYLOAD_FILE"
+    [ "$status" -eq 0 ]
+    [ "$output" = "1.0" ]
+}
+
+@test "bounty_report: empty BOUNTY_API_VERSION emits deprecation warning on stderr" {
+    BOUNTY_API_VERSION=""
+    # Run without `run` so we can capture stderr via subshell redirect
+    local warn_file="$BATS_TMPDIR/warn.txt"
+    bounty_report "dev_start" project=myapp 2>"$warn_file"
+
+    run grep -i "deprecat" "$warn_file"
+    [ "$status" -eq 0 ]
+}
+
+@test "bounty_report: empty BOUNTY_API_VERSION still returns 0" {
+    BOUNTY_API_VERSION=""
+    run bounty_report "dev_start" project=myapp
+    [ "$status" -eq 0 ]
+}

--- a/tests/test_helper/mock-curl.sh
+++ b/tests/test_helper/mock-curl.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Mock curl binary for bats tests.
+# CURL_MOCK_EXIT        — exit code (default: 0)
+# CURL_MOCK_LOG         — if set, each invocation appended as "curl <args>" to this file
+# CURL_PAYLOAD_FILE     — if set, the -d payload body is written to this file
+[ -n "${CURL_MOCK_LOG:-}" ] && printf 'curl %s\n' "$*" >> "$CURL_MOCK_LOG"
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-d" ] && [ "$#" -gt 1 ]; then
+        [ -n "${CURL_PAYLOAD_FILE:-}" ] && printf '%s' "$2" > "$CURL_PAYLOAD_FILE"
+        shift 2
+    else
+        shift
+    fi
+done
+exit "${CURL_MOCK_EXIT:-0}"


### PR DESCRIPTION
## Summary

- `lib/bounty.sh`: Added `_bounty_core_version()` helper that reads `core_version` from `LOOP_VERSION` env var first, then falls back to reading the `VERSION` file directly — makes `bounty.sh` self-sufficient without requiring `lib/version.sh` to be sourced first
- `scripts/po-handler.sh`: Added missing `source "$LOOP_ROOT/lib/bounty.sh"` so `bounty_report` calls in the PO handler are backed by the canonical helper
- `scripts/judge.sh`: Removed duplicate `BOUNTY_URL` and `BOUNTY_TIMEOUT` declarations already provided by `lib/bounty.sh`

All call sites under `scanner/`, `lib/`, `scripts/` now route through the single `bounty_report()` helper rather than hand-rolling payload construction or duplicating configuration.

Closes #4