### PR TITLE
Draft: [LOOP-87] detect draft PRs in review-handler and qa-handler

### DIFF
--- a/scripts/qa-handler.sh
+++ b/scripts/qa-handler.sh
@@ -65,6 +65,18 @@ case "$PR_STATE" in
         ;;
 esac
 
+# Draft check — skip QA without touching retry counter.
+_is_draft=$(gh pr view "$PR_NUM" --repo "$REPO" --json isDraft --jq '.isDraft' 2>/dev/null || echo "false")
+if [ "$_is_draft" = "true" ]; then
+    log "PR #$PR_NUM is a draft — skipping QA"
+    gh label create draft --color "#808080" --description "PR is in Draft state" --repo "$REPO" 2>/dev/null || true
+    backend_remove_label "$REPO" "$PR_NUM" needs-qa
+    backend_remove_label "$REPO" "$PR_NUM" ready-for-qa
+    backend_add_label    "$REPO" "$PR_NUM" draft
+    backend_comment_pr   "$REPO" "$PR_NUM" "PR is in Draft state — review skipped. When ready: mark the PR ready for review on GitHub, remove the \`draft\` label, and re-apply \`needs-review\` to re-enter the pipeline."
+    exit 0
+fi
+
 if [ -z "${QA_VALIDATION_CMD:-}" ]; then
     log "no qa.validation_cmd configured for $SLUG — auto-passing"
     backend_remove_label "$REPO" "$PR_NUM" needs-qa

--- a/scripts/review-handler.sh
+++ b/scripts/review-handler.sh
@@ -56,6 +56,18 @@ fi
 loop_load_project "$SLUG" || { log "ERROR: unknown slug '$SLUG'"; exit 2; }
 loop_load_backend
 
+# Draft check — skip review without touching retry counter.
+_is_draft=$(gh pr view "$PR_NUM" --repo "$REPO" --json isDraft --jq '.isDraft' 2>/dev/null || echo "false")
+if [ "$_is_draft" = "true" ]; then
+    log "PR #$PR_NUM is a draft — skipping review"
+    gh label create draft --color "#808080" --description "PR is in Draft state" --repo "$REPO" 2>/dev/null || true
+    backend_remove_label "$REPO" "$PR_NUM" needs-review
+    backend_remove_label "$REPO" "$PR_NUM" review-pending
+    backend_add_label    "$REPO" "$PR_NUM" draft
+    backend_comment_pr   "$REPO" "$PR_NUM" "PR is in Draft state — review skipped. When ready: mark the PR ready for review on GitHub, remove the \`draft\` label, and re-apply \`needs-review\` to re-enter the pipeline."
+    exit 0
+fi
+
 # PR-scoped lock — allows multiple PRs in the same project to be reviewed in parallel.
 # (Review only reads from origin; no shared working tree state to protect.)
 source "$LOOP_ROOT/lib/lock.sh"

