### PR TITLE
[LOOP-19] Add manual update docs to README and quick-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,32 @@ contract; both are first-class commitments going forward.
 domain specialist agents (frontend / backend / data / devops), expanded
 backend coverage.
 
+## Updating
+
+Until automated updates ship ([#17](https://github.com/svv2014/loop/issues/17)),
+update Loop and loop-monitor manually:
+
+```bash
+# 1. Pull the latest Loop core
+cd ~/projects/loop
+git pull --ff-only
+
+# 2. Pull the latest loop-monitor (if installed)
+cd ~/projects/loop-monitor
+git pull --ff-only
+
+# 3. Restart the Loop services (macOS launchd)
+launchctl kickstart -k gui/$(id -u)/com.user.loop-scanner
+launchctl kickstart -k gui/$(id -u)/com.user.loop-reconciler
+```
+
+On Linux, restart the cron-managed processes by reloading the crontab or
+bouncing the wrapper processes as appropriate for your setup.
+
+Check [CHANGELOG.md](CHANGELOG.md) for migration notes before upgrading,
+especially across MINOR versions (pre-1.0 minor releases may change
+`loop.env` keys or `projects.yaml` schema).
+
 ## Contributing
 
 External contributions welcome. PRs require an approval from a

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -166,3 +166,76 @@ launchctl load ~/Library/LaunchAgents/com.user.loop-scanner.plist
   fails, fix the project; if it passes, check the QA workflow logs.
 
 **More help:** open an issue with the `bug` label.
+
+## Updating Loop
+
+### What changes between versions
+
+Review [CHANGELOG.md](../CHANGELOG.md) before upgrading. Pre-1.0, MINOR
+version bumps (`0.1 → 0.2`) may change `loop.env` keys or the
+`config/projects.yaml` schema; the changelog always includes a migration
+recipe. PATCH bumps are safe to apply without reading the changelog.
+
+### How to update (manual, until `update.sh` ships — see [#17](https://github.com/svv2014/loop/issues/17))
+
+```bash
+# 1. Pull Loop core
+cd ~/projects/loop
+git pull --ff-only
+
+# 2. Pull loop-monitor (if installed)
+cd ~/projects/loop-monitor
+git pull --ff-only
+
+# 3. Restart services — macOS launchd
+launchctl kickstart -k gui/$(id -u)/com.user.loop-scanner
+launchctl kickstart -k gui/$(id -u)/com.user.loop-reconciler
+```
+
+On Linux, restart however your cron wrapper or process supervisor is
+configured (e.g. `systemctl --user restart loop-scanner`).
+
+### How to roll back
+
+```bash
+cd ~/projects/loop
+git checkout <previous-tag>     # e.g. git checkout v0.1.0
+# then restart services as above
+```
+
+Tag history: `git tag --sort=-version:refname | head -10`
+
+### If a launchd service fails to restart
+
+1. Check the exit code:
+   ```bash
+   launchctl list | grep loop
+   ```
+   A non-zero PID column means it crashed on start.
+
+2. Read the error log:
+   ```bash
+   tail -50 ~/.loop/logs/loop-scanner.log
+   tail -50 ~/.loop/logs/loop-reconciler.log
+   ```
+
+3. Common causes:
+   - A new `loop.env` key is required — compare `loop.env` against
+     `loop.env.example` and add the missing variable.
+   - A shell-syntax error in a newly updated script — run
+     `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` to find it.
+
+4. Once fixed, reload:
+   ```bash
+   launchctl kickstart -k gui/$(id -u)/com.user.loop-scanner
+   ```
+
+### Where logs live
+
+| Log file | What it covers |
+|---|---|
+| `~/.loop/logs/loop-scanner.log` | Poller ticks, label events dispatched |
+| `~/.loop/logs/loop-dev-handler.log` | Dev agent output per issue |
+| `~/.loop/logs/loop-review-handler.log` | Review agent output |
+| `~/.loop/logs/loop-qa-handler.log` | QA agent + validation output |
+| `~/.loop/logs/loop-reconciler.log` | Reconciler housekeeping |


### PR DESCRIPTION
Closes #19

## Changes

- **README.md** — added an "Updating" section before "Contributing" with the two `git pull --ff-only` commands (loop core + loop-monitor), `launchctl kickstart` commands to restart services, and links to `CHANGELOG.md` and issue #17 as the future automation.
- **docs/quick-start.md** — appended a `## Updating Loop` section covering: what changes between versions (pointer to CHANGELOG.md), how to roll back with `git checkout <previous-tag>`, what to do when a launchd service fails to restart (exit code check, log locations, common causes), and a table of all log files under `~/.loop/logs/`.

No shell files were touched. `bash -n` and the personal-identifier grep both pass clean.

## Test Plan

- [ ] README.md renders correctly and "Updating" section appears between "Versioning"/"Status" area and "Contributing"
- [ ] `docs/quick-start.md` "Updating Loop" section appears at end of file with correct subsections
- [ ] No absolute personal paths (`/Users/vadim`, `openclaw`, etc.) present in either file
- [ ] `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` passes unchanged
- [ ] Links to CHANGELOG.md and issue #17 resolve correctly