### PR TITLE
Draft: [LOOP-89] Add daily operator digest of stuck pipeline items

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -199,6 +199,23 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-reconciler (check Console.app)" >&2
         fi
     fi
+
+    local digest_plist="$agents_dir/com.user.loop-digest.plist"
+    if [ -f "$digest_plist" ]; then
+        echo "[launchd] com.user.loop-digest already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-digest.plist.template" > "$digest_plist"
+        if launchctl load "$digest_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-digest loaded (08:00 + 18:00 daily)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -288,6 +305,7 @@ bootstrap_pipeline() {
 Log paths:
   Scanner:    $log_dir/loop-scanner.log
   Reconciler: $log_dir/loop-reconciler.log
+  Digest:     $log_dir/loop-digest.log
 
 To add your first project:
   $0 /path/to/your/project [--auto]

--- a/scanner/digest.sh
+++ b/scanner/digest.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# scanner/digest.sh — Daily operator digest of stuck items across all projects.
+#
+# Queries every project in config/projects.yaml for:
+#   - Issues with labels: needs-clarification, blocked
+#   - Issues with operational labels (in-progress, in-review, in-rework)
+#     stuck longer than 2× HANDLER_TIMEOUT (genuine stuck, not mid-flight)
+#
+# Posts a single Markdown digest via loop_notify.
+# Suppressed entirely when zero stuck items exist (no noise).
+#
+# Usage:
+#   scanner/digest.sh              # run across all projects
+#   scanner/digest.sh --dry-run    # print digest to stdout only, no notify
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+# shellcheck source=../lib/config.sh
+source "$LOOP_ROOT/lib/config.sh"
+# shellcheck source=../lib/notify.sh
+source "$LOOP_ROOT/lib/notify.sh"
+
+LOG_FILE="${LOOP_LOG_DIR}/loop-digest.log"
+HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
+# Operational labels are "stuck" when older than 2× handler timeout
+STUCK_THRESHOLD_SEC=$(( HANDLER_TIMEOUT * 2 ))
+
+DRY_RUN=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run) DRY_RUN=true; shift ;;
+        -h|--help) sed -n '1,15p' "$0"; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+log() {
+    printf '[%s] [digest] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >> "$LOG_FILE"
+}
+
+# Fetch open issues with a given label, return JSON array.
+fetch_issues_with_label() {
+    local repo="$1" label="$2"
+    gh issue list --repo "$repo" --label "$label" \
+        --state open --limit 200 \
+        --json number,title,labels,updatedAt,createdAt 2>/dev/null || echo "[]"
+}
+
+# Fetch last comment body for an issue, truncated to 80 chars.
+fetch_last_comment() {
+    local repo="$1" number="$2"
+    local body
+    body=$(gh issue view "$number" --repo "$repo" \
+        --json comments --jq '.comments[-1].body // ""' 2>/dev/null || echo "")
+    # collapse whitespace and truncate
+    body=$(printf '%s' "$body" | tr '\n\r' '  ' | sed 's/  */ /g')
+    if [ ${#body} -gt 80 ]; then
+        printf '%s…' "${body:0:79}"
+    else
+        printf '%s' "$body"
+    fi
+}
+
+# Collect stuck items for one project.
+# Outputs tab-separated: age_h <TAB> number <TAB> labels <TAB> title <TAB> comment
+collect_project_items() {
+    local repo="$1"
+
+    # --- needs-clarification and blocked (always included) ---
+    local nc_json blocked_json merged_json
+    nc_json=$(fetch_issues_with_label "$repo" "needs-clarification")
+    blocked_json=$(fetch_issues_with_label "$repo" "blocked")
+
+    # --- operational labels stuck > 2× HANDLER_TIMEOUT ---
+    local ip_json ir_json irw_json
+    ip_json=$(fetch_issues_with_label "$repo"  "in-progress")
+    ir_json=$(fetch_issues_with_label "$repo"  "in-review")
+    irw_json=$(fetch_issues_with_label "$repo" "in-rework")
+
+    # Merge, deduplicate, classify, and filter by age threshold for operational.
+    merged_json=$(
+        NC="$nc_json" BL="$blocked_json" \
+        IP="$ip_json" IR="$ir_json" IRW="$irw_json" \
+        STUCK_SEC="$STUCK_THRESHOLD_SEC" \
+        python3 - <<'PY'
+import json, os, datetime as dt
+
+def load(var):
+    return json.loads(os.environ.get(var, '[]') or '[]')
+
+nc   = load('NC')
+bl   = load('BL')
+ip   = load('IP')
+ir   = load('IR')
+irw  = load('IRW')
+stuck_sec = int(os.environ.get('STUCK_SEC', '14400'))
+
+now = dt.datetime.now(dt.timezone.utc)
+
+seen = {}
+# needs-clarification + blocked: always include
+for iss in nc + bl:
+    n = iss['number']
+    if n not in seen:
+        seen[n] = iss
+
+# operational: include only if older than stuck threshold
+for iss in ip + ir + irw:
+    n = iss['number']
+    if n in seen:
+        continue
+    up = dt.datetime.fromisoformat(iss['updatedAt'].replace('Z', '+00:00'))
+    age_s = (now - up).total_seconds()
+    if age_s >= stuck_sec:
+        seen[n] = iss
+
+if not seen:
+    import sys; sys.exit(0)
+
+for iss in seen.values():
+    up = dt.datetime.fromisoformat(iss['updatedAt'].replace('Z', '+00:00'))
+    age_h = int((now - up).total_seconds() / 3600)
+    labels = ','.join(l['name'] for l in iss.get('labels', []))
+    title  = iss['title'].replace('\t', ' ')[:80]
+    print(f"{age_h}\t{iss['number']}\t{labels}\t{title}")
+PY
+    )
+
+    [ -z "$merged_json" ] && return 0
+
+    while IFS=$'\t' read -r age_h number labels title; do
+        [ -z "$number" ] && continue
+        local comment
+        comment=$(fetch_last_comment "$repo" "$number")
+        printf '%s\t%s\t%s\t%s\t%s\n' "$age_h" "$number" "$labels" "$title" "$comment"
+    done <<< "$merged_json"
+}
+
+# Build one project section of the digest, sorted by age descending (oldest first).
+# Returns formatted Markdown lines on stdout; empty output means no stuck items.
+build_project_section() {
+    local slug="$1" repo="$2"
+    local raw
+    raw=$(collect_project_items "$repo") || true
+    [ -z "$raw" ] && return 0
+
+    # Sort by age_h descending (oldest first) — field 1
+    local sorted
+    sorted=$(printf '%s\n' "$raw" | sort -t$'\t' -k1 -rn)
+
+    printf '### %s (`%s`)\n' "$slug" "$repo"
+    while IFS=$'\t' read -r age_h number labels title comment; do
+        [ -z "$number" ] && continue
+        local entry="- #${number} (${age_h}h) [${labels}] ${title}"
+        if [ -n "$comment" ]; then
+            entry="${entry} — ${comment}"
+        fi
+        printf '%s\n' "$entry"
+    done <<< "$sorted"
+    printf '\n'
+}
+
+# --- Main ---
+
+log "digest start (dry_run=$DRY_RUN)"
+
+digest_body=""
+
+while IFS= read -r slug; do
+    [ -z "$slug" ] && continue
+    # shellcheck source=../lib/config.sh
+    if ! loop_load_project "$slug" 2>/dev/null; then
+        log "skip $slug (config error)"
+        continue
+    fi
+    section=$(build_project_section "$slug" "$REPO") || true
+    [ -n "$section" ] && digest_body="${digest_body}${section}"
+done < <(loop_list_slugs)
+
+if [ -z "$digest_body" ]; then
+    log "no stuck items — digest suppressed"
+    exit 0
+fi
+
+timestamp=$(date '+%Y-%m-%d %H:%M %Z')
+message="$(printf '## Loop Digest — %s\n\nItems waiting on human input:\n\n%s' "$timestamp" "$digest_body")"
+
+log "posting digest ($(printf '%s' "$message" | wc -l | tr -d ' ') lines)"
+
+if $DRY_RUN; then
+    printf '%s\n' "$message"
+else
+    loop_notify "$message"
+fi
+
+log "digest done"

--- a/templates/launchd/com.user.loop-digest.plist.template
+++ b/templates/launchd/com.user.loop-digest.plist.template
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-digest</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/digest.sh</string>
+    </array>
+    <!-- Run at 08:00 and 18:00 local time daily -->
+    <key>StartCalendarInterval</key>
+    <array>
+        <dict>
+            <key>Hour</key>
+            <integer>8</integer>
+            <key>Minute</key>
+            <integer>0</integer>
+        </dict>
+        <dict>
+            <key>Hour</key>
+            <integer>18</integer>
+            <key>Minute</key>
+            <integer>0</integer>
+        </dict>
+    </array>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-digest.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-digest.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/digest.bats
+++ b/tests/digest.bats
@@ -1,0 +1,278 @@
+#!/usr/bin/env bats
+# tests/digest.bats — unit tests for scanner/digest.sh
+#
+# Uses synthetic fixture data and a mock gh binary.
+# No live gh calls are made.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    # Wire up mock gh
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Suppress LOOP_EXTRA_PATH so env.sh doesn't shadow our mock gh
+    export LOOP_EXTRA_PATH=""
+    export LOOP_NOTIFY=""
+    export LOOP_HANDLER_TIMEOUT="7200"
+
+    # Two-project fixture: alpha + beta
+    cat > "$BATS_TMPDIR/projects.yaml" <<'YAML'
+version: 1
+projects:
+  - slug: alpha
+    name: Alpha Project
+    repo: owner/alpha
+    root: /tmp/fake-alpha
+    default_branch: main
+  - slug: beta
+    name: Beta Project
+    repo: owner/beta
+    root: /tmp/fake-beta
+    default_branch: main
+YAML
+    export LOOP_CONFIG="$BATS_TMPDIR/projects.yaml"
+
+    # Shared mock-gh response control
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/logs" \
+           "$BATS_TMPDIR/projects.yaml" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Helper: build digest from a custom mock-gh script
+# Writes a per-test gh script that returns fixture data based on the call args.
+# ---------------------------------------------------------------------------
+
+make_mock_gh() {
+    # $1 = path to write mock script
+    # $2 = shell snippet to embed (receives "$@" as gh args)
+    local dest="$1" snippet="$2"
+    cat > "$dest" <<SCRIPT
+#!/usr/bin/env bash
+${snippet}
+exit 0
+SCRIPT
+    chmod +x "$dest"
+}
+
+# ---------------------------------------------------------------------------
+# Fixture helpers — produce minimal gh JSON output
+# ---------------------------------------------------------------------------
+
+issue_json() {
+    # $1=number $2=title $3=label $4=updatedAt(ISO8601)
+    printf '[{"number":%s,"title":"%s","labels":[{"name":"%s"}],"updatedAt":"%s","createdAt":"%s"}]' \
+        "$1" "$2" "$3" "$4" "$4"
+}
+
+empty_json() { printf '[]'; }
+
+# ---------------------------------------------------------------------------
+# Test 1: zero stuck items → digest suppressed (no output, exit 0)
+# ---------------------------------------------------------------------------
+
+@test "digest suppressed when no stuck items exist" {
+    make_mock_gh "$BATS_TMPDIR/bin/gh" "printf '[]'"
+
+    run bash "$REPO_ROOT/scanner/digest.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: 3 stuck items in 2 projects → digest contains expected entries
+# ---------------------------------------------------------------------------
+
+@test "digest includes 3 stuck items from 2 projects" {
+    # alpha: issue #1 needs-clarification, issue #2 blocked
+    # beta:  issue #5 needs-clarification
+    # All updatedAt set to far in the past (2000h ago) so age math is reliable.
+    local old_ts="2020-01-01T00:00:00Z"
+    local alpha_nc; alpha_nc=$(issue_json 1 "Alpha needs input" "needs-clarification" "$old_ts")
+    local alpha_bl; alpha_bl=$(issue_json 2 "Alpha is blocked" "blocked" "$old_ts")
+    local beta_nc;  beta_nc=$(issue_json 5 "Beta needs input" "needs-clarification" "$old_ts")
+
+    # Mock gh: dispatch on repo + label args
+    make_mock_gh "$BATS_TMPDIR/bin/gh" "
+case \"\$*\" in
+    *'owner/alpha'*'needs-clarification'*)  printf '%s' '${alpha_nc}' ;;
+    *'owner/alpha'*'blocked'*)             printf '%s' '${alpha_bl}' ;;
+    *'owner/alpha'*'in-progress'*)         printf '[]' ;;
+    *'owner/alpha'*'in-review'*)           printf '[]' ;;
+    *'owner/alpha'*'in-rework'*)           printf '[]' ;;
+    *'owner/beta'*'needs-clarification'*)  printf '%s' '${beta_nc}' ;;
+    *'owner/beta'*'blocked'*)              printf '[]' ;;
+    *'owner/beta'*'in-progress'*)          printf '[]' ;;
+    *'owner/beta'*'in-review'*)            printf '[]' ;;
+    *'owner/beta'*'in-rework'*)            printf '[]' ;;
+    # issue view for last comment
+    *'issue view'*)                         printf '{\"comments\":[{\"body\":\"last comment here\"}]}' ;;
+    *)                                      printf '[]' ;;
+esac
+"
+
+    run bash "$REPO_ROOT/scanner/digest.sh" --dry-run
+    [ "$status" -eq 0 ]
+
+    # Digest header present
+    [[ "$output" == *"Loop Digest"* ]]
+
+    # Both projects appear
+    [[ "$output" == *"alpha"* ]]
+    [[ "$output" == *"beta"* ]]
+
+    # All three issue numbers appear
+    [[ "$output" == *"#1"* ]]
+    [[ "$output" == *"#2"* ]]
+    [[ "$output" == *"#5"* ]]
+
+    # Labels appear
+    [[ "$output" == *"needs-clarification"* ]]
+    [[ "$output" == *"blocked"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: entries sorted by age (oldest first within each project)
+# ---------------------------------------------------------------------------
+
+@test "entries are sorted oldest-first within each project" {
+    # Issue #10 updated 1h ago, issue #20 updated 100h ago → #20 should appear first
+    local recent_ts; recent_ts=$(python3 -c "
+import datetime as dt
+now = dt.datetime.now(dt.timezone.utc)
+print((now - dt.timedelta(hours=1)).strftime('%Y-%m-%dT%H:%M:%SZ'))
+")
+    local old_ts; old_ts=$(python3 -c "
+import datetime as dt
+now = dt.datetime.now(dt.timezone.utc)
+print((now - dt.timedelta(hours=100)).strftime('%Y-%m-%dT%H:%M:%SZ'))
+")
+
+    local iss10; iss10=$(issue_json 10 "Recent issue" "needs-clarification" "$recent_ts")
+    local iss20; iss20=$(issue_json 20 "Old issue" "blocked" "$old_ts")
+
+    make_mock_gh "$BATS_TMPDIR/bin/gh" "
+case \"\$*\" in
+    *'owner/alpha'*'needs-clarification'*) printf '%s' '${iss10}' ;;
+    *'owner/alpha'*'blocked'*)            printf '%s' '${iss20}' ;;
+    *'owner/alpha'*) printf '[]' ;;
+    *'owner/beta'*)  printf '[]' ;;
+    *'issue view'*)  printf '{\"comments\":[]}' ;;
+    *)               printf '[]' ;;
+esac
+"
+    # Strip beta project from fixture so only alpha matters
+    cat > "$BATS_TMPDIR/projects.yaml" <<'YAML'
+version: 1
+projects:
+  - slug: alpha
+    name: Alpha
+    repo: owner/alpha
+    root: /tmp/fake-alpha
+    default_branch: main
+YAML
+
+    run bash "$REPO_ROOT/scanner/digest.sh" --dry-run
+    [ "$status" -eq 0 ]
+
+    # #20 (older) must appear before #10 (newer)
+    local pos10 pos20
+    pos10=$(echo "$output" | grep -n '#10' | cut -d: -f1 | head -1)
+    pos20=$(echo "$output" | grep -n '#20' | cut -d: -f1 | head -1)
+    [ -n "$pos10" ] && [ -n "$pos20" ]
+    [ "$pos20" -lt "$pos10" ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: operational labels stuck >2× HANDLER_TIMEOUT are included
+# ---------------------------------------------------------------------------
+
+@test "in-progress issue stuck over 2x HANDLER_TIMEOUT is included" {
+    export LOOP_HANDLER_TIMEOUT="3600"  # 1h → threshold = 2h
+
+    # Issue updated 3h ago — should be included
+    local old_ts; old_ts=$(python3 -c "
+import datetime as dt
+now = dt.datetime.now(dt.timezone.utc)
+print((now - dt.timedelta(hours=3)).strftime('%Y-%m-%dT%H:%M:%SZ'))
+")
+    local ip_iss; ip_iss=$(issue_json 42 "Stuck in progress" "in-progress" "$old_ts")
+
+    cat > "$BATS_TMPDIR/projects.yaml" <<'YAML'
+version: 1
+projects:
+  - slug: alpha
+    name: Alpha
+    repo: owner/alpha
+    root: /tmp/fake-alpha
+    default_branch: main
+YAML
+
+    make_mock_gh "$BATS_TMPDIR/bin/gh" "
+case \"\$*\" in
+    *'owner/alpha'*'needs-clarification'*) printf '[]' ;;
+    *'owner/alpha'*'blocked'*)            printf '[]' ;;
+    *'owner/alpha'*'in-progress'*)        printf '%s' '${ip_iss}' ;;
+    *'owner/alpha'*'in-review'*)          printf '[]' ;;
+    *'owner/alpha'*'in-rework'*)          printf '[]' ;;
+    *'issue view'*)                        printf '{\"comments\":[]}' ;;
+    *)                                     printf '[]' ;;
+esac
+"
+
+    run bash "$REPO_ROOT/scanner/digest.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"#42"* ]]
+    [[ "$output" == *"in-progress"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: operational label NOT yet over threshold → excluded
+# ---------------------------------------------------------------------------
+
+@test "in-progress issue under 2x HANDLER_TIMEOUT threshold is excluded" {
+    export LOOP_HANDLER_TIMEOUT="7200"  # 2h → threshold = 4h
+
+    # Issue updated 1h ago — below threshold
+    local recent_ts; recent_ts=$(python3 -c "
+import datetime as dt
+now = dt.datetime.now(dt.timezone.utc)
+print((now - dt.timedelta(hours=1)).strftime('%Y-%m-%dT%H:%M:%SZ'))
+")
+    local ip_iss; ip_iss=$(issue_json 99 "Fresh in progress" "in-progress" "$recent_ts")
+
+    cat > "$BATS_TMPDIR/projects.yaml" <<'YAML'
+version: 1
+projects:
+  - slug: alpha
+    name: Alpha
+    repo: owner/alpha
+    root: /tmp/fake-alpha
+    default_branch: main
+YAML
+
+    make_mock_gh "$BATS_TMPDIR/bin/gh" "
+case \"\$*\" in
+    *'owner/alpha'*'needs-clarification'*) printf '[]' ;;
+    *'owner/alpha'*'blocked'*)            printf '[]' ;;
+    *'owner/alpha'*'in-progress'*)        printf '%s' '${ip_iss}' ;;
+    *'owner/alpha'*'in-review'*)          printf '[]' ;;
+    *'owner/alpha'*'in-rework'*)          printf '[]' ;;
+    *)                                     printf '[]' ;;
+esac
+"
+
+    run bash "$REPO_ROOT/scanner/digest.sh" --dry-run
+    [ "$status" -eq 0 ]
+    # No output = digest suppressed = no stuck items
+    [ -z "$output" ]
+}


### PR DESCRIPTION
Closes #89

## Changes
- scanner/digest.sh: daily digest across all projects
- templates/launchd/com.user.loop-digest.plist.template: 08:00+18:00 schedule
- install.sh: register digest in bootstrap
- tests/digest.bats: 5 tests with mock gh, no live calls

## Test Plan
- bash -n and shellcheck -S warning pass
- bats tests/digest.bats
- scanner/digest.sh --dry-run