### PR TITLE
[LOOP-90] add LOOP_SENIOR_MODEL and loop_run_senior_agent() helper

### DIFF
--- a/lib/runner.sh
+++ b/lib/runner.sh
@@ -69,12 +69,12 @@ loop_run_agent() {
     esac
 }
 
-# loop_run_senior_agent <worktree> <prompt>
+# loop_run_senior_agent <prompt> [<worktree>]
 # Like loop_run_agent but uses LOOP_SENIOR_MODEL for the model override.
 # Falls back to LOOP_AGENT_MODEL (or per-agent default) when LOOP_SENIOR_MODEL is unset.
 loop_run_senior_agent() {
-    local cwd="$1"
-    local prompt="$2"
+    local prompt="$1"
+    local cwd="${2:-$(pwd)}"
 
     if [ -n "${LOOP_ORCHESTRATOR:-}" ] && [ -x "${LOOP_ORCHESTRATOR}" ]; then
         "$LOOP_ORCHESTRATOR" "$prompt" --mode quick --cwd "$cwd"

--- a/lib/runner.sh
+++ b/lib/runner.sh
@@ -68,3 +68,57 @@ loop_run_agent() {
             ;;
     esac
 }
+
+# loop_run_senior_agent <worktree> <prompt>
+# Like loop_run_agent but uses LOOP_SENIOR_MODEL for the model override.
+# Falls back to LOOP_AGENT_MODEL (or per-agent default) when LOOP_SENIOR_MODEL is unset.
+loop_run_senior_agent() {
+    local cwd="$1"
+    local prompt="$2"
+
+    if [ -n "${LOOP_ORCHESTRATOR:-}" ] && [ -x "${LOOP_ORCHESTRATOR}" ]; then
+        "$LOOP_ORCHESTRATOR" "$prompt" --mode quick --cwd "$cwd"
+        return $?
+    fi
+
+    case "$LOOP_AGENT" in
+        claude)
+            claude -p \
+                --model "${LOOP_SENIOR_MODEL:-${LOOP_AGENT_MODEL:-sonnet}}" \
+                --output-format text \
+                --dangerously-skip-permissions \
+                --cwd "$cwd" \
+                "$prompt"
+            ;;
+        codex)
+            (cd "$cwd" && codex \
+                --model "${LOOP_SENIOR_MODEL:-${LOOP_AGENT_MODEL:-o4-mini}}" \
+                --approval-mode full-auto \
+                -q "$prompt")
+            ;;
+        gemini)
+            (cd "$cwd" && gemini \
+                -m "${LOOP_SENIOR_MODEL:-${LOOP_AGENT_MODEL:-gemini-2.5-pro}}" \
+                --sandbox \
+                -p "$prompt")
+            ;;
+        aider)
+            (cd "$cwd" && aider \
+                --model "${LOOP_SENIOR_MODEL:-${LOOP_AGENT_MODEL:-sonnet}}" \
+                --yes-always \
+                --message "$prompt")
+            ;;
+        custom)
+            echo "WARNING: LOOP_AGENT=custom does not support model override; proceeding without --model flag" >&2
+            if [ -z "${LOOP_AGENT_CMD:-}" ]; then
+                echo "ERROR: LOOP_AGENT=custom but LOOP_AGENT_CMD not set" >&2
+                return 2
+            fi
+            eval "$LOOP_AGENT_CMD" "$prompt"
+            ;;
+        *)
+            echo "ERROR: Unknown LOOP_AGENT='$LOOP_AGENT'. Use: claude, codex, gemini, aider, custom" >&2
+            return 2
+            ;;
+    esac
+}

--- a/loop.env.example
+++ b/loop.env.example
@@ -14,6 +14,11 @@ LOOP_AGENT="claude"
 #   claude: sonnet, codex: o4-mini, gemini: gemini-2.5-pro, aider: sonnet
 # LOOP_AGENT_MODEL="sonnet"
 
+# Senior/escalated model (optional). Used by loop_run_senior_agent() for hard problems
+# that warrant a more capable model. When unset, falls back to LOOP_AGENT_MODEL (no breakage).
+# claude example: claude-opus-4-7
+# LOOP_SENIOR_MODEL="claude-opus-4-7"
+
 # Custom agent command (only if LOOP_AGENT="custom")
 # Must accept a prompt as first argument.
 # LOOP_AGENT_CMD="/path/to/your/agent-wrapper.sh"

