### PR TITLE
fix(tests): correct backend_comment_pr mock arg in review.bats

### DIFF
--- a/tests/review.bats
+++ b/tests/review.bats
@@ -38,7 +38,7 @@ teardown() {
 
     backend_remove_label() { echo "remove $3" >> "$ops_log"; }
     backend_add_label()    { echo "add $3"    >> "$ops_log"; }
-    backend_comment_pr()   { echo "comment: $4" >> "$comment_log"; }
+    backend_comment_pr()   { echo "comment: $3" >> "$comment_log"; }
     gh() {
         case "$*" in
             *isDraft*) echo "true" ;;
@@ -103,7 +103,7 @@ teardown() {
 
     backend_remove_label() { echo "remove $3" >> "$ops_log"; }
     backend_add_label()    { echo "add $3"    >> "$ops_log"; }
-    backend_comment_pr()   { echo "comment: $4" >> "$comment_log"; }
+    backend_comment_pr()   { echo "comment: $3" >> "$comment_log"; }
     gh() {
         case "$*" in
             *isDraft*) echo "true" ;;


### PR DESCRIPTION
## Problem

Tests 60 and 62 in `tests/review.bats` (added by #95 LOOP-87) used `\$4` in the `backend_comment_pr` mock but the function signature is `(repo, number, body)` — body is `\$3`. The mock captured an empty string and `grep -q "re-apply"` always failed.

These two tests blocked every PR from passing qa-merge CI since #95 merged.

## Fix

Change `echo "comment: \$4"` → `echo "comment: \$3"` in both mock instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)