### PR TITLE
[LOOP-123] simplify README Install section to 3-command Claude+GitHub quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,23 +39,30 @@
 
 ## Install (5 minutes)
 
+Clone, bootstrap, and add your first project:
+
 ```bash
-git clone https://github.com/svv2014/loop.git
-cd loop
-./install.sh --bootstrap            # check tools, write loop.env, register services
+git clone https://github.com/svv2014/loop.git && cd loop
+./install.sh --bootstrap            # check tools, write loop.env, register scanner
 ./install.sh /path/to/your-project  # add a project to the pipeline
 ```
 
-`--bootstrap` checks `gh auth status`, `python3` + `pyyaml`, and at least
-one supported agent CLI; copies `loop.env.example` → `loop.env` and
-`config/projects.example.yaml` → `config/projects.yaml`; registers a
-launchd plist (macOS) or cron entry (Linux) for the scanner and reconciler.
+Set your agent in `loop.env`:
 
-Then label any issue `plan` (or `dev`, depending on your workflow) and
-the scanner picks it up within 5 minutes.
+```bash
+LOOP_AGENT=claude
+LOOP_AGENT_MODEL=sonnet
+```
 
-See [`docs/quick-start.md`](docs/quick-start.md) for a step-by-step
-walkthrough including agent configuration and first-project setup.
+Then label an issue to start the pipeline:
+
+```bash
+gh issue edit <number> --repo owner/repo --add-label plan
+```
+
+The scanner picks it up within 5 minutes and opens a PR automatically.
+
+[More options](docs/quick-start.md) — GitLab, other agents, loop-monitor, and advanced config.
 
 ## How a feature flows through Loop
 


### PR DESCRIPTION
Closes #123

## Changes

Rewrote the `## Install (5 minutes)` section of README.md:
- Reduced prose to ≤ 6 lines; the 3 commands (clone, bootstrap, add-project) are the primary code block
- Added a `loop.env` snippet showing `LOOP_AGENT=claude` and `LOOP_AGENT_MODEL=sonnet`
- Added the label-an-issue step using `gh issue edit --add-label plan`
- Removed GitLab, Jira, and non-Claude agent references from this section
- Replaced the existing quick-start link with a "More options" link to `docs/quick-start.md`
- No other sections, scripts, or files were modified

## Test Plan
- Verify README Install section has exactly 3 commands in the primary code block
- Verify `loop.env` snippet is present with `LOOP_AGENT=claude` and `LOOP_AGENT_MODEL=sonnet`
- Verify label-an-issue step is present
- Verify no GitLab/Jira/non-Claude references remain in the Install section
- Verify "More options" link points to `docs/quick-start.md`
- `bash -n install.sh` passes (install.sh not modified)