### PR TITLE
Draft: [LOOP-30] add lib/cli-hint.sh and inject glab hint into handler prompts

### DIFF
--- a/lib/cli-hint.sh
+++ b/lib/cli-hint.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# lib/cli-hint.sh — backend-aware CLI hint for agent prompts.
+# Sourced by handler scripts; call $(loop_cli_hint) inside a prompt heredoc.
+
+set -euo pipefail
+
+# loop_cli_hint — emits a glab equivalents table when BACKEND=gitlab.
+# Outputs nothing for the github backend so GitHub users see no diff.
+loop_cli_hint() {
+    local backend="${BACKEND:-github}"
+    [ "$backend" != "gitlab" ] && return 0
+    cat <<'HINT'
+
+## GitLab CLI equivalents (BACKEND=gitlab — use glab instead of gh)
+
+This project uses the GitLab backend. Replace every `gh` command with its
+`glab` equivalent listed below.
+
+### Issues
+
+| gh command                                              | glab equivalent                                              |
+|---------------------------------------------------------|--------------------------------------------------------------|
+| gh issue list --repo R --state all --limit N            | glab issue list --repo R --state all --per-page N            |
+| gh issue view N --repo R --json body,labels             | glab issue view N --repo R --output json                     |
+| gh issue view N --repo R --json labels,state            | glab issue view N --repo R --output json                     |
+| gh issue edit N --repo R --add-label L                  | glab issue edit N --repo R --label L                         |
+| gh issue edit N --repo R --remove-label L               | glab issue edit N --repo R --unlabel L                       |
+| gh issue edit N --repo R --body-file FILE               | glab issue update N --repo R --description "$(cat FILE)"     |
+| gh issue comment N --repo R --body 'TEXT'               | glab issue note N --repo R --message 'TEXT'                  |
+| gh issue close N --repo R                               | glab issue close N --repo R                                  |
+
+### Merge Requests (gh pr → glab mr)
+
+| gh command                                              | glab equivalent                                              |
+|---------------------------------------------------------|--------------------------------------------------------------|
+| gh pr create --repo R --title T --body B --label L      | glab mr create --repo R --title T --description B --label L  |
+| gh pr view N --repo R --json state,merged               | glab mr view N --repo R --output json                        |
+| gh pr view N --repo R --json title,body,headRefName,... | glab mr view N --repo R --output json                        |
+| gh pr view N --repo R --json body,reviews,comments,...  | glab mr view N --repo R --output json                        |
+| gh pr view N --repo R --json labels                     | glab mr view N --repo R --output json                        |
+| gh pr diff N --repo R                                   | glab mr diff N --repo R                                      |
+| gh pr checks N --repo R                                 | glab ci status --repo R (for the MR branch)                  |
+| gh pr edit N --repo R --add-label L                     | glab mr update N --repo R --label L                          |
+| gh pr edit N --repo R --remove-label L                  | glab mr update N --repo R --unlabel L                        |
+| gh pr comment N --repo R --body 'TEXT'                  | glab mr note N --repo R --message 'TEXT'                     |
+| gh pr comment N --repo R --body-file FILE               | glab mr note N --repo R --message "$(cat FILE)"              |
+| gh pr review N --repo R --approve --body 'TEXT'         | glab mr approve N --repo R && glab mr note N --repo R --message 'TEXT' |
+| gh pr review N --repo R --request-changes --body 'TEXT' | glab mr revoke N --repo R && glab mr note N --repo R --message 'TEXT' |
+| gh pr list --repo R --state open --json ...             | glab mr list --repo R --state opened --output json           |
+HINT
+}

--- a/scripts/dev-handler.sh
+++ b/scripts/dev-handler.sh
@@ -20,6 +20,8 @@ source "$LOOP_ROOT/lib/backends/backend.sh"
 source "$LOOP_ROOT/lib/bounty.sh"
 # shellcheck source=../lib/notify.sh
 source "$LOOP_ROOT/lib/notify.sh"
+# shellcheck source=../lib/cli-hint.sh
+source "$LOOP_ROOT/lib/cli-hint.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-dev-handler.log"
 MAX_RETRIES=3
@@ -146,6 +148,7 @@ IMPORTANT: The issue MUST end this run with label '${REVIEW_LABEL}' (or 'needs-c
    gh issue view ${ISSUE_NUM} --repo ${REPO} --json labels
 
 If blocked by missing context or an architectural decision, comment on the issue and add label 'needs-clarification' instead of opening a PR.
+$(loop_cli_hint)
 EOF
 )
 

