### PR TITLE
Draft: [LOOP-46] add --to <tag>, --rollback, and update history log

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -6,6 +6,8 @@
 #   ./scripts/update.sh --yes        # fetch + apply even with breaking changes
 #   ./scripts/update.sh --check      # fetch, show full changelog diff, no apply
 #   ./scripts/update.sh --dry-run    # same as --check (alias)
+#   ./scripts/update.sh --to <tag>   # checkout a specific tag instead of pulling
+#   ./scripts/update.sh --rollback   # revert to the SHA recorded before the last update
 #
 # Per-component: if LOOP_MONITOR_ROOT is set in loop.env and points to a git
 # repo, loop-monitor's CHANGELOG.md is also scanned for BREAKING: markers.
@@ -26,15 +28,75 @@ fi
 
 YES=false
 CHECK=false
+TO_TAG=""
+ROLLBACK=false
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --yes)             YES=true;  shift ;;
         --check|--dry-run) CHECK=true; shift ;;
-        -h|--help)         sed -n '2,9p' "$0"; exit 0 ;;
+        --to)              shift; TO_TAG="${1:-}"; [ -n "$TO_TAG" ] || { echo "--to requires a tag argument" >&2; exit 2; }; shift ;;
+        --rollback)        ROLLBACK=true; shift ;;
+        -h|--help)         sed -n '2,13p' "$0"; exit 0 ;;
         *) echo "unknown arg: $1" >&2; exit 2 ;;
     esac
 done
+
+# ── update history log ────────────────────────────────────────────────────────
+LOOP_UPDATE_LOG="${LOOP_UPDATE_LOG:-$HOME/.loop/update-history.log}"
+_log_dir="$(dirname "$LOOP_UPDATE_LOG")"
+
+_record_update() {
+    local repo="$1" from_sha="$2" to_sha="$3"
+    mkdir -p "$_log_dir"
+    printf '%s %s %s %s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$repo" "$from_sha" "$to_sha" \
+        >> "$LOOP_UPDATE_LOG"
+}
+
+# ── --rollback ────────────────────────────────────────────────────────────────
+if $ROLLBACK; then
+    if [ ! -f "$LOOP_UPDATE_LOG" ]; then
+        echo "[update] no update history found at $LOOP_UPDATE_LOG" >&2
+        exit 1
+    fi
+
+    # Read the last entry from the log
+    last_entry="$(tail -n 1 "$LOOP_UPDATE_LOG")"
+    if [ -z "$last_entry" ]; then
+        echo "[update] update history is empty" >&2
+        exit 1
+    fi
+
+    rb_timestamp="$(echo "$last_entry" | awk '{print $1}')"
+    rb_repo="$(echo "$last_entry" | awk '{print $2}')"
+    rb_from_sha="$(echo "$last_entry" | awk '{print $3}')"
+    rb_to_sha="$(echo "$last_entry" | awk '{print $4}')"
+
+    echo "[update] rolling back $rb_repo from $rb_to_sha to $rb_from_sha (recorded at $rb_timestamp)"
+
+    if [ "$rb_repo" = "loop-core" ]; then
+        cd "$LOOP_ROOT"
+        git checkout "$rb_from_sha"
+        echo "[update] loop core rolled back to $rb_from_sha"
+    elif [ "$rb_repo" = "loop-monitor" ]; then
+        if [ -z "${LOOP_MONITOR_ROOT:-}" ] || [ ! -d "${LOOP_MONITOR_ROOT}/.git" ]; then
+            echo "[update] LOOP_MONITOR_ROOT not set or not a git repo; cannot roll back monitor" >&2
+            exit 1
+        fi
+        (cd "$LOOP_MONITOR_ROOT" && git checkout "$rb_from_sha")
+        echo "[update] loop-monitor rolled back to $rb_from_sha"
+        # Restart monitor if possible
+        if command -v systemctl >/dev/null 2>&1; then
+            systemctl --user restart loop-monitor 2>/dev/null || true
+        fi
+    else
+        echo "[update] unknown repo in history: $rb_repo" >&2
+        exit 1
+    fi
+
+    echo "[update] rollback complete."
+    exit 0
+fi
 
 # ── extract BREAKING: entries from a CHANGELOG diff on stdin ─────────────────
 # Prints "  <version header>\n    BREAKING: ..." blocks; empty if none found.
@@ -73,6 +135,43 @@ print('\n'.join(results))
 PY
     )
 }
