### PR TITLE
fix(reconciler): add 'plan' to LOOP_PIPELINE_LABELS

### DIFF
--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -568,7 +568,7 @@ reconcile_worktrees() {
 # Open issues that have no Loop pipeline label at all are invisible to the
 # scanner and all handlers. Detect them and send back to po-review so the PO
 # agent can triage (re-spec, close, cancel, or upgrade to epic).
-LOOP_PIPELINE_LABELS="po-review dev in-progress review-pending needs-review in-review needs-qa ready-for-qa in-rework needs-rework changes-requested needs-clarification blocked qa-fail qa-pass done tracker"
+LOOP_PIPELINE_LABELS="po-review plan dev in-progress review-pending needs-review in-review needs-qa ready-for-qa in-rework needs-rework changes-requested needs-clarification blocked qa-fail qa-pass done tracker"
 
 reconcile_lost_issues() {
     local repo="$1"


### PR DESCRIPTION
## Summary
- \`plan\` was missing from \`LOOP_PIPELINE_LABELS\` in \`reconciler.sh\`
- Issues using \`workflow:default\` carry \`plan\` as their dev-stage trigger, but the reconciler didn't recognise it as a pipeline label
- Result: reconciler classified any \`plan\`-only issue as "lost" and re-routed it to \`po-review\` → bounce cycle for default-workflow projects

## Root cause
\`LOOP_PIPELINE_LABELS\` is the reconciler's known-pipeline-label allowlist. The \`default\` workflow introduced \`plan\` as the dev trigger (vs \`dev\` in \`current\`), but the list was never updated.

## Fix
One-word addition: \`plan\` inserted into \`LOOP_PIPELINE_LABELS\`.

## Test Plan
- [ ] Reconciler no longer routes \`plan\`-labelled issues to \`po-review\`
- [ ] \`loop\` and \`loop-monitor\` issues advance through dev pipeline without bouncing

🤖 Generated with [Claude Code](https://claude.com/claude-code)