### PR TITLE
fix(tests): prevent mock-gh.sh corruption from digest.bats

### DIFF
--- a/tests/digest.bats
+++ b/tests/digest.bats
@@ -56,6 +56,8 @@ make_mock_gh() {
     # $1 = path to write mock script
     # $2 = shell snippet to embed (receives "$@" as gh args)
     local dest="$1" snippet="$2"
+    # Remove any existing symlink before writing so we don't corrupt the target.
+    rm -f "$dest"
     cat > "$dest" <<SCRIPT
 #!/usr/bin/env bash
 ${snippet}


### PR DESCRIPTION
## Problem

`tests/digest.bats::make_mock_gh` used `cat > "$dest"` where `$dest` was `$BATS_TMPDIR/bin/gh` — a symlink pointing to `tests/test_helper/mock-gh.sh`. Writing through a symlink overwrites the target, corrupting the shared mock binary for all test files that run after `digest.bats`.

## Impact

Tests in `github.bats`, `handlers.bats`, and others that rely on `GH_MOCK_OUTPUT` / `GH_MOCK_EXIT` semantics fail because the mock is replaced with a hardcoded `case` statement. This caused CI `qa-merge` failures on PRs #108, #110, #111, #113, and #114.

## Fix

Add `rm -f "$dest"` before `cat > "$dest"` in `make_mock_gh`. This breaks any existing symlink so the subsequent write creates a new regular file, leaving the original `mock-gh.sh` untouched.

Also restores `tests/test_helper/mock-gh.sh` to its canonical content in case it was corrupted in-tree.

## Test plan

- [ ] Run `bats tests/` end-to-end and confirm no failures in `github.bats` or `handlers.bats`
- [ ] Confirm `tests/test_helper/mock-gh.sh` is unchanged after a full `bats tests/` run

🤖 Generated with [Claude Code](https://claude.com/claude-code)