### PR TITLE
[LOOP-131] resolve workflow labels in all handler prompts via loop_label_for

### DIFF
--- a/scripts/dev-handler.sh
+++ b/scripts/dev-handler.sh
@@ -113,7 +113,11 @@ log "worktree ready: $WORKTREE_ROOT (isolated from other handlers)"
 # Resolve workflow-specific labels for this project so the agent prompt + the
 # belt-and-braces apply the right names per the project's active workflow
 # (e.g. needs-review on default, review-pending on current).
-REVIEW_LABEL=$(loop_stage_trigger "$SLUG" review pr 2>/dev/null || echo review-pending)
+_REVIEW_LABEL=$(loop_label_for "$SLUG" "needs-review")
+_REWORK_LABEL=$(loop_label_for "$SLUG" "needs-rework")
+_QA_LABEL=$(loop_label_for "$SLUG" "needs-qa")
+_QA_PASS_LABEL=$(loop_label_for "$SLUG" "qa-pass")
+_QA_FAIL_LABEL=$(loop_label_for "$SLUG" "qa-fail")
 _BACKEND_CLI_NOTE=$(backend_cli_note)
 
 TASK_PROMPT=$(cat <<EOF
@@ -154,11 +158,11 @@ $( [ -n "$DEV_VALIDATION_CMD" ] && echo "4. Run validation: ${DEV_VALIDATION_CMD
 
 ## Test Plan
 <what QA should verify>' \\
-     --label ${REVIEW_LABEL}
+     --label ${_REVIEW_LABEL}
 8. On your own issue — this step is MANDATORY to signal success to the pipeline:
-   gh issue edit ${ISSUE_NUM} --repo ${REPO} --remove-label in-progress --remove-label dev --remove-label plan --remove-label needs-review --remove-label review-pending --add-label ${REVIEW_LABEL}
+   gh issue edit ${ISSUE_NUM} --repo ${REPO} --remove-label in-progress --remove-label dev --remove-label plan --remove-label ${_REVIEW_LABEL} --add-label ${_REVIEW_LABEL}
 
-IMPORTANT: The issue MUST end this run with label '${REVIEW_LABEL}' (or 'needs-clarification' if blocked). Verify with:
+IMPORTANT: The issue MUST end this run with label '${_REVIEW_LABEL}' (or 'needs-clarification' if blocked). Verify with:
    gh issue view ${ISSUE_NUM} --repo ${REPO} --json labels
 
 If blocked by missing context or an architectural decision, comment on the issue and add label 'needs-clarification' instead of opening a PR.
@@ -204,8 +208,8 @@ if matches:
         log "belt-and-braces: found PR #$_dev_pr_num for issue #$ISSUE_NUM"
         if ! backend_pr_has_any_label "$REPO" "$_dev_pr_num" \
                 review-pending needs-review changes-requested needs-rework in-review needs-clarification blocked 'done'; then
-            log "WARN: PR #$_dev_pr_num has no progression label after dev agent — adding '${REVIEW_LABEL}'"
-            backend_add_label "$REPO" "$_dev_pr_num" "$REVIEW_LABEL"
+            log "WARN: PR #$_dev_pr_num has no progression label after dev agent — adding '${_REVIEW_LABEL}'"
+            backend_add_label "$REPO" "$_dev_pr_num" "$_REVIEW_LABEL"
         fi
         # Strip both legacy and canonical issue-side names so the issue ends single-state
         backend_remove_label "$REPO" "$ISSUE_NUM" needs-review review-pending plan dev in-progress

--- a/scripts/dev-rework-handler.sh
+++ b/scripts/dev-rework-handler.sh
@@ -204,7 +204,11 @@ if [ "$REWORK_CONTEXT" = "qa-fail" ]; then
 fi
 
 # Resolve workflow-specific labels for this project (default vs current).
-REVIEW_LABEL=$(loop_stage_trigger "$SLUG" review pr 2>/dev/null || echo review-pending)
+_REVIEW_LABEL=$(loop_label_for "$SLUG" "needs-review")
+_REWORK_LABEL=$(loop_label_for "$SLUG" "needs-rework")
+_QA_LABEL=$(loop_label_for "$SLUG" "needs-qa")
+_QA_PASS_LABEL=$(loop_label_for "$SLUG" "qa-pass")
+_QA_FAIL_LABEL=$(loop_label_for "$SLUG" "qa-fail")
 
 if [ "$REWORK_CONTEXT" = "qa-fail" ]; then
     _REWORK_TRIGGER="a QA failure"
@@ -266,9 +270,9 @@ ${_VALIDATION_STEP}
 7. Post a PR comment summarizing what you changed in response:
 ${_STEP7}
 8. Swap labels -- this is MANDATORY to signal success to the pipeline:
-   gh pr edit ${PR_NUM} --repo ${REPO} --remove-label in-rework --remove-label needs-rework --remove-label changes-requested --remove-label qa-fail --remove-label qa-failed --add-label ${REVIEW_LABEL}
+   gh pr edit ${PR_NUM} --repo ${REPO} --remove-label in-rework --remove-label ${_REWORK_LABEL} --remove-label ${_QA_FAIL_LABEL} --add-label ${_REVIEW_LABEL}
 
-IMPORTANT: The PR MUST end this run with label '${REVIEW_LABEL}' (or 'needs-clarification'/'blocked' if appropriate). Verify with:
+IMPORTANT: The PR MUST end this run with label '${_REVIEW_LABEL}' (or 'needs-clarification'/'blocked' if appropriate). Verify with:
    gh pr view ${PR_NUM} --repo ${REPO} --json labels
 
 If the feedback is unclear or requires architectural input, add label 'needs-clarification' and comment on the PR instead of guessing.
@@ -295,8 +299,8 @@ if loop_run_agent "$TASK_PROMPT" "$WORKTREE_ROOT" 2>&1 | tee -a "$LOG_FILE"; the
     backend_remove_label "$REPO" "$PR_NUM" in-rework needs-rework changes-requested qa-fail qa-failed
     # Belt-and-braces: if agent forgot step 8, ensure PR has a progression label.
     if ! backend_pr_has_any_label "$REPO" "$PR_NUM" review-pending needs-review needs-clarification blocked 'done'; then
-        log "WARN: PR #$PR_NUM has no progression label after rework agent — adding '${REVIEW_LABEL}'"
-        backend_add_label "$REPO" "$PR_NUM" "$REVIEW_LABEL"
+        log "WARN: PR #$PR_NUM has no progression label after rework agent — adding '${_REVIEW_LABEL}'"
+        backend_add_label "$REPO" "$PR_NUM" "$_REVIEW_LABEL"
     fi
     cleanup_worktree
 else

--- a/scripts/po-handler.sh
+++ b/scripts/po-handler.sh
@@ -58,9 +58,7 @@ loop_load_project "$SLUG" || { log "ERROR: unknown slug '$SLUG'"; exit 2; }
 loop_load_backend
 
 _po_trigger=$(loop_label_for "$SLUG" "po-review")
-# Resolve workflow-specific PR labels so paths like G (REFINE-WITH-ACTIVE-MR) use
-# the right rework trigger on `current` workflow projects (changes-requested, not needs-rework).
-_REWORK_LABEL=$(loop_stage_trigger "$SLUG" rework pr 2>/dev/null || echo needs-rework)
+_REWORK_LABEL=$(loop_label_for "$SLUG" "needs-rework")
 
 # Per-issue lock — PO writes only to one issue's body and labels, so two PO
 # workers on different issues in the same project are safe in parallel. The

--- a/scripts/qa-handler.sh
+++ b/scripts/qa-handler.sh
@@ -46,6 +46,10 @@ fi
 loop_load_project "$SLUG" || { log "ERROR: unknown slug '$SLUG'"; exit 2; }
 loop_load_backend
 
+# Resolve workflow-specific labels for this project.
+_QA_PASS_LABEL=$(loop_label_for "$SLUG" "qa-pass")
+_QA_FAIL_LABEL=$(loop_label_for "$SLUG" "qa-fail")
+
 # Per-project lock — only one Loop handler at a time per repo.
 source "$LOOP_ROOT/lib/lock.sh"
 loop_acquire_lock "$SLUG" || { log "ERROR: couldn't acquire lock for $SLUG within 1hr — exiting"; exit 1; }
@@ -79,8 +83,8 @@ if [ -z "${QA_VALIDATION_CMD:-}" ]; then
     backend_remove_label "$REPO" "$PR_NUM" ready-for-qa
     backend_remove_label "$REPO" "$PR_NUM" qa-failed
     backend_remove_label "$REPO" "$PR_NUM" qa-fail
-    backend_remove_label "$REPO" "$PR_NUM" qa-pass
-    backend_add_label "$REPO" "$PR_NUM" qa-pass
+    backend_remove_label "$REPO" "$PR_NUM" "$_QA_PASS_LABEL"
+    backend_add_label "$REPO" "$PR_NUM" "$_QA_PASS_LABEL"
     exit 0
 fi
 
@@ -96,7 +100,7 @@ if (cd "$ROOT" && timeout "$QA_TIMEOUT" bash -c "$QA_VALIDATION_CMD") 2>&1 | tee
     backend_remove_label "$REPO" "$PR_NUM" ready-for-qa
     backend_remove_label "$REPO" "$PR_NUM" qa-failed
     backend_remove_label "$REPO" "$PR_NUM" qa-fail
-    backend_add_label "$REPO" "$PR_NUM" qa-pass
+    backend_add_label "$REPO" "$PR_NUM" "$_QA_PASS_LABEL"
 else
     log "qa failed for PR #$PR_NUM"
     bounty_report "qa_fail" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$SLUG" pr_num="$PR_NUM" || true
@@ -106,7 +110,8 @@ else
     backend_remove_label "$REPO" "$PR_NUM" approved
     backend_remove_label "$REPO" "$PR_NUM" qa-pass
     backend_remove_label "$REPO" "$PR_NUM" qa-failed
-    backend_add_label "$REPO" "$PR_NUM" qa-fail
+    backend_remove_label "$REPO" "$PR_NUM" qa-fail
+    backend_add_label "$REPO" "$PR_NUM" "$_QA_FAIL_LABEL"
     backend_comment_pr "$REPO" "$PR_NUM" \
         "QA validation failed. See loop-qa-handler.log for details."
     exit 1

--- a/scripts/review-handler.sh
+++ b/scripts/review-handler.sh
@@ -56,6 +56,14 @@ fi
 loop_load_project "$SLUG" || { log "ERROR: unknown slug '$SLUG'"; exit 2; }
 loop_load_backend
 
+# Resolve workflow-specific labels for this project so the agent prompt + the
+# belt-and-braces apply the right names per active workflow.
+_REVIEW_LABEL=$(loop_label_for "$SLUG" "needs-review")
+_REWORK_LABEL=$(loop_label_for "$SLUG" "needs-rework")
+_QA_LABEL=$(loop_label_for "$SLUG" "needs-qa")
+_QA_PASS_LABEL=$(loop_label_for "$SLUG" "qa-pass")
+_QA_FAIL_LABEL=$(loop_label_for "$SLUG" "qa-fail")
+
 # Auto-promote drafts — PRs are no longer opened as drafts, but promote any legacy ones.
 _is_draft=$(gh pr view "$PR_NUM" --repo "$REPO" --json isDraft --jq '.isDraft' 2>/dev/null || echo "false")
 if [ "$_is_draft" = "true" ]; then
@@ -77,12 +85,12 @@ retry_clear() { rm -f "$RETRY_FILE"; }
 
 retries=$(retry_count)
 if [ "$retries" -ge "$MAX_RETRIES" ]; then
-    log "PR #$PR_NUM already failed review ${retries}x — labeling needs-rework"
+    log "PR #$PR_NUM already failed review ${retries}x — labeling ${_REWORK_LABEL}"
     backend_remove_label "$REPO" "$PR_NUM" needs-review
     backend_remove_label "$REPO" "$PR_NUM" review-pending
     backend_remove_label "$REPO" "$PR_NUM" in-review
-    backend_remove_label "$REPO" "$PR_NUM" changes-requested
-    backend_add_label "$REPO" "$PR_NUM" needs-rework
+    backend_remove_label "$REPO" "$PR_NUM" "$_REWORK_LABEL"
+    backend_add_label "$REPO" "$PR_NUM" "$_REWORK_LABEL"
     exit 0
 fi
 
@@ -94,10 +102,6 @@ backend_remove_label "$REPO" "$PR_NUM" needs-review
 backend_remove_label "$REPO" "$PR_NUM" review-pending
 backend_add_label "$REPO" "$PR_NUM" in-review
 
-# Resolve workflow-specific labels for this project so the agent prompt + the
-# belt-and-braces apply the right names per active workflow.
-QA_LABEL=$(loop_stage_trigger "$SLUG" qa pr 2>/dev/null || echo ready-for-qa)
-REWORK_LABEL=$(loop_stage_trigger "$SLUG" rework pr 2>/dev/null || echo changes-requested)
 _BACKEND_CLI_NOTE=$(backend_cli_note)
 
 _PROMPT_FILE=$(mktemp /tmp/review-prompt-XXXXXX.txt)
@@ -133,15 +137,15 @@ Your job -- do all of these in sequence:
 
 If APPROVE:
    gh pr review ${PR_NUM} --repo ${REPO} --approve --body '<2-4 sentence summary of what looks good>'
-   gh pr edit ${PR_NUM} --repo ${REPO} --remove-label in-review --remove-label needs-review --remove-label review-pending --remove-label ready-for-qa --remove-label needs-qa --add-label ${QA_LABEL}
+   gh pr edit ${PR_NUM} --repo ${REPO} --remove-label in-review --remove-label ${_REVIEW_LABEL} --remove-label ${_QA_LABEL} --add-label ${_QA_LABEL}
 
 If REQUEST_CHANGES:
    gh pr review ${PR_NUM} --repo ${REPO} --request-changes --body '<specific, actionable feedback -- what to change and why>'
-   gh pr edit ${PR_NUM} --repo ${REPO} --remove-label in-review --remove-label needs-review --remove-label review-pending --remove-label changes-requested --remove-label needs-rework --add-label ${REWORK_LABEL}
+   gh pr edit ${PR_NUM} --repo ${REPO} --remove-label in-review --remove-label ${_REVIEW_LABEL} --remove-label ${_REWORK_LABEL} --add-label ${_REWORK_LABEL}
 
 Be strict but fair. Approve content-adjacent bookkeeping (formatting, docs) liberally. Push back on logic errors, security issues, missing tests where the issue asked for tests, or content that contradicts the cited source (e.g. a lesson that miscites CAR Part X).
 
-IMPORTANT: You MUST finish by applying either '${QA_LABEL}' or '${REWORK_LABEL}' label. The pipeline stalls if neither is applied. Verify with:
+IMPORTANT: You MUST finish by applying either '${_QA_LABEL}' or '${_REWORK_LABEL}' label. The pipeline stalls if neither is applied. Verify with:
    gh pr view ${PR_NUM} --repo ${REPO} --json labels
 
 Report the decision you made and why, in 3 short sentences.
@@ -160,9 +164,9 @@ if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
     # Belt-and-braces: if agent forgot to apply a decision label, default to rework
     # (workflow-resolved) so the PR doesn't silently disappear from the pipeline.
     if ! backend_pr_has_any_label "$REPO" "$PR_NUM" needs-qa ready-for-qa needs-rework changes-requested blocked 'done'; then
-        log "WARN: PR #$PR_NUM has no decision label after review agent — defaulting to '${REWORK_LABEL}'"
+        log "WARN: PR #$PR_NUM has no decision label after review agent — defaulting to '${_REWORK_LABEL}'"
         backend_remove_label "$REPO" "$PR_NUM" needs-rework changes-requested
-        backend_add_label "$REPO" "$PR_NUM" "$REWORK_LABEL"
+        backend_add_label "$REPO" "$PR_NUM" "$_REWORK_LABEL"
     fi
 else
     n=$(retry_incr)
@@ -170,8 +174,8 @@ else
     bounty_report "review_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=reviewer project="$SLUG" pr_num="$PR_NUM" detail="attempt ${n}/${MAX_RETRIES}" || true
     if [ "$n" -ge "$MAX_RETRIES" ]; then
         backend_remove_label "$REPO" "$PR_NUM" in-review
-        backend_remove_label "$REPO" "$PR_NUM" changes-requested
-        backend_add_label "$REPO" "$PR_NUM" needs-rework
+        backend_remove_label "$REPO" "$PR_NUM" "$_REWORK_LABEL"
+        backend_add_label "$REPO" "$PR_NUM" "$_REWORK_LABEL"
         # Post only a short marker — never the agent log/prompt, which contains
         # internal pipeline instructions that must not become public.
         backend_comment_pr "$REPO" "$PR_NUM" \

--- a/tests/handlers.bats
+++ b/tests/handlers.bats
@@ -210,3 +210,89 @@ State: OPEN
     # qa-failed must NOT be added (the typo we fixed)
     ! grep -q "add qa-failed" "$ops_log"
 }
+
+# ---------------------------------------------------------------------------
+# dev-handler prompt label resolution (current vs default workflow)
+# ---------------------------------------------------------------------------
+
+@test "dev-handler prompt: current workflow project — resolved labels used, no canonical default names" {
+    cat > "$BATS_TMPDIR/current.yaml" <<'YAML'
+version: 1
+projects:
+  - slug: current-proj
+    name: Current Project
+    repo: owner/current-repo
+    root: /tmp/fake
+    default_branch: main
+    workflow: default
+    labels:
+      needs-review: review-pending
+      needs-rework: changes-requested
+      needs-qa: ready-for-qa
+YAML
+    export LOOP_CONFIG="$BATS_TMPDIR/current.yaml"
+
+    local _REVIEW_LABEL _REWORK_LABEL _QA_LABEL _QA_PASS_LABEL _QA_FAIL_LABEL
+    _REVIEW_LABEL=$(loop_label_for "current-proj" "needs-review")
+    _REWORK_LABEL=$(loop_label_for "current-proj" "needs-rework")
+    _QA_LABEL=$(loop_label_for "current-proj" "needs-qa")
+    _QA_PASS_LABEL=$(loop_label_for "current-proj" "qa-pass")
+    _QA_FAIL_LABEL=$(loop_label_for "current-proj" "qa-fail")
+
+    # Verify resolution
+    [ "$_REVIEW_LABEL" = "review-pending" ]
+    [ "$_REWORK_LABEL" = "changes-requested" ]
+    [ "$_QA_LABEL" = "ready-for-qa" ]
+    [ "$_QA_PASS_LABEL" = "qa-pass" ]
+    [ "$_QA_FAIL_LABEL" = "qa-fail" ]
+
+    # Build the prompt snippet the same way dev-handler.sh does (unquoted <<EOF)
+    local SLUG=current-proj REPO=owner/current-repo ISSUE_NUM=99
+    local prompt
+    prompt=$(cat <<EOF
+Create PR: gh pr create --repo ${REPO} --label ${_REVIEW_LABEL}
+Edit issue: gh issue edit ${ISSUE_NUM} --repo ${REPO} --remove-label in-progress --remove-label dev --remove-label plan --remove-label ${_REVIEW_LABEL} --add-label ${_REVIEW_LABEL}
+If reviewer requests changes: issue gets label '${_REWORK_LABEL}'.
+If ready for QA: issue gets label '${_QA_LABEL}'.
+IMPORTANT: label '${_REVIEW_LABEL}' (or 'needs-clarification' if blocked).
+EOF
+    )
+
+    # Must NOT contain canonical (default-workflow) names
+    [[ "$prompt" != *"needs-review"* ]]
+    [[ "$prompt" != *"needs-rework"* ]]
+    [[ "$prompt" != *"needs-qa"* ]]
+
+    # Must contain resolved (current-workflow) names
+    [[ "$prompt" == *"review-pending"* ]]
+    [[ "$prompt" == *"changes-requested"* ]]
+    [[ "$prompt" == *"ready-for-qa"* ]]
+}
+
+@test "dev-handler prompt: default workflow project — canonical label names appear in prompt" {
+    # Uses setup fixture.yaml with workflow: default and no label overrides
+
+    local _REVIEW_LABEL _REWORK_LABEL _QA_LABEL
+    _REVIEW_LABEL=$(loop_label_for "test-proj" "needs-review")
+    _REWORK_LABEL=$(loop_label_for "test-proj" "needs-rework")
+    _QA_LABEL=$(loop_label_for "test-proj" "needs-qa")
+
+    [ "$_REVIEW_LABEL" = "needs-review" ]
+    [ "$_REWORK_LABEL" = "needs-rework" ]
+    [ "$_QA_LABEL" = "needs-qa" ]
+
+    local SLUG=test-proj REPO=owner/test-repo ISSUE_NUM=1
+    local prompt
+    prompt=$(cat <<EOF
+Create PR: gh pr create --repo ${REPO} --label ${_REVIEW_LABEL}
+Edit issue: gh issue edit ${ISSUE_NUM} --repo ${REPO} --remove-label in-progress --remove-label dev --remove-label plan --remove-label ${_REVIEW_LABEL} --add-label ${_REVIEW_LABEL}
+If reviewer requests changes: issue gets label '${_REWORK_LABEL}'.
+If ready for QA: issue gets label '${_QA_LABEL}'.
+IMPORTANT: label '${_REVIEW_LABEL}' (or 'needs-clarification' if blocked).
+EOF
+    )
+
+    # Default workflow: canonical names must appear in the prompt
+    [[ "$prompt" == *"needs-review"* ]]
+    [[ "$prompt" != *"review-pending"* ]]
+}

--- a/tests/handlers.bats
+++ b/tests/handlers.bats
@@ -294,5 +294,7 @@ EOF
 
     # Default workflow: canonical names must appear in the prompt
     [[ "$prompt" == *"needs-review"* ]]
+    [[ "$prompt" == *"needs-rework"* ]]
+    [[ "$prompt" == *"needs-qa"* ]]
     [[ "$prompt" != *"review-pending"* ]]
 }


