### PR TITLE
[LOOP-88] PO: preserve original brief on issue expand

### DIFF
--- a/scripts/po-handler.sh
+++ b/scripts/po-handler.sh
@@ -101,6 +101,29 @@ trap '_po_label_cleanup' EXIT TERM INT
 
 ISSUE_BODY=$(backend_issue_view "$REPO" "$ISSUE_NUM" --json body --jq .body 2>/dev/null || echo "")
 
+# Extract the true original body — strips any existing ## Original brief section
+# so re-triaging an already-expanded issue doesn't nest markers.
+_ORIGINAL_BRIEF=$(BODY="$ISSUE_BODY" python3 -c "
+import os, re
+body = os.environ.get('BODY', '').strip()
+# Strip existing marker and everything after it
+body = re.split(r'(?m)^---\s*\n##\s+Original brief', body)[0].rstrip()
+print(body)
+")
+
+if [ -n "$_ORIGINAL_BRIEF" ]; then
+    _ORIG_BRIEF_SECTION="After writing the full spec body above to /tmp/po-${ISSUE_NUM}-body.md, append the following to the file:
+
+---
+
+## Original brief (preserved by PO)
+
+${_ORIGINAL_BRIEF}
+"
+else
+    _ORIG_BRIEF_SECTION="(original body was empty — no brief preserved)"
+fi
+
 # Include recent comments so human steering + prior blocker context is visible to the PO agent.
 ISSUE_COMMENTS=$(backend_issue_view "$REPO" "$ISSUE_NUM" --json comments 2>/dev/null \
     | python3 -c "
@@ -278,6 +301,9 @@ Any gotchas, relevant prior art, or constraints pulled from CLAUDE.md.
 
 ## Out of scope
 What this ticket explicitly does not cover. Prevents scope creep.
+
+ORIGINAL BRIEF PRESERVATION (for path A spec writes):
+${_ORIG_BRIEF_SECTION}
 
 IMPORTANT: The issue MUST end this run with exactly ONE of: dev / needs-clarification / blocked / tracker / closed.
 Verify: gh issue view ${ISSUE_NUM} --repo ${REPO} --json labels,state

--- a/tests/po-body-preserve.bats
+++ b/tests/po-body-preserve.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+# tests/po-body-preserve.bats — unit tests for _ORIGINAL_BRIEF extraction logic.
+#
+# Tests that the python3 snippet in po-handler.sh correctly strips any existing
+# ## Original brief section from the captured issue body so re-triage never
+# nests the marker.
+
+# Inline replication of the python3 extraction snippet from po-handler.sh.
+extract_original_brief() {
+    local body="$1"
+    BODY="$body" python3 -c "
+import os, re
+body = os.environ.get('BODY', '').strip()
+# Strip existing marker and everything after it
+body = re.split(r'(?m)^---\s*\n##\s+Original brief', body)[0].rstrip()
+print(body)
+"
+}
+
+@test "strips existing ## Original brief marker and everything after it" {
+    local input
+    input="$(printf 'do X\n\n---\n\n## Original brief (preserved by PO)\n\nold original')"
+    result=$(extract_original_brief "$input")
+    [ "$result" = "do X" ]
+}
+
+@test "returns body unchanged when no marker is present" {
+    result=$(extract_original_brief "do X")
+    [ "$result" = "do X" ]
+}
+
+@test "returns empty string for an empty body" {
+    result=$(extract_original_brief "")
+    [ -z "$result" ]
+}
+
+@test "returns empty string for a whitespace-only body" {
+    result=$(extract_original_brief "   ")
+    [ -z "$result" ]
+}
+
+@test "strips marker even when body has multiple paragraphs before it" {
+    local input
+    input="$(printf 'line one\n\nline two\n\n---\n\n## Original brief (preserved by PO)\n\nsome old brief')"
+    result=$(extract_original_brief "$input")
+    [ "$result" = "$(printf 'line one\n\nline two')" ]
+}


### PR DESCRIPTION
## Summary
- `scripts/po-handler.sh`: capture and strip any existing `## Original brief` section from the body before PO expansion, then inject the true original back into the new spec via prompt instruction
- Re-triage safe: existing marker is stripped before re-appending (no nesting)
- Empty body: marker is omitted entirely
- `tests/po-body-preserve.bats`: tests for the original-brief extraction logic

## Test plan
- [ ] `bash -n scripts/po-handler.sh` passes
- [ ] `shellcheck -S warning scripts/po-handler.sh` passes
- [ ] `bats tests/po-body-preserve.bats` passes

Closes #88