### PR TITLE
Draft: [LOOP-44] add --core-only, --monitor-only, launchctl restart, and version display to update.sh

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -6,9 +6,11 @@
 #   ./scripts/update.sh --yes        # fetch + apply even with breaking changes
 #   ./scripts/update.sh --check      # fetch, show full changelog diff, no apply
 #   ./scripts/update.sh --dry-run    # same as --check (alias)
+#   ./scripts/update.sh --core-only  # pull loop core only, skip monitor
+#   ./scripts/update.sh --monitor-only  # pull loop-monitor only and restart it
 #
-# Per-component: if LOOP_MONITOR_ROOT is set in loop.env and points to a git
-# repo, loop-monitor's CHANGELOG.md is also scanned for BREAKING: markers.
+# Per-component: if LOOP_MONITOR_ROOT is set (or ~/projects/loop-monitor exists)
+# and points to a git repo, loop-monitor is also updated and restarted.
 #
 # LOOP_ROOT may be overridden via env to point at a different repo root
 # (used by tests; production behavior is unchanged).
@@ -24,14 +26,21 @@ if [ -f "$LOOP_ROOT/loop.env" ]; then
     set +u; . "$LOOP_ROOT/loop.env"; set -u
 fi
 
+# Resolve monitor root: explicit env var, else ~/projects/loop-monitor.
+LOOP_MONITOR_ROOT="${LOOP_MONITOR_ROOT:-$HOME/projects/loop-monitor}"
+
 YES=false
 CHECK=false
+CORE_ONLY=false
+MONITOR_ONLY=false
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --yes)             YES=true;  shift ;;
         --check|--dry-run) CHECK=true; shift ;;
-        -h|--help)         sed -n '2,9p' "$0"; exit 0 ;;
+        --core-only)       CORE_ONLY=true; shift ;;
+        --monitor-only)    MONITOR_ONLY=true; shift ;;
+        -h|--help)         sed -n '2,11p' "$0"; exit 0 ;;
         *) echo "unknown arg: $1" >&2; exit 2 ;;
     esac
 done
@@ -74,29 +83,48 @@ PY
     )
 }
 
+# ── restart loop-monitor service after update ────────────────────────────────
+_restart_monitor() {
+    if [[ "$(uname)" == "Darwin" ]]; then
+        launchctl kickstart -k "gui/$(id -u)/com.loop.loop-monitor" 2>/dev/null \
+            && echo "[update] loop-monitor service restarted." \
+            || echo "[update] note: could not restart loop-monitor via launchctl (service may not be loaded)."
+    else
+        echo "[update] note: loop-monitor restart not automated on Linux — restart it manually if needed."
+    fi
+}
+
 # ── fetch loop core ───────────────────────────────────────────────────────────
-echo "[update] fetching loop core (origin/main) …"
-git fetch origin main --quiet
-
-CORE_UP_TO_DATE=false
-if git diff --quiet HEAD..origin/main; then
-    CORE_UP_TO_DATE=true
-fi
-
+CORE_UP_TO_DATE=true
 CORE_DIFF=""
 CORE_BREAKING=""
-if ! $CORE_UP_TO_DATE; then
-    CORE_DIFF=$(git diff HEAD..origin/main -- CHANGELOG.md 2>/dev/null || true)
-    CORE_BREAKING=$(echo "$CORE_DIFF" | _extract_breaking)
+CORE_VERSION_BEFORE=""
+
+if ! $MONITOR_ONLY; then
+    echo "[update] fetching loop core (origin/main) …"
+    CORE_VERSION_BEFORE="$(cat "$LOOP_ROOT/VERSION" 2>/dev/null || echo unknown)"
+    git fetch origin main --quiet
+
+    CORE_UP_TO_DATE=false
+    if git diff --quiet HEAD..origin/main; then
+        CORE_UP_TO_DATE=true
+    fi
+
+    if ! $CORE_UP_TO_DATE; then
+        CORE_DIFF=$(git diff HEAD..origin/main -- CHANGELOG.md 2>/dev/null || true)
+        CORE_BREAKING=$(echo "$CORE_DIFF" | _extract_breaking)
+    fi
 fi
 
 # ── fetch loop-monitor (optional) ────────────────────────────────────────────
 MONITOR_BREAKING=""
 MONITOR_DIFF=""
 MONITOR_UP_TO_DATE=true  # treated as "not behind" when monitor is not configured
+MONITOR_VERSION_BEFORE=""
 
