### PR TITLE
Draft: [LOOP-66] Update README: fix legacy label names and add missing doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ launchd plist (macOS) or cron entry (Linux) for the scanner and reconciler.
 Then label any issue `plan` (or `dev`, depending on your workflow) and
 the scanner picks it up within 5 minutes.
 
+See [`docs/quick-start.md`](docs/quick-start.md) for a step-by-step
+walkthrough including agent configuration and first-project setup.
+
 ## How a feature flows through Loop
 
 1. **You** open an issue, write what you want, label it `plan`.
@@ -85,7 +88,7 @@ Loop ships three starter workflows in `config/workflows/`:
 | `minimal.yaml` | Solo prototypes. Two stages: `plan → merge`. No review, no QA. |
 | `docs-only.yaml` | Documentation and content PRs. Three stages: `plan → review → merge`. No QA gate. |
 
-`current.yaml` is an operator-local workflow (gitignored). If you're migrating from a repo that already uses legacy labels (`dev` / `needs-review` / `qa-pass`), create it locally — the schema is documented in `config/workflows/README.md`.
+`current.yaml` is an operator-local workflow (gitignored). If you're migrating from a repo that already uses legacy labels (`dev` / `review-pending` / `ready-for-qa`), create it locally — see [`docs/migration-from-asdlc.md`](docs/migration-from-asdlc.md) for a full label mapping and setup instructions.
 
 Per-project workflow + label overrides in `config/projects.yaml`:
 

--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ Author your own — see [`config/workflows/README.md`](config/workflows/README.m
 
 ## Configuration
 
-- `loop.env` — operator-specific env (log dir, agent choice, monitor URL,
-  notification command). Copy from `loop.env.example`. **Not committed.**
+- `loop.env` — operator-specific env (log dir, agent choice, dispatch mode,
+  notifications, PATH extras). Copy from `loop.env.example`. **Not committed.**
 - `config/projects.yaml` — your project registry. **Not committed.**
 - `config/projects.example.yaml` — annotated schema reference.
 - `config/workflows/*.yaml` — pipeline workflow definitions. Committed.


### PR DESCRIPTION
Closes #66

## Changes

**1. Fix incorrect legacy label example** (Workflows section)
The `current.yaml` migration note listed `needs-review` as a legacy label, but `needs-review` is the *default* workflow's label. The actual `current`/legacy workflow uses `review-pending` (review stage) and `ready-for-qa` (QA stage). Corrected to match `docs/migration-from-asdlc.md`. Also replaced the generic config/workflows/README.md pointer with a direct link to the migration guide.

**2. Add link to `docs/quick-start.md`** (Install section)
The file existed but was not linked from the README. Added a one-line pointer after the install steps.

**3. Fix stale `loop.env` description** (Configuration section)
The description said `loop.env` contains "monitor URL" — there is no such variable in `loop.env.example`. Replaced with accurate contents: log dir, agent choice, dispatch mode, notifications, PATH extras.

Both `docs/quick-start.md` and `docs/migration-from-asdlc.md` are now reachable from README. All other links verified against the directory tree — no dead links found. Version (`v0.1.0`) matches VERSION file and CHANGELOG. No personal identifiers added.

## Test Plan

- [ ] Confirm `docs/quick-start.md` and `docs/migration-from-asdlc.md` exist and README links resolve
- [ ] Confirm legacy label names (`review-pending`, `ready-for-qa`) match the `current` workflow in `docs/migration-from-asdlc.md`
- [ ] Confirm loop.env description matches actual `loop.env.example` contents
- [ ] CI passes: `bash -n` syntax check, shellcheck, personal-identifiers grep (README-only change)