+
+# ── --to <tag>: tag-pinned update path ───────────────────────────────────────
+if [ -n "$TO_TAG" ]; then
+    echo "[update] pinning loop core to tag $TO_TAG …"
+    git fetch --tags --quiet
+
+    CORE_FROM_SHA="$(git rev-parse HEAD)"
+    CORE_TO_SHA="$(git rev-parse "refs/tags/${TO_TAG}" 2>/dev/null || git rev-parse "$TO_TAG")"
+
+    if [ "$CORE_FROM_SHA" = "$CORE_TO_SHA" ]; then
+        echo "[update] loop core already at $TO_TAG"
+    else
+        _record_update "loop-core" "$CORE_FROM_SHA" "$CORE_TO_SHA"
+        git checkout "$TO_TAG"
+        echo "[update] loop core updated to tag $TO_TAG ($(cat VERSION 2>/dev/null || echo unknown))"
+    fi
+
+    if [ -n "${LOOP_MONITOR_ROOT:-}" ] && [ -d "${LOOP_MONITOR_ROOT}/.git" ]; then
+        echo "[update] pinning loop-monitor to tag $TO_TAG …"
+        (cd "$LOOP_MONITOR_ROOT" && git fetch --tags --quiet)
+
+        MON_FROM_SHA="$(cd "$LOOP_MONITOR_ROOT" && git rev-parse HEAD)"
+        MON_TO_SHA="$(cd "$LOOP_MONITOR_ROOT" && git rev-parse "refs/tags/${TO_TAG}" 2>/dev/null || \
+                       cd "$LOOP_MONITOR_ROOT" && git rev-parse "$TO_TAG")"
+
+        if [ "$MON_FROM_SHA" = "$MON_TO_SHA" ]; then
+            echo "[update] loop-monitor already at $TO_TAG"
+        else
+            _record_update "loop-monitor" "$MON_FROM_SHA" "$MON_TO_SHA"
+            (cd "$LOOP_MONITOR_ROOT" && git checkout "$TO_TAG")
+            echo "[update] loop-monitor updated to tag $TO_TAG ($(cat "${LOOP_MONITOR_ROOT}/VERSION" 2>/dev/null || echo unknown))"
+        fi
+    fi
+
+    echo "[update] done."
+    exit 0
+fi
 
 # ── fetch loop core ───────────────────────────────────────────────────────────
 echo "[update] fetching loop core (origin/main) …"
@@ -167,14 +266,20 @@ fi
 
 # ── apply ────────────────────────────────────────────────────────────────────
 if ! $CORE_UP_TO_DATE; then
+    CORE_FROM_SHA="$(git rev-parse HEAD)"
     echo "[update] applying loop core …"
     git merge --ff-only origin/main
+    CORE_TO_SHA="$(git rev-parse HEAD)"
+    _record_update "loop-core" "$CORE_FROM_SHA" "$CORE_TO_SHA"
     echo "[update] loop core updated to $(cat VERSION 2>/dev/null || echo unknown)"
 fi
 
 if ! $MONITOR_UP_TO_DATE && [ -n "${LOOP_MONITOR_ROOT:-}" ] && [ -d "${LOOP_MONITOR_ROOT}/.git" ]; then
+    MON_FROM_SHA="$(cd "$LOOP_MONITOR_ROOT" && git rev-parse HEAD)"
     echo "[update] applying loop-monitor …"
     (cd "$LOOP_MONITOR_ROOT" && git merge --ff-only origin/main)
+    MON_TO_SHA="$(cd "$LOOP_MONITOR_ROOT" && git rev-parse HEAD)"
+    _record_update "loop-monitor" "$MON_FROM_SHA" "$MON_TO_SHA"
     echo "[update] loop-monitor updated to $(cat "${LOOP_MONITOR_ROOT}/VERSION" 2>/dev/null || echo unknown)"
 fi
 

--- a/tests/update.bats
+++ b/tests/update.bats
@@ -266,3 +266,86 @@ EOF
     [ "$status" -eq 1 ]
     [[ "$output" != *"loop-monitor"* ]]
 }