-if [ -n "${LOOP_MONITOR_ROOT:-}" ] && [ -d "${LOOP_MONITOR_ROOT}/.git" ]; then
+if ! $CORE_ONLY && [ -d "${LOOP_MONITOR_ROOT}/.git" ]; then
     echo "[update] fetching loop-monitor (${LOOP_MONITOR_ROOT}) …"
+    MONITOR_VERSION_BEFORE="$(cat "${LOOP_MONITOR_ROOT}/VERSION" 2>/dev/null || echo unknown)"
     (cd "$LOOP_MONITOR_ROOT" && git fetch origin main --quiet 2>/dev/null) || true
 
     if (cd "$LOOP_MONITOR_ROOT" && git diff --quiet HEAD..origin/main 2>/dev/null); then
@@ -111,7 +139,7 @@ if [ -n "${LOOP_MONITOR_ROOT:-}" ] && [ -d "${LOOP_MONITOR_ROOT}/.git" ]; then
     fi
 fi
 
-# ── --check: show full diffs and exit without applying ───────────────────────
+# ── --check/--dry-run: show full diffs and exit without applying ──────────────
 if $CHECK; then
     echo ""
     echo "=== loop core changelog ==="
@@ -121,7 +149,7 @@ if $CHECK; then
         echo "$CORE_DIFF" | grep '^+' | grep -v '^+++' | sed 's/^+//' | head -80
     fi
 
-    if [ -n "${LOOP_MONITOR_ROOT:-}" ] && [ -d "${LOOP_MONITOR_ROOT}/.git" ]; then
+    if [ -d "${LOOP_MONITOR_ROOT}/.git" ]; then
         echo ""
         echo "=== loop-monitor changelog ==="
         if $MONITOR_UP_TO_DATE; then
@@ -168,14 +196,17 @@ fi
 # ── apply ────────────────────────────────────────────────────────────────────
 if ! $CORE_UP_TO_DATE; then
     echo "[update] applying loop core …"
+    echo "[update] loop core: ${CORE_VERSION_BEFORE} → applying …"
     git merge --ff-only origin/main
-    echo "[update] loop core updated to $(cat VERSION 2>/dev/null || echo unknown)"
+    echo "[update] loop core updated: ${CORE_VERSION_BEFORE} → $(cat "$LOOP_ROOT/VERSION" 2>/dev/null || echo unknown)"
 fi
 
-if ! $MONITOR_UP_TO_DATE && [ -n "${LOOP_MONITOR_ROOT:-}" ] && [ -d "${LOOP_MONITOR_ROOT}/.git" ]; then
+if ! $MONITOR_UP_TO_DATE && [ -d "${LOOP_MONITOR_ROOT}/.git" ]; then
     echo "[update] applying loop-monitor …"
+    echo "[update] loop-monitor: ${MONITOR_VERSION_BEFORE} → applying …"
     (cd "$LOOP_MONITOR_ROOT" && git merge --ff-only origin/main)
-    echo "[update] loop-monitor updated to $(cat "${LOOP_MONITOR_ROOT}/VERSION" 2>/dev/null || echo unknown)"
+    echo "[update] loop-monitor updated: ${MONITOR_VERSION_BEFORE} → $(cat "${LOOP_MONITOR_ROOT}/VERSION" 2>/dev/null || echo unknown)"
+    _restart_monitor
 fi
 
 echo "[update] done."

--- a/tests/update.bats
+++ b/tests/update.bats
@@ -266,3 +266,90 @@ EOF
     [ "$status" -eq 1 ]
     [[ "$output" != *"loop-monitor"* ]]
 }
