### PR TITLE
[LOOP-6] scanner.sh — drive label polling from workflow helpers

### DIFF
--- a/config/workflows/default.yaml
+++ b/config/workflows/default.yaml
@@ -53,3 +53,9 @@ pr_stages:
     trigger_label: qa-pass
     handler: merge-handler
     on_done: done
+
+  - id: qa-rework
+    trigger_label: qa-fail
+    handler: dev-rework-handler
+    on_done: needs-review
+    on_failed_after_max: blocked

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -18,6 +18,10 @@ source "$LOOP_ROOT/lib/env.sh"
 source "$LOOP_ROOT/lib/config.sh"
 # shellcheck source=../lib/backends/backend.sh
 source "$LOOP_ROOT/lib/backends/backend.sh"
+# workflow helpers (loop_polled_labels, loop_handler_for_label, loop_stage_trigger,
+# loop_workflow_for_project) are already loaded via lib/env.sh → lib/workflow.sh.
+# The line below is for shellcheck only.
+# shellcheck source=../lib/workflow.sh
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
@@ -41,6 +45,20 @@ for arg in "$@"; do
 done
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] $*"; }
+
+# _handler_to_event_type <handler_base_name>
+# Maps a workflow handler name (from workflow YAML) to a loop event type string.
+_handler_to_event_type() {
+    case "$1" in
+        po-handler)          echo "loop.po_review" ;;
+        dev-handler)         echo "loop.dev_issue" ;;
+        review-handler)      echo "loop.pr_review" ;;
+        dev-rework-handler)  echo "loop.dev_rework" ;;
+        qa-handler)          echo "loop.pr_qa" ;;
+        merge-handler)       echo "loop.pr_merge" ;;
+        *)                   echo "loop.$1" ;;
+    esac
+}
 
 # Map event type to handler script (dispatch_direct mode).
 dispatch_direct() {
@@ -122,16 +140,36 @@ emit() {
     fi
 }
 
-# Dedup marker: has this issue/PR already been handed to a handler?
-# Checks both old and new label names for each stage.
+# issue_is_claimed <slug> <repo> <num>
+# Returns 0 if the issue has been dispatched or moved past the issue stage.
+# Claimed labels are derived from the project's workflow PR trigger labels
+# plus a fixed set of handler-set operational labels (in-progress, build, blocked).
 issue_is_claimed() {
-    local repo="$1" num="$2"
+    local slug="$1" repo="$2" num="$3"
+    local pr_trigger_labels
+    pr_trigger_labels=$(loop_polled_labels "$slug" pr 2>/dev/null | tr '\n' ' ')
+    # shellcheck disable=SC2086
     backend_issue_has_any_label "$repo" "$num" \
-        in-progress build blocked \
-        review-pending needs-review \
-        ready-for-qa needs-qa \
-        qa-pass approved \
-        'done'
+        in-progress build blocked 'done' \
+        ${pr_trigger_labels}
+}
+
+# _pr_downstream_labels <slug> <from_label>
+# Returns space-separated PR stage trigger labels that appear after from_label
+# in the project's workflow. Used to determine whether a PR has already moved
+# past the stage we are about to dispatch.
+_pr_downstream_labels() {
+    local slug="$1" from_label="$2"
+    local found=false
+    local result=""
+    while IFS= read -r lbl; do
+        if $found; then
+            result="$result $lbl"
+        elif [ "$lbl" = "$from_label" ]; then
+            found=true
+        fi
+    done < <(loop_polled_labels "$slug" pr 2>/dev/null)
+    echo "$result"
 }
 
 # author_is_allowed <author_login>
@@ -146,38 +184,20 @@ author_is_allowed() {
     return 1
 }
 
-pr_is_claimed_for_review() {
-    local repo="$1" num="$2"
-    backend_pr_has_any_label "$repo" "$num" \
-        in-review \
-        ready-for-qa needs-qa \
-        qa-pass approved \
-        'done'
-}
-
-pr_is_claimed_for_qa() {
-    local repo="$1" num="$2"
-    backend_pr_has_any_label "$repo" "$num" qa-pass approved 'done'
-}
-
-pr_is_claimed_for_rework() {
-    local repo="$1" num="$2"
-    backend_pr_has_any_label "$repo" "$num" in-rework blocked
-}
-
-# count_inflight_prs <repo>
+# count_inflight_prs <slug> <repo>
 # Count open PRs that carry at least one pipeline label.
+# Pipeline labels are derived from the project's workflow PR trigger labels
+# plus handler-set in-flight labels (in-progress, in-review, in-rework).
 count_inflight_prs() {
-    local repo="$1"
+    local slug="$1" repo="$2"
+    local pr_labels
+    pr_labels=$(loop_polled_labels "$slug" pr 2>/dev/null | tr '\n' ' ')
     local raw
     raw=$(backend_list_open_prs_raw "$repo")
+    PIPELINE_LABELS="in-progress in-review in-rework ${pr_labels}" \
     printf '%s\n' "$raw" | python3 -c "
-import json, sys
-pipeline_labels = {
-    'in-progress', 'build', 'review-pending', 'needs-review', 'in-review',
-    'ready-for-qa', 'needs-qa', 'in-rework', 'changes-requested', 'needs-rework',
-    'qa-fail', 'qa-failed', 'qa-pass', 'approved',
-}
+import json, sys, os
+pipeline_labels = set(os.environ.get('PIPELINE_LABELS', '').split())
 prs = json.load(sys.stdin)
 print(sum(
     1 for pr in prs
@@ -186,80 +206,111 @@ print(sum(
 "
 }
 
-scan_project() {
-    local slug="$1"
-    loop_load_project "$slug" || { log "skip: slug '$slug' unloadable"; return; }
-    loop_load_backend
-    local repo="$REPO"
+# _emit_issue_event <type> <slug> <repo> <num> <title> <url>
+# Build and print an issue event JSON string.
+_emit_issue_event() {
+    local type="$1" slug="$2" repo="$3" num="$4" title="$5" url="$6"
+    python3 -c "
+import json,sys
+print(json.dumps({
+    'type': sys.argv[1],
+    'payload': {
+        'slug': sys.argv[2],
+        'repo': sys.argv[3],
+        'issue_number': int(sys.argv[4]),
+        'issue_title': sys.argv[5],
+        'issue_url': sys.argv[6],
+    }
+}))
+" "$type" "$slug" "$repo" "$num" "$title" "$url"
+}
 
-    local _wf
-    _wf=$(loop_workflow_for_project "$slug")
-    log "scan: $slug ($repo) workflow=$_wf"
+# _emit_pr_event <type> <slug> <repo> <num> <title> <url> [extra_key] [extra_val]
+# Build and print a PR event JSON string. extra_key/extra_val add one optional payload field.
+_emit_pr_event() {
+    local type="$1" slug="$2" repo="$3" num="$4" title="$5" url="$6"
+    local extra_key="${7:-}" extra_val="${8:-}"
+    python3 -c "
+import json,sys
+p = {
+    'slug': sys.argv[2],
+    'repo': sys.argv[3],
+    'pr_number': int(sys.argv[4]),
+    'pr_title': sys.argv[5],
+    'pr_url': sys.argv[6],
+}
+if sys.argv[7]:
+    p[sys.argv[7]] = sys.argv[8]
+print(json.dumps({'type': sys.argv[1], 'payload': p}))
+" "$type" "$slug" "$repo" "$num" "$title" "$url" "$extra_key" "$extra_val"
+}
 
-    # --- po-review issues: rough ideas awaiting PO expansion -----------------
+# _scan_issue_stage <slug> <repo> <trigger_label> <handler> <event_type>
+# Handles a single issue stage. dev-handler gets slot/priority/dep-gate logic;
+# all other handlers get a simple poll-and-emit loop.
+_scan_issue_stage() {
+    local slug="$1" repo="$2" trigger_label="$3" handler="$4" event_type="$5"
+
+    if [ "$handler" = "dev-handler" ]; then
+        _scan_dev_issue_stage "$slug" "$repo" "$trigger_label" "$event_type"
+        return
+    fi
+
+    # Simple issue stage (e.g. po-handler)
     while IFS= read -r row; do
         [ -z "$row" ] && continue
-        local num title url
-        num=$(echo "$row"    | python3 -c "import json,sys; print(json.load(sys.stdin)['number'])")
-        title=$(echo "$row"  | python3 -c "import json,sys; print(json.load(sys.stdin)['title'])")
-        url=$(echo "$row"    | python3 -c "import json,sys; print(json.load(sys.stdin)['url'])")
-        local author
-        author=$(echo "$row" | python3 -c "import json,sys; print(json.load(sys.stdin).get('author',''))")
+        local num title url author
+        num=$(printf '%s' "$row"    | python3 -c "import json,sys; print(json.load(sys.stdin)['number'])")
+        title=$(printf '%s' "$row"  | python3 -c "import json,sys; print(json.load(sys.stdin)['title'])")
+        url=$(printf '%s' "$row"    | python3 -c "import json,sys; print(json.load(sys.stdin)['url'])")
+        author=$(printf '%s' "$row" | python3 -c "import json,sys; print(json.load(sys.stdin).get('author',''))")
         if ! author_is_allowed "$author"; then
-            log "skip po-review #$num: author '$author' not in ALLOWED_AUTHORS"
+            log "skip $event_type #$num: author '$author' not in ALLOWED_AUTHORS"
             continue
         fi
-        if issue_is_claimed "$repo" "$num"; then
+        if issue_is_claimed "$slug" "$repo" "$num"; then
             continue
         fi
         local evt
-        evt=$(python3 -c "
-import json,sys
-print(json.dumps({
-    'type':'loop.po_review',
-    'payload':{
-        'slug': sys.argv[1],
-        'repo': sys.argv[2],
-        'issue_number': int(sys.argv[3]),
-        'issue_title': sys.argv[4],
-        'issue_url': sys.argv[5],
-    }
-}))
-" "$slug" "$repo" "$num" "$title" "$url")
-        log "emit loop.po_review #$num $title"
-        emit "$evt" "po_review:${slug}:${num}"
-    done < <(backend_list_issues_with_label "$repo" "$(loop_stage_trigger "$slug" "po" "issue")")
+        evt=$(_emit_issue_event "$event_type" "$slug" "$repo" "$num" "$title" "$url")
+        log "emit $event_type #$num $title"
+        emit "$evt" "${event_type}:${slug}:${num}"
+    done < <(backend_list_issues_with_label "$repo" "$trigger_label")
+}
 
-    # --- dev issues: workflow-driven label (canonical 'plan'). The project's
-    # active workflow + label overrides decide the actual label name (e.g.
-    # 'dev' for projects on `workflow: current`, 'plan' for `default`).
-    local _inflight _slots _rows_tmp _seen_tmp _emitted _di_num _di_title _di_url _di_unmet _di_evt
-    _inflight=$(count_inflight_prs "$repo")
+# _scan_dev_issue_stage — dev_issue with concurrent slot limiting, priority sort, dep gating.
+_scan_dev_issue_stage() {
+    local slug="$1" repo="$2" trigger_label="$3" event_type="$4"
+
+    local _inflight _slots
+    _inflight=$(count_inflight_prs "$slug" "$repo")
     _slots=$(( MAX_CONCURRENT_PRS - _inflight ))
     log "dev_issue: max=${MAX_CONCURRENT_PRS} in-flight=${_inflight} slots=${_slots}"
 
     if [ "$_slots" -le 0 ]; then
         log "skip dev_issue for $slug: ${_inflight}/${MAX_CONCURRENT_PRS} pipeline PRs in flight"
-    else
-        _rows_tmp=$(mktemp)
-        _seen_tmp=$(mktemp)
+        return
+    fi
 
-        # Collect from the project's resolved 'plan' label.
-        # Already priority-sorted by backend_list_issues_with_label.
-        while IFS= read -r _r; do
-            [ -z "$_r" ] && continue
-            _di_num=$(printf '%s' "$_r" | python3 -c "import json,sys; print(json.load(sys.stdin)['number'])")
-            if ! grep -qxF "$_di_num" "$_seen_tmp" 2>/dev/null; then
-                printf '%s\n' "$_di_num" >> "$_seen_tmp"
-                printf '%s\n' "$_r" >> "$_rows_tmp"
-            fi
-        done < <(backend_list_issues_with_label "$repo" "$(loop_stage_trigger "$slug" "plan" "issue" 2>/dev/null || loop_stage_trigger "$slug" "dev" "issue")")
+    local _rows_tmp _seen_tmp
+    _rows_tmp=$(mktemp)
+    _seen_tmp=$(mktemp)
 
-        # Re-sort the combined list by (priority, issue_number) so that cross-label
-        # ordering is correct (e.g. a p0 in 'plan' beats a p2 in 'dev').
-        local _sorted_tmp
-        _sorted_tmp=$(mktemp)
-        _ROWS_FILE="$_rows_tmp" python3 <<'PY' > "$_sorted_tmp"
+    # Collect and deduplicate issues from the workflow's dev trigger label.
+    while IFS= read -r _r; do
+        [ -z "$_r" ] && continue
+        local _n
+        _n=$(printf '%s' "$_r" | python3 -c "import json,sys; print(json.load(sys.stdin)['number'])")
+        if ! grep -qxF "$_n" "$_seen_tmp" 2>/dev/null; then
+            printf '%s\n' "$_n" >> "$_seen_tmp"
+            printf '%s\n' "$_r" >> "$_rows_tmp"
+        fi
+    done < <(backend_list_issues_with_label "$repo" "$trigger_label")
+
+    # Sort by (priority-label, issue_number) so high-priority issues fire first.
+    local _sorted_tmp
+    _sorted_tmp=$(mktemp)
+    _ROWS_FILE="$_rows_tmp" python3 <<'PY' > "$_sorted_tmp"
 import json, sys, os
 PRIORITY = {'p0-critical': 0, 'p1-high': 1, 'p2-medium': 2, 'p3-low': 3}
 rows = []
@@ -276,203 +327,114 @@ rows.sort(key=lambda x: (x[0], x[1]))
 for _, _, line in rows:
     print(line)
 PY
-        mv "$_sorted_tmp" "$_rows_tmp"
+    mv "$_sorted_tmp" "$_rows_tmp"
 
-        _emitted=0
-        while IFS= read -r _row; do
-            [ "$_emitted" -ge "$_slots" ] && break
-            [ -z "$_row" ] && continue
-            _di_num=$(printf '%s' "$_row"    | python3 -c "import json,sys; print(json.load(sys.stdin)['number'])")
-            _di_title=$(printf '%s' "$_row"  | python3 -c "import json,sys; print(json.load(sys.stdin)['title'])")
-            _di_url=$(printf '%s' "$_row"    | python3 -c "import json,sys; print(json.load(sys.stdin)['url'])")
-            local _di_author
-            _di_author=$(printf '%s' "$_row" | python3 -c "import json,sys; print(json.load(sys.stdin).get('author',''))")
-            if ! author_is_allowed "$_di_author"; then
-                log "skip dev_issue #$_di_num: author '$_di_author' not in ALLOWED_AUTHORS"
-                continue
-            fi
-            if issue_is_claimed "$repo" "$_di_num"; then
-                continue
-            fi
-            # Dependency gate: defer if the issue body declares unmet deps in
-            # its "## Dependencies" section. Pickup resumes automatically once deps close.
-            _di_unmet=$(backend_issue_unmet_deps "$repo" "$_di_num" 2>/dev/null || true)
-            if [ -n "$_di_unmet" ]; then
-                log "defer loop.dev_issue #$_di_num $_di_title — unmet deps: $(printf '%s' "$_di_unmet" | tr '\n' ' ')"
-                continue
-            fi
-            _di_evt=$(python3 -c "
-import json,sys
-print(json.dumps({
-    'type':'loop.dev_issue',
-    'payload':{
-        'slug': sys.argv[1],
-        'repo': sys.argv[2],
-        'issue_number': int(sys.argv[3]),
-        'issue_title': sys.argv[4],
-        'issue_url': sys.argv[5],
-    }
-}))
-" "$slug" "$repo" "$_di_num" "$_di_title" "$_di_url")
-            log "emit loop.dev_issue #$_di_num $_di_title"
-            emit "$_di_evt" "dev_issue:${slug}:${_di_num}"
-            _emitted=$(( _emitted + 1 ))
-        done < "$_rows_tmp"
-        rm -f "$_rows_tmp" "$_seen_tmp"
+    local _emitted=0
+    while IFS= read -r _row; do
+        [ "$_emitted" -ge "$_slots" ] && break
+        [ -z "$_row" ] && continue
+        local _num _title _url _author _unmet _evt
+        _num=$(printf '%s' "$_row"    | python3 -c "import json,sys; print(json.load(sys.stdin)['number'])")
+        _title=$(printf '%s' "$_row"  | python3 -c "import json,sys; print(json.load(sys.stdin)['title'])")
+        _url=$(printf '%s' "$_row"    | python3 -c "import json,sys; print(json.load(sys.stdin)['url'])")
+        _author=$(printf '%s' "$_row" | python3 -c "import json,sys; print(json.load(sys.stdin).get('author',''))")
+        if ! author_is_allowed "$_author"; then
+            log "skip dev_issue #$_num: author '$_author' not in ALLOWED_AUTHORS"
+            continue
+        fi
+        if issue_is_claimed "$slug" "$repo" "$_num"; then
+            continue
+        fi
+        # Dependency gate: defer if the issue body declares unmet deps.
+        _unmet=$(backend_issue_unmet_deps "$repo" "$_num" 2>/dev/null || true)
+        if [ -n "$_unmet" ]; then
+            log "defer dev_issue #$_num $_title — unmet deps: $(printf '%s' "$_unmet" | tr '\n' ' ')"
+            continue
+        fi
+        _evt=$(_emit_issue_event "$event_type" "$slug" "$repo" "$_num" "$_title" "$_url")
+        log "emit $event_type #$_num $_title"
+        emit "$_evt" "${event_type}:${slug}:${_num}"
+        _emitted=$(( _emitted + 1 ))
+    done < "$_rows_tmp"
+    rm -f "$_rows_tmp" "$_seen_tmp"
+}
+
+# _scan_pr_stage <slug> <repo> <trigger_label> <handler> <event_type>
+# Polls for PRs carrying trigger_label and emits the appropriate event.
+# A PR is skipped if it has already moved downstream (has a later-stage trigger
+# label) or is actively being handled (in-review / in-rework operational labels).
+_scan_pr_stage() {
+    local slug="$1" repo="$2" trigger_label="$3" handler="$4" event_type="$5"
+
+    local downstream
+    downstream=$(_pr_downstream_labels "$slug" "$trigger_label")
+
+    # For dev-rework-handler: when the trigger label is NOT the workflow's
+    # primary rework trigger (i.e., it comes from a qa-fail stage), add
+    # rework_context so the handler knows the origin.
+    local rework_context_key="" rework_context_val=""
+    if [ "$handler" = "dev-rework-handler" ]; then
+        local rework_trigger
+        rework_trigger=$(loop_stage_trigger "$slug" "rework" "pr" 2>/dev/null || true)
+        if [ -n "$rework_trigger" ] && [ "$trigger_label" != "$rework_trigger" ]; then
+            rework_context_key="rework_context"
+            rework_context_val="qa-fail"
+        fi
     fi
 
-    # --- PRs: review-pending / needs-review (new name); shared dedup key -----
-    _emit_pr_review() {
-        local _row="$1"
-        [ -z "$_row" ] && return 0
+    while IFS= read -r row; do
+        [ -z "$row" ] && continue
         local num title url
-        num=$(echo "$_row"   | python3 -c "import json,sys; print(json.load(sys.stdin)['number'])")
-        title=$(echo "$_row" | python3 -c "import json,sys; print(json.load(sys.stdin)['title'])")
-        url=$(echo "$_row"   | python3 -c "import json,sys; print(json.load(sys.stdin)['url'])")
-        if pr_is_claimed_for_review "$repo" "$num"; then
-            return 0
-        fi
-        local evt
-        evt=$(python3 -c "
-import json,sys
-print(json.dumps({
-    'type':'loop.pr_review',
-    'payload':{
-        'slug': sys.argv[1],
-        'repo': sys.argv[2],
-        'pr_number': int(sys.argv[3]),
-        'pr_title': sys.argv[4],
-        'pr_url': sys.argv[5],
-    }
-}))
-" "$slug" "$repo" "$num" "$title" "$url")
-        log "emit loop.pr_review PR#$num $title"
-        emit "$evt" "pr_review:${slug}:${num}"
-    }
-    while IFS= read -r row; do _emit_pr_review "$row"; done \
-        < <(backend_list_prs_with_label "$repo" "$(loop_stage_trigger "$slug" "review" "pr")")
+        num=$(printf '%s' "$row"   | python3 -c "import json,sys; print(json.load(sys.stdin)['number'])")
+        title=$(printf '%s' "$row" | python3 -c "import json,sys; print(json.load(sys.stdin)['title'])")
+        url=$(printf '%s' "$row"   | python3 -c "import json,sys; print(json.load(sys.stdin)['url'])")
 
-    # --- PRs: changes-requested / needs-rework (new name) → dev_rework ------
-    _emit_dev_rework_cr() {
-        local _row="$1"
-        [ -z "$_row" ] && return 0
-        local num title url
-        num=$(echo "$_row"   | python3 -c "import json,sys; print(json.load(sys.stdin)['number'])")
-        title=$(echo "$_row" | python3 -c "import json,sys; print(json.load(sys.stdin)['title'])")
-        url=$(echo "$_row"   | python3 -c "import json,sys; print(json.load(sys.stdin)['url'])")
-        if pr_is_claimed_for_rework "$repo" "$num"; then
-            return 0
+        # Skip if the PR has moved to a downstream stage or is actively being handled.
+        # in-review / in-rework are handler-set operational labels (not in workflow YAML).
+        # shellcheck disable=SC2086
+        if backend_pr_has_any_label "$repo" "$num" \
+               in-review in-rework 'done' blocked \
+               ${downstream}; then
+            continue
         fi
-        local evt
-        evt=$(python3 -c "
-import json,sys
-print(json.dumps({
-    'type':'loop.dev_rework',
-    'payload':{
-        'slug': sys.argv[1],
-        'repo': sys.argv[2],
-        'pr_number': int(sys.argv[3]),
-        'pr_title': sys.argv[4],
-        'pr_url': sys.argv[5],
-    }
-}))
-" "$slug" "$repo" "$num" "$title" "$url")
-        log "emit loop.dev_rework PR#$num $title"
-        emit "$evt" "dev_rework:${slug}:${num}"
-    }
-    while IFS= read -r row; do _emit_dev_rework_cr "$row"; done \
-        < <(backend_list_prs_with_label "$repo" "$(loop_stage_trigger "$slug" "rework" "pr")")
 
-    # --- PRs: qa-fail / qa-failed (new name) → dev_rework -------------------
-    _emit_dev_rework_qa() {
-        local _row="$1"
-        [ -z "$_row" ] && return 0
-        local num title url
-        num=$(echo "$_row"   | python3 -c "import json,sys; print(json.load(sys.stdin)['number'])")
-        title=$(echo "$_row" | python3 -c "import json,sys; print(json.load(sys.stdin)['title'])")
-        url=$(echo "$_row"   | python3 -c "import json,sys; print(json.load(sys.stdin)['url'])")
-        if pr_is_claimed_for_rework "$repo" "$num"; then
-            return 0
-        fi
         local evt
-        evt=$(python3 -c "
-import json,sys
-print(json.dumps({
-    'type':'loop.dev_rework',
-    'payload':{
-        'slug': sys.argv[1],
-        'repo': sys.argv[2],
-        'pr_number': int(sys.argv[3]),
-        'pr_title': sys.argv[4],
-        'pr_url': sys.argv[5],
-        'rework_context': 'qa-fail',
-    }
-}))
-" "$slug" "$repo" "$num" "$title" "$url")
-        log "emit loop.dev_rework (qa-fail) PR#$num $title"
-        emit "$evt" "dev_rework_qa:${slug}:${num}"
-    }
-    while IFS= read -r row; do _emit_dev_rework_qa "$row"; done \
-        < <(backend_list_prs_with_label "$repo" "$(loop_label_for "$slug" "qa-fail" 2>/dev/null)")
+        evt=$(_emit_pr_event "$event_type" "$slug" "$repo" "$num" "$title" "$url" \
+              "$rework_context_key" "$rework_context_val")
+        log "emit $event_type PR#$num $title"
+        emit "$evt" "${event_type}:${slug}:${num}"
+    done < <(backend_list_prs_with_label "$repo" "$trigger_label")
+}
 
-    # --- PRs: ready-for-qa / needs-qa (new name); shared dedup key -----------
-    _emit_pr_qa() {
-        local _row="$1"
-        [ -z "$_row" ] && return 0
-        local num title url
-        num=$(echo "$_row"   | python3 -c "import json,sys; print(json.load(sys.stdin)['number'])")
-        title=$(echo "$_row" | python3 -c "import json,sys; print(json.load(sys.stdin)['title'])")
-        url=$(echo "$_row"   | python3 -c "import json,sys; print(json.load(sys.stdin)['url'])")
-        if pr_is_claimed_for_qa "$repo" "$num"; then
-            return 0
-        fi
-        local evt
-        evt=$(python3 -c "
-import json,sys
-print(json.dumps({
-    'type':'loop.pr_qa',
-    'payload':{
-        'slug': sys.argv[1],
-        'repo': sys.argv[2],
-        'pr_number': int(sys.argv[3]),
-        'pr_title': sys.argv[4],
-        'pr_url': sys.argv[5],
-    }
-}))
-" "$slug" "$repo" "$num" "$title" "$url")
-        log "emit loop.pr_qa PR#$num $title"
-        emit "$evt" "pr_qa:${slug}:${num}"
-    }
-    while IFS= read -r row; do _emit_pr_qa "$row"; done \
-        < <(backend_list_prs_with_label "$repo" "$(loop_stage_trigger "$slug" "qa" "pr")")
+scan_project() {
+    local slug="$1"
+    loop_load_project "$slug" || { log "skip: slug '$slug' unloadable"; return; }
+    loop_load_backend
+    local repo="$REPO"
 
-    # --- PRs: qa-pass / approved (new name); shared dedup key ---------------
-    _emit_pr_merge() {
-        local _row="$1"
-        [ -z "$_row" ] && return 0
-        local num title url
-        num=$(echo "$_row"   | python3 -c "import json,sys; print(json.load(sys.stdin)['number'])")
-        title=$(echo "$_row" | python3 -c "import json,sys; print(json.load(sys.stdin)['title'])")
-        url=$(echo "$_row"   | python3 -c "import json,sys; print(json.load(sys.stdin)['url'])")
-        local evt
-        evt=$(python3 -c "
-import json,sys
-print(json.dumps({
-    'type':'loop.pr_merge',
-    'payload':{
-        'slug': sys.argv[1],
-        'repo': sys.argv[2],
-        'pr_number': int(sys.argv[3]),
-        'pr_title': sys.argv[4],
-        'pr_url': sys.argv[5],
-    }
-}))
-" "$slug" "$repo" "$num" "$title" "$url")
-        log "emit loop.pr_merge PR#$num $title"
-        emit "$evt" "pr_merge:${slug}:${num}"
-    }
-    while IFS= read -r row; do _emit_pr_merge "$row"; done \
-        < <(backend_list_prs_with_label "$repo" "$(loop_stage_trigger "$slug" "merge" "pr")")
+    local wf_name
+    wf_name=$(loop_workflow_for_project "$slug")
+    log "scan: $slug ($repo) workflow=$wf_name"
+
+    # Issue stages — iterated from the project's active workflow.
+    while IFS= read -r trigger_label; do
+        [ -z "$trigger_label" ] && continue
+        local handler event_type
+        handler=$(loop_handler_for_label "$slug" "$trigger_label" 2>/dev/null || true)
+        [ -z "$handler" ] && continue
+        event_type=$(_handler_to_event_type "$handler")
+        _scan_issue_stage "$slug" "$repo" "$trigger_label" "$handler" "$event_type"
+    done < <(loop_polled_labels "$slug" issue)
+
+    # PR stages — iterated from the project's active workflow.
+    while IFS= read -r trigger_label; do
+        [ -z "$trigger_label" ] && continue
+        local handler event_type
+        handler=$(loop_handler_for_label "$slug" "$trigger_label" 2>/dev/null || true)
+        [ -z "$handler" ] && continue
+        event_type=$(_handler_to_event_type "$handler")
+        _scan_pr_stage "$slug" "$repo" "$trigger_label" "$handler" "$event_type"
+    done < <(loop_polled_labels "$slug" pr)
 }
 
 run_once() {

--- a/tests/scanner.bats
+++ b/tests/scanner.bats
@@ -4,8 +4,11 @@
 #
 # Sourcing strategy: awk extracts all function/variable definitions from
 # scanner.sh and stops before the bare "acquire_lock" call that would start
-# the daemon loop. SCRIPT_DIR/ASDLC_ROOT lines are skipped; ASDLC_ROOT is
+# the daemon loop. SCRIPT_DIR/LOOP_ROOT lines are skipped; LOOP_ROOT is
 # injected first so the lib/ source statements resolve correctly.
+#
+# Note: bash 3.2 (macOS default) does not propagate function definitions from
+# `source <(...)` to the caller's scope. We write to a temp file instead.
 
 setup() {
     REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
@@ -16,27 +19,37 @@ setup() {
     chmod +x "$BATS_TMPDIR/bin/gh"
     export PATH="$BATS_TMPDIR/bin:$PATH"
 
-    # Pre-set log dir so env.sh does not create ~/.asdlc/logs during tests.
-    export ASDLC_LOG_DIR="$BATS_TMPDIR/logs"
-    mkdir -p "$ASDLC_LOG_DIR"
+    # Pre-set log dir so env.sh does not create ~/.loop/logs during tests.
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
 
     unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
 
     # Source scanner.sh function definitions only.
-    # - Inject ASDLC_ROOT before awk output so lib/ sources resolve.
-    # - Strip the SCRIPT_DIR= and ASDLC_ROOT= re-assignments from scanner.sh
-    #   (env.sh uses BASH_SOURCE[0] and will set ASDLC_ROOT correctly anyway).
-    # - Stop awk at the bare "acquire_lock" call to avoid the daemon loop.
-    # shellcheck disable=SC1090
-    source <(
-        printf "ASDLC_ROOT='%s'\n" "$REPO_ROOT"
+    # Write to a temp file: bash 3.2 (macOS) does not propagate function
+    # definitions from `source <(...)` to the caller's scope.
+    # Also strip the arg-parsing for..done block (bats passes test name as $@)
+    # and replace with explicit variable assignments.
+    # Suppress LOOP_EXTRA_PATH so env.sh does not prepend /opt/homebrew/bin
+    # and shadow the mock gh binary we placed in $BATS_TMPDIR/bin.
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
         awk '
-            /^SCRIPT_DIR=/  { next }
-            /^ASDLC_ROOT=/  { next }
-            /^acquire_lock$/ { exit }
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
             { print }
         ' "$REPO_ROOT/scanner/scanner.sh"
-    )
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    # Re-prepend mock bin dir in case env.sh modified PATH.
+    export PATH="$BATS_TMPDIR/bin:$PATH"
 
     # Override paths that scanner.sh hard-codes after sourcing.
     DEDUP_DIR="$BATS_TMPDIR/dedup"
@@ -45,7 +58,7 @@ setup() {
 
     # Ensure emit uses direct mode with no event-queue client.
     DRY_RUN=false
-    ASDLC_DISPATCH_MODE=direct
+    LOOP_DISPATCH_MODE=direct
     BOBA_EVENT_CLIENT=""
 
     # Silence log() output; no-op dispatch_direct to avoid launching handlers.
@@ -55,7 +68,8 @@ setup() {
 
 teardown() {
     rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
-           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" 2>/dev/null || true
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
 }
 
 # ---------------------------------------------------------------------------
@@ -63,141 +77,265 @@ teardown() {
 # ---------------------------------------------------------------------------
 
 @test "_dedup_key: produces non-empty output" {
-    run _dedup_key "asdlc.dev_issue:owner/repo:42"
+    run _dedup_key "loop.dev_issue:owner/repo:42"
     [ "$status" -eq 0 ]
     [ -n "$output" ]
 }
 
 @test "_dedup_key: same input yields same hash" {
     local a b
-    a=$(_dedup_key "asdlc.dev_issue:test-org/test-repo:7")
-    b=$(_dedup_key "asdlc.dev_issue:test-org/test-repo:7")
+    a=$(_dedup_key "loop.dev_issue:test-org/test-repo:7")
+    b=$(_dedup_key "loop.dev_issue:test-org/test-repo:7")
     [ "$a" = "$b" ]
 }
 
 @test "_dedup_key: different inputs yield different hashes" {
     local a b
-    a=$(_dedup_key "asdlc.dev_issue:test-org/test-repo:1")
-    b=$(_dedup_key "asdlc.dev_issue:test-org/test-repo:2")
+    a=$(_dedup_key "loop.dev_issue:test-org/test-repo:1")
+    b=$(_dedup_key "loop.dev_issue:test-org/test-repo:2")
     [ "$a" != "$b" ]
 }
 
 # ---------------------------------------------------------------------------
-# issue_is_claimed
+# _handler_to_event_type
+# ---------------------------------------------------------------------------
+
+@test "_handler_to_event_type: dev-handler maps to loop.dev_issue" {
+    run _handler_to_event_type "dev-handler"
+    [ "$status" -eq 0 ]
+    [ "$output" = "loop.dev_issue" ]
+}
+
+@test "_handler_to_event_type: po-handler maps to loop.po_review" {
+    run _handler_to_event_type "po-handler"
+    [ "$status" -eq 0 ]
+    [ "$output" = "loop.po_review" ]
+}
+
+@test "_handler_to_event_type: review-handler maps to loop.pr_review" {
+    run _handler_to_event_type "review-handler"
+    [ "$status" -eq 0 ]
+    [ "$output" = "loop.pr_review" ]
+}
+
+@test "_handler_to_event_type: dev-rework-handler maps to loop.dev_rework" {
+    run _handler_to_event_type "dev-rework-handler"
+    [ "$status" -eq 0 ]
+    [ "$output" = "loop.dev_rework" ]
+}
+
+@test "_handler_to_event_type: qa-handler maps to loop.pr_qa" {
+    run _handler_to_event_type "qa-handler"
+    [ "$status" -eq 0 ]
+    [ "$output" = "loop.pr_qa" ]
+}
+
+@test "_handler_to_event_type: merge-handler maps to loop.pr_merge" {
+    run _handler_to_event_type "merge-handler"
+    [ "$status" -eq 0 ]
+    [ "$output" = "loop.pr_merge" ]
+}
+
+# ---------------------------------------------------------------------------
+# issue_is_claimed — uses workflow-derived PR stage labels
 # ---------------------------------------------------------------------------
 
 @test "issue_is_claimed: returns 0 when issue has in-progress label" {
     export GH_MOCK_OUTPUT="in-progress"
-    run issue_is_claimed "owner/repo" 1
+    run issue_is_claimed "test-slug" "owner/repo" 1
     [ "$status" -eq 0 ]
 }
 
-@test "issue_is_claimed: returns 0 when issue has review-pending label" {
-    export GH_MOCK_OUTPUT="review-pending"
-    run issue_is_claimed "owner/repo" 1
+@test "issue_is_claimed: returns 0 when issue has needs-review label (default workflow)" {
+    export GH_MOCK_OUTPUT="needs-review"
+    run issue_is_claimed "test-slug" "owner/repo" 1
     [ "$status" -eq 0 ]
 }
 
 @test "issue_is_claimed: returns 0 when issue has qa-pass label" {
     export GH_MOCK_OUTPUT="qa-pass"
-    run issue_is_claimed "owner/repo" 1
+    run issue_is_claimed "test-slug" "owner/repo" 1
     [ "$status" -eq 0 ]
 }
 
-@test "issue_is_claimed: returns 1 when issue has only dev label" {
-    export GH_MOCK_OUTPUT="dev"
-    run issue_is_claimed "owner/repo" 1
+@test "issue_is_claimed: returns 1 when issue has only plan label" {
+    export GH_MOCK_OUTPUT="plan"
+    run issue_is_claimed "test-slug" "owner/repo" 1
     [ "$status" -eq 1 ]
 }
 
 @test "issue_is_claimed: returns 1 when issue has no labels" {
     export GH_MOCK_OUTPUT=""
-    run issue_is_claimed "owner/repo" 1
+    run issue_is_claimed "test-slug" "owner/repo" 1
     [ "$status" -eq 1 ]
 }
 
 # ---------------------------------------------------------------------------
-# pr_is_claimed_for_review
+# _pr_downstream_labels
 # ---------------------------------------------------------------------------
 
-@test "pr_is_claimed_for_review: returns 0 when PR has in-review label" {
-    export GH_MOCK_OUTPUT="in-review"
-    run pr_is_claimed_for_review "owner/repo" 5
+@test "_pr_downstream_labels: default workflow, from needs-review includes rework/qa/merge stages" {
+    # No LOOP_CONFIG → resolves to default workflow
+    unset LOOP_CONFIG
+    run _pr_downstream_labels "test-slug" "needs-review"
     [ "$status" -eq 0 ]
+    [[ "$output" == *"needs-rework"* ]]
+    [[ "$output" == *"needs-qa"* ]]
+    [[ "$output" == *"qa-pass"* ]]
 }
 
-@test "pr_is_claimed_for_review: returns 0 when PR has qa-pass label" {
-    export GH_MOCK_OUTPUT="qa-pass"
-    run pr_is_claimed_for_review "owner/repo" 5
+@test "_pr_downstream_labels: default workflow, from qa-pass excludes upstream stages" {
+    unset LOOP_CONFIG
+    run _pr_downstream_labels "test-slug" "qa-pass"
     [ "$status" -eq 0 ]
-}
-
-@test "pr_is_claimed_for_review: returns 1 when PR has only review-pending" {
-    export GH_MOCK_OUTPUT="review-pending"
-    run pr_is_claimed_for_review "owner/repo" 5
-    [ "$status" -eq 1 ]
-}
-
-@test "pr_is_claimed_for_review: returns 1 when PR has no relevant labels" {
-    export GH_MOCK_OUTPUT="dev"
-    run pr_is_claimed_for_review "owner/repo" 5
-    [ "$status" -eq 1 ]
+    [[ "$output" != *"needs-review"* ]]
+    [[ "$output" != *"needs-rework"* ]]
+    [[ "$output" != *"needs-qa"* ]]
 }
 
 # ---------------------------------------------------------------------------
-# pr_is_claimed_for_qa
+# Workflow-fixture tests: 2 projects, 2 workflows (default + minimal)
+# Verify that loop_polled_labels returns correct labels per workflow,
+# and that scan_project emits correct events per workflow stage.
 # ---------------------------------------------------------------------------
 
-@test "pr_is_claimed_for_qa: returns 0 when PR has qa-pass label" {
-    export GH_MOCK_OUTPUT="qa-pass"
-    run pr_is_claimed_for_qa "owner/repo" 5
+# Write a two-project projects.yaml fixture to $BATS_TMPDIR/fixture.yaml
+_write_fixture_config() {
+    cat > "$BATS_TMPDIR/fixture.yaml" <<'YAML'
+version: 1
+projects:
+  - slug: proj-default
+    name: Default Project
+    repo: owner/default-repo
+    root: /tmp/fake-default
+    default_branch: main
+    workflow: default
+    dev:
+      commit_prefix: DEF
+      max_concurrent_prs: 3
+
+  - slug: proj-minimal
+    name: Minimal Project
+    repo: owner/minimal-repo
+    root: /tmp/fake-minimal
+    default_branch: main
+    workflow: minimal
+    dev:
+      commit_prefix: MIN
+      max_concurrent_prs: 3
+YAML
+}
+
+@test "workflow fixture: proj-default issue labels include po-review and plan" {
+    _write_fixture_config
+    export LOOP_CONFIG="$BATS_TMPDIR/fixture.yaml"
+    run loop_polled_labels "proj-default" issue
     [ "$status" -eq 0 ]
+    [[ "$output" == *"po-review"* ]]
+    [[ "$output" == *"plan"* ]]
 }
 
-@test "pr_is_claimed_for_qa: returns 0 when PR has done label" {
-    export GH_MOCK_OUTPUT="done"
-    run pr_is_claimed_for_qa "owner/repo" 5
+@test "workflow fixture: proj-minimal issue labels include plan but NOT po-review" {
+    _write_fixture_config
+    export LOOP_CONFIG="$BATS_TMPDIR/fixture.yaml"
+    run loop_polled_labels "proj-minimal" issue
     [ "$status" -eq 0 ]
+    [[ "$output" == *"plan"* ]]
+    [[ "$output" != *"po-review"* ]]
 }
 
-@test "pr_is_claimed_for_qa: returns 1 when PR has only ready-for-qa" {
-    export GH_MOCK_OUTPUT="ready-for-qa"
-    run pr_is_claimed_for_qa "owner/repo" 5
-    [ "$status" -eq 1 ]
-}
-
-@test "pr_is_claimed_for_qa: returns 1 when PR has only review-pending" {
-    export GH_MOCK_OUTPUT="review-pending"
-    run pr_is_claimed_for_qa "owner/repo" 5
-    [ "$status" -eq 1 ]
-}
-
-# ---------------------------------------------------------------------------
-# pr_is_claimed_for_rework
-# ---------------------------------------------------------------------------
-
-@test "pr_is_claimed_for_rework: returns 0 when PR has in-rework label" {
-    export GH_MOCK_OUTPUT="in-rework"
-    run pr_is_claimed_for_rework "owner/repo" 5
+@test "workflow fixture: proj-default PR labels include needs-review, needs-qa, qa-pass" {
+    _write_fixture_config
+    export LOOP_CONFIG="$BATS_TMPDIR/fixture.yaml"
+    run loop_polled_labels "proj-default" pr
     [ "$status" -eq 0 ]
+    [[ "$output" == *"needs-review"* ]]
+    [[ "$output" == *"needs-qa"* ]]
+    [[ "$output" == *"qa-pass"* ]]
 }
 
-@test "pr_is_claimed_for_rework: returns 0 when PR has blocked label" {
-    export GH_MOCK_OUTPUT="blocked"
-    run pr_is_claimed_for_rework "owner/repo" 5
+@test "workflow fixture: proj-minimal PR labels use needs-qa for merge (no review stage)" {
+    _write_fixture_config
+    export LOOP_CONFIG="$BATS_TMPDIR/fixture.yaml"
+    run loop_polled_labels "proj-minimal" pr
     [ "$status" -eq 0 ]
+    [[ "$output" == *"needs-qa"* ]]
+    [[ "$output" != *"needs-review"* ]]
 }
 
-@test "pr_is_claimed_for_rework: returns 1 when PR has only changes-requested" {
-    export GH_MOCK_OUTPUT="changes-requested"
-    run pr_is_claimed_for_rework "owner/repo" 5
-    [ "$status" -eq 1 ]
+@test "workflow fixture: proj-default emits loop.dev_issue for plan-labeled issue" {
+    _write_fixture_config
+    export LOOP_CONFIG="$BATS_TMPDIR/fixture.yaml"
+
+    local PLAN_ISSUE
+    PLAN_ISSUE='{"number":1,"title":"Fix thing","url":"http://gh/1","labels":["plan"],"author":"bot"}'
+
+    backend_list_issues_with_label() {
+        local _label="$2"
+        [ "$_label" = "plan" ] && printf '%s\n' "$PLAN_ISSUE"
+        return 0
+    }
+    backend_list_prs_with_label()  { return 0; }
+    backend_list_open_prs_raw()    { echo "[]"; }
+    backend_issue_has_any_label()  { return 1; }
+    backend_pr_has_any_label()     { return 1; }
+    backend_issue_unmet_deps()     { return 1; }
+    loop_load_backend()            { return 0; }
+    loop_load_project() {
+        REPO="owner/default-repo"
+        MAX_CONCURRENT_PRS=3
+        BACKEND=github
+        WORKFLOW=default
+        ALLOWED_AUTHORS=""
+        LOOP_LABEL_OVERRIDES=""
+        return 0
+    }
+
+    local emit_log="$BATS_TMPDIR/emit-default.log"
+    rm -f "$emit_log"
+    emit() { echo "$1" >> "$emit_log"; return 0; }
+
+    scan_project "proj-default"
+
+    [ -f "$emit_log" ]
+    grep -q '"type".*"loop\.dev_issue"' "$emit_log"
 }
 
-@test "pr_is_claimed_for_rework: returns 1 when PR has no relevant labels" {
-    export GH_MOCK_OUTPUT="review-pending"
-    run pr_is_claimed_for_rework "owner/repo" 5
-    [ "$status" -eq 1 ]
+@test "workflow fixture: proj-minimal emits loop.pr_merge for needs-qa PR (no review step)" {
+    _write_fixture_config
+    export LOOP_CONFIG="$BATS_TMPDIR/fixture.yaml"
+
+    local MERGE_PR
+    MERGE_PR='{"number":5,"title":"Merge me","url":"http://gh/5","labels":["needs-qa"],"headRefName":"feat/5","mergeable":"MERGEABLE"}'
+
+    backend_list_issues_with_label() { return 0; }
+    backend_list_prs_with_label() {
+        local _label="$2"
+        [ "$_label" = "needs-qa" ] && printf '%s\n' "$MERGE_PR"
+        return 0
+    }
+    backend_list_open_prs_raw()   { echo "[]"; }
+    backend_pr_has_any_label()    { return 1; }
+    backend_issue_has_any_label() { return 1; }
+    loop_load_backend()           { return 0; }
+    loop_load_project() {
+        REPO="owner/minimal-repo"
+        MAX_CONCURRENT_PRS=3
+        BACKEND=github
+        WORKFLOW=minimal
+        ALLOWED_AUTHORS=""
+        LOOP_LABEL_OVERRIDES=""
+        return 0
+    }
+
+    local emit_log="$BATS_TMPDIR/emit-minimal.log"
+    rm -f "$emit_log"
+    emit() { echo "$1" >> "$emit_log"; return 0; }
+
+    scan_project "proj-minimal"
+
+    [ -f "$emit_log" ]
+    grep -q '"type".*"loop\.pr_merge"' "$emit_log"
 }
 
 # ---------------------------------------------------------------------------
@@ -209,7 +347,7 @@ teardown() {
     dispatch_direct() { return 0; }
     export GH_MOCK_OUTPUT=""
 
-    local json='{"type":"asdlc.dev_issue","payload":{"slug":"test","repo":"owner/repo"}}'
+    local json='{"type":"loop.dev_issue","payload":{"slug":"test","repo":"owner/repo"}}'
     emit "$json" "dev_issue:owner/repo:10"
 
     local key
@@ -222,7 +360,7 @@ teardown() {
     rm -f "$dispatch_log"
     dispatch_direct() { echo "dispatched" >> "$dispatch_log"; return 0; }
 
-    local json='{"type":"asdlc.dev_issue","payload":{"slug":"test","repo":"owner/repo"}}'
+    local json='{"type":"loop.dev_issue","payload":{"slug":"test","repo":"owner/repo"}}'
     emit "$json" "dev_issue:owner/repo:11"
 
     [ -f "$dispatch_log" ]
@@ -241,7 +379,7 @@ teardown() {
     rm -f "$dispatch_log"
     dispatch_direct() { echo "dispatched" >> "$dispatch_log"; return 0; }
 
-    local json='{"type":"asdlc.dev_issue","payload":{}}'
+    local json='{"type":"loop.dev_issue","payload":{}}'
     emit "$json" "dev_issue:owner/repo:12"
 
     [ ! -f "$dispatch_log" ]
@@ -255,7 +393,7 @@ teardown() {
     local before_count
     before_count=$(find "$DEDUP_DIR" -type f | wc -l)
 
-    local json='{"type":"asdlc.dev_issue","payload":{}}'
+    local json='{"type":"loop.dev_issue","payload":{}}'
     emit "$json" ""
 
     local after_count


### PR DESCRIPTION
## Summary

- Refactors `scanner/scanner.sh` to remove all hardcoded label strings; all label lookups now go through `loop_polled_labels`, `loop_handler_for_label`, and `loop_stage_trigger` from `lib/workflow.sh`
- Adds `_handler_to_event_type` mapping workflow handler names → `loop.*` event types, and `_pr_downstream_labels` for generic claimed-state checks
- Updates `config/workflows/default.yaml` to include a `qa-rework` stage with `trigger_label: qa-fail` so `loop_polled_labels` surfaces it automatically
- Fixes `tests/scanner.bats` for bash 3.2 / macOS (`source <(...)` doesn't propagate functions; temp-file strategy used); adds 13 new tests covering two-workflow fixtures (`default` + `minimal`) and event emission verification

Closes #6

## Test plan

- [ ] `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — all pass
- [ ] `shellcheck -S warning lib/*.sh scripts/*.sh scanner/*.sh install.sh` — clean (pre-existing po-handler.sh unrelated)
- [ ] `bats tests/scanner.bats` — 26/26 pass
- [ ] `bats tests/workflow.bats` — 13/14 pass (test 2 pre-existing failure: missing `current.yaml`)
- [ ] Confirm no hardcoded pipeline label strings remain in `scanner/scanner.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)