### PR TITLE
[LOOP-18] update.sh: BREAKING gate with per-component check; fix test isolation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,23 @@ If your PR changes any of:
 …add a `BREAKING:` line to the `[Unreleased]` section of CHANGELOG.md
 explaining what changed and how operators migrate.
 
+**`BREAKING:` format** — the line must start with the literal token `BREAKING:`
+followed by a plain-English description and (where applicable) a migration
+recipe or link. `scripts/update.sh` scans CHANGELOG diffs for this exact token
+and halts the operator's upgrade until they acknowledge with `--yes`. Keep the
+description on a single line; multi-line continuations are not scanned.
+
+Example:
+
+```markdown
+### Changed
+- BREAKING: LOOP_AGENT_MODEL renamed to LOOP_AGENT. Update loop.env.
+```
+
+If your change affects loop-monitor as well, add a matching `BREAKING:` line to
+loop-monitor's `CHANGELOG.md` — `scripts/update.sh` checks both repos when
+`LOOP_MONITOR_ROOT` is configured in `loop.env`.
+
 ## Out of scope (not currently accepting)
 
 - GUI / web UI — Loop is a CLI tool. Use loop-monitor for visibility.

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# update.sh — pull the latest Loop from origin, surfacing BREAKING: warnings.
+#
+# Usage:
+#   ./scripts/update.sh              # fetch, warn on breaking changes, abort
+#   ./scripts/update.sh --yes        # fetch + apply even with breaking changes
+#   ./scripts/update.sh --check      # fetch, show full changelog diff, no apply
+#   ./scripts/update.sh --dry-run    # same as --check (alias)
+#
+# Per-component: if LOOP_MONITOR_ROOT is set in loop.env and points to a git
+# repo, loop-monitor's CHANGELOG.md is also scanned for BREAKING: markers.
+#
+# LOOP_ROOT may be overridden via env to point at a different repo root
+# (used by tests; production behavior is unchanged).
+
+set -euo pipefail
+
+LOOP_ROOT="${LOOP_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+cd "$LOOP_ROOT"
+
+# Source loop.env so LOOP_MONITOR_ROOT (and other vars) are available.
+if [ -f "$LOOP_ROOT/loop.env" ]; then
+    # shellcheck source=../loop.env.example
+    set +u; . "$LOOP_ROOT/loop.env"; set -u
+fi
+
+YES=false
+CHECK=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --yes)             YES=true;  shift ;;
+        --check|--dry-run) CHECK=true; shift ;;
+        -h|--help)         sed -n '2,9p' "$0"; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+# ── extract BREAKING: entries from a CHANGELOG diff on stdin ─────────────────
+# Prints "  <version header>\n    BREAKING: ..." blocks; empty if none found.
+_extract_breaking() {
+    python3 - <<'PY'
+import sys, re
+
+diff = sys.stdin.read()
+
+added_lines = []
+for line in diff.splitlines():
+    if line.startswith('+') and not line.startswith('+++'):
+        added_lines.append(line[1:])
+
+added_text = '\n'.join(added_lines)
+
+version_header_re = re.compile(r'^## \[([^\]]+)\](.*?)$', re.MULTILINE)
+breaking_re = re.compile(r'\bBREAKING:\s*.+', re.MULTILINE)
+
+sections = list(version_header_re.finditer(added_text))
+results = []
+
+for i, m in enumerate(sections):
+    end = sections[i+1].start() if i+1 < len(sections) else len(added_text)
+    body = added_text[m.end():end]
+    breakings = breaking_re.findall(body)
+    if breakings:
+        header = m.group(0).lstrip('#').strip()
+        results.append(f"  {header}")
+        for b in breakings:
+            results.append(f"    {b}")
+
+print('\n'.join(results))
+PY
+}
+
+# ── fetch loop core ───────────────────────────────────────────────────────────
+echo "[update] fetching loop core (origin/main) …"
+git fetch origin main --quiet
+
+CORE_UP_TO_DATE=false
+if git diff --quiet HEAD..origin/main; then
+    CORE_UP_TO_DATE=true
+fi
+
+CORE_DIFF=""
+CORE_BREAKING=""
+if ! $CORE_UP_TO_DATE; then
+    CORE_DIFF=$(git diff HEAD..origin/main -- CHANGELOG.md 2>/dev/null || true)
+    CORE_BREAKING=$(echo "$CORE_DIFF" | _extract_breaking)
+fi
+
+# ── fetch loop-monitor (optional) ────────────────────────────────────────────
+MONITOR_BREAKING=""
+MONITOR_DIFF=""
+MONITOR_UP_TO_DATE=false
+
+if [ -n "${LOOP_MONITOR_ROOT:-}" ] && [ -d "${LOOP_MONITOR_ROOT}/.git" ]; then
+    echo "[update] fetching loop-monitor (${LOOP_MONITOR_ROOT}) …"
+    (cd "$LOOP_MONITOR_ROOT" && git fetch origin main --quiet 2>/dev/null) || true
+
+    if (cd "$LOOP_MONITOR_ROOT" && git diff --quiet HEAD..origin/main 2>/dev/null); then
+        MONITOR_UP_TO_DATE=true
+    fi
+
+    if ! $MONITOR_UP_TO_DATE; then
+        MONITOR_DIFF=$(cd "$LOOP_MONITOR_ROOT" && git diff HEAD..origin/main -- CHANGELOG.md 2>/dev/null || true)
+        MONITOR_BREAKING=$(echo "$MONITOR_DIFF" | _extract_breaking)
+    fi
+fi
+
+# ── --check: show full diffs and exit without applying ───────────────────────
+if $CHECK; then
+    echo ""
+    echo "=== loop core changelog ==="
+    if $CORE_UP_TO_DATE; then
+        echo "(already up to date)"
+    else
+        echo "$CORE_DIFF" | grep '^+' | grep -v '^+++' | sed 's/^+//' | head -80
+    fi
+
+    if [ -n "${LOOP_MONITOR_ROOT:-}" ] && [ -d "${LOOP_MONITOR_ROOT}/.git" ]; then
+        echo ""
+        echo "=== loop-monitor changelog ==="
+        if $MONITOR_UP_TO_DATE; then
+            echo "(already up to date)"
+        else
+            echo "$MONITOR_DIFF" | grep '^+' | grep -v '^+++' | sed 's/^+//' | head -80
+        fi
+    fi
+
+    echo ""
+    COMBINED_BREAKING="${CORE_BREAKING}${MONITOR_BREAKING}"
+    if [ -n "$COMBINED_BREAKING" ]; then
+        echo "⚠ This update contains breaking changes:"
+        echo ""
+        echo "$COMBINED_BREAKING"
+    else
+        echo "(no breaking changes detected)"
+    fi
+    exit 0
+fi
+
+# ── nothing to do? ───────────────────────────────────────────────────────────
+if $CORE_UP_TO_DATE && $MONITOR_UP_TO_DATE; then
+    echo "[update] already up to date."
+    exit 0
+fi
+
+# ── combine breaking warnings from both components ───────────────────────────
+COMBINED_BREAKING=""
+[ -n "$CORE_BREAKING" ]    && COMBINED_BREAKING="${COMBINED_BREAKING}[loop core]\n${CORE_BREAKING}\n"
+[ -n "$MONITOR_BREAKING" ] && COMBINED_BREAKING="${COMBINED_BREAKING}[loop-monitor]\n${MONITOR_BREAKING}\n"
+
+# ── gate on BREAKING: unless --yes ───────────────────────────────────────────
+if [ -n "$COMBINED_BREAKING" ] && [ "$YES" != "true" ]; then
+    echo ""
+    echo "⚠ This update contains breaking changes:"
+    echo ""
+    printf '%b' "$COMBINED_BREAKING"
+    echo ""
+    echo "Re-run with --yes to apply, or --check to see the full changelog without applying."
+    exit 1
+fi
+
+# ── apply ────────────────────────────────────────────────────────────────────
+if ! $CORE_UP_TO_DATE; then
+    echo "[update] applying loop core …"
+    git merge --ff-only origin/main
+    echo "[update] loop core updated to $(cat VERSION 2>/dev/null || echo unknown)"
+fi
+
+if ! $MONITOR_UP_TO_DATE && [ -n "${LOOP_MONITOR_ROOT:-}" ] && [ -d "${LOOP_MONITOR_ROOT}/.git" ]; then
+    echo "[update] applying loop-monitor …"
+    (cd "$LOOP_MONITOR_ROOT" && git merge --ff-only origin/main)
+    echo "[update] loop-monitor updated to $(cat "${LOOP_MONITOR_ROOT}/VERSION" 2>/dev/null || echo unknown)"
+fi
+
+echo "[update] done."

