### PR TITLE
[LOOP-25] Fix GitLab backend bugs and harden backend abstraction

### DIFF
--- a/config/workflows/README.md
+++ b/config/workflows/README.md
@@ -62,6 +62,25 @@ pr_stages:
 - At least one stage (anywhere in `issue_stages` or `pr_stages`)
 - Each stage: `id`, `trigger_label`, `handler`
 
+### Reserved stage IDs
+
+The built-in handlers call `loop_stage_trigger` with specific stage `id`
+values to resolve label names at runtime. Using a different `id` (or
+omitting a stage entirely) causes the handler to fall back to a hardcoded
+default label, which may not match the labels in your project.
+
+| Stage ID | Looked up by | Fallback if absent |
+|---|---|---|
+| `po` | po-handler (trigger strip) | `po-review` |
+| `dev` | dev-handler (trigger strip) | `plan` |
+| `review` | dev-handler, dev-rework-handler | `review-pending` |
+| `rework` | scanner (qa-fail context detection) | `changes-requested` |
+| `qa` | review-handler | `ready-for-qa` |
+
+Custom workflows that rename a stage must use one of these IDs, or
+override the label via the `labels:` map in `config/projects.yaml` so
+the fallback value still matches the label applied in the repo.
+
 ### Validation
 
 ```bash

--- a/lib/backends/backend.sh
+++ b/lib/backends/backend.sh
@@ -100,3 +100,44 @@ loop_load_backend
 
 # (declare this alongside the other backend_* interface functions)
 backend_issue_unmet_deps() { echo "backend_issue_unmet_deps not implemented" >&2; return 1; }
+
+# backend_cli_note — emit a glab/gh CLI reference block for agent prompts.
+# Prints a non-empty note only when BACKEND is gitlab or jira-gitlab so agents
+# know to use glab instead of gh. Prints nothing on the github backend.
+backend_cli_note() {
+    case "${BACKEND:-github}" in
+        gitlab|jira-gitlab) cat <<'CLINOTE'
+
+BACKEND NOTICE: This project uses GitLab. Use glab commands instead of gh:
+  gh issue view N --repo R --json body --jq .body
+    → glab issue view N --repo R --output json | python3 -c "import json,sys; print(json.load(sys.stdin).get('description',''))"
+  gh issue list --repo R --state all --limit 50
+    → glab issue list --repo R --state all --limit 50
+  gh issue edit N --repo R --add-label L --remove-label M
+    → glab issue update N --repo R --add-label L --remove-label M
+  gh issue comment N --repo R --body 'text'
+    → glab issue comment N --repo R --body 'text'
+  gh issue close N --repo R
+    → glab issue close N --repo R
+  gh issue create --repo R --title T --body B --label L
+    → glab issue create --repo R --title T --description B --label L
+  gh pr create --repo R --title T --body B --label L
+    → glab mr create --repo R --title T --description B --label L
+  gh pr view N --repo R --json state,merged
+    → glab mr view N --repo R --output json
+  gh pr diff N --repo R
+    → glab mr diff N --repo R
+  gh pr checks N --repo R
+    → glab pipeline list --source-branch BRANCH --repo R
+  gh pr review N --repo R --approve --body 'text'
+    → glab mr approve N --repo R  (post the body as a separate comment)
+  gh pr review N --repo R --request-changes --body 'text'
+    → glab mr revoke N --repo R  (post the body as a separate comment)
+  gh pr edit N --repo R --add-label L --remove-label M
+    → glab mr update N --repo R --add-label L --remove-label M
+  gh pr comment N --repo R --body 'text'
+    → glab mr comment N --repo R --body 'text'
+CLINOTE
+        ;;
+    esac
+}

--- a/lib/backends/gitlab.sh
+++ b/lib/backends/gitlab.sh
@@ -45,7 +45,7 @@ _gl_parse_repo() {
 
 # Priority-sort jq fragment for issues.
 # Input: JSON array from glab issue list --output json
-# Output: JSONL with Loop schema {number, title, url, labels}
+# Output: JSONL with Loop schema {number, title, url, labels, author}
 _GL_ISSUE_SORT='
   map(
     (.labels // []) as $L |
@@ -54,6 +54,7 @@ _GL_ISSUE_SORT='
       title,
       url: .web_url,
       labels: $L,
+      author: (.author.username // ""),
       _p: (
         if   ($L | index("p0-critical")) then 0
         elif ($L | index("p1-high"))     then 1
@@ -99,7 +100,7 @@ _GL_MR_SORT='
 backend_list_issues_with_label() {
     local repo="$1" label="$2"
     _gl_parse_repo "$repo"
-    glab issue list --repo "$_GL_REPO" --label "$label" --state opened \
+    glab issue list --repo "$_GL_REPO" --label "$label" \
         --output json 2>/dev/null \
     | jq -c "$_GL_ISSUE_SORT" 2>/dev/null || true
 }

--- a/lib/runner.sh
+++ b/lib/runner.sh
@@ -30,11 +30,11 @@ loop_run_agent() {
 
     case "$LOOP_AGENT" in
         claude)
-            claude -p \
+            (cd "$cwd" && claude -p \
                 --model "${LOOP_AGENT_MODEL:-sonnet}" \
                 --output-format text \
                 --dangerously-skip-permissions \
-                "$prompt"
+                "$prompt")
             ;;
         codex)
             codex \

--- a/scripts/dev-handler.sh
+++ b/scripts/dev-handler.sh
@@ -102,15 +102,9 @@ log "worktree ready: $WORKTREE_ROOT (isolated from other handlers)"
 # belt-and-braces apply the right names per the project's active workflow
 # (e.g. needs-review on default, review-pending on current).
 REVIEW_LABEL=$(loop_stage_trigger "$SLUG" review pr 2>/dev/null || echo review-pending)
+_BACKEND_CLI_NOTE=$(backend_cli_note)
 
-if [ -n "$DEV_VALIDATION_CMD" ]; then
-    _VALIDATION_STEP="4. Run validation: ${DEV_VALIDATION_CMD//\{project_root\}/$ROOT}"
-else
-    _VALIDATION_STEP=""
-fi
-
-_PROMPT_FILE=$(mktemp /tmp/dev-prompt-XXXXXX.txt)
-cat > "$_PROMPT_FILE" <<EOF
+TASK_PROMPT=$(cat <<EOF
 You are the Senior Developer for ${NAME} (slug: ${SLUG}).
 Working directory: ${WORKTREE_ROOT}
 Repo: ${REPO}
@@ -129,36 +123,36 @@ Issue body:
 ${ISSUE_BODY}
 
 Your job:
-1. cd ${WORKTREE_ROOT}  (already on origin/${DEFAULT_BRANCH} -- no pull needed)
+1. cd ${WORKTREE_ROOT}  (already on origin/${DEFAULT_BRANCH} — no pull needed)
 2. Create a branch: fix/issue-${ISSUE_NUM}-<slug>  (or feat/issue-${ISSUE_NUM}-<slug> for features)
    If a branch named fix/issue-${ISSUE_NUM}-* or feat/issue-${ISSUE_NUM}-* already exists on origin, delete it first:
    git push origin --delete <existing-branch-name>
 3. Implement the change. Follow CLAUDE.md conventions.
-${_VALIDATION_STEP}
+$( [ -n "$DEV_VALIDATION_CMD" ] && echo "4. Run validation: ${DEV_VALIDATION_CMD//\{project_root\}/$ROOT}" )
 5. Before committing, verify there are actual staged changes:
    git diff --cached --quiet && echo 'WARNING: no staged changes' || true
    If there are no changes to commit, comment on the issue explaining why (e.g. already implemented, out of scope) and add label 'needs-clarification' instead of opening an empty PR.
 6. Commit: git commit -m '[${COMMIT_PREFIX}-${ISSUE_NUM}] <short description>'
 7. Push the branch and open a PR:
-   gh pr create --repo ${REPO} --title '[${COMMIT_PREFIX}-${ISSUE_NUM}] <short description>' \
+   gh pr create --repo ${REPO} --title '[${COMMIT_PREFIX}-${ISSUE_NUM}] <short description>' \\
      --body 'Closes #${ISSUE_NUM}
 
 ## Changes
 <what you changed and why>
 
 ## Test Plan
-<what QA should verify>' \
+<what QA should verify>' \\
      --label ${REVIEW_LABEL}
-8. On your own issue -- this step is MANDATORY to signal success to the pipeline:
+8. On your own issue — this step is MANDATORY to signal success to the pipeline:
    gh issue edit ${ISSUE_NUM} --repo ${REPO} --remove-label in-progress --remove-label dev --remove-label plan --remove-label needs-review --remove-label review-pending --add-label ${REVIEW_LABEL}
 
 IMPORTANT: The issue MUST end this run with label '${REVIEW_LABEL}' (or 'needs-clarification' if blocked). Verify with:
    gh issue view ${ISSUE_NUM} --repo ${REPO} --json labels
 
 If blocked by missing context or an architectural decision, comment on the issue and add label 'needs-clarification' instead of opening a PR.
+${_BACKEND_CLI_NOTE}
 EOF
-TASK_PROMPT=$(cat "$_PROMPT_FILE")
-rm -f "$_PROMPT_FILE"
+)
 
 cleanup_worktree() {
     git -C "$ROOT" worktree remove "$WORKTREE_ROOT" --force 2>/dev/null \
@@ -200,11 +194,21 @@ else
     if [ "$n" -ge "$MAX_RETRIES" ]; then
         backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
         backend_add_label "$REPO" "$ISSUE_NUM" blocked
-        # Post only a short marker — never the agent log/prompt, which contains
-        # internal pipeline instructions that must not become public.
-        gh issue comment "$ISSUE_NUM" --repo "$REPO" \
-            --body "Automated dev cycle failed ${MAX_RETRIES} times. Marking blocked for human review. Operator: see ${LOG_FILE} for the agent transcript." \
-            2>/dev/null || true
+        _fail_body_file=$(mktemp /tmp/loop-fail-XXXXXX.md)
+        {
+            echo "Automated dev cycle failed ${MAX_RETRIES} times. Needs human review."
+            echo ""
+            echo "<details><summary>Last agent output</summary>"
+            echo ""
+            echo '```'
+            tail -n +"$((LOG_CAPTURE_START + 1))" "$LOG_FILE" \
+                | sed 's/\(ANTHROPIC_API_KEY=\|GITHUB_TOKEN=\|GH_TOKEN=\|_SECRET=\)[^ ]*/\1REDACTED/g' \
+                | tail -40
+            echo '```'
+            echo "</details>"
+        } > "$_fail_body_file"
+        backend_comment_issue "$REPO" "$ISSUE_NUM" "$(cat "$_fail_body_file")"
+        rm -f "$_fail_body_file"
         loop_notify "❌ [$SLUG] #$ISSUE_NUM dev failed: agent failed after $MAX_RETRIES attempts"
     else
         backend_remove_label "$REPO" "$ISSUE_NUM" in-progress

