### PR TITLE
[LOOP-28] Fix GitLab backend: remove invalid --state flag and add author field

### DIFF
--- a/lib/backends/gitlab.sh
+++ b/lib/backends/gitlab.sh
@@ -54,6 +54,7 @@ _GL_ISSUE_SORT='
       title,
       url: .web_url,
       labels: $L,
+      author: (.author.username // ""),
       _p: (
         if   ($L | index("p0-critical")) then 0
         elif ($L | index("p1-high"))     then 1
@@ -99,7 +100,7 @@ _GL_MR_SORT='
 backend_list_issues_with_label() {
     local repo="$1" label="$2"
     _gl_parse_repo "$repo"
-    glab issue list --repo "$_GL_REPO" --label "$label" --state opened \
+    glab issue list --repo "$_GL_REPO" --label "$label" \
         --output json 2>/dev/null \
     | jq -c "$_GL_ISSUE_SORT" 2>/dev/null || true
 }

--- a/tests/workflow.bats
+++ b/tests/workflow.bats
@@ -40,14 +40,12 @@ YAML
     [ "$status" -eq 0 ]
 }
 
-@test "validate: all four starter workflows pass validation" {
+@test "validate: all starter workflows pass validation" {
     run loop_workflow_validate "$REPO_ROOT/config/workflows/default.yaml"
     [ "$status" -eq 0 ]
     run loop_workflow_validate "$REPO_ROOT/config/workflows/minimal.yaml"
     [ "$status" -eq 0 ]
     run loop_workflow_validate "$REPO_ROOT/config/workflows/docs-only.yaml"
-    [ "$status" -eq 0 ]
-    run loop_workflow_validate "$REPO_ROOT/config/workflows/current.yaml"
     [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
Closes #28

## Changes
- **`lib/backends/gitlab.sh`**: Removed `--state opened` from `backend_list_issues_with_label` — `glab issue list` defaults to open; the flag was invalid and caused zero results.
- **`lib/backends/gitlab.sh`**: Added `author: (.author.username // "")` to `_GL_ISSUE_SORT` so `ALLOWED_AUTHORS` filtering works correctly on GitLab issues.
- **`tests/workflow.bats`**: Removed stale reference to `config/workflows/current.yaml` which was removed from the repo in c27761b but the test was not updated, causing QA to fail on all PRs.

## Test Plan
- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` passes.
- `bats tests/` passes (83 tests — no regressions).
- On a GitLab-backed project: apply a label to an issue and verify `backend_list_issues_with_label` returns it.
- Verify issues authored by allowed users are correctly surfaced by `ALLOWED_AUTHORS` filtering.