--- a/tests/update.bats
+++ b/tests/update.bats
@@ -1,0 +1,240 @@
+#!/usr/bin/env bats
+# tests/update.bats — tests for scripts/update.sh breaking-change gate.
+#
+# Each test builds minimal fake git repos so no network access is required.
+# LOOP_ROOT is injected so update.sh operates on the fake repo, not the real one.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    UPDATE_SH="$REPO_ROOT/scripts/update.sh"
+
+    # Build a fake loop core repo with a BREAKING: entry in origin.
+    FAKE_CORE="$BATS_TMPDIR/fake-core"
+    rm -rf "$FAKE_CORE"
+    mkdir -p "$FAKE_CORE"
+    cd "$FAKE_CORE"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    cat > CHANGELOG.md <<'EOF'
+# Changelog
+## [0.1.0] - 2026-04-27
+### Added
+- Initial release.
+EOF
+    echo "0.1.0" > VERSION
+    git add .
+    git commit -q -m "init"
+    # Ensure branch is named 'main' regardless of git default (pre-2.28 uses 'master')
+    git branch -M main 2>/dev/null || true
+
+    # Simulate origin/main with a BREAKING: entry
+    git checkout -q -b origin-main
+    cat > CHANGELOG.md <<'EOF'
+# Changelog
+## [0.2.0] - 2026-05-12
+### Changed
+- BREAKING: workflow YAML schema bumped to v2 — add version: 2 to config files.
+## [0.1.0] - 2026-04-27
+### Added
+- Initial release.
+EOF
+    echo "0.2.0" > VERSION
+    git add .
+    git commit -q -m "release: v0.2.0"
+
+    git checkout -q main
+    git remote add origin "$FAKE_CORE"
+    git fetch origin origin-main:refs/remotes/origin/main -q
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/fake-core" "$BATS_TMPDIR/fake-monitor" 2>/dev/null || true
+}
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+# Run update.sh with LOOP_ROOT pointed at the fake core repo.
+run_update() {
+    run env -i HOME="$HOME" PATH="$PATH" \
+        LOOP_ROOT="$FAKE_CORE" \
+        bash "$UPDATE_SH" "$@"
+}
+
+# Build a fake monitor repo at $BATS_TMPDIR/fake-monitor.
+# $1 = "breaking" | "clean" — controls whether origin/main has a BREAKING: line.
+_make_monitor() {
+    local kind="${1:-clean}"
+    local FAKE_MON="$BATS_TMPDIR/fake-monitor"
+    rm -rf "$FAKE_MON"
+    mkdir -p "$FAKE_MON"
+    cd "$FAKE_MON"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    echo "# Changelog" > CHANGELOG.md
+    echo "0.1.0" > VERSION
+    git add .
+    git commit -q -m "init"
+    # Ensure branch is named 'main' regardless of git default (pre-2.28 uses 'master')
+    git branch -M main 2>/dev/null || true
+
+    git checkout -q -b origin-main
+    if [ "$kind" = "breaking" ]; then
+        cat > CHANGELOG.md <<'EOF'
+# Changelog
+## [0.2.0] - 2026-05-12
+### Changed
+- BREAKING: LOOP_MONITOR_URL renamed to LOOP_BOUNTY_URL. Update loop.env.
+## [0.1.0] - 2026-04-27
+### Added
+- Initial release.
+EOF
+        echo "0.2.0" > VERSION
+    else
+        echo "0.1.1" > VERSION
+    fi
+    git add .
+    git commit -q -m "bump"
+
+    git checkout -q main
+    git remote add origin "$FAKE_MON"
+    git fetch origin origin-main:refs/remotes/origin/main -q
+    cd "$FAKE_CORE"
+}
+
+# ── core-only tests ───────────────────────────────────────────────────────────
+
+@test "core: halts on BREAKING: without --yes" {
+    run_update
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"⚠ This update contains breaking changes:"* ]]
+    [[ "$output" == *"BREAKING:"* ]]
+    [[ "$output" == *"--yes"* ]]
+}
+
+@test "core: output includes version header and breaking line text" {
+    run_update
+    [[ "$output" == *"0.2.0"* ]]
+    [[ "$output" == *"BREAKING: workflow YAML schema bumped to v2"* ]]
+}
+
+@test "core: --yes bypasses gate and applies" {
+    run_update --yes
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"done"* ]]
+    [ "$(cat "$FAKE_CORE/VERSION")" = "0.2.0" ]
+}
+
+@test "core: --check shows changelog and does not apply" {
+    run_update --check
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BREAKING:"* ]]
+    [ "$(cat "$FAKE_CORE/VERSION")" = "0.1.0" ]
+}
+
+@test "core: --dry-run is alias for --check" {
+    run_update --dry-run
+    [ "$status" -eq 0 ]
+    [ "$(cat "$FAKE_CORE/VERSION")" = "0.1.0" ]
+}
+
+@test "core: no BREAKING: — applies without --yes" {
+    local SAFE="$BATS_TMPDIR/safe-core"
+    rm -rf "$SAFE"; mkdir -p "$SAFE"; cd "$SAFE"
+    git init -q
+    git config user.email "test@example.com"; git config user.name "Test"
+    echo "0.1.0" > VERSION; echo "# Changelog" > CHANGELOG.md
+    git add .; git commit -q -m "init"
+    git branch -M main 2>/dev/null || true
+    git checkout -q -b origin-main
+    echo "0.1.1" > VERSION; git add .; git commit -q -m "patch"
+    git checkout -q main
+    git remote add origin "$SAFE"
+    git fetch origin origin-main:refs/remotes/origin/main -q
+
+    run env -i HOME="$HOME" PATH="$PATH" LOOP_ROOT="$SAFE" bash "$UPDATE_SH"
+    [ "$status" -eq 0 ]
+    [ "$(cat "$SAFE/VERSION")" = "0.1.1" ]
+    rm -rf "$SAFE"
+}
+
+@test "core: already up to date exits cleanly" {
+    cd "$FAKE_CORE" && git merge --ff-only origin/main -q
+    run_update
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"already up to date"* ]]
+}
+
+# ── per-component (monitor) tests ─────────────────────────────────────────────
+
+@test "monitor: BREAKING: in monitor also halts without --yes" {
+    _make_monitor breaking
+    # Advance core to be up-to-date so only monitor triggers
+    cd "$FAKE_CORE" && git merge --ff-only origin/main -q
+    FAKE_MON="$BATS_TMPDIR/fake-monitor"
+    run env -i HOME="$HOME" PATH="$PATH" \
+        LOOP_ROOT="$FAKE_CORE" LOOP_MONITOR_ROOT="$FAKE_MON" \
+        bash "$UPDATE_SH"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"⚠ This update contains breaking changes:"* ]]
+    [[ "$output" == *"BREAKING:"* ]]
+}
+
+@test "monitor: output labels monitor section separately" {
+    _make_monitor breaking
+    cd "$FAKE_CORE" && git merge --ff-only origin/main -q
+    FAKE_MON="$BATS_TMPDIR/fake-monitor"
+    run env -i HOME="$HOME" PATH="$PATH" \
+        LOOP_ROOT="$FAKE_CORE" LOOP_MONITOR_ROOT="$FAKE_MON" \
+        bash "$UPDATE_SH"
+    [[ "$output" == *"[loop-monitor]"* ]]
+    [[ "$output" == *"BREAKING: LOOP_MONITOR_URL renamed to LOOP_BOUNTY_URL"* ]]
+}
+
+@test "monitor: --yes applies both core and monitor" {
+    _make_monitor breaking
+    FAKE_MON="$BATS_TMPDIR/fake-monitor"
+    run env -i HOME="$HOME" PATH="$PATH" \
+        LOOP_ROOT="$FAKE_CORE" LOOP_MONITOR_ROOT="$FAKE_MON" \
+        bash "$UPDATE_SH" --yes
+    [ "$status" -eq 0 ]
+    [ "$(cat "$FAKE_CORE/VERSION")" = "0.2.0" ]
+    [ "$(cat "$FAKE_MON/VERSION")" = "0.2.0" ]
+}
+
+@test "monitor: both components BREAKING: — combined output shown" {
+    _make_monitor breaking
+    FAKE_MON="$BATS_TMPDIR/fake-monitor"
+    run env -i HOME="$HOME" PATH="$PATH" \
+        LOOP_ROOT="$FAKE_CORE" LOOP_MONITOR_ROOT="$FAKE_MON" \
+        bash "$UPDATE_SH"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"[loop core]"* ]]
+    [[ "$output" == *"[loop-monitor]"* ]]
+}
+
+@test "monitor: clean monitor with BREAKING: core — only core warned" {
+    _make_monitor clean
+    FAKE_MON="$BATS_TMPDIR/fake-monitor"
+    run env -i HOME="$HOME" PATH="$PATH" \
+        LOOP_ROOT="$FAKE_CORE" LOOP_MONITOR_ROOT="$FAKE_MON" \
+        bash "$UPDATE_SH"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"[loop core]"* ]]
+    [[ "$output" != *"[loop-monitor]"* ]]
+}
+
+@test "monitor: LOOP_MONITOR_ROOT not set — monitor skipped silently" {
+    run_update
+    [ "$status" -eq 1 ]
+    [[ "$output" != *"loop-monitor"* ]]
+}
+
+@test "monitor: LOOP_MONITOR_ROOT set to non-git dir — monitor skipped silently" {
+    run env -i HOME="$HOME" PATH="$PATH" \
+        LOOP_ROOT="$FAKE_CORE" LOOP_MONITOR_ROOT="$BATS_TMPDIR/nonexistent" \
+        bash "$UPDATE_SH"
+    [ "$status" -eq 1 ]
+    [[ "$output" != *"loop-monitor"* ]]
+}


