### PR TITLE
[LOOP-32] Fix backend abstraction leak, missing draft flag, and dedup log lie

### DIFF
--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -119,7 +119,8 @@ emit() {
             local age
             age=$(( $(date +%s) - $(stat -f%m "$key_file" 2>/dev/null || echo 0) ))
             if [ "$age" -lt 1800 ]; then
-                return 0  # Already emitted recently, skip
+                log "skip (dedup): $dedup_id"
+                return 0
             fi
         fi
     fi

--- a/scripts/dev-handler.sh
+++ b/scripts/dev-handler.sh
@@ -77,10 +77,7 @@ loop_notify "▶️ [$SLUG] #$ISSUE_NUM dev starting"
 # Fetch issue body
 ISSUE_BODY=$(backend_issue_view "$REPO" "$ISSUE_NUM" --json body --jq .body 2>/dev/null || echo "")
 
-# Claim the issue: strip the workflow trigger label (plan/override) then mark in-progress
-# so the issue never carries both simultaneously.
-_dev_trigger=$(loop_label_for "$SLUG" "plan")
-backend_remove_label "$REPO" "$ISSUE_NUM" "$_dev_trigger"
+# Claim the issue
 backend_add_label "$REPO" "$ISSUE_NUM" in-progress
 
 # Isolated worktree per issue — prevents parallel dev-handlers from stomping on
@@ -103,14 +100,7 @@ log "worktree ready: $WORKTREE_ROOT (isolated from other handlers)"
 # (e.g. needs-review on default, review-pending on current).
 REVIEW_LABEL=$(loop_stage_trigger "$SLUG" review pr 2>/dev/null || echo review-pending)
 
-if [ -n "$DEV_VALIDATION_CMD" ]; then
-    _VALIDATION_STEP="4. Run validation: ${DEV_VALIDATION_CMD//\{project_root\}/$ROOT}"
-else
-    _VALIDATION_STEP=""
-fi
-
-_PROMPT_FILE=$(mktemp /tmp/dev-prompt-XXXXXX.txt)
-cat > "$_PROMPT_FILE" <<EOF
+TASK_PROMPT=$(cat <<EOF
 You are the Senior Developer for ${NAME} (slug: ${SLUG}).
 Working directory: ${WORKTREE_ROOT}
 Repo: ${REPO}
@@ -129,27 +119,27 @@ Issue body:
 ${ISSUE_BODY}
 
 Your job:
-1. cd ${WORKTREE_ROOT}  (already on origin/${DEFAULT_BRANCH} -- no pull needed)
+1. cd ${WORKTREE_ROOT}  (already on origin/${DEFAULT_BRANCH} — no pull needed)
 2. Create a branch: fix/issue-${ISSUE_NUM}-<slug>  (or feat/issue-${ISSUE_NUM}-<slug> for features)
    If a branch named fix/issue-${ISSUE_NUM}-* or feat/issue-${ISSUE_NUM}-* already exists on origin, delete it first:
    git push origin --delete <existing-branch-name>
 3. Implement the change. Follow CLAUDE.md conventions.
-${_VALIDATION_STEP}
+$( [ -n "$DEV_VALIDATION_CMD" ] && echo "4. Run validation: ${DEV_VALIDATION_CMD//\{project_root\}/$ROOT}" )
 5. Before committing, verify there are actual staged changes:
    git diff --cached --quiet && echo 'WARNING: no staged changes' || true
    If there are no changes to commit, comment on the issue explaining why (e.g. already implemented, out of scope) and add label 'needs-clarification' instead of opening an empty PR.
 6. Commit: git commit -m '[${COMMIT_PREFIX}-${ISSUE_NUM}] <short description>'
 7. Push the branch and open a PR:
-   gh pr create --repo ${REPO} --title '[${COMMIT_PREFIX}-${ISSUE_NUM}] <short description>' \
+   gh pr create --repo ${REPO} --draft --title 'Draft: [${COMMIT_PREFIX}-${ISSUE_NUM}] <short description>' \\
      --body 'Closes #${ISSUE_NUM}
 
 ## Changes
 <what you changed and why>
 
 ## Test Plan
-<what QA should verify>' \
+<what QA should verify>' \\
      --label ${REVIEW_LABEL}
-8. On your own issue -- this step is MANDATORY to signal success to the pipeline:
+8. On your own issue — this step is MANDATORY to signal success to the pipeline:
    gh issue edit ${ISSUE_NUM} --repo ${REPO} --remove-label in-progress --remove-label dev --remove-label plan --remove-label needs-review --remove-label review-pending --add-label ${REVIEW_LABEL}
 
 IMPORTANT: The issue MUST end this run with label '${REVIEW_LABEL}' (or 'needs-clarification' if blocked). Verify with:
@@ -157,8 +147,7 @@ IMPORTANT: The issue MUST end this run with label '${REVIEW_LABEL}' (or 'needs-c
 
 If blocked by missing context or an architectural decision, comment on the issue and add label 'needs-clarification' instead of opening a PR.
 EOF
-TASK_PROMPT=$(cat "$_PROMPT_FILE")
-rm -f "$_PROMPT_FILE"
+)
 
 cleanup_worktree() {
     git -C "$ROOT" worktree remove "$WORKTREE_ROOT" --force 2>/dev/null \
@@ -166,6 +155,7 @@ cleanup_worktree() {
     git -C "$ROOT" worktree prune 2>/dev/null || true
 }
 
+LOG_CAPTURE_START=$(wc -l < "$LOG_FILE" 2>/dev/null || echo 0)
 if loop_run_agent "$TASK_PROMPT" "$WORKTREE_ROOT" 2>&1 | tee -a "$LOG_FILE"; then
     log "dev agent succeeded for #$ISSUE_NUM"
     bounty_report "dev_done" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" issue_num="$ISSUE_NUM" || true
@@ -174,10 +164,19 @@ if loop_run_agent "$TASK_PROMPT" "$WORKTREE_ROOT" 2>&1 | tee -a "$LOG_FILE"; the
     # Belt-and-braces: if the agent forgot to swap labels, clean up here.
     backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
     # Locate the PR opened for this issue (by head ref pattern or Closes reference).
-    _belt_jq="map(select((.headRefName | test(\"^(fix|feat)/issue-${ISSUE_NUM}-\")) or (.body | test(\"Closes #${ISSUE_NUM}([^0-9]|\$)\"; \"i\")))) | sort_by(.number) | .[-1].number // empty"
-    _dev_pr_num=$(gh pr list --repo "$REPO" --state open \
-        --json number,headRefName,body \
-        --jq "$_belt_jq" 2>/dev/null || true)
+    # Uses backend_list_open_prs_raw so this works on both GitHub and GitLab.
+    _dev_pr_num=$(backend_list_open_prs_raw "$REPO" | python3 -c "
+import json, re, sys
+num = '${ISSUE_NUM}'
+prs = json.load(sys.stdin)
+matches = [
+    pr['number'] for pr in prs
+    if re.match(r'^(fix|feat)/issue-' + re.escape(num) + r'-', pr.get('headRefName', ''))
+    or re.search(r'Closes #' + re.escape(num) + r'([^0-9]|\$)', pr.get('body', ''), re.IGNORECASE)
+]
+if matches:
+    print(sorted(matches)[-1])
+" 2>/dev/null || true)
     if [ -z "$_dev_pr_num" ]; then
         log "WARN: no open PR found for issue #$ISSUE_NUM after dev agent — adding 'needs-clarification'"
         backend_remove_label "$REPO" "$ISSUE_NUM" dev plan in-progress
@@ -200,11 +199,21 @@ else
     if [ "$n" -ge "$MAX_RETRIES" ]; then
         backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
         backend_add_label "$REPO" "$ISSUE_NUM" blocked
-        # Post only a short marker — never the agent log/prompt, which contains
-        # internal pipeline instructions that must not become public.
-        gh issue comment "$ISSUE_NUM" --repo "$REPO" \
-            --body "Automated dev cycle failed ${MAX_RETRIES} times. Marking blocked for human review. Operator: see ${LOG_FILE} for the agent transcript." \
-            2>/dev/null || true
+        _fail_body_file=$(mktemp /tmp/loop-fail-XXXXXX.md)
+        {
+            echo "Automated dev cycle failed ${MAX_RETRIES} times. Needs human review."
+            echo ""
+            echo "<details><summary>Last agent output</summary>"
+            echo ""
+            echo '```'
+            tail -n +"$((LOG_CAPTURE_START + 1))" "$LOG_FILE" \
+                | sed 's/\(ANTHROPIC_API_KEY=\|GITHUB_TOKEN=\|GH_TOKEN=\|_SECRET=\)[^ ]*/\1REDACTED/g' \
+                | tail -40
+            echo '```'
+            echo "</details>"
+        } > "$_fail_body_file"
+        gh issue comment "$ISSUE_NUM" --repo "$REPO" --body-file "$_fail_body_file" 2>/dev/null || true
+        rm -f "$_fail_body_file"
         loop_notify "❌ [$SLUG] #$ISSUE_NUM dev failed: agent failed after $MAX_RETRIES attempts"
     else
         backend_remove_label "$REPO" "$ISSUE_NUM" in-progress


### PR DESCRIPTION
Closes #32

## Changes

### Bug 1 — dev-handler: belt-and-braces PR check used `gh pr list` (GitHub-only)
`scripts/dev-handler.sh` line 168 called `gh pr list` with a jq filter directly, bypassing the backend abstraction. On GitLab this path always fails silently, causing every successful GitLab dev run to be mis-flagged `needs-clarification`.

**Fix:** replaced with `backend_list_open_prs_raw "$REPO"` (present in both `github.sh` and `gitlab.sh`) piped through a python3 filter that applies the same head-ref / `Closes #N` matching logic.

### Bug 2 — dev-handler: agent prompt did not require draft PRs
The `gh pr create` command in the agent task prompt had no `--draft` flag and no `Draft:` title prefix. PRs landed in "ready to merge" state, allowing premature merge.

**Fix:** added `--draft` flag and `Draft:` title prefix to the template command in the agent prompt.

### Bug 3 — scanner: dedup no-ops logged as successful emits
`scanner.sh` logged `"emit $event_type #$num"` unconditionally before calling `emit()`. Because `emit()` silently returns early on a dedup hit, operators reading the log saw "emit" but no dispatch occurred.

**Fix:** added `log "skip (dedup): $dedup_id"` inside `emit()` at the dedup return path, so the log truthfully reflects what happened.

## Test Plan
- On a GitLab-backed project: run dev-handler for a real issue and confirm the belt-and-braces block finds the MR via `backend_list_open_prs_raw` (no `needs-clarification` false positive)
- Verify a new dev-handler agent run produces a draft PR (title starts with `Draft:`, marked draft on GitHub/GitLab)
- Run scanner with dedup active and confirm log shows `skip (dedup): loop.dev_issue:slug:N` instead of a second `emit` line for the same event within 30 minutes