### PR TITLE
[LOOP-136] replace rubber-stamp QA with four-phase smart verification agent

### DIFF
--- a/scripts/judge.sh
+++ b/scripts/judge.sh
@@ -50,7 +50,11 @@ Classify the outcome as exactly one of:
 Then compute per-role points:
 - dev role:      clean=+3, rework=-1, qa-fail-rework=-2, blocked=0
 - reviewer role: clean=+1, rework=0, qa-fail-rework=-1, blocked=0
-- qa role:       clean=+1, rework=0, qa-fail-rework=+1, blocked=0
+- qa role:       clean=+3, rework=0, qa-fail-rework=+3 if the QA comment shows unmet acceptance criteria (NOT_FOUND or PARTIAL) else +1, blocked=0
+
+Note: for the qa role, check PR comments for a "### QA verification" block. If the block contains
+NOT_FOUND or PARTIAL criteria, the qa-fail-rework outcome is a valid catch worth +3.
+If the QA comment is absent or shows only validation failures (no AC analysis), award +1.
 
 Output ONLY valid JSON with these exact keys (no markdown, no explanation):
 {

--- a/scripts/qa-handler.sh
+++ b/scripts/qa-handler.sh
@@ -4,9 +4,9 @@
 #
 # Event payload: {"slug","repo","pr_number","pr_title","pr_url"}
 #
-# Flow: run qa.validation_cmd if configured — on zero exit, label 'qa-pass';
-# on non-zero, label 'qa-failed'. If no validation_cmd is configured for the
-# project, auto-pass (trust the review handler's decision).
+# Flow: invoke smart four-phase QA agent that verifies acceptance criteria,
+# creates targeted tests, runs regression on touched modules, then runs
+# validation_cmd. Agent posts structured comment and applies qa-pass/qa-failed.
 
 set -euo pipefail
 
@@ -15,12 +15,16 @@ LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # shellcheck source=../lib/config.sh
 # shellcheck source=../lib/env.sh
 source "$LOOP_ROOT/lib/env.sh"
+# shellcheck source=../lib/runner.sh
+source "$LOOP_ROOT/lib/runner.sh"
 source "$LOOP_ROOT/lib/config.sh"
 # shellcheck source=../lib/backends/backend.sh
 source "$LOOP_ROOT/lib/backends/backend.sh"
 source "$LOOP_ROOT/lib/bounty.sh"
 # shellcheck source=../lib/notify.sh
 source "$LOOP_ROOT/lib/notify.sh"
+# shellcheck source=../lib/cli-hint.sh
+source "$LOOP_ROOT/lib/cli-hint.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-qa-handler.log"
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [qa-handler] $*" | tee -a "$LOG_FILE"; }
@@ -73,34 +77,174 @@ if [ "$_is_draft" = "true" ]; then
     backend_remove_label "$REPO" "$PR_NUM" draft 2>/dev/null || true
 fi
 
-if [ -z "${QA_VALIDATION_CMD:-}" ]; then
-    log "no qa.validation_cmd configured for $SLUG — auto-passing"
-    backend_remove_label "$REPO" "$PR_NUM" needs-qa
-    backend_remove_label "$REPO" "$PR_NUM" ready-for-qa
-    backend_remove_label "$REPO" "$PR_NUM" qa-failed
-    backend_remove_label "$REPO" "$PR_NUM" qa-fail
-    backend_remove_label "$REPO" "$PR_NUM" qa-pass
-    backend_add_label "$REPO" "$PR_NUM" qa-pass
-    exit 0
-fi
-
 loop_notify "▶️ [$SLUG] PR#$PR_NUM qa starting"
 
-QA_TIMEOUT="${QA_TIMEOUT_SECONDS:-600}"
-log "running qa validation: $QA_VALIDATION_CMD (cwd=$ROOT, timeout=${QA_TIMEOUT}s)"
-if (cd "$ROOT" && timeout "$QA_TIMEOUT" bash -c "$QA_VALIDATION_CMD") 2>&1 | tee -a "$LOG_FILE"; then
-    log "qa passed for PR #$PR_NUM"
-    bounty_report "qa_pass" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$SLUG" pr_num="$PR_NUM" || true
+_BACKEND_CLI_NOTE=$(backend_cli_note)
+_VALIDATION_CMD="${QA_VALIDATION_CMD:-}"
+
+_PROMPT_FILE=$(mktemp /tmp/qa-prompt-XXXXXX.txt)
+cat > "$_PROMPT_FILE" <<EOF
+You are the Senior QA Verifier for ${NAME} (slug: ${SLUG}).
+Project root: ${ROOT}
+Repo: ${REPO}
+
+READ ${ROOT}/CLAUDE.md first for project conventions.
+If CLAUDE.md is missing, note its absence and proceed with best-practice conventions.
+
+You are performing four-phase smart QA on pull request #${PR_NUM}.
+
+## Setup
+
+1. Check PR state:
+   gh pr view ${PR_NUM} --repo ${REPO} --json state,merged
+   If state=MERGED or state=CLOSED: remove labels 'ready-for-qa' and 'needs-qa',
+   leave a comment "PR already closed/merged — QA skipped.", and stop.
+
+2. Fetch PR details and diff:
+   gh pr view ${PR_NUM} --repo ${REPO} --json title,body,headRefName,files,closingIssuesReferences
+   gh pr diff ${PR_NUM} --repo ${REPO}
+
+3. Identify the linked issue (from closingIssuesReferences). Fetch its body:
+   gh issue view <N> --repo ${REPO} --json body
+
+4. Check if the issue body contains a "## Acceptance Criteria" section with "- [ ]" checkboxes.
+   If it does NOT contain "## Acceptance Criteria": skip Phases 1 and 2, run Phases 3 and 4 only,
+   and note the gap in your PR comment (the issue lacked acceptance criteria).
+
+---
+
+## Phase 1 — Verify each acceptance criterion
+
+Parse the "## Acceptance Criteria" checkboxes from the linked issue body.
+For each criterion output one of:
+- VERIFIED — explain how the diff satisfies it; where possible, prove with a one-line command and quote actual output.
+- NOT_FOUND — the diff does not address this criterion; quote what is missing.
+- PARTIAL — partially addressed; explain what is done and what is missing.
+
+If any criterion is NOT_FOUND or PARTIAL → verdict is qa-fail (list each unmet AC).
+
+---
+
+## Phase 2 — Create tests where they earn their keep
+
+Per-criterion decision: only create a test when the behavior is mechanical (input → output) or
+non-obvious AND the project already has a testing framework (bats / pytest / vitest).
+Write tests in the existing framework, place next to existing tests, run them, and if they pass,
+commit and push to the PR branch:
+
+   cd ${ROOT}
+   git fetch origin
+   git checkout <headRefName>
+   # write test file
+   git add <test-file>
+   git commit -m 'test: add QA-driven tests for PR #${PR_NUM}'
+   git push --force-with-lease origin <headRefName>
+
+Skip test creation for: UI-only changes, doc updates, cases with existing integration coverage,
+or trivially obvious diff hunks. Note the rationale for each skip.
+
+If newly added tests fail → verdict is qa-fail (cite the contradiction).
+
+---
+
+## Phase 3 — Targeted regression on touched modules
+
+List the files this PR touched (from the "files" field of gh pr view).
+For each touched file, find covering test files by convention:
+- tests/<module>.bats (strip path prefix and .sh extension)
+- test_*.py near the file
+- *.test.js / *.spec.js near the file
+
+Run only those covering tests (e.g. bats tests/foo.bats).
+A test failure = regression caused by this PR → verdict is qa-fail (cite the specific failing test).
+If no test coverage exists for a touched file, note it and skip.
+
+---
+
+## Phase 4 — Final regression guard
+
+Run the validation command:
+$([ -n "$_VALIDATION_CMD" ] && printf '   cd %s && %s' "${ROOT}" "$_VALIDATION_CMD" || printf '   (no validation_cmd configured for this project — Phase 4 skipped)')
+
+If validation_cmd fails → verdict is qa-fail (cite the validation failure output).
+
+---
+
+## Decision and labeling
+
+After all phases, post a structured comment on the PR using this template:
+
+\`\`\`
+### QA verification — issue #<N>
+
+**Phase 1: Acceptance criteria**
+1. [✓ VERIFIED] <AC text>
+   _Proof:_ \`<command>\` → \`<output snippet>\`
+2. [✗ NOT_FOUND] <AC text>
+   Diff does not address this. Need: <what>.
+
+**Phase 2: Tests added**
+- \`tests/foo.bats::handles_empty_input\` (covers AC2)
+- (skipped AC1: doc-only change)
+
+**Phase 3: Regression on touched modules**
+- \`lib/foo.sh\` → ran \`tests/foo.bats\` (12 tests, ✓ pass)
+- \`lib/bar.sh\` → no existing test coverage, skipped
+
+**Phase 4: validation_cmd**
+- \`<cmd>\` → ✓ pass
+
+**Verdict:** <qa-pass or qa-fail — reason>
+\`\`\`
+
+Post the comment:
+   gh pr comment ${PR_NUM} --repo ${REPO} --body '<comment text>'
+
+Then apply the label:
+
+If qa-pass:
+   gh pr edit ${PR_NUM} --repo ${REPO} --remove-label needs-qa --remove-label ready-for-qa --remove-label qa-failed --remove-label qa-fail --add-label qa-pass
+
+If qa-fail:
+   gh pr edit ${PR_NUM} --repo ${REPO} --remove-label needs-qa --remove-label ready-for-qa --remove-label approved --remove-label qa-pass --remove-label qa-fail --add-label qa-failed
+
+IMPORTANT: You MUST finish by applying either 'qa-pass' or 'qa-failed'. The pipeline stalls if
+neither is applied. Verify with:
+   gh pr view ${PR_NUM} --repo ${REPO} --json labels
+
+${_BACKEND_CLI_NOTE}
+$(loop_cli_hint)
+EOF
+TASK_PROMPT=$(cat "$_PROMPT_FILE")
+rm -f "$_PROMPT_FILE"
+
+if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
+    log "qa agent finished for PR #$PR_NUM"
     loop_notify "✅ [$SLUG] PR#$PR_NUM qa done"
     backend_remove_label "$REPO" "$PR_NUM" needs-qa
     backend_remove_label "$REPO" "$PR_NUM" ready-for-qa
-    backend_remove_label "$REPO" "$PR_NUM" qa-failed
-    backend_remove_label "$REPO" "$PR_NUM" qa-fail
-    backend_add_label "$REPO" "$PR_NUM" qa-pass
+
+    # Report the actual outcome to bounty based on which label the agent applied.
+    if backend_pr_has_any_label "$REPO" "$PR_NUM" qa-pass; then
+        bounty_report "qa_pass" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$SLUG" pr_num="$PR_NUM" || true
+    else
+        bounty_report "qa_fail" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$SLUG" pr_num="$PR_NUM" || true
+    fi
+
+    # Belt-and-braces: if agent forgot to apply a decision label, default to qa-failed.
+    if ! backend_pr_has_any_label "$REPO" "$PR_NUM" qa-pass qa-failed qa-fail; then
+        log "WARN: PR #$PR_NUM has no QA decision label after agent — defaulting to qa-failed"
+        backend_remove_label "$REPO" "$PR_NUM" qa-pass
+        backend_add_label "$REPO" "$PR_NUM" qa-failed
+        backend_comment_pr "$REPO" "$PR_NUM" \
+            "QA agent ran but did not apply a decision label. Defaulting to qa-failed. Operator: see ${LOG_FILE} for the agent transcript." \
+            2>/dev/null || true
+        bounty_report "qa_fail" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$SLUG" pr_num="$PR_NUM" || true
+    fi
 else
-    log "qa failed for PR #$PR_NUM"
+    log "qa agent failed for PR #$PR_NUM"
     bounty_report "qa_fail" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$SLUG" pr_num="$PR_NUM" || true
-    loop_notify "❌ [$SLUG] PR#$PR_NUM qa failed: validation command failed"
+    loop_notify "❌ [$SLUG] PR#$PR_NUM qa failed: agent error"
     backend_remove_label "$REPO" "$PR_NUM" needs-qa
     backend_remove_label "$REPO" "$PR_NUM" ready-for-qa
     backend_remove_label "$REPO" "$PR_NUM" approved
@@ -108,6 +252,7 @@ else
     backend_remove_label "$REPO" "$PR_NUM" qa-fail
     backend_add_label "$REPO" "$PR_NUM" qa-failed
     backend_comment_pr "$REPO" "$PR_NUM" \
-        "QA validation failed. See loop-qa-handler.log for details."
+        "QA agent failed. Operator: see ${LOG_FILE} for the agent transcript." \
+        2>/dev/null || true
     exit 1
 fi

--- a/tests/qa-smart.bats
+++ b/tests/qa-smart.bats
@@ -1,0 +1,278 @@
+#!/usr/bin/env bats
+# tests/qa-smart.bats — unit tests for smart QA handler logic.
+#
+# Tests: AC parsing, structured comment shape, fallback when no ACs,
+# regression detection on touched files, conditional test-creation logic.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+}
+
+# ---------------------------------------------------------------------------
+# Helpers (mirror logic from qa-handler.sh prompt construction)
+# ---------------------------------------------------------------------------
+
+# Returns "yes" if issue body contains ## Acceptance Criteria section.
+_has_acceptance_criteria() {
+    local body="$1"
+    printf '%s' "$body" | python3 -c "
+import sys, re
+body = sys.stdin.read()
+print('yes' if re.search(r'^##\s+Acceptance Criteria', body, re.MULTILINE) else 'no')
+"
+}
+
+# Extracts - [ ] / - [x] lines from ## Acceptance Criteria section.
+_parse_acceptance_criteria() {
+    local body="$1"
+    printf '%s' "$body" | python3 -c "
+import sys, re
+body = sys.stdin.read()
+m = re.search(r'^##\s+Acceptance Criteria\s*\n(.*?)(?=\n##\s|\Z)', body, re.DOTALL | re.MULTILINE)
+if not m:
+    sys.exit(0)
+for line in m.group(1).splitlines():
+    if re.match(r'\s*-\s*\[[ xX]\]', line):
+        print(line.strip())
+"
+}
+
+# Finds test files by bats convention for a given source file.
+_find_bats_test() {
+    local repo_root="$1"
+    local source_file="$2"
+    local module
+    module=$(basename "$source_file" .sh)
+    local candidate="$repo_root/tests/${module}.bats"
+    [ -f "$candidate" ] && echo "$candidate" || true
+}
+
+# ---------------------------------------------------------------------------
+# AC detection
+# ---------------------------------------------------------------------------
+
+@test "AC detection: finds ## Acceptance Criteria section" {
+    local body
+    body="$(printf '## Summary\nText\n\n## Acceptance Criteria\n- [ ] Criterion one\n- [ ] Criterion two')"
+    result=$(_has_acceptance_criteria "$body")
+    [ "$result" = "yes" ]
+}
+
+@test "AC detection: returns no when section is absent" {
+    local body
+    body="$(printf '## Summary\n- Some summary item')"
+    result=$(_has_acceptance_criteria "$body")
+    [ "$result" = "no" ]
+}
+
+@test "AC detection: returns no for empty body" {
+    result=$(_has_acceptance_criteria "")
+    [ "$result" = "no" ]
+}
+
+# ---------------------------------------------------------------------------
+# AC parsing
+# ---------------------------------------------------------------------------
+
+@test "AC parsing: extracts checkboxes from Acceptance Criteria section" {
+    local body
+    body="$(printf '## Summary\nSome text\n\n## Acceptance Criteria\n- [ ] First criterion\n- [ ] Second criterion\n\n## Notes\nSome notes')"
+    count=$(_parse_acceptance_criteria "$body" | wc -l | tr -d ' ')
+    [ "$count" = "2" ]
+}
+
+@test "AC parsing: ignores checkboxes outside Acceptance Criteria section" {
+    local body
+    body="$(printf '## Notes\n- [ ] Not a criterion\n\n## Acceptance Criteria\n- [ ] Real criterion')"
+    output=$(_parse_acceptance_criteria "$body")
+    count=$(echo "$output" | wc -l | tr -d ' ')
+    [ "$count" = "1" ]
+    echo "$output" | grep -q "Real criterion"
+    ! echo "$output" | grep -q "Not a criterion"
+}
+
+@test "AC parsing: returns empty when no Acceptance Criteria section" {
+    local body
+    body="$(printf '## Summary\n- Some summary')"
+    output=$(_parse_acceptance_criteria "$body")
+    [ -z "$output" ]
+}
+
+@test "AC parsing: handles checked checkboxes as valid ACs" {
+    local body
+    body="$(printf '## Acceptance Criteria\n- [x] Already done\n- [ ] Not done')"
+    count=$(_parse_acceptance_criteria "$body" | wc -l | tr -d ' ')
+    [ "$count" = "2" ]
+}
+
+# ---------------------------------------------------------------------------
+# Structured comment shape
+# ---------------------------------------------------------------------------
+
+@test "QA comment template: contains all four phase headers and Verdict" {
+    local comment
+    comment="$(cat <<'COMMENT'
+### QA verification — issue #42
+
+**Phase 1: Acceptance criteria**
+1. [✓ VERIFIED] Criterion one
+   _Proof:_ `bash -n lib/foo.sh` → `OK`
+
+**Phase 2: Tests added**
+- (skipped: doc-only change)
+
+**Phase 3: Regression on touched modules**
+- `lib/foo.sh` → no existing test coverage, skipped
+
+**Phase 4: validation_cmd**
+- `bash -n lib/*.sh scripts/*.sh` → ✓ pass
+
+**Verdict:** qa-pass
+COMMENT
+)"
+    echo "$comment" | grep -q "Phase 1: Acceptance criteria"
+    echo "$comment" | grep -q "Phase 2: Tests added"
+    echo "$comment" | grep -q "Phase 3: Regression on touched modules"
+    echo "$comment" | grep -q "Phase 4: validation_cmd"
+    echo "$comment" | grep -q "Verdict:"
+}
+
+@test "QA comment template: issue number appears in heading" {
+    local issue_num=99
+    local comment="### QA verification — issue #${issue_num}"
+    echo "$comment" | grep -q "issue #99"
+}
+
+@test "QA comment template: NOT_FOUND marker triggers qa-fail verdict" {
+    local comment
+    comment="$(printf '**Phase 1: Acceptance criteria**\n1. [✗ NOT_FOUND] Missing feature\n\n**Verdict:** qa-fail — AC1 not delivered.')"
+    echo "$comment" | grep -q "NOT_FOUND"
+    echo "$comment" | grep -q "qa-fail"
+}
+
+# ---------------------------------------------------------------------------
+# Fallback when no ACs
+# ---------------------------------------------------------------------------
+
+@test "fallback: no AC section causes phases 1-2 to be skipped" {
+    local body
+    body="$(printf '## Summary\nJust a plain issue with no acceptance criteria')"
+    local run_phases_1_2=false
+    local gap_noted=false
+    if [ "$(_has_acceptance_criteria "$body")" = "yes" ]; then
+        run_phases_1_2=true
+    else
+        gap_noted=true
+    fi
+    [ "$run_phases_1_2" = "false" ]
+    [ "$gap_noted" = "true" ]
+}
+
+@test "fallback: AC section present enables phases 1-2" {
+    local body
+    body="$(printf '## Acceptance Criteria\n- [ ] Do something')"
+    local run_phases_1_2=false
+    if [ "$(_has_acceptance_criteria "$body")" = "yes" ]; then
+        run_phases_1_2=true
+    fi
+    [ "$run_phases_1_2" = "true" ]
+}
+
+@test "fallback: comment notes issue lacked criteria" {
+    local body
+    body="$(printf '## Summary\nNo criteria here')"
+    local comment=""
+    if [ "$(_has_acceptance_criteria "$body")" = "no" ]; then
+        comment="Note: the linked issue has no ## Acceptance Criteria section — phases 1 and 2 were skipped."
+    fi
+    echo "$comment" | grep -q "lacked\|no ## Acceptance Criteria\|were skipped"
+}
+
+# ---------------------------------------------------------------------------
+# Regression detection on touched files
+# ---------------------------------------------------------------------------
+
+@test "regression: finds existing bats test for lib/ module" {
+    # qa-smart.bats itself acts as a test for the qa-handler module lookup
+    local repo_root="$LOOP_ROOT"
+    local touched_file="lib/qa-handler.sh"
+    result=$(_find_bats_test "$repo_root" "$touched_file")
+    # qa-handler.bats does not exist but the function returns empty (not error)
+    # Verify scanner.bats DOES exist (known file)
+    result2=$(_find_bats_test "$repo_root" "scanner/scanner.sh")
+    [ -n "$result2" ]
+    echo "$result2" | grep -q "scanner.bats"
+}
+
+@test "regression: returns empty for module with no test file" {
+    local repo_root="$BATS_TMPDIR/fake-repo-$$"
+    mkdir -p "$repo_root/tests"
+    result=$(_find_bats_test "$repo_root" "lib/no-such-module.sh")
+    [ -z "$result" ]
+}
+
+@test "regression: test file convention strips .sh extension" {
+    local repo_root="$BATS_TMPDIR/conv-repo-$$"
+    mkdir -p "$repo_root/tests"
+    touch "$repo_root/tests/workflow.bats"
+    result=$(_find_bats_test "$repo_root" "lib/workflow.sh")
+    [ -n "$result" ]
+    echo "$result" | grep -q "workflow.bats"
+}
+
+@test "regression: test file convention works for scripts/ path" {
+    local repo_root="$BATS_TMPDIR/scripts-repo-$$"
+    mkdir -p "$repo_root/tests"
+    touch "$repo_root/tests/qa-handler.bats"
+    result=$(_find_bats_test "$repo_root" "scripts/qa-handler.sh")
+    [ -n "$result" ]
+    echo "$result" | grep -q "qa-handler.bats"
+}
+
+# ---------------------------------------------------------------------------
+# Conditional test-creation logic
+# ---------------------------------------------------------------------------
+
+@test "test creation: skipped for markdown file" {
+    local file="docs/README.md"
+    local should_create_test=true
+    case "$file" in
+        *.md|*.txt|docs/*) should_create_test=false ;;
+    esac
+    [ "$should_create_test" = "false" ]
+}
+
+@test "test creation: skipped for plain text file" {
+    local file="CHANGELOG.txt"
+    local should_create_test=true
+    case "$file" in
+        *.md|*.txt|docs/*) should_create_test=false ;;
+    esac
+    [ "$should_create_test" = "false" ]
+}
+
+@test "test creation: attempted for shell lib file with framework present" {
+    local file="lib/foo.sh"
+    local has_framework=true
+    local is_doc_only=false
+    local should_create_test=false
+    case "$file" in
+        *.md|*.txt|docs/*) is_doc_only=true ;;
+    esac
+    if [ "$is_doc_only" = "false" ] && [ "$has_framework" = "true" ]; then
+        should_create_test=true
+    fi
+    [ "$should_create_test" = "true" ]
+}
+
+@test "test creation: skipped when no testing framework detected" {
+    local file="lib/foo.sh"
+    local has_framework=false
+    local is_doc_only=false
+    local should_create_test=false
+    if [ "$is_doc_only" = "false" ] && [ "$has_framework" = "true" ]; then
+        should_create_test=true
+    fi
+    [ "$should_create_test" = "false" ]
+}


### PR DESCRIPTION
Closes #136

## Changes

**`scripts/qa-handler.sh`** — Full rewrite to smart four-phase agent:
- Sources `lib/runner.sh` and `lib/cli-hint.sh` (same orchestrator path as review/dev handlers)
- Builds a detailed four-phase prompt: AC verification → targeted test creation → regression on touched modules → validation_cmd
- Agent has read access to linked issue body (via `gh issue view`), PR diff, project test files, and a `bash` tool to run proofs/tests
- Agent posts the structured `### QA verification` comment on PR before applying `qa-pass`/`qa-failed`
- Fallback: if issue has no `## Acceptance Criteria` section, phases 1–2 skipped with a note in comment
- Agent commits any new tests to PR branch with `git push --force-with-lease`
- Phase 3 identifies test files via convention (`tests/<module>.bats`, `test_*.py`, `*.test.js`)
- Phase 4 runs `validation_cmd` (or skips with note if not configured)
- Belt-and-braces: defaults to `qa-failed` if agent exits without applying a decision label
- Bounty outcome now based on actual label applied (not just agent exit code)

**`scripts/judge.sh`** — Rubric update for qa role:
- `clean` (qa_pass): +3 (up from +1), matching `dev_clean`
- `qa-fail-rework` with valid bug catch (NOT_FOUND/PARTIAL in QA comment): +3 (up from +1)

**`tests/qa-smart.bats`** — 21 new bats tests covering:
- AC parsing (Python regex extraction from issue body)
- Structured comment shape (all four phase headers + Verdict present)
- Fallback when no ACs (phases 1–2 skipped, gap noted)
- Regression detection on touched files (convention-based test file lookup)
- Conditional test-creation logic (skips for doc/UI, requires framework)

## Test Plan
- All 21 bats tests in `tests/qa-smart.bats` pass (`bats tests/qa-smart.bats`)
- `bash -n` syntax check clean on all scripts
- `shellcheck -S warning` clean on all scripts