### PR TITLE
[LOOP-18] add update.sh with BREAKING: change gate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,19 @@ If your PR changes any of:
 …add a `BREAKING:` line to the `[Unreleased]` section of CHANGELOG.md
 explaining what changed and how operators migrate.
 
+**`BREAKING:` format** — the line must start with the literal word `BREAKING:`
+followed by a plain-English description and (where applicable) a migration
+recipe or link. `scripts/update.sh` scans for this token and halts the
+operator's upgrade until they acknowledge with `--yes`. Keep the line
+self-contained; multi-line continuations are ignored by the scanner.
+
+Example:
+
+```markdown
+### Changed
+- BREAKING: LOOP_AGENT_MODEL renamed to LOOP_AGENT. Set in loop.env.
+```
+
 ## Out of scope (not currently accepting)
 
 - GUI / web UI — Loop is a CLI tool. Use loop-monitor for visibility.

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# update.sh — pull the latest Loop from origin, surfacing BREAKING: warnings.
+#
+# Usage:
+#   ./scripts/update.sh              # fetch, warn on breaking changes, abort
+#   ./scripts/update.sh --yes        # fetch + apply even with breaking changes
+#   ./scripts/update.sh --check      # fetch, show full changelog diff, no apply
+#   ./scripts/update.sh --dry-run    # fetch only, no apply (alias for --check)
+
+set -euo pipefail
+
+LOOP_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$LOOP_ROOT"
+
+YES=false
+CHECK=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --yes)       YES=true;  shift ;;
+        --check|--dry-run) CHECK=true; shift ;;
+        -h|--help)   sed -n '2,8p' "$0"; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+# ── fetch ────────────────────────────────────────────────────────────────────
+echo "[update] fetching origin/main …"
+git fetch origin main --quiet
+
+# Nothing to do?
+if git diff --quiet HEAD..origin/main; then
+    echo "[update] already up to date."
+    exit 0
+fi
+
+# ── parse CHANGELOG diff for BREAKING: lines ─────────────────────────────────
+CHANGELOG_DIFF=$(git diff HEAD..origin/main -- CHANGELOG.md 2>/dev/null || true)
+
+_extract_breaking() {
+    # For each added BREAKING: line, find the nearest preceding version header.
+    python3 - <<'PY'
+import sys, re
+
+diff = sys.stdin.read()
+
+# Collect added lines (strip leading +, skip diff header lines starting with +++)
+added_lines = []
+for line in diff.splitlines():
+    if line.startswith('+') and not line.startswith('+++'):
+        added_lines.append(line[1:])
+
+# Reconstruct the added CHANGELOG text
+added_text = '\n'.join(added_lines)
+
+# Find version headers and their associated BREAKING: entries
+version_header_re = re.compile(r'^## \[([^\]]+)\](.*?)$', re.MULTILINE)
+breaking_re = re.compile(r'\bBREAKING:\s*.+', re.MULTILINE)
+
+sections = list(version_header_re.finditer(added_text))
+results = []
+
+for i, m in enumerate(sections):
+    end = sections[i+1].start() if i+1 < len(sections) else len(added_text)
+    body = added_text[m.end():end]
+    breakings = breaking_re.findall(body)
+    if breakings:
+        header = m.group(0).lstrip('#').strip()
+        results.append(f"  {header}")
+        for b in breakings:
+            # indent continuation lines for readability
+            lines = b.splitlines()
+            results.append(f"    {lines[0]}")
+            for extra in lines[1:]:
+                results.append(f"              {extra}")
+
+print('\n'.join(results))
+PY
+}
+
+BREAKING=$(echo "$CHANGELOG_DIFF" | _extract_breaking)
+
+# ── --check: show full diff and exit ─────────────────────────────────────────
+if $CHECK; then
+    echo "[update] changelog between HEAD and origin/main:"
+    echo "$CHANGELOG_DIFF" | grep '^+' | grep -v '^+++' | sed 's/^+//'
+    echo ""
+    if [ -n "$BREAKING" ]; then
+        echo "⚠ This update contains breaking changes:"
+        echo "$BREAKING"
+    else
+        echo "(no breaking changes detected)"
+    fi
+    exit 0
+fi
+
+# ── gate on BREAKING: if --yes not given ─────────────────────────────────────
+if [ -n "$BREAKING" ] && [ "$YES" != "true" ]; then
+    echo ""
+    echo "⚠ This update contains breaking changes:"
+    echo ""
+    echo "$BREAKING"
+    echo ""
+    echo "Re-run with --yes to apply, or --check to see the full changelog without applying."
+    exit 1
+fi
+
+# ── apply ────────────────────────────────────────────────────────────────────
+echo "[update] applying …"
+git merge --ff-only origin/main
+
+echo "[update] done. version: $(cat VERSION 2>/dev/null || echo unknown)"

