### PR TITLE
Draft: [LOOP-25] Fix remaining GitLab bugs: backend_cli_note, failure comments, runner cwd, stage ID docs

### DIFF
--- a/config/workflows/README.md
+++ b/config/workflows/README.md
@@ -62,6 +62,25 @@ pr_stages:
 - At least one stage (anywhere in `issue_stages` or `pr_stages`)
 - Each stage: `id`, `trigger_label`, `handler`
 
+### Reserved stage IDs
+
+The built-in handlers call `loop_stage_trigger` with fixed stage `id`
+values to resolve label names at runtime. If a custom workflow omits a
+stage or uses a different `id`, the handler falls back to a hardcoded
+default label, which may not match your project's label vocabulary.
+
+| Stage ID | Looked up by | Fallback label if absent |
+|---|---|---|
+| `po` | po-handler (trigger strip) | `po-review` |
+| `dev` | dev-handler (trigger strip) | `plan` |
+| `review` | dev-handler, dev-rework-handler | `review-pending` |
+| `rework` | scanner (qa-fail context detection) | `changes-requested` |
+| `qa` | review-handler | `ready-for-qa` |
+
+Custom workflows that rename a stage must either keep one of these IDs or
+add a matching entry to the `labels:` map in `config/projects.yaml` so
+the fallback resolves correctly.
+
 ### Validation
 
 ```bash

--- a/lib/backends/backend.sh
+++ b/lib/backends/backend.sh
@@ -100,3 +100,44 @@ loop_load_backend
 
 # (declare this alongside the other backend_* interface functions)
 backend_issue_unmet_deps() { echo "backend_issue_unmet_deps not implemented" >&2; return 1; }
+
+# backend_cli_note — emit a CLI reference block for agent prompts.
+# On gitlab/jira-gitlab backends, prints a glab/gh equivalence table so
+# the agent knows to use glab instead of gh. Prints nothing on github.
+backend_cli_note() {
+    case "${BACKEND:-github}" in
+        gitlab|jira-gitlab) cat <<'CLINOTE'
+
+BACKEND NOTICE: This project uses GitLab. Use glab commands instead of gh:
+  gh issue view N --repo R --json body --jq .body
+    → glab issue view N --repo R --output json | python3 -c "import json,sys; print(json.load(sys.stdin).get('description',''))"
+  gh issue list --repo R --state all --limit 50
+    → glab issue list --repo R --state all --limit 50
+  gh issue edit N --repo R --add-label L --remove-label M
+    → glab issue update N --repo R --add-label L --remove-label M
+  gh issue comment N --repo R --body 'text'
+    → glab issue comment N --repo R --body 'text'
+  gh issue close N --repo R
+    → glab issue close N --repo R
+  gh issue create --repo R --title T --body B --label L
+    → glab issue create --repo R --title T --description B --label L
+  gh pr create --repo R --title T --body B --label L
+    → glab mr create --repo R --title T --description B --label L
+  gh pr view N --repo R --json state,merged
+    → glab mr view N --repo R --output json
+  gh pr diff N --repo R
+    → glab mr diff N --repo R
+  gh pr checks N --repo R
+    → glab pipeline list --source-branch BRANCH --repo R
+  gh pr review N --repo R --approve --body 'text'
+    → glab mr approve N --repo R  (post review body as a separate comment)
+  gh pr review N --repo R --request-changes --body 'text'
+    → glab mr revoke N --repo R  (post review body as a separate comment)
+  gh pr edit N --repo R --add-label L --remove-label M
+    → glab mr update N --repo R --add-label L --remove-label M
+  gh pr comment N --repo R --body 'text'
+    → glab mr comment N --repo R --body 'text'
+CLINOTE
+        ;;
+    esac
+}

--- a/lib/runner.sh
+++ b/lib/runner.sh
@@ -30,11 +30,11 @@ loop_run_agent() {
 
     case "$LOOP_AGENT" in
         claude)
-            claude -p \
+            (cd "$cwd" && claude -p \
                 --model "${LOOP_AGENT_MODEL:-sonnet}" \
                 --output-format text \
                 --dangerously-skip-permissions \
-                "$prompt"
+                "$prompt")
             ;;
         codex)
             codex \

--- a/scripts/dev-handler.sh
+++ b/scripts/dev-handler.sh
@@ -99,6 +99,7 @@ log "worktree ready: $WORKTREE_ROOT (isolated from other handlers)"
 # belt-and-braces apply the right names per the project's active workflow
 # (e.g. needs-review on default, review-pending on current).
 REVIEW_LABEL=$(loop_stage_trigger "$SLUG" review pr 2>/dev/null || echo review-pending)
+_BACKEND_CLI_NOTE=$(backend_cli_note)
 
 TASK_PROMPT=$(cat <<EOF
 You are the Senior Developer for ${NAME} (slug: ${SLUG}).
@@ -146,6 +147,7 @@ IMPORTANT: The issue MUST end this run with label '${REVIEW_LABEL}' (or 'needs-c
    gh issue view ${ISSUE_NUM} --repo ${REPO} --json labels
 
 If blocked by missing context or an architectural decision, comment on the issue and add label 'needs-clarification' instead of opening a PR.
+${_BACKEND_CLI_NOTE}
 EOF
 )
 
@@ -212,7 +214,7 @@ else
             echo '```'
             echo "</details>"
         } > "$_fail_body_file"