+
+# ── --rollback tests ──────────────────────────────────────────────────────────
+
+@test "rollback: reads history log and calls git checkout with correct SHA" {
+    FAKE_HIST="$BATS_TMPDIR/update-history.log"
+    # Record the current HEAD as from_sha, and a fake to_sha
+    from_sha="$(cd "$FAKE_CORE" && git rev-parse HEAD)"
+    to_sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+    # Pre-populate the history log with a loop-core entry
+    printf '2026-04-28T10:00:00Z loop-core %s %s\n' "$from_sha" "$to_sha" > "$FAKE_HIST"
+
+    # Advance FAKE_CORE to origin/main so from_sha is a reachable ancestor
+    cd "$FAKE_CORE" && git merge --ff-only origin/main -q
+
+    run env -i HOME="$HOME" PATH="$PATH" \
+        LOOP_ROOT="$FAKE_CORE" \
+        LOOP_UPDATE_LOG="$FAKE_HIST" \
+        bash "$UPDATE_SH" --rollback
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"rolling back loop-core"* ]]
+    # Verify git checkout returned to from_sha
+    current_sha="$(cd "$FAKE_CORE" && git rev-parse HEAD)"
+    [ "$current_sha" = "$from_sha" ]
+}
+
+@test "rollback: fails gracefully when history log is missing" {
+    run env -i HOME="$HOME" PATH="$PATH" \
+        LOOP_ROOT="$FAKE_CORE" \
+        LOOP_UPDATE_LOG="$BATS_TMPDIR/nonexistent-history.log" \
+        bash "$UPDATE_SH" --rollback
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"no update history found"* ]]
+}
+
+@test "rollback: fails gracefully when history log is empty" {
+    FAKE_HIST="$BATS_TMPDIR/empty-history.log"
+    : > "$FAKE_HIST"
+    run env -i HOME="$HOME" PATH="$PATH" \
+        LOOP_ROOT="$FAKE_CORE" \
+        LOOP_UPDATE_LOG="$FAKE_HIST" \
+        bash "$UPDATE_SH" --rollback
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"update history is empty"* ]]
+}
+
+# ── --to <tag> tests ──────────────────────────────────────────────────────────
+
+@test "to-tag: checks out the specified tag in loop core" {
+    FAKE_HIST="$BATS_TMPDIR/tag-history.log"
+
+    # Create a tag at the current HEAD (0.1.0) in origin, then clone
+    cd "$BATS_TMPDIR/fake-origin"
+    git tag v0.1.0 HEAD~1 2>/dev/null || git tag v0.1.0 HEAD
+
+    cd "$FAKE_CORE"
+    git fetch --tags --quiet
+
+    run env -i HOME="$HOME" PATH="$PATH" \
+        LOOP_ROOT="$FAKE_CORE" \
+        LOOP_UPDATE_LOG="$FAKE_HIST" \
+        bash "$UPDATE_SH" --to v0.1.0
+    # tag points to current HEAD so "already at" or success
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"v0.1.0"* ]]
+}
+
+@test "history: normal --yes update records from/to SHAs in log" {
+    FAKE_HIST="$BATS_TMPDIR/record-history.log"
+
+    from_sha="$(cd "$FAKE_CORE" && git rev-parse HEAD)"
+
+    run env -i HOME="$HOME" PATH="$PATH" \
+        LOOP_ROOT="$FAKE_CORE" \
+        LOOP_UPDATE_LOG="$FAKE_HIST" \
+        bash "$UPDATE_SH" --yes
+    [ "$status" -eq 0 ]
+
+    [ -f "$FAKE_HIST" ]
+    log_line="$(cat "$FAKE_HIST")"
+    [[ "$log_line" == *"loop-core"* ]]
+    [[ "$log_line" == *"$from_sha"* ]]
+}


### PR DESCRIPTION
Closes #46

## Changes

**`scripts/update.sh`**
- Added `--to <tag>` flag: fetches tags then runs `git checkout <tag>` on loop-core (and loop-monitor if configured); records history before applying; prints which tag was applied.
- Added `--rollback` flag: reads the last entry from `~/.loop/update-history.log`, calls `git checkout <from-sha>` to revert; attempts monitor service restart via `systemctl` if rolling back the monitor.
- Before any `--yes` or normal update, records `<timestamp> <repo> <from-sha> <to-sha>` to `~/.loop/update-history.log` (append-only).
- Added `LOOP_UPDATE_LOG` env override for tests.
- Argument parser handles `--to` requiring a value; unknown args still error.

**`tests/update.bats`**
- Added `rollback: reads history log and calls git checkout with correct SHA` — creates a pre-populated history log, advances the fake repo, runs `--rollback`, verifies HEAD returns to `from_sha`.
- Added `rollback: fails gracefully when history log is missing`.
- Added `rollback: fails gracefully when history log is empty`.
- Added `to-tag: checks out the specified tag in loop core`.
- Added `history: normal --yes update records from/to SHAs in log`.

## Test Plan

- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — passes (verified locally)
- `shellcheck -S warning lib/*.sh scripts/*.sh scanner/*.sh install.sh` — passes (no output)
- New bats tests cover `--rollback` golden path, missing log, empty log, `--to <tag>`, and history recording