### PR TITLE
Draft: [LOOP-69] lib/recovery.sh scaffold, stuck-label timeout, orphan worktree cleanup

### DIFF
--- a/lib/recovery.sh
+++ b/lib/recovery.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# lib/recovery.sh — active-recovery helpers for scanner/reconciler.sh.
+#
+# Exports:
+#   recovery_check_stuck_labels <slug>   — strip timed-out operational labels
+#   recovery_prune_orphan_worktrees      — remove worktrees with no handler + no PR
+#
+# Sourced by scanner/reconciler.sh after lib/env.sh, lib/config.sh, and the
+# backend adapter. All backend_* functions must already be in scope.
+
+# Default timeout (seconds). Overridable in loop.env.
+HANDLER_TIMEOUT="${HANDLER_TIMEOUT:-3600}"
+
+# Operational label → canonical upstream trigger mapping.
+# Used to restore the pipeline trigger after a stuck-label strip.
+_RECOVERY_OP_TO_TRIGGER=(
+    "in-progress:dev"
+    "in-rework:needs-rework"
+    "in-review:needs-review"
+)
+
+# _recovery_trigger_for_op <operational_label>
+# Echoes the canonical upstream trigger label for a given operational label,
+# or an empty string if not recognised.
+_recovery_trigger_for_op() {
+    local op="$1"
+    local entry
+    for entry in "${_RECOVERY_OP_TO_TRIGGER[@]}"; do
+        if [ "${entry%%:*}" = "$op" ]; then
+            echo "${entry#*:}"
+            return 0
+        fi
+    done
+}
+
+# recovery_check_stuck_labels <slug>
+#
+# For each open issue or PR carrying an operational label (in-progress,
+# in-rework, in-review) that:
+#   - has not been updated within HANDLER_TIMEOUT * 1.5 seconds, AND
+#   - has no live handler process (checked via per-issue lock files)
+#
+# strips the operational label and restores the upstream trigger so the
+# pipeline can retry. Uses loop_label_for to respect per-project overrides.
+#
+# DRY_RUN and log() must be available in the caller's scope.
+recovery_check_stuck_labels() {
+    local slug="$1"
+    local repo
+    repo="${REPO:-}"
+    if [ -z "$repo" ]; then
+        log "[recovery] ERROR: REPO not set for slug=$slug"
+        return 1
+    fi
+
+    local timeout_secs
+    timeout_secs=$(python3 -c "import math; print(int(math.ceil(${HANDLER_TIMEOUT} * 1.5)))")
+    log "[$repo] recovery: checking stuck operational labels (timeout=${timeout_secs}s)"
+
+    local lock_dir="${LOOP_LOCK_DIR:-/tmp/loop-locks}"
+    local op_entry trigger_canon op_label issues_json candidates
+
+    for op_entry in "${_RECOVERY_OP_TO_TRIGGER[@]}"; do
+        op_label="${op_entry%%:*}"
+        trigger_canon="${op_entry#*:}"
+
+        # Resolve the project-specific label name for both labels
+        local actual_op actual_trigger
+        actual_op=$(loop_label_for "$slug" "$op_label" 2>/dev/null || echo "$op_label")
+        actual_trigger=$(loop_label_for "$slug" "$trigger_canon" 2>/dev/null || echo "$trigger_canon")
+
+        # Fetch issues with this operational label
+        issues_json=$(backend_list_open_issues_raw "$repo" "$actual_op" 2>/dev/null || echo "[]")
+
+        # Filter to those exceeding the timeout
+        candidates=$(ISS="$issues_json" CUTOFF_S="$timeout_secs" python3 - <<'PY'
+import json, os, datetime as dt
+issues = json.loads(os.environ['ISS'])
+cutoff_s = int(os.environ['CUTOFF_S'])
+now = dt.datetime.now(dt.timezone.utc)
+for iss in issues:
+    up = dt.datetime.fromisoformat(iss['updatedAt'].replace('Z', '+00:00'))
+    age_s = int((now - up).total_seconds())
+    if age_s >= cutoff_s:
+        print(f"{iss['number']}\t{age_s}\t{iss['title'][:60]}")
+PY
+)
+
+        [ -z "$candidates" ] && continue
+
+        while IFS=$'\t' read -r num age_s title; do
+            [ -z "$num" ] && continue
+
+            # Check for a live handler process via per-issue lock files.
+            local handler_alive=false lf pid
+            for lf in \
+                "$lock_dir/${slug}-issue-${num}.lock" \
+                "$lock_dir/po-${slug}-${num}.lock" \
+                "$lock_dir/${slug}-rework-${num}.lock"; do
+                [ -f "$lf" ] || continue
+                pid=$(cat "$lf" 2>/dev/null || echo "")
+                if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+                    handler_alive=true; break
+                fi
+            done
+
+            if $handler_alive; then
+                log "[$repo] recovery: issue #$num has live handler — skip ($op_label)"
+                continue
+            fi
+
+            log "[$repo] recovery: STUCK $op_label on issue #$num (${age_s}s, no handler): $title → $actual_trigger"
+            loop_notify "Loop recovery: $repo — issue #$num stuck in $op_label for ${age_s}s with no handler; restoring $actual_trigger"
+
+            if ${DRY_RUN:-false}; then
+                continue
+            fi
+
+            backend_remove_label "$repo" "$num" "$actual_op" \
+                || log "[$repo] recovery: WARN failed to remove $actual_op from #$num"
+            backend_add_label "$repo" "$num" "$actual_trigger" \
+                || log "[$repo] recovery: WARN failed to add $actual_trigger to #$num"
+        done <<< "$candidates"
+    done
+}
+
+# recovery_prune_orphan_worktrees
+#
+# Scans /tmp/loop-worktree-* directories that do NOT have the standard
+# slug-specific naming (those are handled by reconcile_worktrees). For each:
+#   - Skips dirs modified within the last 10 minutes (handler may be mid-flight)
+#   - Checks if a handler lock file with a live PID covers this dir
+#   - Checks if an open PR exists for the issue number embedded in the dirname
+#   - Removes the directory (git worktree remove --force then rm -rf fallback)
+#     if neither condition is true
+#
+# ROOT and REPO must be set. DRY_RUN and log() must be available.
+recovery_prune_orphan_worktrees() {
+    local repo="${REPO:-}"
+    local root="${ROOT:-}"
+
+    log "[recovery] pruning orphan worktrees under /tmp/loop-worktree-*"
+
+    local now_sec
+    now_sec=$(date +%s)
+    local grace=600  # 10-minute grace window
+
+    local lock_dir="${LOOP_LOCK_DIR:-/tmp/loop-locks}"
+    local wt_dir base num mtime age
+
+    for wt_dir in /tmp/loop-worktree-*/; do
+        [ -d "$wt_dir" ] || continue
+        wt_dir="${wt_dir%/}"
+        base=$(basename "$wt_dir")
+
+        # Extract trailing numeric token as issue/PR number
+        num=$(echo "$base" | grep -oE '[0-9]+$' || true)
+        if [ -z "$num" ]; then
+            log "[recovery] SKIP $wt_dir — cannot extract issue number"
+            continue
+        fi
+
+        # Recent-activity grace window
+        mtime=$(python3 -c "import os,sys; print(int(os.stat(sys.argv[1]).st_mtime))" "$wt_dir" 2>/dev/null || echo 0)
+        age=$(( now_sec - mtime ))
+        if [ "$age" -lt "$grace" ]; then
+            log "[recovery] SKIP $wt_dir — recently modified (${age}s < ${grace}s)"
+            continue
+        fi
+
+        # Check for a live handler lock referencing this worktree/issue
+        local handler_alive=false lf pid
+        for lf in "$lock_dir"/*"-${num}.lock" "$lock_dir"/*"-${num}-"*.lock; do
+            [ -f "$lf" ] || continue
+            pid=$(cat "$lf" 2>/dev/null || echo "")
+            if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+                handler_alive=true; break
+            fi
+        done
+
+        if $handler_alive; then
+            log "[recovery] SKIP $wt_dir — live handler found"
+            continue
+        fi
+
+        # Check for an open PR closing this issue
+        local open_pr_count
+        if [ -n "$repo" ]; then
+            open_pr_count=$(gh pr list --repo "$repo" --state open \
+                --json number,body --jq \
+                "[.[] | select(.body | test(\"(clos(e|es|ed)|fix(|es|ed)|resolv(e|es|ed))\\\\s+#${num}\"; \"i\"))] | length" \
+                2>/dev/null || echo 0)
+        else
+            open_pr_count=0
+        fi
+
+        if [ "${open_pr_count:-0}" -gt 0 ]; then
+            log "[recovery] SKIP $wt_dir — open PR exists for issue #$num"
+            continue
+        fi
+
+        log "[recovery] ORPHAN worktree $wt_dir (issue #$num, no handler, no open PR)"
+        loop_notify "Loop recovery: removing orphaned worktree $wt_dir (issue #$num, no handler, no open PR)"
+
+        if ${DRY_RUN:-false}; then
+            continue
+        fi
+
+        if [ -n "$root" ]; then
+            git -C "$root" worktree remove "$wt_dir" --force 2>/dev/null \
+                || rm -rf "$wt_dir"
+        else
+            rm -rf "$wt_dir"
+        fi
+    done
+}

--- a/loop.env.example
+++ b/loop.env.example
@@ -55,6 +55,13 @@ LOOP_DISPATCH_MODE="direct"
 # macOS (Homebrew): /opt/homebrew/bin:/usr/local/bin — Linux: /usr/local/bin or similar.
 LOOP_EXTRA_PATH="/opt/homebrew/bin:/usr/local/bin"
 
+# ─── Recovery ────────────────────────────────────────────────────────────────
+# Seconds before an operational label (in-progress, in-rework, in-review) with
+# no live handler process is considered stuck. Recovery strips the label and
+# restores the upstream trigger so the pipeline can retry. Default: 3600 (1h).
+# The stuck-label check fires when age >= HANDLER_TIMEOUT * 1.5.
+# HANDLER_TIMEOUT=3600
+
 # ─── Bounty / loop-monitor ────────────────────────────────────────────────────
 # Stable identifier for this Loop instance sent with every bounty/event payload.
 # Lets loop-monitor distinguish multiple Loop instances reporting to the same endpoint.

--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -28,6 +28,8 @@ source "$LOOP_ROOT/lib/env.sh"
 source "$LOOP_ROOT/lib/config.sh"
 # shellcheck source=../lib/backends/backend.sh
 source "$LOOP_ROOT/lib/backends/backend.sh"
+# shellcheck source=../lib/recovery.sh
+source "$LOOP_ROOT/lib/recovery.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-reconciler.log"
 LOCK_FILE="/tmp/loop-reconciler.lock"
@@ -729,6 +731,8 @@ run_project() {
     reconcile_unblock "$REPO"
     reconcile_orphaned_in_progress "$REPO" "$slug"
     reconcile_worktrees "$slug" "$REPO"
+    recovery_check_stuck_labels "$slug"
+    recovery_prune_orphan_worktrees
 }
 
 acquire_lock

--- a/tests/reconciler.bats
+++ b/tests/reconciler.bats
@@ -1,0 +1,220 @@
+#!/usr/bin/env bats
+# tests/reconciler.bats — unit tests for lib/recovery.sh helpers.
+#
+# Tests are self-contained: gh, backend_*, loop_label_for, loop_notify, and log
+# are all stubbed so no real GitHub or filesystem state is needed.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    # Expose mock-gh.sh as the gh binary via a per-test temp bin directory.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+    export LOOP_LOCK_DIR="$BATS_TMPDIR/locks"
+    mkdir -p "$LOOP_LOCK_DIR"
+
+    # Set required globals that recovery.sh functions depend on.
+    export LOOP_ROOT="$REPO_ROOT"
+    export REPO="owner/test-repo"
+    export ROOT="$BATS_TMPDIR/fake-root"
+    export DRY_RUN=false
+    export HANDLER_TIMEOUT=3600
+
+    # Stub library functions so we can source recovery.sh in isolation.
+    loop_label_for()             { echo "$2"; }
+    loop_notify()                { :; }
+    log()                        { :; }
+    backend_list_open_issues_raw() { echo "${GH_MOCK_OUTPUT:-[]}"; }
+    backend_remove_label()       { echo "remove_label $3" >> "$BATS_TMPDIR/ops.log"; }
+    backend_add_label()          { echo "add_label $3"    >> "$BATS_TMPDIR/ops.log"; }
+
+    # Source only recovery.sh (it does not call acquire_lock on source).
+    # shellcheck disable=SC1090
+    source "$REPO_ROOT/lib/recovery.sh"
+
+    rm -f "$BATS_TMPDIR/ops.log"
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/logs" \
+           "$BATS_TMPDIR/locks" "$BATS_TMPDIR/ops.log" \
+           "$BATS_TMPDIR/fake-root" 2>/dev/null || true
+    # Clean up any worktree dirs created during tests
+    rm -rf /tmp/loop-worktree-bats-test-* 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# recovery_check_stuck_labels
+# ---------------------------------------------------------------------------
+
+@test "recovery_check_stuck_labels: skips issues updated within timeout" {
+    # updatedAt = now (0 seconds old) — must NOT be stripped
+    local now_iso
+    now_iso=$(python3 -c "import datetime; print(datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))")
+    export GH_MOCK_OUTPUT="[{\"number\":1,\"title\":\"fresh issue\",\"updatedAt\":\"${now_iso}\",\"labels\":[{\"name\":\"in-progress\"}]}]"
+
+    run recovery_check_stuck_labels "test-proj"
+    [ "$status" -eq 0 ]
+    # No label operations should have occurred
+    [ ! -f "$BATS_TMPDIR/ops.log" ] || ! grep -q "remove_label" "$BATS_TMPDIR/ops.log"
+}
+
+@test "recovery_check_stuck_labels: strips stuck in-progress and restores dev" {
+    # updatedAt = 2 hours ago (> HANDLER_TIMEOUT * 1.5 = 5400s)
+    local old_iso
+    old_iso=$(python3 -c "
+import datetime
+t = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=2)
+print(t.strftime('%Y-%m-%dT%H:%M:%SZ'))
+")
+    export GH_MOCK_OUTPUT="[{\"number\":42,\"title\":\"stuck issue\",\"updatedAt\":\"${old_iso}\",\"labels\":[{\"name\":\"in-progress\"}]}]"
+
+    # No lock file → handler not alive
+    run recovery_check_stuck_labels "test-proj"
+    [ "$status" -eq 0 ]
+    grep -q "remove_label in-progress" "$BATS_TMPDIR/ops.log"
+    grep -q "add_label dev"            "$BATS_TMPDIR/ops.log"
+}
+
+@test "recovery_check_stuck_labels: skips issue with live handler lock" {
+    local old_iso
+    old_iso=$(python3 -c "
+import datetime
+t = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=2)
+print(t.strftime('%Y-%m-%dT%H:%M:%SZ'))
+")
+    export GH_MOCK_OUTPUT="[{\"number\":7,\"title\":\"live handler issue\",\"updatedAt\":\"${old_iso}\",\"labels\":[{\"name\":\"in-progress\"}]}]"
+
+    # Write a lock file for this issue with our own PID (process is alive)
+    echo "$$" > "$LOOP_LOCK_DIR/test-proj-issue-7.lock"
+
+    run recovery_check_stuck_labels "test-proj"
+    [ "$status" -eq 0 ]
+    # No label operations should occur when handler is alive
+    [ ! -f "$BATS_TMPDIR/ops.log" ] || ! grep -q "remove_label" "$BATS_TMPDIR/ops.log"
+}
+
+@test "recovery_check_stuck_labels: strips stuck in-rework and restores needs-rework" {
+    local old_iso
+    old_iso=$(python3 -c "
+import datetime
+t = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=3)
+print(t.strftime('%Y-%m-%dT%H:%M:%SZ'))
+")
+
+    # Override backend stub to return in-rework issue only for that label query
+    local call_count=0
+    backend_list_open_issues_raw() {
+        local _repo="$1" lbl="$2"
+        if [ "$lbl" = "in-rework" ]; then
+            echo "[{\"number\":55,\"title\":\"rework stuck\",\"updatedAt\":\"${old_iso}\",\"labels\":[{\"name\":\"in-rework\"}]}]"
+        else
+            echo "[]"
+        fi
+    }
+
+    run recovery_check_stuck_labels "test-proj"
+    [ "$status" -eq 0 ]
+    grep -q "remove_label in-rework"   "$BATS_TMPDIR/ops.log"
+    grep -q "add_label needs-rework"   "$BATS_TMPDIR/ops.log"
+}
+
+@test "recovery_check_stuck_labels: dry-run suppresses label mutations" {
+    local old_iso
+    old_iso=$(python3 -c "
+import datetime
+t = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=2)
+print(t.strftime('%Y-%m-%dT%H:%M:%SZ'))
+")
+    export GH_MOCK_OUTPUT="[{\"number\":99,\"title\":\"dry run issue\",\"updatedAt\":\"${old_iso}\",\"labels\":[{\"name\":\"in-progress\"}]}]"
+    DRY_RUN=true
+
+    run recovery_check_stuck_labels "test-proj"
+    [ "$status" -eq 0 ]
+    # No label operations should occur in dry-run mode
+    [ ! -f "$BATS_TMPDIR/ops.log" ] || ! grep -q "remove_label" "$BATS_TMPDIR/ops.log"
+}
+
+# ---------------------------------------------------------------------------
+# recovery_prune_orphan_worktrees
+# ---------------------------------------------------------------------------
+
+@test "recovery_prune_orphan_worktrees: removes orphan dir with no handler and no open PR" {
+    local wt_dir="/tmp/loop-worktree-bats-test-123"
+    mkdir -p "$wt_dir"
+    # Make it old enough to exceed the grace window (touch mtime to epoch-ish)
+    python3 -c "import os; os.utime('$wt_dir', (0, 0))"
+
+    # gh returns 0 open PRs for issue 123
+    export GH_MOCK_OUTPUT="0"
+
+    run recovery_prune_orphan_worktrees
+    [ "$status" -eq 0 ]
+    [ ! -d "$wt_dir" ]
+}
+
+@test "recovery_prune_orphan_worktrees: skips dir with open PR" {
+    local wt_dir="/tmp/loop-worktree-bats-test-456"
+    mkdir -p "$wt_dir"
+    python3 -c "import os; os.utime('$wt_dir', (0, 0))"
+
+    # Mock gh to return 1 open PR (jq output of the count query)
+    export GH_MOCK_OUTPUT="1"
+
+    run recovery_prune_orphan_worktrees
+    [ "$status" -eq 0 ]
+    [ -d "$wt_dir" ]
+    rm -rf "$wt_dir"
+}
+
+@test "recovery_prune_orphan_worktrees: skips recently modified dir" {
+    local wt_dir="/tmp/loop-worktree-bats-test-789"
+    mkdir -p "$wt_dir"
+    # Do NOT touch mtime — it's fresh (just created = now)
+
+    export GH_MOCK_OUTPUT="0"
+
+    run recovery_prune_orphan_worktrees
+    [ "$status" -eq 0 ]
+    # Dir must still exist (within grace window)
+    [ -d "$wt_dir" ]
+    rm -rf "$wt_dir"
+}
+
+@test "recovery_prune_orphan_worktrees: skips dir with live handler lock" {
+    local wt_dir="/tmp/loop-worktree-bats-test-321"
+    mkdir -p "$wt_dir"
+    python3 -c "import os; os.utime('$wt_dir', (0, 0))"
+
+    # Write a live lock for issue 321
+    echo "$$" > "$LOOP_LOCK_DIR/proj-321.lock"
+
+    export GH_MOCK_OUTPUT="0"
+
+    run recovery_prune_orphan_worktrees
+    [ "$status" -eq 0 ]
+    # Dir must survive because handler is alive
+    [ -d "$wt_dir" ]
+    rm -rf "$wt_dir"
+}
+
+@test "recovery_prune_orphan_worktrees: dry-run does not remove dir" {
+    local wt_dir="/tmp/loop-worktree-bats-test-999"
+    mkdir -p "$wt_dir"
+    python3 -c "import os; os.utime('$wt_dir', (0, 0))"
+
+    export GH_MOCK_OUTPUT="0"
+    DRY_RUN=true
+
+    run recovery_prune_orphan_worktrees
+    [ "$status" -eq 0 ]
+    # Dir must survive in dry-run
+    [ -d "$wt_dir" ]
+    rm -rf "$wt_dir"
+}


### PR DESCRIPTION
Closes #69

## Changes

- **`lib/recovery.sh`** (new): Foundational recovery helper library sourced by the reconciler. Exports two functions:
  - `recovery_check_stuck_labels <slug>`: Scans open issues carrying operational labels (`in-progress`, `in-rework`, `in-review`). For each issue where age ≥ `HANDLER_TIMEOUT * 1.5` seconds and no live handler lock exists, strips the operational label and restores the upstream trigger (`dev`, `needs-rework`, `needs-review`) via `loop_label_for` to respect per-project overrides.
  - `recovery_prune_orphan_worktrees`: Scans `/tmp/loop-worktree-*` directories for entries with no live handler PID and no open PR referencing the embedded issue number. Removes orphans (git worktree remove + rm -rf fallback). Skips dirs modified within 10-minute grace window.
  - `HANDLER_TIMEOUT` defaults to 3600s; overridable via `loop.env`.

- **`scanner/reconciler.sh`**: Sources `lib/recovery.sh`; calls `recovery_check_stuck_labels` and `recovery_prune_orphan_worktrees` at the end of each project's reconciliation run.

- **`loop.env.example`**: Documents the `HANDLER_TIMEOUT` variable with explanation of the 1.5× multiplier.

- **`tests/reconciler.bats`** (new): 9 bats tests covering:
  - Stuck-label timeout: skips fresh issues, strips timed-out in-progress→dev, skips with live handler lock, strips in-rework→needs-rework, dry-run suppresses mutations.
  - Orphan worktree prune: removes orphan with no handler/PR, skips with open PR, skips recently-modified dirs, skips with live handler lock, dry-run suppresses removal.

## Test Plan

- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — all pass (verified)
- `shellcheck -S warning lib/*.sh scripts/*.sh scanner/*.sh install.sh` — clean (verified)
- No personal identifiers in committed files (verified)
- `bats tests/reconciler.bats` — run all 9 new tests