### PR TITLE
[LOOP-25] Fix GitLab backend bugs and harden backend abstraction

### DIFF
--- a/config/workflows/README.md
+++ b/config/workflows/README.md
@@ -62,6 +62,25 @@ pr_stages:
 - At least one stage (anywhere in `issue_stages` or `pr_stages`)
 - Each stage: `id`, `trigger_label`, `handler`
 
+### Reserved stage IDs
+
+The built-in handlers call `loop_stage_trigger` with specific stage `id`
+values to resolve label names at runtime. If a custom workflow uses a
+different `id` (or omits a stage), the handler falls back to a hardcoded
+default label, which may not match the labels in your project.
+
+| Stage ID | Looked up by | Fallback if absent |
+|---|---|---|
+| `po` | po-handler (trigger strip) | `po-review` |
+| `dev` | dev-handler (trigger strip) | `plan` |
+| `review` | dev-handler, dev-rework-handler | `review-pending` |
+| `rework` | scanner (qa-fail context detection) | `changes-requested` |
+| `qa` | review-handler | `ready-for-qa` |
+
+Custom workflows that rename a stage must either keep one of these IDs or
+override the matching label via the `labels:` map in `config/projects.yaml`
+so the fallback value still matches the label applied in the repo.
+
 ### Validation
 
 ```bash

--- a/lib/backends/backend.sh
+++ b/lib/backends/backend.sh
@@ -100,3 +100,44 @@ loop_load_backend
 
 # (declare this alongside the other backend_* interface functions)
 backend_issue_unmet_deps() { echo "backend_issue_unmet_deps not implemented" >&2; return 1; }
+
+# backend_cli_note — emit a glab/gh CLI reference block for agent prompts.
+# Prints a non-empty note only when BACKEND is gitlab or jira-gitlab so agents
+# know to use glab instead of gh. Prints nothing for the github backend.
+backend_cli_note() {
+    case "${BACKEND:-github}" in
+        gitlab|jira-gitlab) cat <<'CLINOTE'
+
+BACKEND NOTICE: This project uses GitLab. Use glab commands instead of gh:
+  gh issue view N --repo R --json body --jq .body
+    → glab issue view N --repo R --output json | python3 -c "import json,sys; print(json.load(sys.stdin).get('description',''))"
+  gh issue list --repo R --state all --limit 50
+    → glab issue list --repo R --state all --limit 50
+  gh issue edit N --repo R --add-label L --remove-label M
+    → glab issue update N --repo R --add-label L --remove-label M
+  gh issue comment N --repo R --body 'text'
+    → glab issue comment N --repo R --body 'text'
+  gh issue close N --repo R
+    → glab issue close N --repo R
+  gh issue create --repo R --title T --body B --label L
+    → glab issue create --repo R --title T --description B --label L
+  gh pr create --repo R --title T --body B --label L
+    → glab mr create --repo R --title T --description B --label L
+  gh pr view N --repo R --json state,merged
+    → glab mr view N --repo R --output json
+  gh pr diff N --repo R
+    → glab mr diff N --repo R
+  gh pr checks N --repo R
+    → glab pipeline list --source-branch BRANCH --repo R
+  gh pr review N --repo R --approve --body 'text'
+    → glab mr approve N --repo R  (post the body as a separate comment)
+  gh pr review N --repo R --request-changes --body 'text'
+    → glab mr revoke N --repo R  (post the body as a separate comment)
+  gh pr edit N --repo R --add-label L --remove-label M
+    → glab mr update N --repo R --add-label L --remove-label M
+  gh pr comment N --repo R --body 'text'
+    → glab mr comment N --repo R --body 'text'
+CLINOTE
+        ;;
+    esac
+}

--- a/lib/backends/gitlab.sh
+++ b/lib/backends/gitlab.sh
@@ -45,7 +45,7 @@ _gl_parse_repo() {
 
 # Priority-sort jq fragment for issues.
 # Input: JSON array from glab issue list --output json
-# Output: JSONL with Loop schema {number, title, url, labels}
+# Output: JSONL with Loop schema {number, title, url, labels, author}
 _GL_ISSUE_SORT='
   map(
     (.labels // []) as $L |
@@ -54,6 +54,7 @@ _GL_ISSUE_SORT='
       title,
       url: .web_url,
       labels: $L,
+      author: (.author.username // ""),
       _p: (
         if   ($L | index("p0-critical")) then 0
         elif ($L | index("p1-high"))     then 1
@@ -99,7 +100,7 @@ _GL_MR_SORT='
 backend_list_issues_with_label() {
     local repo="$1" label="$2"
     _gl_parse_repo "$repo"
-    glab issue list --repo "$_GL_REPO" --label "$label" --state opened \
+    glab issue list --repo "$_GL_REPO" --label "$label" \
         --output json 2>/dev/null \
     | jq -c "$_GL_ISSUE_SORT" 2>/dev/null || true
 }

--- a/lib/runner.sh
+++ b/lib/runner.sh
@@ -30,11 +30,11 @@ loop_run_agent() {
 
     case "$LOOP_AGENT" in
         claude)
-            claude -p \
+            (cd "$cwd" && claude -p \
                 --model "${LOOP_AGENT_MODEL:-sonnet}" \
                 --output-format text \
                 --dangerously-skip-permissions \
-                "$prompt"
+                "$prompt")
             ;;
         codex)
             codex \

--- a/scripts/dev-handler.sh
+++ b/scripts/dev-handler.sh
@@ -102,6 +102,7 @@ log "worktree ready: $WORKTREE_ROOT (isolated from other handlers)"
 # belt-and-braces apply the right names per the project's active workflow
 # (e.g. needs-review on default, review-pending on current).
 REVIEW_LABEL=$(loop_stage_trigger "$SLUG" review pr 2>/dev/null || echo review-pending)
+_BACKEND_CLI_NOTE=$(backend_cli_note)
 
 if [ -n "$DEV_VALIDATION_CMD" ]; then
     _VALIDATION_STEP="4. Run validation: ${DEV_VALIDATION_CMD//\{project_root\}/$ROOT}"
@@ -156,6 +157,7 @@ IMPORTANT: The issue MUST end this run with label '${REVIEW_LABEL}' (or 'needs-c
    gh issue view ${ISSUE_NUM} --repo ${REPO} --json labels
 
 If blocked by missing context or an architectural decision, comment on the issue and add label 'needs-clarification' instead of opening a PR.
+${_BACKEND_CLI_NOTE}
 EOF
 TASK_PROMPT=$(cat "$_PROMPT_FILE")
 rm -f "$_PROMPT_FILE"
@@ -200,11 +202,8 @@ else
     if [ "$n" -ge "$MAX_RETRIES" ]; then
         backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
         backend_add_label "$REPO" "$ISSUE_NUM" blocked
-        # Post only a short marker — never the agent log/prompt, which contains
-        # internal pipeline instructions that must not become public.
-        gh issue comment "$ISSUE_NUM" --repo "$REPO" \
-            --body "Automated dev cycle failed ${MAX_RETRIES} times. Marking blocked for human review. Operator: see ${LOG_FILE} for the agent transcript." \
-            2>/dev/null || true
+        backend_comment_issue "$REPO" "$ISSUE_NUM" \
+            "Automated dev cycle failed ${MAX_RETRIES} times. Marking blocked for human review. Operator: see ${LOG_FILE} for the agent transcript."
         loop_notify "❌ [$SLUG] #$ISSUE_NUM dev failed: agent failed after $MAX_RETRIES attempts"
     else
         backend_remove_label "$REPO" "$ISSUE_NUM" in-progress

--- a/scripts/dev-rework-handler.sh
+++ b/scripts/dev-rework-handler.sh
@@ -193,6 +193,8 @@ else
     _VALIDATION_STEP=""
 fi
 
+_BACKEND_CLI_NOTE=$(backend_cli_note)
+
 _PROMPT_FILE=$(mktemp /tmp/rework-prompt-XXXXXX.txt)
 cat > "$_PROMPT_FILE" <<EOF
 You are the Senior Developer for ${NAME} (slug: ${SLUG}), reworking a PR after ${_REWORK_TRIGGER}.
@@ -230,6 +232,7 @@ IMPORTANT: The PR MUST end this run with label '${REVIEW_LABEL}' (or 'needs-clar
    gh pr view ${PR_NUM} --repo ${REPO} --json labels
 
 If the feedback is unclear or requires architectural input, add label 'needs-clarification' and comment on the PR instead of guessing.
+${_BACKEND_CLI_NOTE}
 EOF
 TASK_PROMPT=$(cat "$_PROMPT_FILE")
 rm -f "$_PROMPT_FILE"
@@ -262,11 +265,8 @@ else
     if [ "$n" -ge "$MAX_RETRIES" ]; then
         backend_remove_label "$REPO" "$PR_NUM" in-rework
         backend_add_label "$REPO" "$PR_NUM" blocked
-        # Post only a short marker to the PR — never the agent log/prompt, which
-        # contains internal pipeline instructions that should not be public.
-        gh pr comment "$PR_NUM" --repo "$REPO" \
-            --body "Automated rework failed ${MAX_RETRIES} times. Marking blocked for human review. Operator: see ${LOG_FILE} for the agent transcript." \
-            2>/dev/null || true
+        backend_comment_pr "$REPO" "$PR_NUM" \
+            "Automated rework failed ${MAX_RETRIES} times. Marking blocked for human review. Operator: see ${LOG_FILE} for the agent transcript."
         loop_notify "❌ [$SLUG] PR#$PR_NUM dev-rework failed: agent failed after $MAX_RETRIES attempts"
     else
         backend_remove_label "$REPO" "$PR_NUM" in-rework

--- a/scripts/po-handler.sh
+++ b/scripts/po-handler.sh
@@ -105,6 +105,8 @@ except Exception:
     pass
 " || echo "")
 
+_BACKEND_CLI_NOTE=$(backend_cli_note)
+
 _PROMPT_FILE=$(mktemp /tmp/po-prompt-XXXXXX.txt)
 cat > "$_PROMPT_FILE" <<EOF
 You are the Product Owner agent for ${NAME} (slug: ${SLUG}).
@@ -191,6 +193,7 @@ What this ticket explicitly does not cover. Prevents scope creep.
 IMPORTANT: The issue MUST end this run with exactly ONE of: dev / needs-clarification / blocked / tracker / closed.
 Verify: gh issue view ${ISSUE_NUM} --repo ${REPO} --json labels,state
 Report your decision (A/B/C/D/E/F) and why in 2 sentences.
+${_BACKEND_CLI_NOTE}
 EOF
 TASK_PROMPT=$(cat "$_PROMPT_FILE")
 rm -f "$_PROMPT_FILE"
@@ -201,9 +204,9 @@ _post_failure_comment() {
     # internal pipeline instructions that must not become public.
     local body="Automated ${label_ctx} failed ${max} times. Needs human clarification. Operator: see ${LOG_FILE} for the agent transcript."
     if [ "$target_type" = "issue" ]; then
-        gh issue comment "$target_num" --repo "$REPO" --body "$body" 2>/dev/null || true
+        backend_comment_issue "$REPO" "$target_num" "$body"
     else
-        gh pr comment "$target_num" --repo "$REPO" --body "$body" 2>/dev/null || true
+        backend_comment_pr "$REPO" "$target_num" "$body"
     fi
 }
 

--- a/scripts/review-handler.sh
+++ b/scripts/review-handler.sh
@@ -88,6 +88,7 @@ backend_add_label "$REPO" "$PR_NUM" in-review
 # belt-and-braces apply the right names per active workflow.
 QA_LABEL=$(loop_stage_trigger "$SLUG" qa pr 2>/dev/null || echo ready-for-qa)
 REWORK_LABEL=$(loop_stage_trigger "$SLUG" rework pr 2>/dev/null || echo changes-requested)
+_BACKEND_CLI_NOTE=$(backend_cli_note)
 
 _PROMPT_FILE=$(mktemp /tmp/review-prompt-XXXXXX.txt)
 cat > "$_PROMPT_FILE" <<EOF
@@ -134,6 +135,7 @@ IMPORTANT: You MUST finish by applying either '${QA_LABEL}' or '${REWORK_LABEL}'
    gh pr view ${PR_NUM} --repo ${REPO} --json labels
 
 Report the decision you made and why, in 3 short sentences.
+${_BACKEND_CLI_NOTE}
 EOF
 TASK_PROMPT=$(cat "$_PROMPT_FILE")
 rm -f "$_PROMPT_FILE"
@@ -159,11 +161,8 @@ else
         backend_remove_label "$REPO" "$PR_NUM" in-review
         backend_remove_label "$REPO" "$PR_NUM" changes-requested
         backend_add_label "$REPO" "$PR_NUM" needs-rework
-        # Post only a short marker — never the agent log/prompt, which contains
-        # internal pipeline instructions that must not become public.
-        gh pr comment "$PR_NUM" --repo "$REPO" \
-            --body "Automated review failed ${MAX_RETRIES} times. Needs human eyes. Operator: see ${LOG_FILE} for the agent transcript." \
-            2>/dev/null || true
+        backend_comment_pr "$REPO" "$PR_NUM" \
+            "Automated review failed ${MAX_RETRIES} times. Needs human eyes. Operator: see ${LOG_FILE} for the agent transcript."
         loop_notify "❌ [$SLUG] PR#$PR_NUM review failed: agent failed after $MAX_RETRIES attempts"
     else
         backend_remove_label "$REPO" "$PR_NUM" in-review


### PR DESCRIPTION
Closes #25

## Changes

**Bug 1 — GitLab: invalid \`--state opened\` flag**
Removed \`--state opened\` from \`glab issue list\` in \`backend_list_issues_with_label\` (\`lib/backends/gitlab.sh\`). The flag does not exist in glab; open issues are returned by default, so the call was returning nothing.

**Bug 2 — GitLab: \`author\` field missing from \`_GL_ISSUE_SORT\`**
Added \`author: (.author.username // "")\` to the \`_GL_ISSUE_SORT\` jq fragment. Without it the scanner's \`ALLOWED_AUTHORS\` check received an empty string for every GitLab issue and silently skipped all of them.

**Bug 3 — Reserved stage IDs undocumented**
Added a **Reserved stage IDs** table to \`config/workflows/README.md\` listing which \`id\` values the built-in handlers resolve via \`loop_stage_trigger\`, which handler uses each, and the hardcoded fallback label when the ID is absent.

**Bug 4 — Agent prompts hardcode \`gh\` CLI**
Added \`backend_cli_note()\` to \`lib/backends/backend.sh\`. When \`\$BACKEND\` is \`gitlab\` or \`jira-gitlab\` it emits a glab/gh equivalence reference table covering all common issue and MR commands. Injected \`\${_BACKEND_CLI_NOTE}\` at the end of the agent prompts in \`po-handler\`, \`dev-handler\`, \`review-handler\`, and \`dev-rework-handler\`.

**Bug 5 — Failure comments bypass backend abstraction**
Replaced hardcoded \`gh issue comment\` / \`gh pr comment\` calls in the max-retry failure paths of all four handlers with \`backend_comment_issue\` / \`backend_comment_pr\`, which dispatch correctly to \`glab\` on GitLab projects.

**Bug 6 — \`loop_run_agent\` ignores \`\$cwd\` for Claude**
Wrapped the \`claude\` case in \`lib/runner.sh\` with \`(cd "\$cwd" && ...)\` so the Claude process starts from the correct working directory (typically the isolated worktree root) rather than the handler's launch directory.

## Test Plan

- [ ] On GitLab project: \`backend_list_issues_with_label\` returns open issues (no \`--state opened\` error)
- [ ] On GitLab: scanner \`ALLOWED_AUTHORS\` filter correctly allows/skips issues by \`.author.username\`
- [ ] \`config/workflows/README.md\` reserved stage ID table matches actual IDs used in \`default.yaml\`
- [ ] On GitLab project: agent prompt includes the glab CLI equivalence block
- [ ] On GitHub project: agent prompt contains no glab block (no regression)
- [ ] On GitLab: max-retry failure comments are posted via \`glab issue/mr comment\`
- [ ] dev-handler: claude agent runs with \`pwd\` = \`\$WORKTREE_ROOT\`