### PR TITLE
Draft: [LOOP-25] Fix GitLab compat: backend_cli_note injection and stage ID docs

### DIFF
--- a/config/workflows/README.md
+++ b/config/workflows/README.md
@@ -62,6 +62,25 @@ pr_stages:
 - At least one stage (anywhere in `issue_stages` or `pr_stages`)
 - Each stage: `id`, `trigger_label`, `handler`
 
+### Reserved stage IDs
+
+The built-in handlers call `loop_stage_trigger` with fixed stage `id` values to
+resolve label names at runtime. If a custom workflow omits a stage or uses a
+different `id`, the handler falls back to the hardcoded default label shown below,
+which may not match your project's label vocabulary.
+
+| Stage ID | Used by | Fallback label if absent |
+|---|---|---|
+| `po` | po-handler (trigger strip) | `po-review` |
+| `dev` | dev-handler (trigger strip) | `plan` |
+| `review` | dev-handler, dev-rework-handler | `review-pending` |
+| `rework` | review-handler (reject path) | `changes-requested` |
+| `qa` | review-handler (approve path) | `ready-for-qa` |
+
+Custom workflows that rename a stage must either keep one of these `id` values or
+add a matching `labels:` override in `config/projects.yaml` so the fallback
+resolves correctly.
+
 ### Validation
 
 ```bash

--- a/lib/backends/backend.sh
+++ b/lib/backends/backend.sh
@@ -104,3 +104,44 @@ loop_load_backend
 
 # (declare this alongside the other backend_* interface functions)
 backend_issue_unmet_deps() { echo "backend_issue_unmet_deps not implemented" >&2; return 1; }
+
+# backend_cli_note — emit a CLI equivalence block for agent prompts.
+# On gitlab/jira-gitlab backends, prints a glab/gh translation table so the
+# agent knows to substitute glab for gh commands. Prints nothing on github.
+backend_cli_note() {
+    case "${BACKEND:-github}" in
+        gitlab|jira-gitlab) cat <<'CLINOTE'
+
+BACKEND NOTICE: This project uses GitLab. Use glab commands instead of gh:
+  gh issue view N --repo R --json body --jq .body
+    → glab issue view N --repo R --output json | python3 -c "import json,sys; print(json.load(sys.stdin).get('description',''))"
+  gh issue list --repo R --state all --limit 50
+    → glab issue list --repo R --state all --limit 50
+  gh issue edit N --repo R --add-label L --remove-label M
+    → glab issue update N --repo R --add-label L --remove-label M
+  gh issue comment N --repo R --body 'text'
+    → glab issue comment N --repo R --body 'text'
+  gh issue close N --repo R
+    → glab issue close N --repo R
+  gh issue create --repo R --title T --body B --label L
+    → glab issue create --repo R --title T --description B --label L
+  gh pr create --repo R --title T --body B --label L
+    → glab mr create --repo R --title T --description B --label L
+  gh pr view N --repo R --json state,merged
+    → glab mr view N --repo R --output json
+  gh pr diff N --repo R
+    → glab mr diff N --repo R
+  gh pr checks N --repo R
+    → glab pipeline list --source-branch BRANCH --repo R
+  gh pr review N --repo R --approve --body 'text'
+    → glab mr approve N --repo R  (post review body as a separate comment)
+  gh pr review N --repo R --request-changes --body 'text'
+    → glab mr revoke N --repo R  (post review body as a separate comment)
+  gh pr edit N --repo R --add-label L --remove-label M
+    → glab mr update N --repo R --add-label L --remove-label M
+  gh pr comment N --repo R --body 'text'
+    → glab mr comment N --repo R --body 'text'
+CLINOTE
+        ;;
+    esac
+}

--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -745,9 +745,8 @@ PY
     local pr_num pr_state issue_nums issue_num
     for pr_num in $conflict_prs; do
         # Check actual merge state
-        pr_state=$(backend_pr_view "$repo" "$pr_num" --json mergeable,mergeStateStatus,body 2>/dev/null || echo "{}")
-        local mergeable merge_status body
-        mergeable=$(echo "$pr_state" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('mergeable',''))" 2>/dev/null || echo "")
+        pr_state=$(backend_pr_view "$repo" "$pr_num" --json mergeStateStatus,body 2>/dev/null || echo "{}")
+        local merge_status body
         merge_status=$(echo "$pr_state" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('mergeStateStatus',''))" 2>/dev/null || echo "")
         body=$(echo "$pr_state" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('body',''))" 2>/dev/null || echo "")
 

--- a/scripts/dev-handler.sh
+++ b/scripts/dev-handler.sh
@@ -114,6 +114,7 @@ log "worktree ready: $WORKTREE_ROOT (isolated from other handlers)"
 # belt-and-braces apply the right names per the project's active workflow
 # (e.g. needs-review on default, review-pending on current).
 REVIEW_LABEL=$(loop_stage_trigger "$SLUG" review pr 2>/dev/null || echo review-pending)
+_BACKEND_CLI_NOTE=$(backend_cli_note)
 
 TASK_PROMPT=$(cat <<EOF
 You are the Senior Developer for ${NAME} (slug: ${SLUG}).
@@ -161,6 +162,7 @@ IMPORTANT: The issue MUST end this run with label '${REVIEW_LABEL}' (or 'needs-c
    gh issue view ${ISSUE_NUM} --repo ${REPO} --json labels
 
 If blocked by missing context or an architectural decision, comment on the issue and add label 'needs-clarification' instead of opening a PR.
+${_BACKEND_CLI_NOTE}
 $(loop_cli_hint)
 EOF
 )

--- a/scripts/dev-rework-handler.sh
+++ b/scripts/dev-rework-handler.sh
@@ -194,6 +194,7 @@ if [ -n "$DEV_VALIDATION_CMD" ]; then
 else
     _VALIDATION_STEP=""
 fi
+_BACKEND_CLI_NOTE=$(backend_cli_note)
 
 _PROMPT_FILE=$(mktemp /tmp/rework-prompt-XXXXXX.txt)
 cat > "$_PROMPT_FILE" <<EOF
@@ -232,6 +233,7 @@ IMPORTANT: The PR MUST end this run with label '${REVIEW_LABEL}' (or 'needs-clar
    gh pr view ${PR_NUM} --repo ${REPO} --json labels
 
 If the feedback is unclear or requires architectural input, add label 'needs-clarification' and comment on the PR instead of guessing.
+${_BACKEND_CLI_NOTE}
 $(loop_cli_hint)
 EOF
 TASK_PROMPT=$(cat "$_PROMPT_FILE")

--- a/scripts/po-handler.sh
+++ b/scripts/po-handler.sh
@@ -194,6 +194,7 @@ if [ -n "$_IN_FLIGHT_PR" ]; then
     _report_line="Report your decision (A/B/C/D/E/F/G/H/I/J) and why in 2 sentences."
 fi
 
+_BACKEND_CLI_NOTE=$(backend_cli_note)
 _PROMPT_FILE=$(mktemp /tmp/po-prompt-XXXXXX.txt)
 cat > "$_PROMPT_FILE" <<EOF
 You are the Product Owner agent for ${NAME} (slug: ${SLUG}).
@@ -280,6 +281,7 @@ What this ticket explicitly does not cover. Prevents scope creep.
 IMPORTANT: The issue MUST end this run with exactly ONE of: dev / needs-clarification / blocked / tracker / closed.
 Verify: gh issue view ${ISSUE_NUM} --repo ${REPO} --json labels,state
 ${_report_line}
+${_BACKEND_CLI_NOTE}
 $(loop_cli_hint)
 EOF
 TASK_PROMPT=$(cat "$_PROMPT_FILE")

--- a/scripts/review-handler.sh
+++ b/scripts/review-handler.sh
@@ -102,6 +102,7 @@ backend_add_label "$REPO" "$PR_NUM" in-review
 # belt-and-braces apply the right names per active workflow.
 QA_LABEL=$(loop_stage_trigger "$SLUG" qa pr 2>/dev/null || echo ready-for-qa)
 REWORK_LABEL=$(loop_stage_trigger "$SLUG" rework pr 2>/dev/null || echo changes-requested)
+_BACKEND_CLI_NOTE=$(backend_cli_note)
 
 _PROMPT_FILE=$(mktemp /tmp/review-prompt-XXXXXX.txt)
 cat > "$_PROMPT_FILE" <<EOF
@@ -148,6 +149,7 @@ IMPORTANT: You MUST finish by applying either '${QA_LABEL}' or '${REWORK_LABEL}'
    gh pr view ${PR_NUM} --repo ${REPO} --json labels
 
 Report the decision you made and why, in 3 short sentences.
+${_BACKEND_CLI_NOTE}
 $(loop_cli_hint)
 EOF
 TASK_PROMPT=$(cat "$_PROMPT_FILE")


### PR DESCRIPTION
Closes #25

Note: bugs 1 and 2 from issue #25 were already fixed in main via PR #63 ([LOOP-28]). Bugs 5 and 6 were also fixed in main before this branch was created. This PR addresses the remaining two bugs.

## Changes

**Bug 3 — Reserved stage IDs undocumented**
Added a **Reserved stage IDs** table to `config/workflows/README.md` listing the stage `id` values that built-in handlers resolve via `loop_stage_trigger`, which handler uses each, and the fallback label applied when the ID is absent from a custom workflow.

**Bug 4 — Agent prompts hardcode `gh` CLI commands**
- Added `backend_cli_note()` to `lib/backends/backend.sh`: emits a glab/gh equivalence table when `BACKEND=gitlab` or `jira-gitlab`; prints nothing on GitHub projects.
- Injected `_BACKEND_CLI_NOTE=$(backend_cli_note)` before each handler's prompt and `${_BACKEND_CLI_NOTE}` inside the prompt heredoc for all four handlers: `dev-handler.sh`, `po-handler.sh`, `review-handler.sh`, `dev-rework-handler.sh`.

## Test Plan
- `bash -n` syntax check passes on all scripts
- `shellcheck -S warning` passes (pre-existing SC2034 in reconciler.sh is not introduced by this PR)
- On a GitHub-backed project `backend_cli_note` emits nothing — prompts unchanged
- On a GitLab-backed project the glab equivalence table appears in every agent prompt