### PR TITLE
[LOOP-8] Document current workflow label vocabulary and migration path

### DIFF
--- a/config/workflows/README.md
+++ b/config/workflows/README.md
@@ -9,12 +9,12 @@ This dir contains starter workflows. Operators can author their own.
 
 ## Files
 
-| File | Purpose |
-|---|---|
-| `default.yaml` | Recommended for new repos. Clean canonical labels: `plan` / `needs-review` / `needs-qa` / `qa-pass` / `qa-fail`. |
-| `current.yaml` | Legacy-vocabulary mirror. Uses `dev` instead of `plan`; matches the label set in svv2014 projects at v0.1.0 migration. |
-| `minimal.yaml` | Two-stage pipeline (`plan → merge`). No review, no QA. Solo prototypes only. |
-| `docs-only.yaml` | Three-stage pipeline (`plan → review → merge`). No QA. For documentation and content-only PRs. |
+| File | Ships? | Purpose |
+|---|---|---|
+| `default.yaml` | Yes | Recommended for new repos. Clean canonical labels: `plan` / `needs-review` / `needs-qa` / `qa-pass` / `qa-fail`. |
+| `minimal.yaml` | Yes | Two-stage pipeline (`plan → merge`). No review, no QA. Solo prototypes only. |
+| `docs-only.yaml` | Yes | Three-stage pipeline (`plan → review → merge`). No QA. For documentation and content-only PRs. |
+| `current.yaml` | **No — gitignored** | Operator-local legacy-vocabulary mirror. Not committed to this repo. See [Operator-local workflows](#operator-local-workflows) and [docs/migration-from-asdlc.md](../../docs/migration-from-asdlc.md). |
 
 ## Schema (v1)
 
@@ -105,6 +105,43 @@ override any of them via the `labels:` map in `config/projects.yaml`.
 
 **Terminal labels** (valid transition targets, never trigger a stage):
 `done`, `blocked`, `needs-clarification`, `qa-fail`
+
+## `current` workflow label vocabulary
+
+`current.yaml` is the operator-local legacy-vocabulary mirror. It uses a
+different set of label names from `default.yaml` to preserve in-flight
+labels on repos that were already running under the original svv2014 label
+scheme before Loop's `default` workflow was introduced.
+
+**Pipeline flow:**
+
+```
+po-review (issue) → dev (issue) → review-pending (PR) → ready-for-qa (PR)
+    → qa-pass / qa-fail (PR) → merge → done
+```
+
+**Issue labels:**
+
+| Label | Role |
+|---|---|
+| `po-review` | PO expansion stage (same as `default`) |
+| `dev` | Dev implementation stage (`plan` in `default`) |
+| `blocked` | Terminal: issue cannot proceed |
+| `needs-clarification` | Terminal: awaiting author reply |
+
+**PR labels:**
+
+| Label | Role |
+|---|---|
+| `review-pending` | Code review stage (`needs-review` in `default`) |
+| `changes-requested` | Sent back to dev after review rejection (`needs-rework` in `default`) |
+| `ready-for-qa` | QA / automated test stage (`needs-qa` in `default`) |
+| `qa-pass` | QA passed; triggers merge (same as `default`) |
+| `qa-fail` | QA failed; triggers rework or close (same as `default`) |
+| `done` | Terminal: PR merged and issue closed (same as `default`) |
+
+See [docs/migration-from-asdlc.md](../../docs/migration-from-asdlc.md) for a full
+side-by-side mapping and instructions for creating your own `current.yaml`.
 
 ## Per-project overrides
 

--- a/docs/migration-from-asdlc.md
+++ b/docs/migration-from-asdlc.md
@@ -1,0 +1,127 @@
+# Migrating from the legacy label set to Loop workflows
+
+This guide is for operators whose repos were already using the original
+label vocabulary (sometimes called the "asdlc" or "svv2014" label set)
+before Loop's `default` workflow was introduced. It explains how to keep
+those existing labels working during a migration window using the
+`current` workflow.
+
+## Label mapping: `default` workflow vs `current` workflow
+
+| Stage | `default` label | `current` label | Shared? |
+|---|---|---|---|
+| PO expansion (issue) | `po-review` | `po-review` | Yes |
+| Dev implementation (issue) | `plan` | `dev` | No |
+| Code review (PR) | `needs-review` | `review-pending` | No |
+| Sent back for rework (PR) | `needs-rework` | `changes-requested` | No |
+| QA / automated tests (PR) | `needs-qa` | `ready-for-qa` | No |
+| QA passed / merge gate (PR) | `qa-pass` | `qa-pass` | Yes |
+| QA failed (PR) | `qa-fail` | `qa-fail` | Yes |
+| Closed / shipped (PR+issue) | `done` | `done` | Yes |
+| Blocked — needs human (issue) | `blocked` | `blocked` | Yes |
+| Awaiting author reply (issue) | `needs-clarification` | `needs-clarification` | Yes |
+
+In short: four labels differ (`plan`→`dev`, `needs-review`→`review-pending`,
+`needs-rework`→`changes-requested`, `needs-qa`→`ready-for-qa`); everything
+else is identical.
+
+## Creating your `current.yaml`
+
+`config/workflows/current.yaml` is **gitignored by design** — it is
+operator-local and must not be committed to the Loop repo. Create it on
+each machine where the Loop scanner runs.
+
+Copy the schema below into `config/workflows/current.yaml`:
+
+```yaml
+# Operator-local workflow — DO NOT COMMIT.
+# Mirrors the legacy svv2014 label vocabulary for in-flight repos.
+# See docs/migration-from-asdlc.md for context.
+
+version: 1
+name: current
+description: |
+  Legacy-vocabulary mirror. Preserves in-flight labels for repos already
+  using the original label set before Loop's default workflow landed.
+  Pipeline: po-review → dev → review-pending → ready-for-qa → qa-pass/qa-fail → done.
+
+issue_stages:
+  - id: po
+    trigger_label: po-review
+    handler: po-handler
+    on_done: dev
+    on_blocked: blocked
+    on_clarification: needs-clarification
+
+  - id: dev
+    trigger_label: dev
+    handler: dev-handler
+    on_done: review-pending
+    on_failed_after_max: blocked
+
+pr_stages:
+  - id: review
+    trigger_label: review-pending
+    handler: review-handler
+    decisions:
+      approve: ready-for-qa
+      reject: changes-requested
+
+  - id: rework
+    trigger_label: changes-requested
+    handler: dev-rework-handler
+    on_done: review-pending
+    on_failed_after_max: blocked
+
+  - id: qa
+    trigger_label: ready-for-qa
+    handler: qa-handler
+    on_pass: qa-pass
+    on_fail: qa-fail
+
+  - id: merge
+    trigger_label: qa-pass
+    handler: merge-handler
+    on_done: done
+
+  - id: qa-rework
+    trigger_label: qa-fail
+    handler: dev-rework-handler
+    on_done: review-pending
+    on_failed_after_max: blocked
+```
+
+Validate after saving:
+
+```bash
+./scripts/validate-workflow.sh config/workflows/current.yaml
+```
+
+## Opting a project into the `current` workflow
+
+In `config/projects.yaml`, set `workflow: current` for any project whose
+repo uses the legacy label vocabulary:
+
+```yaml
+projects:
+  - name: My Legacy Repo
+    slug: myrepo
+    repo: owner/my-repo
+    workflow: current
+```
+
+No `labels:` overrides are needed — the `current` workflow already uses
+the legacy vocabulary as its canonical names.
+
+## Migration path to `default`
+
+When you are ready to cut over a repo to the `default` workflow:
+
+1. Wait until all in-flight issues and PRs are closed or relabelled.
+2. Rename the legacy labels in GitHub (repo Settings → Labels) to the
+   `default` names: `dev`→`plan`, `review-pending`→`needs-review`,
+   `changes-requested`→`needs-rework`, `ready-for-qa`→`needs-qa`.
+3. Change `workflow: current` to `workflow: default` in `config/projects.yaml`.
+4. Restart the scanner.
+
+This is an operator task and does not require changes to the Loop repo.


### PR DESCRIPTION
Closes #8

## Changes

- **`config/workflows/README.md`**: Updated the files table to clearly mark `current.yaml` as gitignored/operator-local (not shipped). Added a new `## current workflow label vocabulary` section documenting the full pipeline flow (`po-review → dev → review-pending → ready-for-qa → qa-pass/qa-fail → done`), with per-label tables for issue and PR stages, and cross-references to the migration doc.

- **`docs/migration-from-asdlc.md`** (new): Comprehensive migration guide with (a) a side-by-side label mapping table showing which labels differ between `default` and `current` workflows, (b) the full `current.yaml` YAML schema operators can paste to create their local file, (c) instructions for opting a project into `workflow: current` via `projects.yaml`, and (d) a step-by-step migration path back to `default` when ready.

No shell files were modified.

## Test Plan

- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` passes (verified locally — no shell files changed)
- Confirm `config/workflows/current.yaml` is NOT tracked (it remains in `.gitignore` line 16)
- README files table now has a "Ships?" column clearly distinguishing committed workflows from the gitignored `current.yaml`
- Migration doc YAML schema validates against the workflow schema described in README