### PR TITLE
[LOOP-83] add --draft to backend_open_pr in gitlab and github backends

### DIFF
--- a/lib/backends/github.sh
+++ b/lib/backends/github.sh
@@ -74,7 +74,7 @@ backend_pr_view() {
 # backend_open_pr <repo> <title> <body_file> <label>
 backend_open_pr() {
     local repo="$1" title="$2" body_file="$3" label="$4"
-    gh pr create --repo "$repo" --title "$title" --body-file "$body_file" --label "$label"
+    gh pr create --repo "$repo" --title "$title" --body-file "$body_file" --label "$label" --draft
 }
 
 # backend_close_issue <repo> <number>

--- a/lib/backends/gitlab.sh
+++ b/lib/backends/gitlab.sh
@@ -193,6 +193,7 @@ backend_open_pr() {
         --title "$title" \
         --description "$body" \
         --label "$label" \
+        --draft \
         2>/dev/null || true
 }
 


### PR DESCRIPTION
Closes #83

## Changes

- **`lib/backends/gitlab.sh`**: Added `--draft` flag to `glab mr create` in `backend_open_pr`. GitLab MRs are now created in Draft state, preventing premature merges before human review.
- **`lib/backends/github.sh`**: Added `--draft` flag to `gh pr create` in `backend_open_pr`. GitHub PRs are now also created as drafts, consistent with the GitLab behavior.

Both backends now gate new PRs/MRs behind Draft status, which must be explicitly promoted to ready (via `backend_pr_ready`) before merging is possible.

## Test Plan

- With `backend: gitlab`, trigger `dev-handler.sh` on an issue; verify `glab mr view N --output json | jq .draft` returns `true`
- With `backend: github`, trigger `dev-handler.sh`; verify the created PR is in Draft state
- `bash -n` and `shellcheck -S warning` pass on all modified files (verified locally)