### PR TITLE
[LOOP-28] Fix GitLab backend: remove invalid --state flag and add author to _GL_ISSUE_SORT

### DIFF
--- a/lib/backends/gitlab.sh
+++ b/lib/backends/gitlab.sh
@@ -54,6 +54,7 @@ _GL_ISSUE_SORT='
       title,
       url: .web_url,
       labels: $L,
+      author: (.author.username // ""),
       _p: (
         if   ($L | index("p0-critical")) then 0
         elif ($L | index("p1-high"))     then 1
@@ -99,7 +100,7 @@ _GL_MR_SORT='
 backend_list_issues_with_label() {
     local repo="$1" label="$2"
     _gl_parse_repo "$repo"
-    glab issue list --repo "$_GL_REPO" --label "$label" --state opened \
+    glab issue list --repo "$_GL_REPO" --label "$label" \
         --output json 2>/dev/null \
     | jq -c "$_GL_ISSUE_SORT" 2>/dev/null || true
 }


### PR DESCRIPTION
Closes #28

## Changes
- **`lib/backends/gitlab.sh` — `backend_list_issues_with_label`**: Removed `--state opened` from the `glab issue list` call. This flag is invalid for `glab` and caused the command to return zero results. The default behaviour is already to list open issues.
- **`lib/backends/gitlab.sh` — `_GL_ISSUE_SORT`**: Added `author: (.author.username // "")` to the jq fragment so the `author` field is surfaced in the Loop issue schema, enabling `ALLOWED_AUTHORS` filtering to work correctly on GitLab issues.

Only `lib/backends/gitlab.sh` is touched; no other files changed.

## Test Plan
- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` passes (CI gate).
- `shellcheck -S warning lib/*.sh scripts/*.sh scanner/*.sh install.sh` passes.
- On a GitLab-backed project: apply a label to an open issue and confirm `backend_list_issues_with_label` now returns it (previously returned nothing due to the invalid flag).
- Confirm issues are filtered correctly when `ALLOWED_AUTHORS` is set — the `author` field is now populated from `.author.username`.