-        gh issue comment "$ISSUE_NUM" --repo "$REPO" --body-file "$_fail_body_file" 2>/dev/null || true
+        backend_comment_issue "$REPO" "$ISSUE_NUM" "$(cat "$_fail_body_file")"
         rm -f "$_fail_body_file"
         loop_notify "❌ [$SLUG] #$ISSUE_NUM dev failed: agent failed after $MAX_RETRIES attempts"
     else

--- a/scripts/dev-rework-handler.sh
+++ b/scripts/dev-rework-handler.sh
@@ -193,6 +193,8 @@ else
     _VALIDATION_STEP=""
 fi
 
+_BACKEND_CLI_NOTE=$(backend_cli_note)
+
 _PROMPT_FILE=$(mktemp /tmp/rework-prompt-XXXXXX.txt)
 cat > "$_PROMPT_FILE" <<EOF
 You are the Senior Developer for ${NAME} (slug: ${SLUG}), reworking a PR after ${_REWORK_TRIGGER}.
@@ -230,6 +232,7 @@ IMPORTANT: The PR MUST end this run with label '${REVIEW_LABEL}' (or 'needs-clar
    gh pr view ${PR_NUM} --repo ${REPO} --json labels
 
 If the feedback is unclear or requires architectural input, add label 'needs-clarification' and comment on the PR instead of guessing.
+${_BACKEND_CLI_NOTE}
 EOF
 TASK_PROMPT=$(cat "$_PROMPT_FILE")
 rm -f "$_PROMPT_FILE"
@@ -262,11 +265,8 @@ else
     if [ "$n" -ge "$MAX_RETRIES" ]; then
         backend_remove_label "$REPO" "$PR_NUM" in-rework
         backend_add_label "$REPO" "$PR_NUM" blocked
-        # Post only a short marker to the PR — never the agent log/prompt, which
-        # contains internal pipeline instructions that should not be public.
-        gh pr comment "$PR_NUM" --repo "$REPO" \
-            --body "Automated rework failed ${MAX_RETRIES} times. Marking blocked for human review. Operator: see ${LOG_FILE} for the agent transcript." \
-            2>/dev/null || true
+        backend_comment_pr "$REPO" "$PR_NUM" \
+            "Automated rework failed ${MAX_RETRIES} times. Marking blocked for human review. Operator: see ${LOG_FILE} for the agent transcript."
         loop_notify "❌ [$SLUG] PR#$PR_NUM dev-rework failed: agent failed after $MAX_RETRIES attempts"
     else
         backend_remove_label "$REPO" "$PR_NUM" in-rework

--- a/scripts/po-handler.sh
+++ b/scripts/po-handler.sh
@@ -105,6 +105,8 @@ except Exception:
     pass
 " || echo "")
 
+_BACKEND_CLI_NOTE=$(backend_cli_note)
+
 _PROMPT_FILE=$(mktemp /tmp/po-prompt-XXXXXX.txt)
 cat > "$_PROMPT_FILE" <<EOF
 You are the Product Owner agent for ${NAME} (slug: ${SLUG}).
@@ -191,6 +193,7 @@ What this ticket explicitly does not cover. Prevents scope creep.
 IMPORTANT: The issue MUST end this run with exactly ONE of: dev / needs-clarification / blocked / tracker / closed.
 Verify: gh issue view ${ISSUE_NUM} --repo ${REPO} --json labels,state
 Report your decision (A/B/C/D/E/F) and why in 2 sentences.
+${_BACKEND_CLI_NOTE}
 EOF
 TASK_PROMPT=$(cat "$_PROMPT_FILE")
 rm -f "$_PROMPT_FILE"
@@ -201,9 +204,9 @@ _post_failure_comment() {
     # internal pipeline instructions that must not become public.
     local body="Automated ${label_ctx} failed ${max} times. Needs human clarification. Operator: see ${LOG_FILE} for the agent transcript."
     if [ "$target_type" = "issue" ]; then
-        gh issue comment "$target_num" --repo "$REPO" --body "$body" 2>/dev/null || true
+        backend_comment_issue "$REPO" "$target_num" "$body"
     else
-        gh pr comment "$target_num" --repo "$REPO" --body "$body" 2>/dev/null || true
+        backend_comment_pr "$REPO" "$target_num" "$body"
     fi
 }
 

--- a/scripts/review-handler.sh
+++ b/scripts/review-handler.sh
@@ -88,6 +88,7 @@ backend_add_label "$REPO" "$PR_NUM" in-review
 # belt-and-braces apply the right names per active workflow.
 QA_LABEL=$(loop_stage_trigger "$SLUG" qa pr 2>/dev/null || echo ready-for-qa)
 REWORK_LABEL=$(loop_stage_trigger "$SLUG" rework pr 2>/dev/null || echo changes-requested)
+_BACKEND_CLI_NOTE=$(backend_cli_note)
 
 _PROMPT_FILE=$(mktemp /tmp/review-prompt-XXXXXX.txt)
 cat > "$_PROMPT_FILE" <<EOF
@@ -134,6 +135,7 @@ IMPORTANT: You MUST finish by applying either '${QA_LABEL}' or '${REWORK_LABEL}'
    gh pr view ${PR_NUM} --repo ${REPO} --json labels
 
 Report the decision you made and why, in 3 short sentences.
+${_BACKEND_CLI_NOTE}
 EOF
 TASK_PROMPT=$(cat "$_PROMPT_FILE")
 rm -f "$_PROMPT_FILE"
@@ -159,11 +161,8 @@ else
         backend_remove_label "$REPO" "$PR_NUM" in-review
         backend_remove_label "$REPO" "$PR_NUM" changes-requested
         backend_add_label "$REPO" "$PR_NUM" needs-rework
-        # Post only a short marker — never the agent log/prompt, which contains
-        # internal pipeline instructions that must not become public.
-        gh pr comment "$PR_NUM" --repo "$REPO" \
-            --body "Automated review failed ${MAX_RETRIES} times. Needs human eyes. Operator: see ${LOG_FILE} for the agent transcript." \
-            2>/dev/null || true
+        backend_comment_pr "$REPO" "$PR_NUM" \
+            "Automated review failed ${MAX_RETRIES} times. Needs human eyes. Operator: see ${LOG_FILE} for the agent transcript."
         loop_notify "❌ [$SLUG] PR#$PR_NUM review failed: agent failed after $MAX_RETRIES attempts"
     else
         backend_remove_label "$REPO" "$PR_NUM" in-review


### PR DESCRIPTION
Closes #25

Note: bugs 1 and 2 from this issue were already fixed in main via PR #63 ([LOOP-28]).
This PR addresses the remaining four bugs.

## Changes

**Bug 3 — Reserved stage IDs undocumented**
Added a **Reserved stage IDs** table to \`config/workflows/README.md\` listing the stage \`id\` values that built-in handlers resolve via \`loop_stage_trigger\`, which handler uses each, and the fallback label applied when the ID is absent from a custom workflow.

**Bug 4 — Agent prompts hardcode \`gh\` CLI**
Added \`backend_cli_note()\` to \`lib/backends/backend.sh\`. When \`\$BACKEND\` is \`gitlab\` or \`jira-gitlab\`, it prints a glab/gh equivalence reference table covering all common issue and MR commands. Injected \`\${_BACKEND_CLI_NOTE}\` at the end of the agent prompts in \`dev-handler\`, \`po-handler\`, \`review-handler\`, and \`dev-rework-handler\` — emits nothing on the github backend.

**Bug 5 — Failure comments bypass backend abstraction**
Replaced hardcoded \`gh issue comment\` / \`gh pr comment\` calls in the max-retry failure paths of all four handlers with \`backend_comment_issue\` / \`backend_comment_pr\`, which dispatch correctly to \`glab\` on GitLab projects.

**Bug 6 — \`loop_run_agent\` ignores \`\$cwd\` for Claude**
Wrapped the \`claude\` invocation in \`lib/runner.sh\` with \`(cd "\$cwd" && ...)\` so the Claude process starts in the correct working directory (typically the isolated worktree root) rather than the handler's launch directory.

## Test Plan

- [ ] \`config/workflows/README.md\` reserved stage ID table matches the IDs actually used in \`default.yaml\`
- [ ] On GitHub project: agent prompts contain no glab block (no regression)
- [ ] On GitLab project: agent prompt includes the glab CLI equivalence block
- [ ] On GitLab: max-retry failure comments are posted via \`glab issue/mr comment\` (not \`gh\`)
- [ ] dev-handler: Claude agent \`pwd\` = \`\$WORKTREE_ROOT\` (not the handler's launch directory)