### PR DESCRIPTION
Closes #131

## Changes

All five handler scripts now resolve workflow-specific label names via `loop_label_for "$SLUG" <canonical>` before building their agent prompts, instead of hardcoding default-workflow strings. This ensures agents on non-default-workflow projects (e.g. `current` workflow) see the correct label names in their prompts.

**dev-handler.sh**: Replaced `loop_stage_trigger` call with five `loop_label_for` calls for `_REVIEW_LABEL`, `_REWORK_LABEL`, `_QA_LABEL`, `_QA_PASS_LABEL`, `_QA_FAIL_LABEL`. Prompt heredoc updated to use `${_REVIEW_LABEL}` throughout, eliminating hardcoded `needs-review`/`review-pending` from the remove-label list.

**dev-rework-handler.sh**: Same five-label resolution block. Prompt step 8 now uses `${_REWORK_LABEL}` and `${_QA_FAIL_LABEL}` in remove-label args instead of hardcoded `needs-rework`, `changes-requested`, `qa-fail`, `qa-failed`.

**review-handler.sh**: Moved label resolution before the MAX_RETRIES check (so the resolved vars are available for the early-exit path). Uses `loop_label_for` instead of `loop_stage_trigger`. All prompt `--add-label` and `--remove-label` args use `${_QA_LABEL}` and `${_REWORK_LABEL}`. Belt-and-braces and failure paths also use resolved vars.

**qa-handler.sh**: No agent prompt exists, so added `_QA_PASS_LABEL` and `_QA_FAIL_LABEL` resolution. All `backend_add_label` calls for `qa-pass` and `qa-fail`/`qa-failed` now use the resolved vars.

**po-handler.sh**: Added `_REWORK_LABEL` resolution alongside `_po_trigger`. Path G in `_MR_PATHS` now uses `${_REWORK_LABEL}` instead of hardcoded `needs-rework`.

**tests/handlers.bats**: Two new tests added:
- `current` workflow fixture (via label overrides): asserts resolved labels are `review-pending`/`changes-requested`/`ready-for-qa` and a prompt built from them does NOT contain `needs-review`, `needs-rework`, `needs-qa`
- `default` workflow fixture: asserts canonical names are preserved unchanged

## Test Plan

- Run `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — all must pass (zero output)
- Run `shellcheck -S warning lib/*.sh scripts/*.sh scanner/*.sh install.sh` — no warnings
- Run `bats tests/handlers.bats` on a machine with bats installed — all existing tests plus two new tests must pass
- For a project with `current` workflow (`needs-review` → `review-pending`, etc.), trigger dev-handler and verify the agent prompt contains `review-pending` not `needs-review`