### PR TITLE
[LOOP-92] escalate to senior-dev before blocking on rework exhaustion

### DIFF
--- a/scripts/dev-rework-handler.sh
+++ b/scripts/dev-rework-handler.sh
@@ -99,14 +99,53 @@ _block_linked_issue() {
         2>/dev/null || true
 }
 
+SENIOR_ESCALATION_MARKER="Escalating to senior-dev for one final attempt"
+
+_is_senior_escalated() {
+    [ -z "$LINKED_ISSUE" ] && return 1
+    local count
+    count=$(gh issue view "$LINKED_ISSUE" --repo "$REPO" --json comments \
+        --jq "[.comments[] | select(.body | contains(\"${SENIOR_ESCALATION_MARKER}\"))] | length" \
+        2>/dev/null || echo "0")
+    [ "${count:-0}" -gt 0 ]
+}
+
+_escalate_to_senior() {
+    [ -z "$LINKED_ISSUE" ] && return 0
+    backend_comment_issue "$REPO" "$LINKED_ISSUE" \
+        "Dev rework exhausted ${MAX_RETRIES} attempts. Escalating to senior-dev for one final attempt." \
+        2>/dev/null || true
+    backend_add_label "$REPO" "$LINKED_ISSUE" senior-dev 2>/dev/null || true
+}
+
+_block_linked_issue_senior_failed() {
+    [ -z "$LINKED_ISSUE" ] && return 0
+    backend_add_label "$REPO" "$LINKED_ISSUE" blocked 2>/dev/null || true
+    backend_comment_issue "$REPO" "$LINKED_ISSUE" \
+        "Senior-dev attempt also failed. Marking blocked for human review." \
+        2>/dev/null || true
+}
+
 if [ "$retries" -ge "$MAX_RETRIES" ]; then
-    log "PR #$PR_NUM rework failed ${retries}x — labeling blocked"
-    backend_remove_label "$REPO" "$PR_NUM" "$SOURCE_LABEL"
-    backend_remove_label "$REPO" "$PR_NUM" in-rework
-    backend_add_label "$REPO" "$PR_NUM" blocked
-    backend_comment_pr "$REPO" "$PR_NUM" \
-        "Automated rework failed ${MAX_RETRIES} times. Needs human eyes."
-    _block_linked_issue
+    log "PR #$PR_NUM rework failed ${retries}x — checking escalation path"
+    backend_remove_label "$REPO" "$PR_NUM" "$SOURCE_LABEL" 2>/dev/null || true
+    backend_remove_label "$REPO" "$PR_NUM" in-rework 2>/dev/null || true
+    if [ -n "$LINKED_ISSUE" ] && ! _is_senior_escalated; then
+        log "escalating issue #$LINKED_ISSUE to senior-dev"
+        _escalate_to_senior
+        backend_comment_pr "$REPO" "$PR_NUM" \
+            "Dev rework exhausted ${MAX_RETRIES} attempts. Escalating to senior-dev for one final attempt." \
+            2>/dev/null || true
+        loop_notify "⬆️ [$SLUG] PR#$PR_NUM dev-rework exhausted — escalated issue #$LINKED_ISSUE to senior-dev"
+    else
+        log "senior-dev escalation already attempted — labeling blocked"
+        backend_add_label "$REPO" "$PR_NUM" blocked
+        backend_comment_pr "$REPO" "$PR_NUM" \
+            "Senior-dev attempt also failed. Marking blocked for human review. Operator: see ${LOG_FILE} for the agent transcript." \
+            2>/dev/null || true
+        _block_linked_issue_senior_failed
+        loop_notify "❌ [$SLUG] PR#$PR_NUM dev-rework blocked after senior-dev escalation also failed"
+    fi
     exit 0
 fi
 
@@ -266,13 +305,23 @@ else
     bounty_report "rework_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" pr_num="$PR_NUM" detail="attempt ${n}/${MAX_RETRIES}" || true
     if [ "$n" -ge "$MAX_RETRIES" ]; then
         backend_remove_label "$REPO" "$PR_NUM" in-rework
