### PR TITLE
Draft: [LOOP-56] add backend_find_pr_for_issue to all backends

### DIFF
--- a/lib/backends/backend.sh
+++ b/lib/backends/backend.sh
@@ -70,6 +70,10 @@
 #   backend_issue_unmet_deps <repo> <number>
 #     Print each unmet dependency (#NNN) declared in the issue's "## Dependencies"
 #     section, one per line. Empty output = all deps met or none declared.
+#
+#   backend_find_pr_for_issue <repo> <issue_num>
+#     Print the open PR/MR number whose body references the given issue, or
+#     empty string if none found. Always exits 0.
 
 set -euo pipefail
 

--- a/lib/backends/github.sh
+++ b/lib/backends/github.sh
@@ -124,6 +124,24 @@ backend_merge_pr() {
     gh pr merge "$number" "$strategy_flag" --repo "$repo" --delete-branch
 }
 
+# backend_find_pr_for_issue <repo> <issue_num>
+# Prints the open PR number whose body closes the given issue, or empty string.
+# Always exits 0.
+backend_find_pr_for_issue() {
+    local repo="$1" issue_num="$2"
+    local result
+    result=$(gh pr list --repo "$repo" --state open \
+        --json number \
+        --search "Closes #${issue_num} in:body" \
+        2>/dev/null \
+        | python3 -c "
+import json, sys
+prs = json.load(sys.stdin)
+print(prs[0]['number'] if prs else '')
+" 2>/dev/null || true)
+    printf '%s' "${result:-}"
+}
+
 # ---------------------------------------------------------------------------
 # Extended interface — bulk operations used by reconciler
 # ---------------------------------------------------------------------------

--- a/lib/backends/gitlab.sh
+++ b/lib/backends/gitlab.sh
@@ -273,6 +273,27 @@ backend_merge_pr() {
     glab mr merge "${gl_args[@]}"
 }
 
+# backend_find_pr_for_issue <repo> <issue_num>
+# Prints the open MR number whose description references the given issue, or
+# empty string. Always exits 0.
+backend_find_pr_for_issue() {
+    local repo="$1" issue_num="$2"
+    _gl_parse_repo "$repo"
+    local result
+    result=$(glab mr list --repo "$_GL_REPO" --state opened --output json \
+        2>/dev/null \
+        | python3 -c "
+import json, sys
+mrs = json.load(sys.stdin)
+ref = '#' + sys.argv[1]
+for mr in mrs:
+    if ref in (mr.get('description') or ''):
+        print(mr['iid'])
+        break
+" "$issue_num" 2>/dev/null || true)
+    printf '%s' "${result:-}"
+}
+
 # ---------------------------------------------------------------------------
 # Extended interface — bulk operations used by scanner/reconciler
 # ---------------------------------------------------------------------------

--- a/lib/backends/jira-gitlab.sh
+++ b/lib/backends/jira-gitlab.sh
@@ -284,3 +284,10 @@ print(urllib.parse.quote(jql))
 }
 
 # backend_list_open_prs_raw and backend_list_merged_prs_raw are inherited from gitlab.sh.
+
+# backend_find_pr_for_issue <repo> <issue_num>
+# Jira issues use project-scoped keys (e.g. PROJ-42), not numeric GitHub/GitLab
+# references, so MR description search is not reliable. Return empty; exits 0.
+backend_find_pr_for_issue() {
+    return 0
+}


### PR DESCRIPTION
Closes #56

## Changes

Added `backend_find_pr_for_issue <repo> <issue_num>` to the backend abstraction layer:

- **`lib/backends/github.sh`**: Uses `gh pr list --search "Closes #N in:body"` filtered to open PRs; extracts number via python3 heredoc on the JSON result.
- **`lib/backends/gitlab.sh`**: Uses `glab mr list --state opened --output json` and filters MR descriptions containing `#<issue_num>` via python3 heredoc.
- **`lib/backends/jira-gitlab.sh`**: Stub that returns empty and exits 0 — Jira issues use project-scoped keys (e.g. `PROJ-42`), not numeric `#N` references, so MR description search is not reliable.
- **`lib/backends/backend.sh`**: Added function to the abstract interface documentation.

All implementations always exit 0 and print empty string when no PR/MR is found.

## Test Plan

- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — passes (all syntax clean)
- `shellcheck -S warning` — passes (no warnings)
- Manual: call `backend_find_pr_for_issue <repo> <issue_num>` against a repo with a known open PR whose body contains `Closes #N`; verify the correct PR number is returned
- Manual: call against an issue with no open PR; verify empty string returned and exit code 0