--- a/scripts/dev-rework-handler.sh
+++ b/scripts/dev-rework-handler.sh
@@ -193,6 +193,8 @@ else
     _VALIDATION_STEP=""
 fi
 
+_BACKEND_CLI_NOTE=$(backend_cli_note)
+
 _PROMPT_FILE=$(mktemp /tmp/rework-prompt-XXXXXX.txt)
 cat > "$_PROMPT_FILE" <<EOF
 You are the Senior Developer for ${NAME} (slug: ${SLUG}), reworking a PR after ${_REWORK_TRIGGER}.
@@ -230,6 +232,7 @@ IMPORTANT: The PR MUST end this run with label '${REVIEW_LABEL}' (or 'needs-clar
    gh pr view ${PR_NUM} --repo ${REPO} --json labels
 
 If the feedback is unclear or requires architectural input, add label 'needs-clarification' and comment on the PR instead of guessing.
+${_BACKEND_CLI_NOTE}
 EOF
 TASK_PROMPT=$(cat "$_PROMPT_FILE")
 rm -f "$_PROMPT_FILE"
@@ -262,11 +265,21 @@ else
     if [ "$n" -ge "$MAX_RETRIES" ]; then
         backend_remove_label "$REPO" "$PR_NUM" in-rework
         backend_add_label "$REPO" "$PR_NUM" blocked
-        # Post only a short marker to the PR — never the agent log/prompt, which
-        # contains internal pipeline instructions that should not be public.
-        gh pr comment "$PR_NUM" --repo "$REPO" \
-            --body "Automated rework failed ${MAX_RETRIES} times. Marking blocked for human review. Operator: see ${LOG_FILE} for the agent transcript." \
-            2>/dev/null || true
+        _fail_body_file=$(mktemp /tmp/loop-fail-XXXXXX.md)
+        {
+            echo "Automated rework failed ${MAX_RETRIES} times. Needs human eyes."
+            echo ""
+            echo "<details><summary>Last agent output</summary>"
+            echo ""
+            echo '```'
+            tail -n +"$((LOG_CAPTURE_START + 1))" "$LOG_FILE" \
+                | sed 's/\(ANTHROPIC_API_KEY=\|GITHUB_TOKEN=\|GH_TOKEN=\|_SECRET=\)[^ ]*/\1REDACTED/g' \
+                | tail -40
+            echo '```'
+            echo "</details>"
+        } > "$_fail_body_file"
+        backend_comment_pr "$REPO" "$PR_NUM" "$(cat "$_fail_body_file")"
+        rm -f "$_fail_body_file"
         loop_notify "❌ [$SLUG] PR#$PR_NUM dev-rework failed: agent failed after $MAX_RETRIES attempts"
     else
         backend_remove_label "$REPO" "$PR_NUM" in-rework

--- a/scripts/po-handler.sh
+++ b/scripts/po-handler.sh
@@ -105,6 +105,8 @@ except Exception:
     pass
 " || echo "")
 
+_BACKEND_CLI_NOTE=$(backend_cli_note)
+
 _PROMPT_FILE=$(mktemp /tmp/po-prompt-XXXXXX.txt)
 cat > "$_PROMPT_FILE" <<EOF
 You are the Product Owner agent for ${NAME} (slug: ${SLUG}).
@@ -191,20 +193,32 @@ What this ticket explicitly does not cover. Prevents scope creep.
 IMPORTANT: The issue MUST end this run with exactly ONE of: dev / needs-clarification / blocked / tracker / closed.
 Verify: gh issue view ${ISSUE_NUM} --repo ${REPO} --json labels,state
 Report your decision (A/B/C/D/E/F) and why in 2 sentences.
+${_BACKEND_CLI_NOTE}
 EOF
 TASK_PROMPT=$(cat "$_PROMPT_FILE")
 rm -f "$_PROMPT_FILE"
 
 _post_failure_comment() {
     local target_type="$1" target_num="$2" label_ctx="$3" _attempt="$4" max="$5"
-    # Post only a short marker — never the agent log/prompt, which contains
-    # internal pipeline instructions that must not become public.
-    local body="Automated ${label_ctx} failed ${max} times. Needs human clarification. Operator: see ${LOG_FILE} for the agent transcript."
+    local body_file; body_file=$(mktemp /tmp/loop-fail-XXXXXX.md)
+    {
+        echo "Automated ${label_ctx} failed ${max} times. Needs human clarification."
+        echo ""
+        echo "<details><summary>Last agent output</summary>"
+        echo ""
+        echo '```'
+        tail -n +"$((LOG_CAPTURE_START + 1))" "$LOG_FILE" \
+            | sed 's/\(ANTHROPIC_API_KEY=\|GITHUB_TOKEN=\|GH_TOKEN=\|_SECRET=\)[^ ]*/\1REDACTED/g' \
+            | tail -40
+        echo '```'
+        echo "</details>"
+    } > "$body_file"
     if [ "$target_type" = "issue" ]; then
-        gh issue comment "$target_num" --repo "$REPO" --body "$body" 2>/dev/null || true
+        backend_comment_issue "$REPO" "$target_num" "$(cat "$body_file")"
     else
-        gh pr comment "$target_num" --repo "$REPO" --body "$body" 2>/dev/null || true
+        backend_comment_pr "$REPO" "$target_num" "$(cat "$body_file")"
     fi
+    rm -f "$body_file"
 }
 
 if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then

--- a/scripts/review-handler.sh
+++ b/scripts/review-handler.sh
@@ -88,9 +88,9 @@ backend_add_label "$REPO" "$PR_NUM" in-review
 # belt-and-braces apply the right names per active workflow.
 QA_LABEL=$(loop_stage_trigger "$SLUG" qa pr 2>/dev/null || echo ready-for-qa)
 REWORK_LABEL=$(loop_stage_trigger "$SLUG" rework pr 2>/dev/null || echo changes-requested)
+_BACKEND_CLI_NOTE=$(backend_cli_note)
 
-_PROMPT_FILE=$(mktemp /tmp/review-prompt-XXXXXX.txt)
-cat > "$_PROMPT_FILE" <<EOF
+TASK_PROMPT=$(cat <<EOF
 You are the Senior Code Reviewer for ${NAME} (slug: ${SLUG}).
 Project root: ${ROOT}
 Repo: ${REPO}
@@ -101,7 +101,7 @@ If CLAUDE.md is missing, proceed with general best-practice conventions and note
 You are reviewing pull request #${PR_NUM}: ${PR_TITLE}
 URL: ${PR_URL}
 
-Your job -- do all of these in sequence:
+Your job — do all of these in sequence:
 
 0. Check PR state before reviewing:
    gh pr view ${PR_NUM} --repo ${REPO} --json state,merged
@@ -112,9 +112,9 @@ Your job -- do all of these in sequence:
    gh pr view ${PR_NUM} --repo ${REPO} --json title,body,headRefName,files,closingIssuesReferences
    gh pr diff ${PR_NUM} --repo ${REPO}
    If the diff is empty (no files changed), immediately REQUEST_CHANGES with the explanation that an empty diff cannot be reviewed.
-3. Check CI status -- note any failing checks:
+3. Check CI status — note any failing checks:
    gh pr checks ${PR_NUM} --repo ${REPO}
-   If required checks are failing, REQUEST_CHANGES citing the failing checks (unless the failures are pre-existing and clearly unrelated to this PR scope -- document your reasoning if you choose to ignore them).
+   If required checks are failing, REQUEST_CHANGES citing the failing checks (unless the failures are pre-existing and clearly unrelated to this PR scope — document your reasoning if you choose to ignore them).
 4. For every issue this PR claims to close, fetch the issue body and verify the acceptance criteria are met:
    gh issue view <N> --repo ${REPO} --json body,labels
 5. Spot-check the diff: does the code match the issue spec? Any obvious bugs, regressions, or scope creep? Is the commit message / PR body aligned with CLAUDE.md conventions?
@@ -125,7 +125,7 @@ If APPROVE:
    gh pr edit ${PR_NUM} --repo ${REPO} --remove-label in-review --remove-label needs-review --remove-label review-pending --remove-label ready-for-qa --remove-label needs-qa --add-label ${QA_LABEL}
 
 If REQUEST_CHANGES:
-   gh pr review ${PR_NUM} --repo ${REPO} --request-changes --body '<specific, actionable feedback -- what to change and why>'
+   gh pr review ${PR_NUM} --repo ${REPO} --request-changes --body '<specific, actionable feedback — what to change and why>'
    gh pr edit ${PR_NUM} --repo ${REPO} --remove-label in-review --remove-label needs-review --remove-label review-pending --remove-label changes-requested --remove-label needs-rework --add-label ${REWORK_LABEL}
 
 Be strict but fair. Approve content-adjacent bookkeeping (formatting, docs) liberally. Push back on logic errors, security issues, missing tests where the issue asked for tests, or content that contradicts the cited source (e.g. a lesson that miscites CAR Part X).
@@ -134,9 +134,9 @@ IMPORTANT: You MUST finish by applying either '${QA_LABEL}' or '${REWORK_LABEL}'
    gh pr view ${PR_NUM} --repo ${REPO} --json labels
 
 Report the decision you made and why, in 3 short sentences.
+${_BACKEND_CLI_NOTE}
 EOF
-TASK_PROMPT=$(cat "$_PROMPT_FILE")
-rm -f "$_PROMPT_FILE"
+)
 
 if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
     log "review agent finished for PR #$PR_NUM"
@@ -159,11 +159,21 @@ else
         backend_remove_label "$REPO" "$PR_NUM" in-review
         backend_remove_label "$REPO" "$PR_NUM" changes-requested
         backend_add_label "$REPO" "$PR_NUM" needs-rework
-        # Post only a short marker — never the agent log/prompt, which contains
-        # internal pipeline instructions that must not become public.
-        gh pr comment "$PR_NUM" --repo "$REPO" \
-            --body "Automated review failed ${MAX_RETRIES} times. Needs human eyes. Operator: see ${LOG_FILE} for the agent transcript." \
-            2>/dev/null || true
+        _fail_body_file=$(mktemp /tmp/loop-fail-XXXXXX.md)
+        {
+            echo "Automated review failed ${MAX_RETRIES} times. Needs human eyes."
+            echo ""
+            echo "<details><summary>Last agent output</summary>"
+            echo ""
+            echo '```'
+            tail -n +"$((LOG_CAPTURE_START + 1))" "$LOG_FILE" \
+                | sed 's/\(ANTHROPIC_API_KEY=\|GITHUB_TOKEN=\|GH_TOKEN=\|_SECRET=\)[^ ]*/\1REDACTED/g' \
+                | tail -40
+            echo '```'
+            echo "</details>"
+        } > "$_fail_body_file"
+        backend_comment_pr "$REPO" "$PR_NUM" "$(cat "$_fail_body_file")"
+        rm -f "$_fail_body_file"
         loop_notify "❌ [$SLUG] PR#$PR_NUM review failed: agent failed after $MAX_RETRIES attempts"
     else
         backend_remove_label "$REPO" "$PR_NUM" in-review


### PR DESCRIPTION
Closes #25

## Changes

**Bug 1 — GitLab: invalid \`--state opened\` flag**
Removed \`--state opened\` from \`glab issue list\` in \`backend_list_issues_with_label\` (\`lib/backends/gitlab.sh\`). This flag doesn't exist in glab; open issues are returned by default, so the flag was preventing issues from ever being found.

**Bug 2 — GitLab: \`author\` field missing from \`_GL_ISSUE_SORT\`**
Added \`author: (.author.username // "")\` to the \`_GL_ISSUE_SORT\` jq fragment. Without it the \`author\` key was absent from every GitLab issue row, causing the scanner's \`ALLOWED_AUTHORS\` check to silently skip all issues.

**Bug 3 — Scanner: reserved stage IDs undocumented**
Added a **Reserved stage IDs** table to \`config/workflows/README.md\` documenting which \`id\` values the built-in handlers resolve via \`loop_stage_trigger\`, which handler uses each, and the hardcoded fallback label when the ID is absent.

**Bug 4 — Agent prompts hardcode \`gh\` CLI**
Added \`backend_cli_note()\` to \`lib/backends/backend.sh\`. When \`\$BACKEND\` is \`gitlab\` or \`jira-gitlab\` it emits a glab/gh equivalence reference table (all common issue and MR commands). Injected \`\${_BACKEND_CLI_NOTE}\` at the end of the agent prompts in \`po-handler\`, \`dev-handler\`, \`review-handler\`, and \`dev-rework-handler\`.

**Bug 5 — \`_post_failure_comment\` bypasses backend abstraction**
Replaced hardcoded \`gh issue comment\` / \`gh pr comment\` calls in the max-retry failure paths of all four handlers with \`backend_comment_issue\` / \`backend_comment_pr\`, which route correctly to \`glab\` on GitLab projects.

**Bug 6 — \`loop_run_agent\` ignores \`\$cwd\` for Claude**
Wrapped the \`claude\` case in \`lib/runner.sh\` with \`(cd "\$cwd" && ...)\` so the agent process starts from the correct working directory (the isolated worktree root) rather than wherever the handler launched from.

## Test Plan

- [ ] On GitLab project: \`backend_list_issues_with_label\` returns open issues (no \`--state opened\` error)
- [ ] On GitLab: scanner \`ALLOWED_AUTHORS\` filter correctly allows/skips issues by \`.author.username\`
- [ ] README reserved stage ID table is accurate against \`default.yaml\` stage IDs
- [ ] On GitLab project: agent prompt includes the glab CLI equivalence block
- [ ] On GitHub project: agent prompt contains no glab block (no regression)
- [ ] On GitLab: max-retry failure comment is posted via \`glab issue/mr comment\`
- [ ] dev-handler worktree: claude agent \`pwd\` output matches \`\$WORKTREE_ROOT\`