--- a/tests/review.bats
+++ b/tests/review.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+# tests/review.bats — unit tests for draft PR detection in review-handler and qa-handler.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_WORKFLOW_DIR="$REPO_ROOT/config/workflows"
+    # shellcheck source=../lib/workflow.sh
+    source "$REPO_ROOT/lib/workflow.sh"
+
+    cat > "$BATS_TMPDIR/fixture.yaml" <<'YAML'
+version: 1
+projects:
+  - slug: test-proj
+    name: Test Project
+    repo: owner/test-repo
+    root: /tmp/fake
+    default_branch: main
+    workflow: default
+YAML
+    export LOOP_CONFIG="$BATS_TMPDIR/fixture.yaml"
+}
+
+teardown() {
+    rm -f "$BATS_TMPDIR/fixture.yaml" \
+          "$BATS_TMPDIR/label-ops.log" \
+          "$BATS_TMPDIR/comment-ops.log"
+}
+
+# ---------------------------------------------------------------------------
+# review-handler draft detection
+# ---------------------------------------------------------------------------
+
+@test "review-handler draft: isDraft=true → removes review labels, adds draft, posts comment, exits 0" {
+    local ops_log="$BATS_TMPDIR/label-ops.log"
+    local comment_log="$BATS_TMPDIR/comment-ops.log"
+    rm -f "$ops_log" "$comment_log"
+
+    backend_remove_label() { echo "remove $3" >> "$ops_log"; }
+    backend_add_label()    { echo "add $3"    >> "$ops_log"; }
+    backend_comment_pr()   { echo "comment: $4" >> "$comment_log"; }
+    gh() {
+        case "$*" in
+            *isDraft*) echo "true" ;;
+            *) true ;;
+        esac
+    }
+
+    # Replicate draft-check block from review-handler.sh
+    local REPO="owner/test-repo"
+    local PR_NUM="42"
+    _is_draft=$(gh pr view "$PR_NUM" --repo "$REPO" --json isDraft --jq '.isDraft' 2>/dev/null || echo "false")
+
+    local _exit_code=1
+    if [ "$_is_draft" = "true" ]; then
+        gh label create draft --color "#808080" --description "PR is in Draft state" --repo "$REPO" 2>/dev/null || true
+        backend_remove_label "$REPO" "$PR_NUM" needs-review
+        backend_remove_label "$REPO" "$PR_NUM" review-pending
+        backend_add_label    "$REPO" "$PR_NUM" draft
+        backend_comment_pr   "$REPO" "$PR_NUM" "PR is in Draft state — review skipped. When ready: mark the PR ready for review on GitHub, remove the \`draft\` label, and re-apply \`needs-review\` to re-enter the pipeline."
+        _exit_code=0
+    fi
+
+    [ "$_exit_code" -eq 0 ]
+    grep -q "remove needs-review"   "$ops_log"
+    grep -q "remove review-pending" "$ops_log"
+    grep -q "add draft"             "$ops_log"
+    ! grep -q "add needs-review"    "$ops_log"
+    grep -q "re-apply"              "$comment_log"
+    ! grep -q "automatically"       "$comment_log"
+}
+
+@test "review-handler draft: isDraft=false → draft path not taken, draft label not added" {
+    local ops_log="$BATS_TMPDIR/label-ops.log"
+    rm -f "$ops_log"
+
+    backend_remove_label() { echo "remove $3" >> "$ops_log"; }
+    backend_add_label()    { echo "add $3"    >> "$ops_log"; }
+    gh() { echo "false"; }
+
+    local REPO="owner/test-repo"
+    local PR_NUM="42"
+    _is_draft=$(gh pr view "$PR_NUM" --repo "$REPO" --json isDraft --jq '.isDraft' 2>/dev/null || echo "false")
+
+    local _draft_path_taken=false
+    if [ "$_is_draft" = "true" ]; then
+        _draft_path_taken=true
+        backend_add_label "$REPO" "$PR_NUM" draft
+    fi
+
+    [ "$_draft_path_taken" = "false" ]
+    [ ! -f "$ops_log" ] || ! grep -q "add draft" "$ops_log"
+}
+
+# ---------------------------------------------------------------------------
+# qa-handler draft detection
+# ---------------------------------------------------------------------------
+
+@test "qa-handler draft: isDraft=true → removes qa labels, adds draft, posts comment, exits 0" {
+    local ops_log="$BATS_TMPDIR/label-ops.log"
+    local comment_log="$BATS_TMPDIR/comment-ops.log"
+    rm -f "$ops_log" "$comment_log"
+
+    backend_remove_label() { echo "remove $3" >> "$ops_log"; }
+    backend_add_label()    { echo "add $3"    >> "$ops_log"; }
+    backend_comment_pr()   { echo "comment: $4" >> "$comment_log"; }
+    gh() {
+        case "$*" in
+            *isDraft*) echo "true" ;;
+            *) true ;;
+        esac
+    }
+
+    local REPO="owner/test-repo"
+    local PR_NUM="42"
+    _is_draft=$(gh pr view "$PR_NUM" --repo "$REPO" --json isDraft --jq '.isDraft' 2>/dev/null || echo "false")
+
+    local _exit_code=1
+    if [ "$_is_draft" = "true" ]; then
+        gh label create draft --color "#808080" --description "PR is in Draft state" --repo "$REPO" 2>/dev/null || true
+        backend_remove_label "$REPO" "$PR_NUM" needs-qa
+        backend_remove_label "$REPO" "$PR_NUM" ready-for-qa
+        backend_add_label    "$REPO" "$PR_NUM" draft
+        backend_comment_pr   "$REPO" "$PR_NUM" "PR is in Draft state — review skipped. When ready: mark the PR ready for review on GitHub, remove the \`draft\` label, and re-apply \`needs-review\` to re-enter the pipeline."
+        _exit_code=0
+    fi
+
+    [ "$_exit_code" -eq 0 ]
+    grep -q "remove needs-qa"      "$ops_log"
+    grep -q "remove ready-for-qa"  "$ops_log"
+    grep -q "add draft"            "$ops_log"
+    ! grep -q "add needs-qa"       "$ops_log"
+    grep -q "re-apply"             "$comment_log"
+    ! grep -q "automatically"      "$comment_log"
+}


### PR DESCRIPTION
Closes #87

## Changes

- **scripts/review-handler.sh**: Added `isDraft` check after `loop_load_backend`, before lock acquisition and retry logic. When `isDraft=true`: create `draft` label if absent, remove `needs-review`/`review-pending`, add `draft`, post comment with explicit manual re-entry steps, exit 0 (retry counter untouched).

- **scripts/qa-handler.sh**: Same draft guard added after the existing MERGED/CLOSED pre-flight check. When `isDraft=true`: create `draft` label if absent, remove `needs-qa`/`ready-for-qa`, add `draft`, post same comment, exit 0.

- **Comment text**: "PR is in Draft state — review skipped. When ready: mark the PR ready for review on GitHub, remove the \`draft\` label, and re-apply \`needs-review\` to re-enter the pipeline." — explicitly lists both manual steps the operator must take (no misleading "automatically").

- **tests/review.bats** (new): Three bats tests covering:
  1. review-handler `isDraft=true`: exits 0, removes `needs-review`/`review-pending`, adds `draft`, comment contains "re-apply" not "automatically"
  2. review-handler `isDraft=false`: draft path not taken, `draft` label never added
  3. qa-handler `isDraft=true`: exits 0, removes `needs-qa`/`ready-for-qa`, adds `draft`, comment correct

## Test Plan

- [ ] `bash -n` passes on all modified files (verified locally)
- [ ] `shellcheck -S warning` passes on all modified files (verified locally)
- [ ] Apply `needs-review` to a draft PR; confirm handler: exits 0, PR has `draft` label, comment lists manual re-entry steps, retry file not incremented
- [ ] Apply `needs-qa` to a draft PR; confirm qa-handler: exits 0, PR has `draft` label, comment correct
- [ ] Mark draft PR ready, remove `draft` label, re-apply `needs-review`; confirm review proceeds normally