-        backend_add_label "$REPO" "$PR_NUM" blocked
-        # Post only a short marker to the PR — never the agent log/prompt, which
-        # contains internal pipeline instructions that should not be public.
-        backend_comment_pr "$REPO" "$PR_NUM" \
-            "Automated rework failed ${MAX_RETRIES} times. Marking blocked for human review. Operator: see ${LOG_FILE} for the agent transcript." \
-            2>/dev/null || true
-        loop_notify "❌ [$SLUG] PR#$PR_NUM dev-rework failed: agent failed after $MAX_RETRIES attempts"
+        if [ -n "$LINKED_ISSUE" ] && ! _is_senior_escalated; then
+            log "escalating issue #$LINKED_ISSUE to senior-dev after $MAX_RETRIES failed rework attempts"
+            _escalate_to_senior
+            # Post only a short marker to the PR — never the agent log/prompt, which
+            # contains internal pipeline instructions that should not be public.
+            backend_comment_pr "$REPO" "$PR_NUM" \
+                "Dev rework exhausted ${MAX_RETRIES} attempts. Escalating to senior-dev for one final attempt." \
+                2>/dev/null || true
+            loop_notify "⬆️ [$SLUG] PR#$PR_NUM dev-rework exhausted — escalated issue #$LINKED_ISSUE to senior-dev"
+        else
+            backend_add_label "$REPO" "$PR_NUM" blocked
+            backend_comment_pr "$REPO" "$PR_NUM" \
+                "Senior-dev attempt also failed. Marking blocked for human review. Operator: see ${LOG_FILE} for the agent transcript." \
+                2>/dev/null || true
+            _block_linked_issue_senior_failed
+            loop_notify "❌ [$SLUG] PR#$PR_NUM dev-rework blocked after senior-dev escalation also failed"
+        fi
     else
         backend_remove_label "$REPO" "$PR_NUM" in-rework
         backend_add_label "$REPO" "$PR_NUM" "$SOURCE_LABEL"


### PR DESCRIPTION
Closes #92

## Changes

Modified `scripts/dev-rework-handler.sh` to escalate to `senior-dev` instead of immediately blocking when the rework retry budget is exhausted:

- Added `SENIOR_ESCALATION_MARKER` constant used to detect if escalation already occurred
- Added `_is_senior_escalated()`: checks linked issue comments for the escalation marker to determine if a senior-dev escalation has already been attempted
- Added `_escalate_to_senior()`: posts the escalation comment and adds `senior-dev` label to the linked issue
- Added `_block_linked_issue_senior_failed()`: posts the senior-failure fallback comment and adds `blocked` to the linked issue
- Modified the early exhaustion check (top of script, `retries >= MAX_RETRIES`): now escalates to senior-dev if not already escalated, otherwise blocks
- Modified the in-run failure exhaustion block (`n >= MAX_RETRIES`): same logic — escalate first, block only on second failure

The escalation is a label transition on the **linked issue** (not the PR), consistent with CLAUDE.md's "labels drive the pipeline state machine" convention.

**Escalation flow:**
1. Rework exhausts `MAX_RETRIES` → post escalation comment on issue + add `senior-dev` label → exit 0
2. If senior-dev handler runs and the issue comes back into rework and exhausts again → post senior-failure comment + add `blocked` label on both PR and issue

## Test Plan

- Verify `bash -n` passes on all scripts (CI step 1)
- Verify `shellcheck -S warning` passes on all scripts (CI step 2)
- Simulate retry exhaustion with no prior escalation: confirm `senior-dev` label added to linked issue and escalation comment posted
- Simulate retry exhaustion with prior escalation comment present: confirm `blocked` label added and senior-failure comment posted
- Verify `MAX_RETRIES` still controls rework budget (no change to that logic)
- Verify success path (agent succeeds) is unchanged