--- a/tests/update.bats
+++ b/tests/update.bats
@@ -1,0 +1,153 @@
+#!/usr/bin/env bats
+# tests/update.bats — tests for scripts/update.sh breaking-change gate.
+#
+# We exercise the Python extraction logic directly by feeding synthetic
+# CHANGELOG diffs and checking the exit code + output of update.sh.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    UPDATE_SH="$REPO_ROOT/scripts/update.sh"
+
+    # Scratch dir for a fake git repo
+    FAKE_REPO="$BATS_TMPDIR/fake-repo"
+    rm -rf "$FAKE_REPO"
+    mkdir -p "$FAKE_REPO"
+    cd "$FAKE_REPO"
+
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test"
+
+    # Base CHANGELOG with no breaking entries
+    cat > CHANGELOG.md <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+## [0.1.0] - 2026-04-27
+
+### Added
+- Initial release.
+
+[0.1.0]: https://github.com/example/repo/releases/tag/v0.1.0
+EOF
+    echo "0.1.0" > VERSION
+    git add .
+    git commit -q -m "init"
+
+    # Simulate origin/main with a new commit that has a BREAKING: entry
+    git checkout -q -b origin-main
+    cat > CHANGELOG.md <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+## [0.2.0] - 2026-05-12
+
+### Changed
+- BREAKING: workflow YAML schema bumped to v2 — see migration recipe.
+
+## [0.1.0] - 2026-04-27
+
+### Added
+- Initial release.
+
+[Unreleased]: https://github.com/example/repo/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/example/repo/releases/tag/v0.2.0
+[0.1.0]: https://github.com/example/repo/releases/tag/v0.1.0
+EOF
+    echo "0.2.0" > VERSION
+    git add .
+    git commit -q -m "release: v0.2.0"
+
+    # Return to main; register "origin" as the local origin-main branch
+    git checkout -q main
+    git remote add origin "$FAKE_REPO"
+    git fetch origin origin-main:refs/remotes/origin/main -q
+}
+
+teardown() {
+    rm -rf "$FAKE_REPO" 2>/dev/null || true
+}
+
+# ── helper to run update.sh inside the fake repo ─────────────────────────────
+run_update() {
+    run bash "$UPDATE_SH" "$@"
+}
+
+# ── tests ─────────────────────────────────────────────────────────────────────
+
+@test "update: halts when BREAKING: present and --yes not given" {
+    cd "$FAKE_REPO"
+    git checkout -q main
+    run_update
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"⚠ This update contains breaking changes:"* ]]
+    [[ "$output" == *"BREAKING:"* ]]
+    [[ "$output" == *"--yes"* ]]
+}
+
+@test "update: output includes version header and breaking line" {
+    cd "$FAKE_REPO"
+    git checkout -q main
+    run_update
+    [[ "$output" == *"0.2.0"* ]]
+    [[ "$output" == *"BREAKING: workflow YAML schema bumped to v2"* ]]
+}
+
+@test "update: applies when --yes is given with breaking changes" {
+    cd "$FAKE_REPO"
+    git checkout -q main
+    run_update --yes
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"done"* ]]
+    [ "$(cat VERSION)" = "0.2.0" ]
+}
+
+@test "update: --check shows changelog and does not apply" {
+    cd "$FAKE_REPO"
+    git checkout -q main
+    run_update --check
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BREAKING:"* ]]
+    # Version file must not have changed (not applied)
+    [ "$(cat VERSION)" = "0.1.0" ]
+}
+
+@test "update: no breaking changes — applies without --yes" {
+    # Create a fake repo where the new commit has no BREAKING: line
+    SAFE_REPO="$BATS_TMPDIR/safe-repo"
+    rm -rf "$SAFE_REPO"
+    mkdir -p "$SAFE_REPO"
+    cd "$SAFE_REPO"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    echo "0.1.0" > VERSION
+    echo "# Changelog" > CHANGELOG.md
+    git add .
+    git commit -q -m "init"
+
+    git checkout -q -b origin-main
+    echo "0.1.1" > VERSION
+    git add .
+    git commit -q -m "patch"
+
+    git checkout -q main
+    git remote add origin "$SAFE_REPO"
+    git fetch origin origin-main:refs/remotes/origin/main -q
+
+    run bash "$UPDATE_SH"
+    [ "$status" -eq 0 ]
+    [ "$(cat VERSION)" = "0.1.1" ]
+}
+
+@test "update: reports already up to date when nothing to fetch" {
+    cd "$FAKE_REPO"
+    git checkout -q main
+    # Advance main to match origin
+    git merge --ff-only origin/main -q
+    run_update
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"already up to date"* ]]
+}


### PR DESCRIPTION
Closes #18

## Changes

- **`scripts/update.sh`** — new script that:
  1. Fetches `origin/main`
  2. Parses the `CHANGELOG.md` diff for `BREAKING:` lines (via an inlined Python snippet)
  3. Prints a formatted warning with version/date headers and the breaking lines
  4. Exits 1 unless `--yes` is passed
  5. `--check` shows the full changelog diff without applying
  6. `--dry-run` is an alias for `--check`
  7. Fast-forwards to `origin/main` on success

- **`tests/update.bats`** — synthetic git repos to exercise:
  - gate triggers on BREAKING: without `--yes`
  - output includes version header and breaking line text
  - `--yes` bypasses gate and applies
  - `--check` shows diff without applying
  - clean update (no BREAKING:) applies without `--yes`
  - already-up-to-date reports cleanly

- **`CONTRIBUTING.md`** — added explicit `BREAKING:` format spec and example so contributors know what syntax the scanner expects

## Test Plan

- [ ] `bash -n` passes on all scripts
- [ ] `shellcheck -S warning` passes
- [ ] `bats tests/update.bats` — all 6 tests green
- [ ] Manual: create a CHANGELOG with a `BREAKING:` entry; run `./scripts/update.sh` → should halt with warning; run with `--yes` → should apply