### PR TITLE
fix: route dev agent through quick mode (1800s timeout fix)

### DIFF
--- a/lib/runner.sh
+++ b/lib/runner.sh
@@ -21,8 +21,10 @@ loop_run_agent() {
     local cwd="${2:-$(pwd)}"
 
     # If a full orchestrator is configured, use it (backward compat)
+    # --mode quick skips the planner's 1800s subtask cap — the dev prompt is
+    # already fully specified, so decomposition only adds latency and timeout risk.
     if [ -n "${LOOP_ORCHESTRATOR:-}" ] && [ -x "${LOOP_ORCHESTRATOR}" ]; then
-        "$LOOP_ORCHESTRATOR" "$prompt" --cwd "$cwd"
+        "$LOOP_ORCHESTRATOR" "$prompt" --mode quick --cwd "$cwd"
         return $?
     fi
 


### PR DESCRIPTION
## Summary

- `lib/runner.sh`: pass `--mode quick` when invoking `LOOP_ORCHESTRATOR`
- Bypasses the planner's 1800s subtask estimate cap that was killing all dev agents
- The dev prompt from `dev-handler.sh` is already fully specified (git/gh steps 1–8), so planner decomposition only added latency and timeout risk
- Quick mode uses the guardrail max (3600s), giving agents the full hour they need

## Root Cause

Dev handlers were routing through `_run_background_with_task` in the orchestrator (auto-detected as "complex" due to long prompt). The planner decomposed into subtasks with `estimated_seconds=1800`. `ClaudeCliWorker` uses this as the `asyncio.wait_for` timeout → killed after 30 min with 0 files changed.

## Test Plan
- [ ] Trigger a dev handler on a simple loop task, confirm it runs beyond 30 min without timeout
- [ ] Confirm `[quick]` log line appears in `loop-dev-handler.log`
- [ ] Confirm issue ends with `needs-review` label after agent completes