### PR TITLE
[LOOP-132] fix docs: replace plan with po-review/dev as pipeline entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,11 @@ LOOP_AGENT_MODEL=sonnet
 Then label an issue to start the pipeline:
 
 ```bash
-gh issue edit <number> --repo owner/repo --add-label plan
+# Rough idea — PO agent expands the spec, then implements:
+gh issue edit <number> --repo owner/repo --add-label po-review
+
+# Already have a full spec — skip PO and go straight to implementation:
+gh issue edit <number> --repo owner/repo --add-label dev
 ```
 
 The scanner picks it up within 5 minutes and opens a PR automatically.
@@ -72,7 +76,7 @@ The scanner picks it up within 5 minutes and opens a PR automatically.
 
 ## How a feature flows through Loop
 
-1. **You** open an issue, write what you want, label it `plan`.
+1. **You** open an issue, write what you want, label it `po-review` (rough idea — PO agent expands the spec first) or `dev` (pre-written spec — skip straight to implementation).
 2. **Scanner** notices the label within 5 minutes, fires the dev handler.
 3. **Dev handler** invokes your AI agent in an isolated git worktree.
    Agent reads the issue, writes code, opens a PR, labels it
@@ -97,7 +101,7 @@ Loop ships three starter workflows in `config/workflows/`:
 
 | Workflow | When to use |
 |---|---|
-| `default.yaml` | New repos. Clean canonical labels: `plan` / `needs-review` / `needs-qa` / `qa-pass`. Five-stage pipeline with PO expansion + rework loop. |
+| `default.yaml` | New repos. Clean canonical labels: `po-review` / `dev` / `needs-review` / `needs-qa` / `qa-pass`. Five-stage pipeline with PO expansion + rework loop. |
 | `minimal.yaml` | Solo prototypes. Two stages: `plan → merge`. No review, no QA. |
 | `docs-only.yaml` | Documentation and content PRs. Three stages: `plan → review → merge`. No QA gate. |
 

--- a/docs/label-lifecycle.md
+++ b/docs/label-lifecycle.md
@@ -8,17 +8,19 @@ labels on success; the scanner uses labels to decide what's actionable.
 ```
 (new)
   │
-  │  human opens issue with label: plan (deprecated alias: dev)
+  │  human opens issue with label: po-review (rough idea → PO expands spec)
+  │                             or dev (pre-written spec → straight to implementation)
   ▼
-plan (dev) ──────────► build (in-progress)
-                           │
-                           │ dev-handler runs agent, opens PR
-                           ▼
-                      needs-review (review-pending)  (on issue; also set on PR)
-                           │
-                           │ merge-handler closes issue when PR merges
-                           ▼
-                         done  (issue closed)
+po-review ──► po-handler expands spec ──► dev
+dev ──────────────────────────────────────► build (in-progress)
+                                               │
+                                               │ dev-handler runs agent, opens PR
+                                               ▼
+                                          needs-review (review-pending)  (on issue; also set on PR)
+                                               │
+                                               │ merge-handler closes issue when PR merges
+                                               ▼
+                                             done  (issue closed)
 
  Failure paths:
     build ──► (retries < 3) ──► cleared, scanner re-emits next tick
@@ -56,7 +58,8 @@ Both the new canonical name and its deprecated alias trigger the same event.
 
 | Source | Emits event type | Claimed if any of these labels present |
 |---|---|---|
-| Issue has `plan` or `dev` | `loop.dev_issue` | build, in-progress, blocked, needs-review, review-pending, needs-qa, ready-for-qa, approved, qa-pass, done |
+| Issue has `po-review` | `loop.po_review` | build, in-progress, blocked, needs-review, review-pending, needs-qa, ready-for-qa, approved, qa-pass, done |
+| Issue has `dev` | `loop.dev_issue` | build, in-progress, blocked, needs-review, review-pending, needs-qa, ready-for-qa, approved, qa-pass, done |
 | PR has `needs-review` or `review-pending` | `loop.pr_review` | in-review, needs-qa, ready-for-qa, approved, qa-pass, done |
 | PR has `needs-qa` or `ready-for-qa` | `loop.pr_qa` | approved, qa-pass, done |
 | PR has `approved` or `qa-pass` | `loop.pr_merge` | (none — idempotent until merged) |

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -37,10 +37,10 @@ Register your repo with the pipeline.
 
 ## Step 4 — Label an issue
 
-Apply `plan` to any open issue to hand it off to the agent.
+Apply `po-review` to hand off a rough idea (the PO agent expands the spec, then implements). Use `dev` to skip PO and go straight to implementation.
 
 ```bash
-gh issue edit N --repo owner/repo --add-label plan
+gh issue edit N --repo owner/repo --add-label po-review
 ```
 
 ## Step 5 — Watch it ship


### PR DESCRIPTION
Closes #132

## Changes

- **README.md** — Install section: replaced `--add-label plan` with two commands showing `po-review` (rough idea, PO expands spec) and `dev` (pre-written spec, direct implementation). Updated "How a feature flows" step 1 to reference `po-review`/`dev`. Updated the Workflows table `default.yaml` row to list `po-review / dev / needs-review / needs-qa / qa-pass` instead of `plan / ...`.
- **docs/quick-start.md** — Step 4: changed label command from `--add-label plan` to `--add-label po-review`, updated the header text, and added a one-line explanation of when to use `po-review` vs `dev`.
- **docs/label-lifecycle.md** — Issue states diagram updated to show `po-review` and `dev` as the two entry points (removing `plan`). Scanner filters table split into two rows: one for `po-review` (`loop.po_review`) and one for `dev` (`loop.dev_issue`), removing the outdated `plan or dev` combined entry.

No shell scripts or workflow YAML files were modified — docs-only change as required.

## Test Plan

- Verify README.md Install section no longer mentions `plan` as a labeling instruction
- Verify README.md "How a feature flows" step 1 references `po-review`/`dev`
- Verify README.md Workflows table `default.yaml` row lists correct canonical labels
- Verify docs/quick-start.md Step 4 uses `--add-label po-review` and includes the `po-review` vs `dev` explanation
- Verify docs/label-lifecycle.md presents `po-review` and `dev` as entry points, not `plan`
- Confirm `bash -n` passes on all shell scripts (docs-only change, no scripts touched)