### PR TITLE
[LOOP-139] qa-handler: extract AC checkboxes and inject into agent prompt

### DIFF
--- a/scripts/qa-handler.sh
+++ b/scripts/qa-handler.sh
@@ -4,9 +4,10 @@
 #
 # Event payload: {"slug","repo","pr_number","pr_title","pr_url"}
 #
-# Flow: run qa.validation_cmd if configured — on zero exit, label 'qa-pass';
-# on non-zero, label 'qa-fail'. If no validation_cmd is configured for the
-# project, auto-pass (trust the review handler's decision).
+# Phase 1 (smart QA): extracts ## Acceptance Criteria checkboxes from the linked
+# issue and injects them into the agent prompt so the agent can verify each
+# criterion against the PR diff.  Falls back to validation_cmd-only when no
+# AC section is found.
 
 set -euo pipefail
 
@@ -16,11 +17,15 @@ LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # shellcheck source=../lib/env.sh
 source "$LOOP_ROOT/lib/env.sh"
 source "$LOOP_ROOT/lib/config.sh"
+# shellcheck source=../lib/runner.sh
+source "$LOOP_ROOT/lib/runner.sh"
 # shellcheck source=../lib/backends/backend.sh
 source "$LOOP_ROOT/lib/backends/backend.sh"
 source "$LOOP_ROOT/lib/bounty.sh"
 # shellcheck source=../lib/notify.sh
 source "$LOOP_ROOT/lib/notify.sh"
+# shellcheck source=../lib/cli-hint.sh
+source "$LOOP_ROOT/lib/cli-hint.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-qa-handler.log"
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [qa-handler] $*" | tee -a "$LOG_FILE"; }
@@ -73,34 +78,156 @@ if [ "$_is_draft" = "true" ]; then
     backend_remove_label "$REPO" "$PR_NUM" draft 2>/dev/null || true
 fi
 
-if [ -z "${QA_VALIDATION_CMD:-}" ]; then
-    log "no qa.validation_cmd configured for $SLUG — auto-passing"
-    backend_remove_label "$REPO" "$PR_NUM" needs-qa
-    backend_remove_label "$REPO" "$PR_NUM" ready-for-qa
-    backend_remove_label "$REPO" "$PR_NUM" qa-failed
-    backend_remove_label "$REPO" "$PR_NUM" qa-fail
-    backend_remove_label "$REPO" "$PR_NUM" qa-pass
-    backend_add_label "$REPO" "$PR_NUM" qa-pass
-    exit 0
-fi
-
 loop_notify "▶️ [$SLUG] PR#$PR_NUM qa starting"
 
