### PR TITLE
[LOOP-75] Reconciler: unblock PRs/issues when declared dependencies are merged

### DIFF
--- a/lib/recovery.sh
+++ b/lib/recovery.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# lib/recovery.sh — recovery helpers for the Loop reconciler.
+#
+# Sourced by scanner/reconciler.sh. Requires REPO, DRY_RUN, log(), and
+# loop_notify() to be available in the caller's environment, along with
+# the backend functions loaded by loop_load_backend.
+
+set -euo pipefail
+
+# recovery_check_dependencies <slug>
+#
+# For each open issue and PR carrying the `blocked` label whose body contains
+# a `## Dependencies` section: if every #N reference in that section is CLOSED
+# or MERGED, remove `blocked`, restore the upstream trigger label, and post a
+# human-readable comment. Items with no `## Dependencies` heading are skipped
+# silently. Items with one or more open deps are left unchanged with a single
+# log line.
+#
+# Restore label: `loop_label_for <slug> dev` for issues (fallback: "dev");
+# always `needs-review` for PRs.
+recovery_check_dependencies() {
+    local slug="$1"
+    local repo="${REPO:-}"
+    [ -z "$repo" ] && { log "[recovery] ERROR: REPO not set"; return 1; }
+
+    log "[$repo] recovery_check_dependencies: scanning blocked issues and PRs"
+
+    # ---- Blocked issues -------------------------------------------------------
+    local blocked_json
+    blocked_json=$(backend_list_open_issues_raw "$repo" "blocked")
+
+    local candidates
+    candidates=$(ITEMS="$blocked_json" python3 - <<'PY'
+import json, os, re
+items = json.loads(os.environ['ITEMS'])
+NUM = re.compile(r'#(\d+)')
+for item in items:
+    body = item.get('body') or ''
+    lines = body.splitlines()
+    in_dep = False
+    dep_lines = []
+    for line in lines:
+        if re.match(r'^##\s+Dependencies\s*$', line, re.I):
+            in_dep = True
+            continue
+        if in_dep and re.match(r'^##', line):
+            break
+        if in_dep:
+            dep_lines.append(line)
+    if not in_dep:
+        continue
+    deps = sorted(set(int(n) for n in NUM.findall('\n'.join(dep_lines))))
+    deps = [n for n in deps if n != item['number']]
+    if not deps:
+        continue
+    print(f"{item['number']}\t{','.join(str(n) for n in deps)}\t{item['title'][:60]}")
+PY
+)
+
+    local num deps trigger_label dep_list
+    local all_closed unresolved dep dep_arr st
+    while IFS=$'\t' read -r num deps _title; do
+        [ -z "$num" ] && continue
+        all_closed=true
+        unresolved=""
+        IFS=',' read -ra dep_arr <<< "$deps"
+        for dep in "${dep_arr[@]}"; do
+            st=$(gh issue view "$dep" --repo "$repo" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+            if [ "$st" != "CLOSED" ]; then
+                st=$(gh pr view "$dep" --repo "$repo" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+            fi
+            if [ "$st" = "CLOSED" ] || [ "$st" = "MERGED" ]; then
+                : # dep satisfied
+            else
+                all_closed=false
+                unresolved="${unresolved}#${dep} (${st}) "
+            fi
+        done
+
+        if $all_closed; then
+            trigger_label=$(loop_label_for "$slug" "dev" 2>/dev/null) || trigger_label="dev"
+            [ -z "$trigger_label" ] && trigger_label="dev"
+            dep_list=$(DEP_NUMS="$deps" python3 -c "
+import os; nums=os.environ['DEP_NUMS'].split(','); print(', '.join('#'+n for n in nums))")
+            log "[$repo] UNBLOCK issue #$num (deps ${deps} satisfied): restoring to ${trigger_label}"
+            loop_notify "Loop reconciler: $repo — unblocking issue #$num; deps (${deps}) all closed. Relabeling → ${trigger_label}." || true
+            $DRY_RUN && continue
+            backend_remove_label "$repo" "$num" blocked \
+                || log "[$repo] WARN: failed to remove blocked from issue #$num"
+            backend_add_label "$repo" "$num" "$trigger_label" \
+                || log "[$repo] WARN: failed to add ${trigger_label} to issue #$num"
+            backend_comment_issue "$repo" "$num" \
+                "Dependency ${dep_list} is now closed/merged. Unblocking and restoring to pipeline." \
+                || log "[$repo] WARN: failed to comment on issue #$num"
+        else
+            log "[$repo] issue #$num still blocked by: ${unresolved}"
+        fi
+    done <<< "$candidates"
+
+    # ---- Blocked PRs ----------------------------------------------------------
+    local all_prs_json
+    all_prs_json=$(backend_list_open_prs_raw "$repo")
+
+    local pr_candidates
+    pr_candidates=$(PJSON="$all_prs_json" python3 - <<'PY'
+import json, os, re
+prs = json.loads(os.environ['PJSON'])
+NUM = re.compile(r'#(\d+)')
+for pr in prs:
+    lbls = [l['name'] if isinstance(l, dict) else l for l in pr.get('labels', [])]
+    if 'blocked' not in lbls:
+        continue
+    body = pr.get('body') or ''
+    lines = body.splitlines()
+    in_dep = False
+    dep_lines = []
+    for line in lines:
+        if re.match(r'^##\s+Dependencies\s*$', line, re.I):
+            in_dep = True
+            continue
+        if in_dep and re.match(r'^##', line):
+            break
+        if in_dep:
+            dep_lines.append(line)
+    if not in_dep:
+        continue
+    deps = sorted(set(int(n) for n in NUM.findall('\n'.join(dep_lines))))
+    deps = [n for n in deps if n != pr['number']]
+    if not deps:
+        continue
+    print(f"{pr['number']}\t{','.join(str(n) for n in deps)}\t{pr['title'][:60]}")
+PY
+)
+
+    local pr_num
+    while IFS=$'\t' read -r pr_num deps _title; do
+        [ -z "$pr_num" ] && continue
+        all_closed=true
+        unresolved=""
+        IFS=',' read -ra dep_arr <<< "$deps"
+        for dep in "${dep_arr[@]}"; do
+            st=$(gh issue view "$dep" --repo "$repo" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+            if [ "$st" != "CLOSED" ]; then
+                st=$(gh pr view "$dep" --repo "$repo" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+            fi
+            if [ "$st" = "CLOSED" ] || [ "$st" = "MERGED" ]; then
+                : # dep satisfied
+            else
+                all_closed=false
+                unresolved="${unresolved}#${dep} (${st}) "
+            fi
+        done
+
+        if $all_closed; then
+            dep_list=$(DEP_NUMS="$deps" python3 -c "
+import os; nums=os.environ['DEP_NUMS'].split(','); print(', '.join('#'+n for n in nums))")
+            log "[$repo] UNBLOCK PR #$pr_num (deps ${deps} satisfied): restoring to needs-review"
+            loop_notify "Loop reconciler: $repo — unblocking PR #$pr_num; deps (${deps}) all closed. Relabeling → needs-review." || true
+            $DRY_RUN && continue
+            backend_remove_label "$repo" "$pr_num" blocked \
+                || log "[$repo] WARN: failed to remove blocked from PR #$pr_num"
+            backend_add_label "$repo" "$pr_num" needs-review \
+                || log "[$repo] WARN: failed to add needs-review to PR #$pr_num"
+            backend_comment_pr "$repo" "$pr_num" \
+                "Dependency ${dep_list} is now closed/merged. Unblocking and restoring to pipeline." \
+                || log "[$repo] WARN: failed to comment on PR #$pr_num"
+        else
+            log "[$repo] PR #$pr_num still blocked by: ${unresolved}"
+        fi
+    done <<< "$pr_candidates"
+}

--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -28,6 +28,8 @@ source "$LOOP_ROOT/lib/env.sh"
 source "$LOOP_ROOT/lib/config.sh"
 # shellcheck source=../lib/backends/backend.sh
 source "$LOOP_ROOT/lib/backends/backend.sh"
+# shellcheck source=../lib/recovery.sh
+source "$LOOP_ROOT/lib/recovery.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-reconciler.log"
 LOCK_FILE="/tmp/loop-reconciler.lock"
@@ -1090,6 +1092,7 @@ run_project() {
     reconcile_conflict_blocked_prs "$REPO"
     reconcile_stale_blocked_issues "$REPO"
     reconcile_qa_failures "$REPO"
+    recovery_check_dependencies "$slug"
     reconcile_worktrees "$slug" "$REPO"
 }
 

--- a/tests/reconciler.bats
+++ b/tests/reconciler.bats
@@ -1,0 +1,203 @@
+#!/usr/bin/env bats
+# tests/reconciler.bats — unit tests for recovery_check_dependencies in lib/recovery.sh.
+#
+# Backend functions and gh are stubbed as shell functions so no real GitHub
+# calls are made. Two scenarios are covered:
+#   (1) all declared deps closed  → blocked removed + trigger added + comment posted
+#   (2) one dep still open        → no label change, no comment
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_WORKFLOW_DIR="$REPO_ROOT/config/workflows"
+
+    # Minimal project config so loop_label_for resolves to "dev".
+    cat > "$BATS_TMPDIR/fixture.yaml" <<'YAML'
+version: 1
+projects:
+  - slug: test-proj
+    name: Test Project
+    repo: owner/test-repo
+    root: /tmp/fake
+    default_branch: main
+    workflow: default
+YAML
+    export LOOP_CONFIG="$BATS_TMPDIR/fixture.yaml"
+
+    # Source workflow.sh so loop_label_for is available.
+    # shellcheck source=../lib/workflow.sh
+    source "$REPO_ROOT/lib/workflow.sh"
+
+    # Ops log captures every label/comment call.
+    OPS_LOG="$BATS_TMPDIR/ops.log"
+    rm -f "$OPS_LOG"
+
+    # Stub backend functions.
+    backend_list_open_issues_raw() { echo "${MOCK_ISSUES_JSON:-[]}"; }
+    backend_list_open_prs_raw()    { echo "${MOCK_PRS_JSON:-[]}"; }
+    backend_remove_label()         { echo "remove_label $2 $3" >> "$OPS_LOG"; }
+    backend_add_label()            { echo "add_label $2 $3"    >> "$OPS_LOG"; }
+    backend_comment_issue()        { echo "comment_issue $2"   >> "$OPS_LOG"; }
+    backend_comment_pr()           { echo "comment_pr $2"      >> "$OPS_LOG"; }
+
+    # Stub gh: returns state based on GH_STATE_MAP entries "num:STATE num:STATE ...".
+    gh() {
+        local cmd="$1" subcmd="$2"  # e.g. "issue" "view"
+        local num state
+        # Extract number from args (3rd positional arg after "issue view" or "pr view").
+        num="$3"
+        # Look up in GH_STATE_MAP (space-separated "N:STATE" pairs).
+        state="UNKNOWN"
+        local pair
+        for pair in ${GH_STATE_MAP:-}; do
+            if [ "${pair%%:*}" = "$num" ]; then
+                state="${pair#*:}"
+                break
+            fi
+        done
+        # Honour --jq '.state' output format.
+        echo "$state"
+        return 0
+    }
+
+    # Stub loop_notify and log so they don't write to disk.
+    loop_notify() { :; }
+    log()         { :; }
+
+    # DRY_RUN=false so mutations are executed.
+    DRY_RUN=false
+
+    # REPO must be set (normally exported by loop_load_project).
+    export REPO="owner/test-repo"
+
+    # Source recovery.sh after stubs are in place.
+    # shellcheck source=../lib/recovery.sh
+    source "$REPO_ROOT/lib/recovery.sh"
+}
+
+teardown() {
+    rm -f "$BATS_TMPDIR/fixture.yaml" "$BATS_TMPDIR/ops.log" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 1: all declared dependencies are closed → unblock + restore + comment
+# ---------------------------------------------------------------------------
+
+@test "recovery_check_dependencies: all deps closed removes blocked and restores trigger label" {
+    # Issue #10 is blocked; its ## Dependencies section references #100 and #101.
+    export MOCK_ISSUES_JSON='[{
+        "number": 10,
+        "title": "Implement feature X",
+        "labels": [{"name":"blocked"}],
+        "body": "## Summary\nDoes stuff.\n\n## Dependencies\n- #100\n- #101\n\n## Notes\nNone.",
+        "updatedAt": "2024-01-01T00:00:00Z"
+    }]'
+    export MOCK_PRS_JSON='[]'
+
+    # Both deps are closed.
+    export GH_STATE_MAP="100:CLOSED 101:CLOSED"
+
+    run recovery_check_dependencies "test-proj"
+    [ "$status" -eq 0 ]
+
+    # blocked must be removed.
+    grep -q "remove_label 10 blocked" "$OPS_LOG"
+
+    # trigger label (dev) must be added.
+    grep -q "add_label 10 dev" "$OPS_LOG"
+
+    # comment must be posted on the issue.
+    grep -q "comment_issue 10" "$OPS_LOG"
+}
+
+@test "recovery_check_dependencies: all deps closed — remove precedes add" {
+    export MOCK_ISSUES_JSON='[{
+        "number": 20,
+        "title": "Another blocked issue",
+        "labels": [{"name":"blocked"}],
+        "body": "## Dependencies\n- #200\n",
+        "updatedAt": "2024-01-01T00:00:00Z"
+    }]'
+    export MOCK_PRS_JSON='[]'
+    export GH_STATE_MAP="200:CLOSED"
+
+    run recovery_check_dependencies "test-proj"
+    [ "$status" -eq 0 ]
+
+    local rm_line add_line
+    rm_line=$(grep -n "remove_label 20 blocked" "$OPS_LOG" | cut -d: -f1)
+    add_line=$(grep -n "add_label 20 dev"       "$OPS_LOG" | cut -d: -f1)
+    [ "$rm_line" -lt "$add_line" ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 2: one or more deps still open → no label change, no comment
+# ---------------------------------------------------------------------------
+
+@test "recovery_check_dependencies: one dep open leaves issue unchanged" {
+    export MOCK_ISSUES_JSON='[{
+        "number": 30,
+        "title": "Blocked issue with open dep",
+        "labels": [{"name":"blocked"}],
+        "body": "## Dependencies\n- #300\n- #301\n",
+        "updatedAt": "2024-01-01T00:00:00Z"
+    }]'
+    export MOCK_PRS_JSON='[]'
+
+    # #300 closed but #301 still open.
+    export GH_STATE_MAP="300:CLOSED 301:OPEN"
+
+    run recovery_check_dependencies "test-proj"
+    [ "$status" -eq 0 ]
+
+    # No label mutations and no comment.
+    [ ! -f "$OPS_LOG" ] || ! grep -q "remove_label 30" "$OPS_LOG"
+    [ ! -f "$OPS_LOG" ] || ! grep -q "add_label 30"    "$OPS_LOG"
+    [ ! -f "$OPS_LOG" ] || ! grep -q "comment_issue 30" "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 3: issue with no ## Dependencies section is skipped silently
+# ---------------------------------------------------------------------------
+
+@test "recovery_check_dependencies: issue without Dependencies section is untouched" {
+    export MOCK_ISSUES_JSON='[{
+        "number": 40,
+        "title": "Blocked but no dep section",
+        "labels": [{"name":"blocked"}],
+        "body": "No special sections here.",
+        "updatedAt": "2024-01-01T00:00:00Z"
+    }]'
+    export MOCK_PRS_JSON='[]'
+    export GH_STATE_MAP=""
+
+    run recovery_check_dependencies "test-proj"
+    [ "$status" -eq 0 ]
+
+    [ ! -f "$OPS_LOG" ] || [ ! -s "$OPS_LOG" ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 4: blocked PR with all deps closed → unblock + needs-review + comment
+# ---------------------------------------------------------------------------
+
+@test "recovery_check_dependencies: blocked PR with all deps closed restores needs-review" {
+    export MOCK_ISSUES_JSON='[]'
+    export MOCK_PRS_JSON='[{
+        "number": 50,
+        "title": "Blocked PR waiting on dep",
+        "headRefName": "feat/issue-50",
+        "labels": [{"name":"blocked"}],
+        "body": "## Dependencies\n- #400\n",
+        "createdAt": "2024-01-01T00:00:00Z",
+        "updatedAt": "2024-01-01T00:00:00Z"
+    }]'
+    export GH_STATE_MAP="400:CLOSED"
+
+    run recovery_check_dependencies "test-proj"
+    [ "$status" -eq 0 ]
+
+    grep -q "remove_label 50 blocked"   "$OPS_LOG"
+    grep -q "add_label 50 needs-review" "$OPS_LOG"
+    grep -q "comment_pr 50"             "$OPS_LOG"
+}


### PR DESCRIPTION
Closes #75

## Changes

- **`lib/recovery.sh`** (new): Adds `recovery_check_dependencies <slug>`. Scans all open issues and PRs with the `blocked` label; for each one whose body contains a `## Dependencies` section with `#N` references, checks every dep via `gh issue view` / `gh pr view`. If all deps are `CLOSED` or `MERGED`: removes `blocked`, restores the upstream trigger label (`loop_label_for dev` for issues, `needs-review` for PRs), and posts a human-readable comment. Items with no `## Dependencies` heading are skipped silently. Items with open deps get a single log line.

- **`scanner/reconciler.sh`**: Sources `lib/recovery.sh` and calls `recovery_check_dependencies "$slug"` in `run_project` on each reconciler tick.

- **`tests/reconciler.bats`** (new): 5 bats tests covering:
  1. All deps closed → `blocked` removed, trigger label added, comment posted
  2. Remove precedes add (ordering assertion)
  3. One dep still open → no label change, no comment
  4. Issue without `## Dependencies` section is skipped silently
  5. Blocked PR with all deps closed → `blocked` removed, `needs-review` added, PR comment posted

## Test Plan

- `bash -n` and `shellcheck -S warning` pass on all modified/created files ✓
- `bats tests/reconciler.bats` → 5/5 tests pass ✓
- QA should verify: a blocked issue with a `## Dependencies` section listing a now-closed issue gets unblocked and relabeled `dev` on the next reconciler tick, with a comment referencing the dep number