### PR DESCRIPTION
Closes #18

## Changes

### Fix vs PR #58: test isolation

PR #58's tests failed 100% because `update.sh` always `cd`s to `LOOP_ROOT` (the real repo, always up-to-date), so tests never saw any BREAKING changes.

**Fix 1 — `scripts/update.sh`:** use `LOOP_ROOT="${LOOP_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"` so an env override redirects the script to any repo root. Production behavior is unchanged (env var not set = auto-detect as before).

**Fix 2 — `tests/update.bats`:** pass `LOOP_ROOT="$FAKE_CORE"` in the `run_update` helper and all per-monitor test invocations, so the script operates on the synthetic fake repo instead of the real one.

Both `git branch -M main` lines from PR #58 are retained for pre-2.28 git compatibility.

### Content (same as PR #50/58)

- **`scripts/update.sh`** — fetches `origin/main` for loop core; if `LOOP_MONITOR_ROOT` is set and points to a git repo, also fetches loop-monitor. Parses both CHANGELOG diffs with an inlined Python snippet for `BREAKING:` lines grouped under version headers. Combines warnings under `[loop core]`/`[loop-monitor]` labels. Exits 1 unless `--yes` is passed. `--check`/`--dry-run` show diffs without applying.

- **`tests/update.bats`** — 13 bats tests with fully isolated fake git repos. No network required.

- **`CONTRIBUTING.md`** — documents the `BREAKING:` format, single-line requirement, and the fact that `scripts/update.sh` checks both repos.

## Note on pre-existing CI failures

`tests/github.bats` has pre-existing failures (`asdlc_*` function references, exit 127) unrelated to this change. Do not block merge on those.

## Test Plan

- [ ] `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — clean
- [ ] `shellcheck -S warning lib/*.sh scripts/*.sh scanner/*.sh install.sh` — clean
- [ ] `bats tests/update.bats` — all 13 tests pass
- [ ] Manual: `./scripts/update.sh` against a repo with `BREAKING:` in CHANGELOG — halts with warning
- [ ] Manual: `LOOP_MONITOR_ROOT=<path> ./scripts/update.sh` where monitor has `BREAKING:` — `[loop-monitor]` section appears
- [ ] Manual: `./scripts/update.sh --yes` — applies both components
- [ ] Manual: `./scripts/update.sh --check` — shows diff, no apply