### PR TITLE
Draft: [LOOP-68] bounty: add loop_id field to every event payload

### DIFF
--- a/lib/bounty.sh
+++ b/lib/bounty.sh
@@ -24,6 +24,24 @@ _bounty_core_version() {
     printf 'unknown'
 }
 
+# Resolve a stable per-instance identifier.
+# Overridable via LOOP_ID env var; otherwise derived from hostname + first 8 hex
+# chars of the sha256 hash of $LOOP_ROOT (md5 fallback on macOS without coreutils).
+_bounty_loop_id() {
+    if [ -n "${LOOP_ID:-}" ]; then
+        printf '%s' "$LOOP_ID"
+        return
+    fi
+    local host root_hash
+    host="$(hostname 2>/dev/null || printf 'localhost')"
+    if command -v sha256sum >/dev/null 2>&1; then
+        root_hash="$(printf '%s' "${LOOP_ROOT:-/}" | sha256sum | cut -c1-8)"
+    else
+        root_hash="$(printf '%s' "${LOOP_ROOT:-/}" | md5 -q 2>/dev/null | cut -c1-8)"
+    fi
+    printf '%s-%s' "$host" "${root_hash:-00000000}"
+}
+
 # bounty_report <event> [key=value ...]
 # Keys: agent model role project issue_num pr_num detail
 # Example: bounty_report "dev_start" role=dev model=sonnet project=myapp issue_num=42
@@ -52,7 +70,7 @@ bounty_report() {
 
     local payload
     payload=$(
-        _API="$api_ver" _CV="$(_bounty_core_version)" \
+        _API="$api_ver" _CV="$(_bounty_core_version)" _LI="$(_bounty_loop_id)" \
         _BE="$event" _BA="$agent" _BM="$model" _BR="$role" \
         _BP="$project" _BD="$detail" _BI="$issue_num" _BPN="$pr_num" \
         python3 - <<'PY'
@@ -60,6 +78,7 @@ import json, os, datetime
 d = {
     "api":          os.environ.get("_API") or "1.0",
     "core_version": os.environ.get("_CV") or "unknown",
+    "loop_id":      os.environ.get("_LI") or "unknown",
     "event":        os.environ.get("_BE", "unknown"),
     "agent":        os.environ.get("_BA") or None,
     "model":        os.environ.get("_BM") or None,

--- a/loop.env.example
+++ b/loop.env.example
@@ -54,3 +54,10 @@ LOOP_DISPATCH_MODE="direct"
 # PATH additions for cron/launchd (gh, python3, agent CLI must be reachable).
 # macOS (Homebrew): /opt/homebrew/bin:/usr/local/bin — Linux: /usr/local/bin or similar.
 LOOP_EXTRA_PATH="/opt/homebrew/bin:/usr/local/bin"
+
+# ─── Bounty / loop-monitor ────────────────────────────────────────────────────
+# Stable identifier for this Loop instance sent with every bounty/event payload.
+# Lets loop-monitor distinguish multiple Loop instances reporting to the same endpoint.
+# Defaults to: <hostname>-<first8ofsha256(LOOP_ROOT)>. Set explicitly to pin the id
+# across host renames or when running multiple instances on the same host.
+# LOOP_ID="my-instance-id"

--- a/tests/bounty.bats
+++ b/tests/bounty.bats
@@ -198,3 +198,62 @@ if not cv:
 PY
     [ "$status" -eq 0 ]
 }
+
+# ---------------------------------------------------------------------------
+# loop_id — stable per-instance identifier
+# ---------------------------------------------------------------------------
+
+@test "bounty_report: default loop_id is stable across two calls with same env" {
+    BOUNTY_API_VERSION="1.0"
+    unset LOOP_ID
+    export LOOP_ROOT="$BATS_TMPDIR"
+
+    bounty_report "dev_done" project=myapp issue_num=1
+    [ -f "$PAYLOAD_FILE" ]
+    local id1
+    id1="$(python3 -c "import json,sys; d=json.load(sys.stdin); print(d['loop_id'])" < "$PAYLOAD_FILE")"
+
+    rm -f "$PAYLOAD_FILE"
+    bounty_report "dev_done" project=myapp issue_num=1
+    [ -f "$PAYLOAD_FILE" ]
+    local id2
+    id2="$(python3 -c "import json,sys; d=json.load(sys.stdin); print(d['loop_id'])" < "$PAYLOAD_FILE")"
+
+    [ "$id1" = "$id2" ]
+    [ -n "$id1" ]
+}
+
+@test "bounty_report: LOOP_ID env override appears in payload" {
+    BOUNTY_API_VERSION="1.0"
+    export LOOP_ID="test-instance-abc"
+
+    bounty_report "merge_done" project=myapp pr_num=5
+
+    [ -f "$PAYLOAD_FILE" ]
+    run python3 -c "import json,sys; d=json.load(sys.stdin); print(d['loop_id'])" < "$PAYLOAD_FILE"
+    [ "$status" -eq 0 ]
+    [ "$output" = "test-instance-abc" ]
+}
+
+@test "bounty_report: core_version and loop_id present for po_start, dev_done, rework_failed" {
+    BOUNTY_API_VERSION="1.0"
+    export LOOP_VERSION="2.0.0"
+    export LOOP_ID="ci-instance"
+
+    for event in po_start dev_done rework_failed; do
+        rm -f "$PAYLOAD_FILE"
+        bounty_report "$event" project=myapp issue_num=10
+
+        [ -f "$PAYLOAD_FILE" ]
+        run python3 - "$PAYLOAD_FILE" "$event" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    d = json.load(f)
+ev = sys.argv[2]
+assert d.get("core_version"), f"core_version missing for {ev}"
+assert d.get("loop_id"), f"loop_id missing for {ev}"
+assert d["event"] == ev, f"event mismatch: {d['event']} != {ev}"
+PY
+        [ "$status" -eq 0 ]
+    done
+}


### PR DESCRIPTION
Closes #68

## Changes

- **`lib/bounty.sh`**: Added `_bounty_loop_id()` helper that computes a stable per-instance identifier from `hostname` + first 8 hex chars of `sha256sum`/`md5` hash of `$LOOP_ROOT`. The value is overridable via the `LOOP_ID` env var. The `loop_id` field is now injected into every `bounty_report` payload via the Python heredoc alongside the existing `core_version`.

- **`loop.env.example`**: Added `LOOP_ID` documentation block in a new `─── Bounty / loop-monitor ───` section explaining its purpose (distinguishing multiple Loop instances on the same monitor endpoint) and the default derivation formula.

- **`tests/bounty.bats`**: Three new tests added:
  1. `default loop_id is stable across two calls with same env` — verifies determinism
  2. `LOOP_ID env override appears in payload` — verifies override is respected
  3. `core_version and loop_id present for po_start, dev_done, rework_failed` — verifies fields appear across ≥3 distinct event types

All 17 tests pass. `bash -n` and `shellcheck -S warning` clean on all modified files.

## Test Plan
- Run `bats tests/bounty.bats` — all 17 tests should pass
- Verify `loop_id` appears in a live bounty payload: `bounty_report "dev_done" project=test | ...`
- Confirm `LOOP_ID=custom-id bounty_report "merge_done"` emits `"loop_id":"custom-id"` in the payload
- Check `loop.env.example` contains the `LOOP_ID` comment in the new section