### PR TITLE
[LOOP-69] lib/recovery.sh: stuck-label timeout + orphan worktree cleanup

### DIFF
--- a/lib/recovery.sh
+++ b/lib/recovery.sh
@@ -4,6 +4,11 @@
 # Sourced by scanner/reconciler.sh. Requires REPO, DRY_RUN, log(), and
 # loop_notify() to be available in the caller's environment, along with
 # the backend functions loaded by loop_load_backend.
+#
+# Exports:
+#   recovery_check_dependencies <slug>   — unblock when declared deps are merged
+#   recovery_check_stuck_labels <slug>   — strip timed-out operational labels
+#   recovery_prune_orphan_worktrees      — remove worktrees with no handler + no PR
 
 set -euo pipefail
 
@@ -168,4 +173,212 @@ import os; nums=os.environ['DEP_NUMS'].split(','); print(', '.join('#'+n for n i
             log "[$repo] PR #$pr_num still blocked by: ${unresolved}"
         fi
     done <<< "$pr_candidates"
+}
+
+# Default timeout (seconds). Overridable in loop.env.
+HANDLER_TIMEOUT="${HANDLER_TIMEOUT:-3600}"
+
+# Operational label → canonical upstream trigger mapping.
+# Used to restore the pipeline trigger after a stuck-label strip.
+#
+# Note: "in-review" is aspirational — the review-handler does not yet write it
+# in the default workflow. The entry is included here so the recovery logic is
+# ready when a future handler begins using it, and is harmless if no issue ever
+# carries that label.
+_RECOVERY_OP_TO_TRIGGER=(
+    "in-progress:dev"
+    "in-rework:needs-rework"
+    "in-review:needs-review"
+)
+
+# _recovery_trigger_for_op <operational_label>
+# Echoes the canonical upstream trigger label for a given operational label,
+# or an empty string if not recognised.
+_recovery_trigger_for_op() {
+    local op="$1"
+    local entry
+    for entry in "${_RECOVERY_OP_TO_TRIGGER[@]}"; do
+        if [ "${entry%%:*}" = "$op" ]; then
+            echo "${entry#*:}"
+            return 0
+        fi
+    done
+}
+
+# recovery_check_stuck_labels <slug>
+#
+# For each open issue or PR carrying an operational label (in-progress,
+# in-rework, in-review) that:
+#   - has not been updated within HANDLER_TIMEOUT * 1.5 seconds, AND
+#   - has no live handler process (checked via per-issue lock files)
+#
+# strips the operational label and restores the upstream trigger so the
+# pipeline can retry. Uses loop_label_for to respect per-project overrides.
+#
+# DRY_RUN and log() must be available in the caller's scope.
+recovery_check_stuck_labels() {
+    local slug="$1"
+    local repo
+    repo="${REPO:-}"
+    if [ -z "$repo" ]; then
+        log "[recovery] ERROR: REPO not set for slug=$slug"
+        return 1
+    fi
+
+    local timeout_secs
+    timeout_secs=$(python3 -c "import math; print(int(math.ceil(${HANDLER_TIMEOUT} * 1.5)))")
+    log "[$repo] recovery: checking stuck operational labels (timeout=${timeout_secs}s)"
+
+    local lock_dir="${LOOP_LOCK_DIR:-/tmp/loop-locks}"
+    local op_entry trigger_canon op_label issues_json candidates
+
+    for op_entry in "${_RECOVERY_OP_TO_TRIGGER[@]}"; do
+        op_label="${op_entry%%:*}"
+        trigger_canon="${op_entry#*:}"
+
+        # Resolve the project-specific label name for both labels
+        local actual_op actual_trigger
+        actual_op=$(loop_label_for "$slug" "$op_label" 2>/dev/null || echo "$op_label")
+        actual_trigger=$(loop_label_for "$slug" "$trigger_canon" 2>/dev/null || echo "$trigger_canon")
+
+        # Fetch issues with this operational label
+        issues_json=$(backend_list_open_issues_raw "$repo" "$actual_op" 2>/dev/null || echo "[]")
+
+        # Filter to those exceeding the timeout
+        candidates=$(ISS="$issues_json" CUTOFF_S="$timeout_secs" python3 - <<'PY'
+import json, os, datetime as dt
+issues = json.loads(os.environ['ISS'])
+cutoff_s = int(os.environ['CUTOFF_S'])
+now = dt.datetime.now(dt.timezone.utc)
+for iss in issues:
+    up = dt.datetime.fromisoformat(iss['updatedAt'].replace('Z', '+00:00'))
+    age_s = int((now - up).total_seconds())
+    if age_s >= cutoff_s:
+        print(f"{iss['number']}\t{age_s}\t{iss['title'][:60]}")
+PY
+)
+
+        [ -z "$candidates" ] && continue
+
+        while IFS=$'\t' read -r num age_s title; do
+            [ -z "$num" ] && continue
+
+            # Check for a live handler process via per-issue lock files.
+            local handler_alive=false lf pid
+            for lf in \
+                "$lock_dir/${slug}-issue-${num}.lock" \
+                "$lock_dir/po-${slug}-${num}.lock" \
+                "$lock_dir/${slug}-rework-${num}.lock"; do
+                [ -f "$lf" ] || continue
+                pid=$(cat "$lf" 2>/dev/null || echo "")
+                if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+                    handler_alive=true; break
+                fi
+            done
+
+            if $handler_alive; then
+                log "[$repo] recovery: issue #$num has live handler — skip ($op_label)"
+                continue
+            fi
+
+            log "[$repo] recovery: STUCK $op_label on issue #$num (${age_s}s, no handler): $title → $actual_trigger"
+            loop_notify "Loop recovery: $repo — issue #$num stuck in $op_label for ${age_s}s with no handler; restoring $actual_trigger"
+
+            if ${DRY_RUN:-false}; then
+                continue
+            fi
+
+            backend_remove_label "$repo" "$num" "$actual_op" \
+                || log "[$repo] recovery: WARN failed to remove $actual_op from #$num"
+            backend_add_label "$repo" "$num" "$actual_trigger" \
+                || log "[$repo] recovery: WARN failed to add $actual_trigger to #$num"
+        done <<< "$candidates"
+    done
+}
+
+# recovery_prune_orphan_worktrees
+#
+# Scans /tmp/loop-worktree-* directories. For each:
+#   - Skips dirs modified within the last 10 minutes (handler may be mid-flight)
+#   - Checks if a handler lock file with a live PID covers this dir
+#   - Uses backend_find_pr_for_issue to check if an open PR exists for the issue
+#     number embedded in the dirname (works across github/gitlab/jira-gitlab)
+#   - Removes the directory (git worktree remove --force then rm -rf fallback)
+#     if neither condition is true
+#
+# ROOT and REPO must be set. DRY_RUN and log() must be available.
+recovery_prune_orphan_worktrees() {
+    local repo="${REPO:-}"
+    local root="${ROOT:-}"
+
+    log "[recovery] pruning orphan worktrees under /tmp/loop-worktree-*"
+
+    local now_sec
+    now_sec=$(date +%s)
+    local grace=600  # 10-minute grace window
+
+    local lock_dir="${LOOP_LOCK_DIR:-/tmp/loop-locks}"
+    local wt_dir base num mtime age
+
+    for wt_dir in /tmp/loop-worktree-*/; do
+        [ -d "$wt_dir" ] || continue
+        wt_dir="${wt_dir%/}"
+        base=$(basename "$wt_dir")
+
+        # Extract trailing numeric token as issue/PR number
+        num=$(echo "$base" | grep -oE '[0-9]+$' || true)
+        if [ -z "$num" ]; then
+            log "[recovery] SKIP $wt_dir — cannot extract issue number"
+            continue
+        fi
+
+        # Recent-activity grace window
+        mtime=$(python3 -c "import os,sys; print(int(os.stat(sys.argv[1]).st_mtime))" "$wt_dir" 2>/dev/null || echo 0)
+        age=$(( now_sec - mtime ))
+        if [ "$age" -lt "$grace" ]; then
+            log "[recovery] SKIP $wt_dir — recently modified (${age}s < ${grace}s)"
+            continue
+        fi
+
+        # Check for a live handler lock referencing this worktree/issue
+        local handler_alive=false lf pid
+        for lf in "$lock_dir"/*"-${num}.lock" "$lock_dir"/*"-${num}-"*.lock; do
+            [ -f "$lf" ] || continue
+            pid=$(cat "$lf" 2>/dev/null || echo "")
+            if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+                handler_alive=true; break
+            fi
+        done
+
+        if $handler_alive; then
+            log "[recovery] SKIP $wt_dir — live handler found"
+            continue
+        fi
+
+        # Check for an open PR closing this issue using the backend abstraction
+        # (supports github, gitlab, and jira-gitlab deployments).
+        local open_pr=""
+        if [ -n "$repo" ]; then
+            open_pr=$(backend_find_pr_for_issue "$repo" "$num" 2>/dev/null || true)
+        fi
+
+        if [ -n "${open_pr:-}" ]; then
+            log "[recovery] SKIP $wt_dir — open PR #$open_pr exists for issue #$num"
+            continue
+        fi
+
+        log "[recovery] ORPHAN worktree $wt_dir (issue #$num, no handler, no open PR)"
+        loop_notify "Loop recovery: removing orphaned worktree $wt_dir (issue #$num, no handler, no open PR)"
+
+        if ${DRY_RUN:-false}; then
+            continue
+        fi
+
+        if [ -n "$root" ]; then
+            git -C "$root" worktree remove "$wt_dir" --force 2>/dev/null \
+                || rm -rf "$wt_dir"
+        else
+            rm -rf "$wt_dir"
+        fi
+    done
 }

--- a/loop.env.example
+++ b/loop.env.example
@@ -55,6 +55,13 @@ LOOP_DISPATCH_MODE="direct"
 # macOS (Homebrew): /opt/homebrew/bin:/usr/local/bin — Linux: /usr/local/bin or similar.
 LOOP_EXTRA_PATH="/opt/homebrew/bin:/usr/local/bin"
 
+# ─── Recovery ────────────────────────────────────────────────────────────────
+# Seconds before an operational label (in-progress, in-rework, in-review) with
+# no live handler process is considered stuck. Recovery strips the label and
+# restores the upstream trigger so the pipeline can retry. Default: 3600 (1h).
+# The stuck-label check fires when label age >= HANDLER_TIMEOUT * 1.5.
+# HANDLER_TIMEOUT=3600
+
 # ─── Bounty / loop-monitor ────────────────────────────────────────────────────
 # Stable identifier for this Loop instance sent with every bounty/event payload.
 # Lets loop-monitor distinguish multiple Loop instances reporting to the same endpoint.

--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -1226,6 +1226,8 @@ run_project() {
     reconcile_qa_failures "$REPO"
     recovery_check_dependencies "$slug"
     reconcile_worktrees "$slug" "$REPO"
+    recovery_check_stuck_labels "$slug"
+    recovery_prune_orphan_worktrees
 }
 
 acquire_lock

--- a/tests/reconciler.bats
+++ b/tests/reconciler.bats
@@ -30,7 +30,7 @@ YAML
     source "$REPO_ROOT/lib/workflow.sh"
 
     # Ops log captures every label/comment call.
-    OPS_LOG="$BATS_TMPDIR/ops.log"
+    export OPS_LOG="$BATS_TMPDIR/ops.log"
     rm -f "$OPS_LOG"
 
     # Globals needed by recovery functions.
@@ -46,10 +46,10 @@ YAML
     # backend_list_open_issues_raw honours GH_MOCK_ISSUES or MOCK_ISSUES_JSON
     backend_list_open_issues_raw() { echo "${GH_MOCK_ISSUES:-${MOCK_ISSUES_JSON:-[]}}"; }
     backend_list_open_prs_raw()    { echo "${MOCK_PRS_JSON:-[]}"; }
-    backend_remove_label()         { echo "remove_label $3" >> "$OPS_LOG"; }
-    backend_add_label()            { echo "add_label $3"    >> "$OPS_LOG"; }
-    backend_comment_issue()        { echo "comment_issue $2" >> "$OPS_LOG"; }
-    backend_comment_pr()           { echo "comment_pr $2"   >> "$OPS_LOG"; }
+    backend_remove_label()         { echo "remove_label $2 $3" >> "$OPS_LOG"; }
+    backend_add_label()            { echo "add_label $2 $3"    >> "$OPS_LOG"; }
+    backend_comment_issue()        { echo "comment_issue $2"   >> "$OPS_LOG"; }
+    backend_comment_pr()           { echo "comment_pr $2"      >> "$OPS_LOG"; }
     backend_find_pr_for_issue()    { echo "${GH_MOCK_PR_NUM:-}"; }
 
     # Stub gh: returns state based on GH_STATE_MAP entries "num:STATE num:STATE ...".
@@ -205,57 +205,6 @@ teardown() {
     grep -q "remove_label 50 blocked"   "$OPS_LOG"
     grep -q "add_label 50 needs-review" "$OPS_LOG"
     grep -q "comment_pr 50"             "$OPS_LOG"
-=======
-# tests/reconciler.bats — unit tests for lib/recovery.sh helpers.
-#
-# Tests are self-contained: gh, backend_*, loop_label_for, loop_notify, and log
-# are all stubbed so no real GitHub or filesystem state is needed.
-
-setup() {
-    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
-
-    # Expose mock-gh.sh as the gh binary via a per-test temp bin directory.
-    mkdir -p "$BATS_TMPDIR/bin"
-    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
-    chmod +x "$BATS_TMPDIR/bin/gh"
-    export PATH="$BATS_TMPDIR/bin:$PATH"
-
-    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
-    mkdir -p "$LOOP_LOG_DIR"
-    export LOOP_EXTRA_PATH=""
-    export LOOP_LOCK_DIR="$BATS_TMPDIR/locks"
-    mkdir -p "$LOOP_LOCK_DIR"
-
-    # Set required globals that recovery.sh functions depend on.
-    export LOOP_ROOT="$REPO_ROOT"
-    export REPO="owner/test-repo"
-    export ROOT="$BATS_TMPDIR/fake-root"
-    export DRY_RUN=false
-    export HANDLER_TIMEOUT=3600
-
-    # Stub library functions so we can source recovery.sh in isolation.
-    loop_label_for()              { echo "$2"; }
-    loop_notify()                 { :; }
-    log()                         { :; }
-    backend_list_open_issues_raw(){ echo "${GH_MOCK_ISSUES:-[]}"; }
-    backend_remove_label()        { echo "remove_label $3" >> "$BATS_TMPDIR/ops.log"; }
-    backend_add_label()           { echo "add_label $3"    >> "$BATS_TMPDIR/ops.log"; }
-    # Default: no open PR found for any issue
-    backend_find_pr_for_issue()   { echo "${GH_MOCK_PR_NUM:-}"; }
-
-    # Source only recovery.sh (it does not call acquire_lock on source).
-    # shellcheck disable=SC1090
-    source "$REPO_ROOT/lib/recovery.sh"
-
-    rm -f "$BATS_TMPDIR/ops.log"
-}
-
-teardown() {
-    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/logs" \
-           "$BATS_TMPDIR/locks" "$BATS_TMPDIR/ops.log" \
-           "$BATS_TMPDIR/fake-root" 2>/dev/null || true
-    # Clean up any worktree dirs created during tests
-    rm -rf /tmp/loop-worktree-bats-test-* 2>/dev/null || true
 }
 
 # ---------------------------------------------------------------------------
@@ -287,8 +236,8 @@ print(t.strftime('%Y-%m-%dT%H:%M:%SZ'))
     # No lock file → handler not alive
     run recovery_check_stuck_labels "test-proj"
     [ "$status" -eq 0 ]
-    grep -q "remove_label in-progress" "$BATS_TMPDIR/ops.log"
-    grep -q "add_label dev"            "$BATS_TMPDIR/ops.log"
+    grep -q "remove_label 42 in-progress" "$BATS_TMPDIR/ops.log"
+    grep -q "add_label 42 dev"            "$BATS_TMPDIR/ops.log"
 }
 
 @test "recovery_check_stuck_labels: skips issue with live handler lock" {
@@ -329,8 +278,8 @@ print(t.strftime('%Y-%m-%dT%H:%M:%SZ'))
 
     run recovery_check_stuck_labels "test-proj"
     [ "$status" -eq 0 ]
-    grep -q "remove_label in-rework"   "$BATS_TMPDIR/ops.log"
-    grep -q "add_label needs-rework"   "$BATS_TMPDIR/ops.log"
+    grep -q "remove_label 55 in-rework"   "$BATS_TMPDIR/ops.log"
+    grep -q "add_label 55 needs-rework"   "$BATS_TMPDIR/ops.log"
 }
 
 @test "recovery_check_stuck_labels: dry-run suppresses label mutations" {
@@ -427,5 +376,4 @@ print(t.strftime('%Y-%m-%dT%H:%M:%SZ'))
     # Dir must survive in dry-run
     [ -d "$wt_dir" ]
     rm -rf "$wt_dir"
->>>>>>> f680355 ([LOOP-69] add lib/recovery.sh: stuck-label timeout + orphan worktree cleanup)
 }

--- a/tests/reconciler.bats
+++ b/tests/reconciler.bats
@@ -1,10 +1,11 @@
 #!/usr/bin/env bats
-# tests/reconciler.bats — unit tests for recovery_check_dependencies in lib/recovery.sh.
+# tests/reconciler.bats — unit tests for lib/recovery.sh helpers.
 #
 # Backend functions and gh are stubbed as shell functions so no real GitHub
-# calls are made. Two scenarios are covered:
-#   (1) all declared deps closed  → blocked removed + trigger added + comment posted
-#   (2) one dep still open        → no label change, no comment
+# calls are made. Covers:
+#   recovery_check_dependencies — unblock when declared deps are merged
+#   recovery_check_stuck_labels — strip timed-out operational labels
+#   recovery_prune_orphan_worktrees — remove orphan worktrees
 
 setup() {
     REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
@@ -32,21 +33,29 @@ YAML
     OPS_LOG="$BATS_TMPDIR/ops.log"
     rm -f "$OPS_LOG"
 
+    # Globals needed by recovery functions.
+    export REPO="owner/test-repo"
+    export ROOT="$BATS_TMPDIR/fake-root"
+    export DRY_RUN=false
+    export HANDLER_TIMEOUT=3600
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    export LOOP_LOCK_DIR="$BATS_TMPDIR/locks"
+    mkdir -p "$LOOP_LOG_DIR" "$LOOP_LOCK_DIR"
+
     # Stub backend functions.
-    backend_list_open_issues_raw() { echo "${MOCK_ISSUES_JSON:-[]}"; }
+    # backend_list_open_issues_raw honours GH_MOCK_ISSUES or MOCK_ISSUES_JSON
+    backend_list_open_issues_raw() { echo "${GH_MOCK_ISSUES:-${MOCK_ISSUES_JSON:-[]}}"; }
     backend_list_open_prs_raw()    { echo "${MOCK_PRS_JSON:-[]}"; }
-    backend_remove_label()         { echo "remove_label $2 $3" >> "$OPS_LOG"; }
-    backend_add_label()            { echo "add_label $2 $3"    >> "$OPS_LOG"; }
-    backend_comment_issue()        { echo "comment_issue $2"   >> "$OPS_LOG"; }
-    backend_comment_pr()           { echo "comment_pr $2"      >> "$OPS_LOG"; }
+    backend_remove_label()         { echo "remove_label $3" >> "$OPS_LOG"; }
+    backend_add_label()            { echo "add_label $3"    >> "$OPS_LOG"; }
+    backend_comment_issue()        { echo "comment_issue $2" >> "$OPS_LOG"; }
+    backend_comment_pr()           { echo "comment_pr $2"   >> "$OPS_LOG"; }
+    backend_find_pr_for_issue()    { echo "${GH_MOCK_PR_NUM:-}"; }
 
     # Stub gh: returns state based on GH_STATE_MAP entries "num:STATE num:STATE ...".
     gh() {
-        local cmd="$1" subcmd="$2"  # e.g. "issue" "view"
         local num state
-        # Extract number from args (3rd positional arg after "issue view" or "pr view").
         num="$3"
-        # Look up in GH_STATE_MAP (space-separated "N:STATE" pairs).
         state="UNKNOWN"
         local pair
         for pair in ${GH_STATE_MAP:-}; do
@@ -55,7 +64,6 @@ YAML
                 break
             fi
         done
-        # Honour --jq '.state' output format.
         echo "$state"
         return 0
     }
@@ -64,19 +72,16 @@ YAML
     loop_notify() { :; }
     log()         { :; }
 
-    # DRY_RUN=false so mutations are executed.
-    DRY_RUN=false
-
-    # REPO must be set (normally exported by loop_load_project).
-    export REPO="owner/test-repo"
-
     # Source recovery.sh after stubs are in place.
     # shellcheck source=../lib/recovery.sh
     source "$REPO_ROOT/lib/recovery.sh"
 }
 
 teardown() {
-    rm -f "$BATS_TMPDIR/fixture.yaml" "$BATS_TMPDIR/ops.log" 2>/dev/null || true
+    rm -rf "$BATS_TMPDIR/fixture.yaml" "$BATS_TMPDIR/ops.log" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/locks" \
+           "$BATS_TMPDIR/fake-root" 2>/dev/null || true
+    rm -rf /tmp/loop-worktree-bats-test-* 2>/dev/null || true
 }
 
 # ---------------------------------------------------------------------------
@@ -200,4 +205,227 @@ teardown() {
     grep -q "remove_label 50 blocked"   "$OPS_LOG"
     grep -q "add_label 50 needs-review" "$OPS_LOG"
     grep -q "comment_pr 50"             "$OPS_LOG"
+=======
+# tests/reconciler.bats — unit tests for lib/recovery.sh helpers.
+#
+# Tests are self-contained: gh, backend_*, loop_label_for, loop_notify, and log
+# are all stubbed so no real GitHub or filesystem state is needed.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    # Expose mock-gh.sh as the gh binary via a per-test temp bin directory.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+    export LOOP_LOCK_DIR="$BATS_TMPDIR/locks"
+    mkdir -p "$LOOP_LOCK_DIR"
+
+    # Set required globals that recovery.sh functions depend on.
+    export LOOP_ROOT="$REPO_ROOT"
+    export REPO="owner/test-repo"
+    export ROOT="$BATS_TMPDIR/fake-root"
+    export DRY_RUN=false
+    export HANDLER_TIMEOUT=3600
+
+    # Stub library functions so we can source recovery.sh in isolation.
+    loop_label_for()              { echo "$2"; }
+    loop_notify()                 { :; }
+    log()                         { :; }
+    backend_list_open_issues_raw(){ echo "${GH_MOCK_ISSUES:-[]}"; }
+    backend_remove_label()        { echo "remove_label $3" >> "$BATS_TMPDIR/ops.log"; }
+    backend_add_label()           { echo "add_label $3"    >> "$BATS_TMPDIR/ops.log"; }
+    # Default: no open PR found for any issue
+    backend_find_pr_for_issue()   { echo "${GH_MOCK_PR_NUM:-}"; }
+
+    # Source only recovery.sh (it does not call acquire_lock on source).
+    # shellcheck disable=SC1090
+    source "$REPO_ROOT/lib/recovery.sh"
+
+    rm -f "$BATS_TMPDIR/ops.log"
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/logs" \
+           "$BATS_TMPDIR/locks" "$BATS_TMPDIR/ops.log" \
+           "$BATS_TMPDIR/fake-root" 2>/dev/null || true
+    # Clean up any worktree dirs created during tests
+    rm -rf /tmp/loop-worktree-bats-test-* 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# recovery_check_stuck_labels
+# ---------------------------------------------------------------------------
+
+@test "recovery_check_stuck_labels: skips issues updated within timeout" {
+    # updatedAt = now (0 seconds old) — must NOT be stripped
+    local now_iso
+    now_iso=$(python3 -c "import datetime; print(datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))")
+    export GH_MOCK_ISSUES="[{\"number\":1,\"title\":\"fresh issue\",\"updatedAt\":\"${now_iso}\",\"labels\":[{\"name\":\"in-progress\"}]}]"
+
+    run recovery_check_stuck_labels "test-proj"
+    [ "$status" -eq 0 ]
+    # No label operations should have occurred
+    [ ! -f "$BATS_TMPDIR/ops.log" ] || ! grep -q "remove_label" "$BATS_TMPDIR/ops.log"
+}
+
+@test "recovery_check_stuck_labels: strips stuck in-progress and restores dev" {
+    # updatedAt = 2 hours ago (> HANDLER_TIMEOUT * 1.5 = 5400s)
+    local old_iso
+    old_iso=$(python3 -c "
+import datetime
+t = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=2)
+print(t.strftime('%Y-%m-%dT%H:%M:%SZ'))
+")
+    export GH_MOCK_ISSUES="[{\"number\":42,\"title\":\"stuck issue\",\"updatedAt\":\"${old_iso}\",\"labels\":[{\"name\":\"in-progress\"}]}]"
+
+    # No lock file → handler not alive
+    run recovery_check_stuck_labels "test-proj"
+    [ "$status" -eq 0 ]
+    grep -q "remove_label in-progress" "$BATS_TMPDIR/ops.log"
+    grep -q "add_label dev"            "$BATS_TMPDIR/ops.log"
+}
+
+@test "recovery_check_stuck_labels: skips issue with live handler lock" {
+    local old_iso
+    old_iso=$(python3 -c "
+import datetime
+t = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=2)
+print(t.strftime('%Y-%m-%dT%H:%M:%SZ'))
+")
+    export GH_MOCK_ISSUES="[{\"number\":7,\"title\":\"live handler issue\",\"updatedAt\":\"${old_iso}\",\"labels\":[{\"name\":\"in-progress\"}]}]"
+
+    # Write a lock file for this issue with our own PID (process is alive)
+    echo "$$" > "$LOOP_LOCK_DIR/test-proj-issue-7.lock"
+
+    run recovery_check_stuck_labels "test-proj"
+    [ "$status" -eq 0 ]
+    # No label operations should occur when handler is alive
+    [ ! -f "$BATS_TMPDIR/ops.log" ] || ! grep -q "remove_label" "$BATS_TMPDIR/ops.log"
+}
+
+@test "recovery_check_stuck_labels: strips stuck in-rework and restores needs-rework" {
+    local old_iso
+    old_iso=$(python3 -c "
+import datetime
+t = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=3)
+print(t.strftime('%Y-%m-%dT%H:%M:%SZ'))
+")
+
+    # Return in-rework issue only for that label query, empty for the others
+    backend_list_open_issues_raw() {
+        local _repo="$1" lbl="$2"
+        if [ "$lbl" = "in-rework" ]; then
+            echo "[{\"number\":55,\"title\":\"rework stuck\",\"updatedAt\":\"${old_iso}\",\"labels\":[{\"name\":\"in-rework\"}]}]"
+        else
+            echo "[]"
+        fi
+    }
+
+    run recovery_check_stuck_labels "test-proj"
+    [ "$status" -eq 0 ]
+    grep -q "remove_label in-rework"   "$BATS_TMPDIR/ops.log"
+    grep -q "add_label needs-rework"   "$BATS_TMPDIR/ops.log"
+}
+
+@test "recovery_check_stuck_labels: dry-run suppresses label mutations" {
+    local old_iso
+    old_iso=$(python3 -c "
+import datetime
+t = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=2)
+print(t.strftime('%Y-%m-%dT%H:%M:%SZ'))
+")
+    export GH_MOCK_ISSUES="[{\"number\":99,\"title\":\"dry run issue\",\"updatedAt\":\"${old_iso}\",\"labels\":[{\"name\":\"in-progress\"}]}]"
+    DRY_RUN=true
+
+    run recovery_check_stuck_labels "test-proj"
+    [ "$status" -eq 0 ]
+    # No label operations should occur in dry-run mode
+    [ ! -f "$BATS_TMPDIR/ops.log" ] || ! grep -q "remove_label" "$BATS_TMPDIR/ops.log"
+}
+
+# ---------------------------------------------------------------------------
+# recovery_prune_orphan_worktrees
+# ---------------------------------------------------------------------------
+
+@test "recovery_prune_orphan_worktrees: removes orphan dir with no handler and no open PR" {
+    local wt_dir="/tmp/loop-worktree-bats-test-123"
+    mkdir -p "$wt_dir"
+    # Make it old enough to exceed the grace window
+    python3 -c "import os; os.utime('$wt_dir', (0, 0))"
+
+    # backend_find_pr_for_issue returns empty → no open PR
+    export GH_MOCK_PR_NUM=""
+
+    run recovery_prune_orphan_worktrees
+    [ "$status" -eq 0 ]
+    [ ! -d "$wt_dir" ]
+}
+
+@test "recovery_prune_orphan_worktrees: skips dir with open PR" {
+    local wt_dir="/tmp/loop-worktree-bats-test-456"
+    mkdir -p "$wt_dir"
+    python3 -c "import os; os.utime('$wt_dir', (0, 0))"
+
+    # backend_find_pr_for_issue returns a PR number → open PR exists
+    # REPO must be set so the function actually calls backend_find_pr_for_issue
+    export REPO="owner/test-repo"
+    export GH_MOCK_PR_NUM="10"
+
+    run recovery_prune_orphan_worktrees
+    [ "$status" -eq 0 ]
+    [ -d "$wt_dir" ]
+    rm -rf "$wt_dir"
+}
+
+@test "recovery_prune_orphan_worktrees: skips recently modified dir" {
+    local wt_dir="/tmp/loop-worktree-bats-test-789"
+    mkdir -p "$wt_dir"
+    # Do NOT touch mtime — it's fresh (just created = now)
+
+    export GH_MOCK_PR_NUM=""
+
+    run recovery_prune_orphan_worktrees
+    [ "$status" -eq 0 ]
+    # Dir must still exist (within grace window)
+    [ -d "$wt_dir" ]
+    rm -rf "$wt_dir"
+}
+
+@test "recovery_prune_orphan_worktrees: skips dir with live handler lock" {
+    local wt_dir="/tmp/loop-worktree-bats-test-321"
+    mkdir -p "$wt_dir"
+    python3 -c "import os; os.utime('$wt_dir', (0, 0))"
+
+    # Write a live lock for issue 321 using our own PID
+    echo "$$" > "$LOOP_LOCK_DIR/proj-321.lock"
+
+    export GH_MOCK_PR_NUM=""
+
+    run recovery_prune_orphan_worktrees
+    [ "$status" -eq 0 ]
+    # Dir must survive because handler is alive
+    [ -d "$wt_dir" ]
+    rm -rf "$wt_dir"
+}
+
+@test "recovery_prune_orphan_worktrees: dry-run does not remove dir" {
+    local wt_dir="/tmp/loop-worktree-bats-test-999"
+    mkdir -p "$wt_dir"
+    python3 -c "import os; os.utime('$wt_dir', (0, 0))"
+
+    export GH_MOCK_PR_NUM=""
+    DRY_RUN=true
+
+    run recovery_prune_orphan_worktrees
+    [ "$status" -eq 0 ]
+    # Dir must survive in dry-run
+    [ -d "$wt_dir" ]
+    rm -rf "$wt_dir"
+>>>>>>> f680355 ([LOOP-69] add lib/recovery.sh: stuck-label timeout + orphan worktree cleanup)
 }


### PR DESCRIPTION
Closes #69

## Changes

**`lib/recovery.sh`** (new) — foundational recovery helper library sourced by the reconciler. Exports two functions:

- `recovery_check_stuck_labels <slug>`: For each open issue carrying `in-progress`, `in-rework`, or `in-review` longer than `HANDLER_TIMEOUT * 1.5` seconds with no live handler lock, strips the operational label and restores the upstream trigger (`dev`, `needs-rework`, `needs-review`) using `loop_label_for` to respect per-project label overrides. Skips issues whose lock file holds a live PID.

- `recovery_prune_orphan_worktrees`: Scans `/tmp/loop-worktree-*` directories. Skips dirs modified within 10 minutes (grace window) or with a live handler PID. Uses `backend_find_pr_for_issue` (not direct `gh pr list`) so the check works across github, gitlab, and jira-gitlab backends. Removes dirs with no live handler and no open PR via `git worktree remove --force` + `rm -rf` fallback.

- `HANDLER_TIMEOUT` defaults to 3600s; overridable via `loop.env`.

- Added aspirational comment on `in-review` entry explaining it's forward-looking (review-handler does not yet write this label).

**`scanner/reconciler.sh`**: Sources `lib/recovery.sh`; calls `recovery_check_stuck_labels` and `recovery_prune_orphan_worktrees` at end of each project reconciliation sweep.

**`loop.env.example`**: Documents the `HANDLER_TIMEOUT` variable.

**`tests/reconciler.bats`** (new) — 9 bats tests with all dependencies stubbed (no real GitHub calls):
- Stuck-label: skips fresh issues, strips timed-out `in-progress`→`dev`, skips with live handler lock, strips `in-rework`→`needs-rework`, dry-run suppression.
- Orphan prune: removes orphan with no handler/PR, skips dir with open PR (REPO set, mock returns PR number), skips recently-modified dir, skips with live handler lock, dry-run suppression.

## Fixes from review

- **Replaced direct `gh pr list` with `backend_find_pr_for_issue`** in `recovery_prune_orphan_worktrees` — works across all backends.
- **Fixed test bug**: `REPO` is now explicitly set in the "skips dir with open PR" test so `backend_find_pr_for_issue` is actually invoked (and the mock returns a PR number); `GH_MOCK_PR_NUM` drives the stub return value consistently across all prune tests.
- **Rebased onto current main**: picks up the SC2034 fix and all other reconciler additions landed after the original branch was cut.

## Test Plan

- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — all pass
- `shellcheck -S warning lib/*.sh scripts/*.sh scanner/*.sh install.sh` — clean
- `bats tests/reconciler.bats` — 9 new tests