+
+# ── --core-only tests ─────────────────────────────────────────────────────────
+
+@test "--core-only: skips monitor even when LOOP_MONITOR_ROOT is a valid git repo" {
+    _make_monitor clean
+    FAKE_MON="$BATS_TMPDIR/fake-monitor"
+    run env -i HOME="$HOME" PATH="$PATH" \
+        LOOP_ROOT="$FAKE_CORE" LOOP_MONITOR_ROOT="$FAKE_MON" \
+        bash "$UPDATE_SH" --core-only --yes
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"loop-monitor"* ]]
+    [[ "$output" == *"done"* ]]
+}
+
+@test "--core-only with breaking core: halts without --yes" {
+    run_update --core-only
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"⚠ This update contains breaking changes:"* ]]
+}
+
+# ── --monitor-only tests ──────────────────────────────────────────────────────
+
+@test "--monitor-only: skips loop core pull" {
+    _make_monitor clean
+    FAKE_MON="$BATS_TMPDIR/fake-monitor"
+    run env -i HOME="$HOME" PATH="$PATH" \
+        LOOP_ROOT="$FAKE_CORE" LOOP_MONITOR_ROOT="$FAKE_MON" \
+        bash "$UPDATE_SH" --monitor-only --yes
+    [ "$status" -eq 0 ]
+    # Core VERSION must not have changed (still at old commit)
+    [ "$(cat "$FAKE_CORE/VERSION")" = "0.1.0" ]
+    # Monitor must have been updated
+    [ "$(cat "$FAKE_MON/VERSION")" = "0.1.1" ]
+}
+
+@test "--monitor-only: does not fetch or mention loop core" {
+    _make_monitor clean
+    FAKE_MON="$BATS_TMPDIR/fake-monitor"
+    run env -i HOME="$HOME" PATH="$PATH" \
+        LOOP_ROOT="$FAKE_CORE" LOOP_MONITOR_ROOT="$FAKE_MON" \
+        bash "$UPDATE_SH" --monitor-only --yes
+    [[ "$output" != *"loop core"* ]]
+}
+
+# ── launchctl restart stub test ───────────────────────────────────────────────
+
+@test "restart: launchctl kickstart called after monitor update (mocked)" {
+    _make_monitor clean
+    FAKE_MON="$BATS_TMPDIR/fake-monitor"
+
+    # Stub directory with a fake launchctl that records invocations.
+    local STUB_DIR="$BATS_TMPDIR/stubs"
+    mkdir -p "$STUB_DIR"
+    local CALL_LOG="$BATS_TMPDIR/launchctl-calls.log"
+    cat > "$STUB_DIR/launchctl" <<'SH'
+#!/usr/bin/env bash
+echo "launchctl $*" >> "$CALL_LOG"
+SH
+    chmod +x "$STUB_DIR/launchctl"
+
+    # Stub uname to always return Darwin so the launchctl path is taken.
+    cat > "$STUB_DIR/uname" <<'SH'
+#!/usr/bin/env bash
+echo "Darwin"
+SH
+    chmod +x "$STUB_DIR/uname"
+
+    run env -i HOME="$HOME" PATH="$STUB_DIR:$PATH" \
+        LOOP_ROOT="$FAKE_CORE" LOOP_MONITOR_ROOT="$FAKE_MON" \
+        CALL_LOG="$CALL_LOG" \
+        bash "$UPDATE_SH" --monitor-only --yes
+
+    [ "$status" -eq 0 ]
+    [ -f "$CALL_LOG" ]
+    grep -q "kickstart" "$CALL_LOG"
+    grep -q "com.loop.loop-monitor" "$CALL_LOG"
+}
+
+# ── VERSION before/after display ──────────────────────────────────────────────
+
+@test "version: output includes before and after version for core update" {
+    run_update --yes
+    [ "$status" -eq 0 ]
+    # Should show both the old version (0.1.0) and new version (0.2.0)
+    [[ "$output" == *"0.1.0"* ]]
+    [[ "$output" == *"0.2.0"* ]]
+}


### PR DESCRIPTION
Closes #44

## Changes

`scripts/update.sh` already existed with breaking-change detection from a sibling issue. This PR adds the missing acceptance criteria from issue #44:

- **`--core-only` flag**: pulls loop core only, skips monitor entirely
- **`--monitor-only` flag**: pulls loop-monitor only and restarts it (skips core fetch)
- **`_restart_monitor` helper**: calls `launchctl kickstart -k gui/$(id -u)/com.loop.loop-monitor` on macOS; logs a manual-restart note on Linux
- **VERSION before/after display**: captures VERSION before pull and prints both old and new versions in the update log
- **Default monitor path**: defaults `LOOP_MONITOR_ROOT` to `~/projects/loop-monitor` when not set in `loop.env`; silently skips if the directory is not a git repo

`tests/update.bats` additions:
- `--core-only`: verifies monitor is skipped even when `LOOP_MONITOR_ROOT` is a valid git repo
- `--core-only` with breaking changes: halts without `--yes`
- `--monitor-only`: verifies core VERSION unchanged and monitor VERSION updated
- `--monitor-only`: verifies no core fetch output
- launchctl stub test: uses `PATH`-based stubs for `launchctl` and `uname` to verify `kickstart -k gui/.../com.loop.loop-monitor` is called after monitor update
- Version before/after display: verifies both old (0.1.0) and new (0.2.0) appear in output

All existing tests preserved; `bash -n` and `shellcheck -S warning` pass on all shell files.

## Test Plan
- `bash -n scripts/update.sh` — must pass
- `shellcheck -S warning scripts/update.sh` — must pass
- Run `bats tests/update.bats` — all tests pass
- Manual smoke: `./scripts/update.sh --dry-run`, `./scripts/update.sh --core-only`, `./scripts/update.sh --monitor-only`