### PR TITLE
[LOOP-90] add LOOP_SENIOR_MODEL and loop_run_senior_agent() helper

### DIFF
--- a/lib/runner.sh
+++ b/lib/runner.sh
@@ -68,3 +68,57 @@ loop_run_agent() {
             ;;
     esac
 }
+
+# loop_run_senior_agent <prompt> <cwd>
+# Like loop_run_agent but uses LOOP_SENIOR_MODEL for the model override.
+# Falls back to LOOP_AGENT_MODEL (or per-agent default) when LOOP_SENIOR_MODEL is unset.
+loop_run_senior_agent() {
+    local prompt="$1"
+    local cwd="${2:-$(pwd)}"
+
+    if [ -n "${LOOP_ORCHESTRATOR:-}" ] && [ -x "${LOOP_ORCHESTRATOR}" ]; then
+        "$LOOP_ORCHESTRATOR" "$prompt" --mode quick --cwd "$cwd"
+        return $?
+    fi
+
+    case "$LOOP_AGENT" in
+        claude)
+            claude -p \
+                --model "${LOOP_SENIOR_MODEL:-${LOOP_AGENT_MODEL:-sonnet}}" \
+                --output-format text \
+                --dangerously-skip-permissions \
+                --cwd "$cwd" \
+                "$prompt"
+            ;;
+        codex)
+            (cd "$cwd" && codex \
+                --model "${LOOP_SENIOR_MODEL:-${LOOP_AGENT_MODEL:-o4-mini}}" \
+                --approval-mode full-auto \
+                -q "$prompt")
+            ;;
+        gemini)
+            (cd "$cwd" && gemini \
+                -m "${LOOP_SENIOR_MODEL:-${LOOP_AGENT_MODEL:-gemini-2.5-pro}}" \
+                --sandbox \
+                -p "$prompt")
+            ;;
+        aider)
+            (cd "$cwd" && aider \
+                --model "${LOOP_SENIOR_MODEL:-${LOOP_AGENT_MODEL:-sonnet}}" \
+                --yes-always \
+                --message "$prompt")
+            ;;
+        custom)
+            echo "WARNING: LOOP_AGENT=custom does not support model override; proceeding without --model flag" >&2
+            if [ -z "${LOOP_AGENT_CMD:-}" ]; then
+                echo "ERROR: LOOP_AGENT=custom but LOOP_AGENT_CMD not set" >&2
+                return 2
+            fi
+            eval "$LOOP_AGENT_CMD" "$prompt"
+            ;;
+        *)
+            echo "ERROR: Unknown LOOP_AGENT='$LOOP_AGENT'. Use: claude, codex, gemini, aider, custom" >&2
+            return 2
+            ;;
+    esac
+}

--- a/loop.env.example
+++ b/loop.env.example
@@ -14,6 +14,11 @@ LOOP_AGENT="claude"
 #   claude: sonnet, codex: o4-mini, gemini: gemini-2.5-pro, aider: sonnet
 # LOOP_AGENT_MODEL="sonnet"
 
+# Senior/escalated model (optional). Used by loop_run_senior_agent() for hard problems
+# that warrant a more capable model. Defaults to LOOP_AGENT_MODEL when unset (no escalation).
+# claude default: claude-opus-4-7
+# LOOP_SENIOR_MODEL="claude-opus-4-7"
+
 # Custom agent command (only if LOOP_AGENT="custom")
 # Must accept a prompt as first argument.
 # LOOP_AGENT_CMD="/path/to/your/agent-wrapper.sh"


### PR DESCRIPTION
Closes #90

## Changes
- **`lib/runner.sh`**: added `loop_run_senior_agent <prompt> <cwd>` (same argument order as `loop_run_agent`: `$1=prompt`, `$2=cwd`). The function mirrors `loop_run_agent` in full — including the `LOOP_ORCHESTRATOR` fast-path — but substitutes `LOOP_SENIOR_MODEL` as the model override for each backend (`--model` for claude/codex/aider, `-m` for gemini). When `LOOP_SENIOR_MODEL` is unset it falls back to `${LOOP_AGENT_MODEL:-<per-agent-default>}`, preserving identical behaviour to `loop_run_agent`. The `custom` agent emits a warning and runs without a model flag since there is no standard override mechanism.
- **`loop.env.example`**: documented `LOOP_SENIOR_MODEL` in the Agent section, explaining its purpose (escalated/hard-problem invocations) and the claude default (`claude-opus-4-7`).

## Test Plan
- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — must pass (no syntax errors)
- `shellcheck -S warning lib/*.sh scripts/*.sh scanner/*.sh install.sh` — must pass (no warnings)
- Source `lib/runner.sh` and call `loop_run_senior_agent "$PROMPT" "$WORKTREE_ROOT"` — verify `$1` is treated as the prompt and `$2` as the working directory
- With `LOOP_SENIOR_MODEL` unset: verify invocation uses the same model as `loop_run_agent`
- With `LOOP_SENIOR_MODEL=claude-opus-4-7`: verify claude branch passes `--model claude-opus-4-7`
- With `LOOP_AGENT=custom` and `LOOP_AGENT_CMD` set: verify warning is printed but call succeeds