+# ── Linked issue + AC extraction ────────────────────────────────────────────
+
+# Resolve linked issue from PR body ("Closes #N").
+LINKED_ISSUE_NUM=$(gh pr view "$PR_NUM" --repo "$REPO" --json body --jq '.body' 2>/dev/null \
+    | grep -oiE '(closes|fixes|resolves) #[0-9]+' | grep -oE '[0-9]+' | head -1 || echo "")
+
+ISSUE_BODY=""
+if [ -n "$LINKED_ISSUE_NUM" ]; then
+    ISSUE_BODY=$(backend_issue_view "$REPO" "$LINKED_ISSUE_NUM" --json body --jq .body 2>/dev/null || echo "")
+    log "linked issue #${LINKED_ISSUE_NUM} found; body length=${#ISSUE_BODY}"
+fi
+
+# Extract ## Acceptance Criteria checkboxes using an inline python3 snippet.
+AC_LIST=$(ISSUE_BODY="$ISSUE_BODY" python3 -c "
+import os, re
+body = os.environ.get('ISSUE_BODY', '').strip()
+match = re.search(r'(?m)^\#{1,3}\s+Acceptance Criteria\s*$', body)
+if not match:
+    print('__NO_AC_SECTION__')
+else:
+    rest = body[match.end():]
+    section = re.split(r'(?m)^\#{1,3}\s+', rest)[0]
+    checkboxes = re.findall(r'- \[[ xX]\] .+', section)
+    if not checkboxes:
+        print('__NO_AC_SECTION__')
+    else:
+        for i, cb in enumerate(checkboxes, 1):
+            text = re.sub(r'^- \[[ xX]\] ', '', cb).strip()
+            print(f'{i}. {text}')
+" 2>/dev/null || echo "__NO_AC_SECTION__")
+
+if [ "$AC_LIST" = "__NO_AC_SECTION__" ]; then
+    log "no ## Acceptance Criteria section found in linked issue — falling back to validation_cmd only"
+    AC_SECTION="(No acceptance criteria found — falling back to validation_cmd only)"
+    AC_INSTRUCTION=""
+else
+    log "extracted AC list from issue #${LINKED_ISSUE_NUM}"
+    AC_SECTION="## Acceptance Criteria (from issue #${LINKED_ISSUE_NUM})
+
+${AC_LIST}"
+    AC_INSTRUCTION="For each numbered criterion above, output exactly one of:
+- VERIFIED — the diff satisfies this criterion; provide a one-line rationale and, where mechanical, a proof command with expected output.
+- NOT_FOUND — the diff does not address this criterion; quote what is missing.
+- PARTIAL — partially addressed; explain what is done and what is still missing.
+
+If ANY criterion is NOT_FOUND or PARTIAL the final verdict must be qa-fail."
+fi
+
+# ── Validation command section ───────────────────────────────────────────────
+
 QA_TIMEOUT="${QA_TIMEOUT_SECONDS:-600}"
-log "running qa validation: $QA_VALIDATION_CMD (cwd=$ROOT, timeout=${QA_TIMEOUT}s)"
-if (cd "$ROOT" && timeout "$QA_TIMEOUT" bash -c "$QA_VALIDATION_CMD") 2>&1 | tee -a "$LOG_FILE"; then
-    log "qa passed for PR #$PR_NUM"
+if [ -n "${QA_VALIDATION_CMD:-}" ]; then
+    VALIDATION_SECTION="## Phase 4: validation_cmd
+
+Run the project validation command (timeout ${QA_TIMEOUT}s):
+  cd ${ROOT} && timeout ${QA_TIMEOUT} bash -c \"${QA_VALIDATION_CMD}\"
+
+If this exits non-zero, the verdict must be qa-fail even if all ACs are VERIFIED."
+else
+    VALIDATION_SECTION="## Phase 4: validation_cmd
+
+No validation_cmd is configured for this project. Skip this phase."
+fi
+
+# ── Agent prompt ─────────────────────────────────────────────────────────────
+
+_BACKEND_CLI_NOTE=$(backend_cli_note)
+_PROMPT_FILE=$(mktemp /tmp/qa-prompt-XXXXXX.txt)
+cat > "$_PROMPT_FILE" <<EOF
+You are the QA agent for ${NAME} (slug: ${SLUG}).
+Project root: ${ROOT}
+Repo: ${REPO}
+
+READ ${ROOT}/CLAUDE.md first for project conventions.
+If CLAUDE.md is missing, proceed with general best-practice conventions.
+
+You are reviewing pull request #${PR_NUM} for QA.
+
+Your job — do all of these in sequence:
+
+0. Check PR state before proceeding:
+   gh pr view ${PR_NUM} --repo ${REPO} --json state,merged
+   If state=MERGED or state=CLOSED: remove labels needs-qa and ready-for-qa, leave a brief comment, and stop.
+
+1. Fetch the PR diff:
+   gh pr diff ${PR_NUM} --repo ${REPO}
+
+2. Evaluate acceptance criteria:
+
+${AC_SECTION}
+
+${AC_INSTRUCTION}
+
+3. ${VALIDATION_SECTION}
+
+4. Post a structured comment on the PR using this template:
+
+\`\`\`
+### QA verification — issue #${LINKED_ISSUE_NUM:-N/A}
+
+**Phase 1: Acceptance criteria**
+<numbered AC results with VERIFIED/NOT_FOUND/PARTIAL and rationale>
+
+**Phase 4: validation_cmd**
+<result of running validation_cmd, or "skipped — not configured">
+
+**Verdict:** <qa-pass or qa-fail — one-line reason>
+\`\`\`
+
+   Post the comment:
+   gh pr comment ${PR_NUM} --repo ${REPO} --body '<the structured comment>'
+
+5. Apply labels based on the verdict:
+
+   If qa-pass (all ACs VERIFIED and validation_cmd passed or not configured):
+     gh pr edit ${PR_NUM} --repo ${REPO} --remove-label needs-qa --remove-label ready-for-qa --remove-label qa-failed --remove-label qa-fail --remove-label qa-pass --add-label qa-pass
+
+   If qa-fail (any AC NOT_FOUND/PARTIAL or validation_cmd failed):
+     gh pr edit ${PR_NUM} --repo ${REPO} --remove-label needs-qa --remove-label ready-for-qa --remove-label approved --remove-label qa-pass --remove-label qa-failed --add-label qa-fail
+
+IMPORTANT: You MUST finish by applying either 'qa-pass' or 'qa-fail'. The pipeline stalls if neither is applied. Verify with:
+   gh pr view ${PR_NUM} --repo ${REPO} --json labels
+
+Report the verdict and why in 2 sentences.
+${_BACKEND_CLI_NOTE}
+$(loop_cli_hint)
+EOF
+TASK_PROMPT=$(cat "$_PROMPT_FILE")
+rm -f "$_PROMPT_FILE"
+
+# ── Run agent ────────────────────────────────────────────────────────────────
+
+if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
+    log "qa agent succeeded for PR #$PR_NUM"
     bounty_report "qa_pass" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$SLUG" pr_num="$PR_NUM" || true
     loop_notify "✅ [$SLUG] PR#$PR_NUM qa done"
-    backend_remove_label "$REPO" "$PR_NUM" needs-qa
-    backend_remove_label "$REPO" "$PR_NUM" ready-for-qa
-    backend_remove_label "$REPO" "$PR_NUM" qa-failed
-    backend_remove_label "$REPO" "$PR_NUM" qa-fail
-    backend_add_label "$REPO" "$PR_NUM" qa-pass
+    # Belt-and-braces: if agent forgot to apply a decision label, default to qa-fail
+    # so the PR doesn't silently disappear from the pipeline.
+    if ! backend_pr_has_any_label "$REPO" "$PR_NUM" qa-pass qa-fail blocked 'done'; then
+        log "WARN: PR #$PR_NUM has no qa decision label after agent — defaulting to qa-fail"
+        backend_remove_label "$REPO" "$PR_NUM" needs-qa
+        backend_remove_label "$REPO" "$PR_NUM" ready-for-qa
+        backend_add_label "$REPO" "$PR_NUM" qa-fail
+    fi
 else
-    log "qa failed for PR #$PR_NUM"
+    log "qa agent failed for PR #$PR_NUM"
     bounty_report "qa_fail" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$SLUG" pr_num="$PR_NUM" || true
-    loop_notify "❌ [$SLUG] PR#$PR_NUM qa failed: validation command failed"
+    loop_notify "❌ [$SLUG] PR#$PR_NUM qa failed: agent error"
     backend_remove_label "$REPO" "$PR_NUM" needs-qa
     backend_remove_label "$REPO" "$PR_NUM" ready-for-qa
     backend_remove_label "$REPO" "$PR_NUM" approved
@@ -108,6 +235,6 @@ else
     backend_remove_label "$REPO" "$PR_NUM" qa-failed
     backend_add_label "$REPO" "$PR_NUM" qa-fail
     backend_comment_pr "$REPO" "$PR_NUM" \
-        "QA validation failed. See loop-qa-handler.log for details."
+        "QA agent failed. See loop-qa-handler.log for details."
     exit 1
 fi

--- a/scripts/qa-handler.sh
+++ b/scripts/qa-handler.sh
@@ -96,7 +96,7 @@ fi
 AC_LIST=$(ISSUE_BODY="$ISSUE_BODY" python3 -c "
 import os, re
 body = os.environ.get('ISSUE_BODY', '').strip()
-match = re.search(r'(?m)^\#{1,3}\s+Acceptance Criteria\s*$', body)
+match = re.search(r'(?m)^\#{1,3}\s+Acceptance Criteria\s*$', body, re.IGNORECASE)
 if not match:
     print('__NO_AC_SECTION__')
 else:
@@ -132,14 +132,14 @@ fi
 
 QA_TIMEOUT="${QA_TIMEOUT_SECONDS:-600}"
 if [ -n "${QA_VALIDATION_CMD:-}" ]; then
-    VALIDATION_SECTION="## Phase 4: validation_cmd
+    VALIDATION_SECTION="## Phase 3: validation_cmd
 
 Run the project validation command (timeout ${QA_TIMEOUT}s):
   cd ${ROOT} && timeout ${QA_TIMEOUT} bash -c \"${QA_VALIDATION_CMD}\"
 
 If this exits non-zero, the verdict must be qa-fail even if all ACs are VERIFIED."
 else
-    VALIDATION_SECTION="## Phase 4: validation_cmd
+    VALIDATION_SECTION="## Phase 3: validation_cmd
 
 No validation_cmd is configured for this project. Skip this phase."
 fi
@@ -160,22 +160,22 @@ You are reviewing pull request #${PR_NUM} for QA.
 
 Your job — do all of these in sequence:
 
-0. Check PR state before proceeding:
+Phase 0: Check PR state before proceeding:
    gh pr view ${PR_NUM} --repo ${REPO} --json state,merged
    If state=MERGED or state=CLOSED: remove labels needs-qa and ready-for-qa, leave a brief comment, and stop.
 
-1. Fetch the PR diff:
+Phase 1: Fetch the PR diff:
    gh pr diff ${PR_NUM} --repo ${REPO}
 
-2. Evaluate acceptance criteria:
+Phase 2: Evaluate acceptance criteria:
 
 ${AC_SECTION}
 
 ${AC_INSTRUCTION}
 
-3. ${VALIDATION_SECTION}
+Phase 3: ${VALIDATION_SECTION}
 
-4. Post a structured comment on the PR using this template:
+Phase 4: Post a structured comment on the PR using this template:
 
 \`\`\`
 ### QA verification — issue #${LINKED_ISSUE_NUM:-N/A}
@@ -183,7 +183,7 @@ ${AC_INSTRUCTION}
 **Phase 1: Acceptance criteria**
 <numbered AC results with VERIFIED/NOT_FOUND/PARTIAL and rationale>
 
-**Phase 4: validation_cmd**
+**Phase 3: validation_cmd**
 <result of running validation_cmd, or "skipped — not configured">
 
 **Verdict:** <qa-pass or qa-fail — one-line reason>
@@ -192,7 +192,7 @@ ${AC_INSTRUCTION}
    Post the comment:
    gh pr comment ${PR_NUM} --repo ${REPO} --body '<the structured comment>'
 
-5. Apply labels based on the verdict:
+Phase 5: Apply labels based on the verdict:
 
    If qa-pass (all ACs VERIFIED and validation_cmd passed or not configured):
      gh pr edit ${PR_NUM} --repo ${REPO} --remove-label needs-qa --remove-label ready-for-qa --remove-label qa-failed --remove-label qa-fail --remove-label qa-pass --add-label qa-pass

--- a/tests/handlers.bats
+++ b/tests/handlers.bats
@@ -195,7 +195,7 @@ _extract_ac_list() {
     ISSUE_BODY="$body" python3 -c "
 import os, re
 body = os.environ.get('ISSUE_BODY', '').strip()
-match = re.search(r'(?m)^\#{1,3}\s+Acceptance Criteria\s*$', body)
+match = re.search(r'(?m)^\#{1,3}\s+Acceptance Criteria\s*$', body, re.IGNORECASE)
 if not match:
     print('__NO_AC_SECTION__')
 else:
@@ -256,23 +256,108 @@ BODY
     [ "$result" = "__NO_AC_SECTION__" ]
 }
 
-@test "qa-handler prompt: AC list injected when ACs found" {
-    local ac_list
-    ac_list="$(printf '1. First criterion\n2. Second criterion')"
+@test "qa-handler AC extraction: case-insensitive heading — ACCEPTANCE CRITERIA uppercase matches" {
+    local body
+    body="$(cat <<'BODY'
+## ACCEPTANCE CRITERIA
+- [ ] Uppercase heading criterion
 
-    # Simulate how the prompt is assembled when ACs are present
+## Notes
+Nothing else.
+BODY
+)"
+    local result
+    result=$(_extract_ac_list "$body")
+
+    [[ "$result" != "__NO_AC_SECTION__" ]]
+    echo "$result" | grep -q "1\. Uppercase heading criterion"
+}
+
+@test "qa-handler AC extraction: case-insensitive heading — mixed case 'Acceptance criteria' matches" {
+    local body
+    body="$(cat <<'BODY'
+## Acceptance criteria
+- [ ] Mixed-case heading criterion
+
+## Notes
+Nothing else.
+BODY
+)"
+    local result
+    result=$(_extract_ac_list "$body")
+
+    [[ "$result" != "__NO_AC_SECTION__" ]]
+    echo "$result" | grep -q "1\. Mixed-case heading criterion"
+}
+
+@test "qa-handler linked issue: Fixes #N pattern extracted correctly" {
+    # Test that the grep pattern used in qa-handler matches 'Fixes #N'
+    local pr_body="This PR implements the feature.\n\nFixes #99"
+    local issue_num
+    issue_num=$(printf '%b' "$pr_body" \
+        | grep -oiE '(closes|fixes|resolves) #[0-9]+' | grep -oE '[0-9]+' | head -1 || echo "")
+    [ "$issue_num" = "99" ]
+}
+
+@test "qa-handler linked issue: Resolves #N pattern extracted correctly" {
+    local pr_body="Resolves #123 — implements feature X"
+    local issue_num
+    issue_num=$(printf '%b' "$pr_body" \
+        | grep -oiE '(closes|fixes|resolves) #[0-9]+' | grep -oE '[0-9]+' | head -1 || echo "")
+    [ "$issue_num" = "123" ]
+}
+
+@test "qa-handler linked issue: no link keyword — issue num is empty" {
+    local pr_body="This PR does something without a linked issue"
+    local issue_num
+    issue_num=$(printf '%b' "$pr_body" \
+        | grep -oiE '(closes|fixes|resolves) #[0-9]+' | grep -oE '[0-9]+' | head -1 || echo "")
+    [ -z "$issue_num" ]
+}
+
+@test "qa-handler prompt: AC section built from _extract_ac_list output when issue linked" {
+    # Mock LINKED_ISSUE_NUM and ISSUE_BODY, verify AC_SECTION is assembled correctly
+    local LINKED_ISSUE_NUM="42"
+    local body
+    body="$(cat <<'BODY'
+## Acceptance Criteria
+- [ ] First criterion
+- [x] Second criterion
+BODY
+)"
+    local ac_list
+    ac_list=$(_extract_ac_list "$body")
+
+    # ac_list must not be sentinel
+    [[ "$ac_list" != "__NO_AC_SECTION__" ]]
+
+    # assemble the AC section as qa-handler does
     local ac_section
-    ac_section="## Acceptance Criteria (from issue #42)
+    ac_section="## Acceptance Criteria (from issue #${LINKED_ISSUE_NUM})
 
 ${ac_list}"
 
+    [[ "$ac_section" == *"issue #42"* ]]
     [[ "$ac_section" == *"1. First criterion"* ]]
     [[ "$ac_section" == *"2. Second criterion"* ]]
-    [[ "$ac_section" == *"issue #42"* ]]
 }
 
-@test "qa-handler prompt: fallback note when no ACs found" {
-    local ac_section="(No acceptance criteria found — falling back to validation_cmd only)"
+@test "qa-handler prompt: fallback path when no AC section found" {
+    local body="## Objective
+No acceptance criteria here."
+    local ac_list
+    ac_list=$(_extract_ac_list "$body")
+
+    [ "$ac_list" = "__NO_AC_SECTION__" ]
+
+    # Replicate label-fallback path from qa-handler.sh
+    local ac_section ac_instruction
+    if [ "$ac_list" = "__NO_AC_SECTION__" ]; then
+        ac_section="(No acceptance criteria found — falling back to validation_cmd only)"
+        ac_instruction=""
+    fi
+
     [[ "$ac_section" == *"No acceptance criteria found"* ]]
     [[ "$ac_section" == *"falling back to validation_cmd only"* ]]
+    [ -z "$ac_instruction" ]
 }

--- a/tests/handlers.bats
+++ b/tests/handlers.bats
@@ -184,3 +184,95 @@ State: OPEN
     [ -z "$_IN_FLIGHT_PR" ]
     [ -z "$_MR_PREAMBLE" ]
 }
+
+# ---------------------------------------------------------------------------
+# qa-handler AC extraction (Phase 1)
+# ---------------------------------------------------------------------------
+
+# Replicates the inline python3 AC-extraction snippet from qa-handler.sh.
+_extract_ac_list() {
+    local body="$1"
+    ISSUE_BODY="$body" python3 -c "
+import os, re
+body = os.environ.get('ISSUE_BODY', '').strip()
+match = re.search(r'(?m)^\#{1,3}\s+Acceptance Criteria\s*$', body)
+if not match:
+    print('__NO_AC_SECTION__')
+else:
+    rest = body[match.end():]
+    section = re.split(r'(?m)^\#{1,3}\s+', rest)[0]
+    checkboxes = re.findall(r'- \[[ xX]\] .+', section)
+    if not checkboxes:
+        print('__NO_AC_SECTION__')
+    else:
+        for i, cb in enumerate(checkboxes, 1):
+            text = re.sub(r'^- \[[ xX]\] ', '', cb).strip()
+            print(f'{i}. {text}')
+"
+}
+
+@test "qa-handler AC extraction: checkboxes present — returns numbered list" {
+    local body
+    body="$(cat <<'BODY'
+## Objective
+Do a thing.
+
+## Acceptance Criteria
+- [ ] First criterion is met
+- [x] Second criterion already checked
+- [ ] Third criterion to verify
+
+## Notes
+Nothing else.
+BODY
+)"
+    local result
+    result=$(_extract_ac_list "$body")
+
+    [[ "$result" != "__NO_AC_SECTION__" ]]
+    echo "$result" | grep -q "1\. First criterion is met"
+    echo "$result" | grep -q "2\. Second criterion already checked"
+    echo "$result" | grep -q "3\. Third criterion to verify"
+}
+
+@test "qa-handler AC extraction: no Acceptance Criteria section — returns sentinel" {
+    local body
+    body="$(cat <<'BODY'
+## Objective
+Do a thing.
+
+## Notes
+No acceptance criteria here.
+BODY
+)"
+    local result
+    result=$(_extract_ac_list "$body")
+    [ "$result" = "__NO_AC_SECTION__" ]
+}
+
+@test "qa-handler AC extraction: empty body — returns sentinel" {
+    local result
+    result=$(_extract_ac_list "")
+    [ "$result" = "__NO_AC_SECTION__" ]
+}
+
+@test "qa-handler prompt: AC list injected when ACs found" {
+    local ac_list
+    ac_list="$(printf '1. First criterion\n2. Second criterion')"
+
+    # Simulate how the prompt is assembled when ACs are present
+    local ac_section
+    ac_section="## Acceptance Criteria (from issue #42)
+
+${ac_list}"
+
+    [[ "$ac_section" == *"1. First criterion"* ]]
+    [[ "$ac_section" == *"2. Second criterion"* ]]
+    [[ "$ac_section" == *"issue #42"* ]]
+}
+
+@test "qa-handler prompt: fallback note when no ACs found" {
+    local ac_section="(No acceptance criteria found — falling back to validation_cmd only)"
+    [[ "$ac_section" == *"No acceptance criteria found"* ]]
+    [[ "$ac_section" == *"falling back to validation_cmd only"* ]]
+}


### PR DESCRIPTION
Closes #139

## Changes

**`scripts/qa-handler.sh`** — Phase 1 of smart QA:
- Sources `lib/runner.sh` and `lib/cli-hint.sh` so the handler runs via the agent orchestrator (same path as dev/review handlers) instead of executing `validation_cmd` directly in a shell
- Resolves the linked issue number from the PR body using the `Closes #N` / `Fixes #N` / `Resolves #N` pattern
- Fetches the linked issue body and extracts `## Acceptance Criteria` checkboxes via an inline python3 snippet (same pattern as po-handler's body extraction)
- If ACs are found: builds a numbered AC list and injects VERIFIED / NOT_FOUND / PARTIAL instructions into the agent prompt
- If no `## Acceptance Criteria` section: prompt includes `(No acceptance criteria found — falling back to validation_cmd only)` and proceeds to Phase 4
- Agent is instructed to post a structured QA comment (using the template from #136) on the PR before applying `qa-pass` or `qa-fail`
- `validation_cmd` (if configured) becomes Phase 4 in the agent prompt; if not configured the agent notes it and skips
- Belt-and-braces: if the agent exits zero but forgot to apply a decision label, defaults to `qa-fail` to prevent silent pipeline stalls

**`tests/handlers.bats`** — 5 new bats tests:
- AC extraction with checkboxes present (unchecked + checked): returns numbered list
- AC extraction with no `## Acceptance Criteria` section: returns `__NO_AC_SECTION__` sentinel
- AC extraction with empty body: returns sentinel
- Prompt assembly: AC list injected correctly with issue reference
- Prompt assembly: fallback note present when no ACs found

## Test Plan
- All 11 bats tests in `tests/handlers.bats` pass (`bats tests/handlers.bats`)
- `bash -n` syntax check: all scripts clean
- `shellcheck -S warning`: no warnings