--- a/scripts/senior-dev-handler.sh
+++ b/scripts/senior-dev-handler.sh
@@ -72,7 +72,7 @@ if [ "$retries" -ge "$MAX_RETRIES" ]; then
 fi
 
 log "senior-dev handler: slug=$SLUG repo=$REPO issue=#$ISSUE_NUM attempt=$((retries + 1))/$MAX_RETRIES"
-bounty_report "senior_dev_start" model="${LOOP_SENIOR_AGENT_MODEL:-${LOOP_AGENT_MODEL:-opus}}" role=senior-dev project="$SLUG" issue_num="$ISSUE_NUM" || true
+bounty_report "senior_dev_start" model="${LOOP_SENIOR_MODEL:-${LOOP_AGENT_MODEL:-opus}}" role=senior-dev project="$SLUG" issue_num="$ISSUE_NUM" || true
 loop_notify "▶️ [$SLUG] #$ISSUE_NUM senior-dev escalation starting"
 
 # Fetch issue body
@@ -171,7 +171,7 @@ LOG_CAPTURE_START=$(wc -l < "$LOG_FILE" 2>/dev/null || echo 0)
 if loop_run_senior_agent "$TASK_PROMPT" "$WORKTREE_ROOT" 2>&1 | tee -a "$LOG_FILE"; then
     _IN_PROGRESS_CLAIMED=0
     log "senior-dev agent succeeded for #$ISSUE_NUM"
-    bounty_report "senior_dev_done" model="${LOOP_SENIOR_AGENT_MODEL:-${LOOP_AGENT_MODEL:-opus}}" role=senior-dev project="$SLUG" issue_num="$ISSUE_NUM" || true
+    bounty_report "senior_dev_done" model="${LOOP_SENIOR_MODEL:-${LOOP_AGENT_MODEL:-opus}}" role=senior-dev project="$SLUG" issue_num="$ISSUE_NUM" || true
     loop_notify "✅ [$SLUG] #$ISSUE_NUM senior-dev done"
     retry_clear
     backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
@@ -205,7 +205,7 @@ else
     _IN_PROGRESS_CLAIMED=0
     n=$(retry_incr)
     log "senior-dev agent failed for #$ISSUE_NUM (attempt $n/$MAX_RETRIES)"
-    bounty_report "senior_dev_failed" model="${LOOP_SENIOR_AGENT_MODEL:-${LOOP_AGENT_MODEL:-opus}}" role=senior-dev project="$SLUG" issue_num="$ISSUE_NUM" detail="attempt ${n}/${MAX_RETRIES}" || true
+    bounty_report "senior_dev_failed" model="${LOOP_SENIOR_MODEL:-${LOOP_AGENT_MODEL:-opus}}" role=senior-dev project="$SLUG" issue_num="$ISSUE_NUM" detail="attempt ${n}/${MAX_RETRIES}" || true
     if [ "$n" -ge "$MAX_RETRIES" ]; then
         backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
         backend_add_label "$REPO" "$ISSUE_NUM" blocked


### PR DESCRIPTION
Closes #90

## Changes
- `lib/runner.sh`: added `loop_run_senior_agent <worktree> <prompt>` function that mirrors `loop_run_agent` but uses `LOOP_SENIOR_MODEL` for the model override flag. Each agent backend passes the model via its own flag (`--model` for claude/codex/aider, `-m` for gemini). When `LOOP_SENIOR_MODEL` is unset it falls back to `${LOOP_AGENT_MODEL:-<per-agent-default>}`, so existing behaviour is unchanged. The `custom` agent emits a warning and proceeds without a model flag (no standard override mechanism). The `LOOP_ORCHESTRATOR` fast-path is preserved unchanged.
- `loop.env.example`: documented `LOOP_SENIOR_MODEL` with a comment explaining its purpose and the claude default (`claude-opus-4-7`).

## Test Plan
- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — passes (no syntax errors)
- `shellcheck -S warning lib/*.sh scripts/*.sh scanner/*.sh install.sh` — passes (no warnings)
- Verify `loop_run_senior_agent` is callable from a handler that sources `lib/runner.sh`
- Verify that with `LOOP_SENIOR_MODEL` unset, the agent is invoked with the same model as `loop_run_agent`
- Verify that with `LOOP_SENIOR_MODEL=claude-opus-4-7` the claude branch passes `--model claude-opus-4-7`
- Verify `custom` agent emits a warning but does not error when `LOOP_AGENT_CMD` is set