--- a/scripts/dev-rework-handler.sh
+++ b/scripts/dev-rework-handler.sh
@@ -24,6 +24,8 @@ source "$LOOP_ROOT/lib/backends/backend.sh"
 source "$LOOP_ROOT/lib/bounty.sh"
 # shellcheck source=../lib/notify.sh
 source "$LOOP_ROOT/lib/notify.sh"
+# shellcheck source=../lib/cli-hint.sh
+source "$LOOP_ROOT/lib/cli-hint.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-dev-rework-handler.log"
 MAX_RETRIES=2
@@ -230,6 +232,7 @@ IMPORTANT: The PR MUST end this run with label '${REVIEW_LABEL}' (or 'needs-clar
    gh pr view ${PR_NUM} --repo ${REPO} --json labels
 
 If the feedback is unclear or requires architectural input, add label 'needs-clarification' and comment on the PR instead of guessing.
+$(loop_cli_hint)
 EOF
 TASK_PROMPT=$(cat "$_PROMPT_FILE")
 rm -f "$_PROMPT_FILE"

--- a/scripts/po-handler.sh
+++ b/scripts/po-handler.sh
@@ -25,6 +25,8 @@ source "$LOOP_ROOT/lib/backends/backend.sh"
 source "$LOOP_ROOT/lib/bounty.sh"
 # shellcheck source=../lib/notify.sh
 source "$LOOP_ROOT/lib/notify.sh"
+# shellcheck source=../lib/cli-hint.sh
+source "$LOOP_ROOT/lib/cli-hint.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-po-handler.log"
 MAX_RETRIES=2
@@ -191,6 +193,7 @@ What this ticket explicitly does not cover. Prevents scope creep.
 IMPORTANT: The issue MUST end this run with exactly ONE of: dev / needs-clarification / blocked / tracker / closed.
 Verify: gh issue view ${ISSUE_NUM} --repo ${REPO} --json labels,state
 Report your decision (A/B/C/D/E/F) and why in 2 sentences.
+$(loop_cli_hint)
 EOF
 TASK_PROMPT=$(cat "$_PROMPT_FILE")
 rm -f "$_PROMPT_FILE"

--- a/scripts/review-handler.sh
+++ b/scripts/review-handler.sh
@@ -23,6 +23,8 @@ source "$LOOP_ROOT/lib/backends/backend.sh"
 source "$LOOP_ROOT/lib/bounty.sh"
 # shellcheck source=../lib/notify.sh
 source "$LOOP_ROOT/lib/notify.sh"
+# shellcheck source=../lib/cli-hint.sh
+source "$LOOP_ROOT/lib/cli-hint.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-review-handler.log"
 MAX_RETRIES=2
@@ -134,6 +136,7 @@ IMPORTANT: You MUST finish by applying either '${QA_LABEL}' or '${REWORK_LABEL}'
    gh pr view ${PR_NUM} --repo ${REPO} --json labels
 
 Report the decision you made and why, in 3 short sentences.
+$(loop_cli_hint)
 EOF
 TASK_PROMPT=$(cat "$_PROMPT_FILE")
 rm -f "$_PROMPT_FILE"


### PR DESCRIPTION
Closes #30

## Changes

Added `lib/cli-hint.sh` with a single function `loop_cli_hint()`:
- Returns nothing when `BACKEND=github` (the default) — zero impact on existing GitHub workflows
- Emits a markdown reference table of `glab` equivalents for every `gh issue` / `gh pr` command when `BACKEND=gitlab`

Updated four handler scripts to source `lib/cli-hint.sh` and expand `$(loop_cli_hint)` at the end of each agent prompt:
- `scripts/po-handler.sh` — covers `gh issue list/view/edit/comment/close`
- `scripts/dev-handler.sh` — covers `gh pr create`, `gh issue edit/view`
- `scripts/dev-rework-handler.sh` — covers `gh pr view/edit/comment`
- `scripts/review-handler.sh` — covers `gh pr view/diff/checks/review/edit/comment`, `gh issue view`

The hint is injected via `$(loop_cli_hint)` inside each unquoted `<<EOF` heredoc, so it expands at runtime only when the project's `BACKEND=gitlab`.

## Test Plan

- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — passes (verified)
- `shellcheck -S warning lib/*.sh scripts/*.sh scanner/*.sh install.sh` — passes (verified)
- With `BACKEND=gitlab` set: run any handler and confirm the glab equivalents table appears at the end of the agent prompt
- With `BACKEND=github` (or unset): confirm no CLI hint is added to the prompt