### PR TITLE
[LOOP-133] 3-command onboarding: agent auto-detect + smoke test + loop status

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,22 +43,18 @@ The name is a nod to _loup_, French for wolf — a predator that hunts in packs,
 - **Backend agnostic** — GitHub default; GitLab and Jira+GitLab adapters
   ship in `lib/backends/`.
 
-## Install (5 minutes)
+## Install
 
-Clone, bootstrap, and add your first project:
+Three commands. No file editing required.
 
 ```bash
 git clone https://github.com/svv2014/loop.git && cd loop
-./install.sh --bootstrap            # check tools, write loop.env, register scanner
-./install.sh /path/to/your-project  # add a project to the pipeline
+./install.sh --bootstrap            # auto-detects agent, writes loop.env, registers scanner
+./install.sh /path/to/your-project  # registers project + smoke-tests the scanner
 ```
 
-Set your agent in `loop.env`:
-
-```bash
-LOOP_AGENT=claude
-LOOP_AGENT_MODEL=sonnet
-```
+Bootstrap auto-detects your agent (`claude`, `codex`, `gemini`, or `aider`) and writes
+`LOOP_AGENT` to `loop.env`. No manual editing needed for the happy path.
 
 Then label an issue to start the pipeline:
 
@@ -72,7 +68,31 @@ gh issue edit <number> --repo owner/repo --add-label dev
 
 The scanner picks it up within 5 minutes and opens a PR automatically.
 
-[More options](docs/quick-start.md) — GitLab, other agents, loop-monitor, and advanced config.
+```bash
+# Check that everything is healthy at any time:
+./install.sh status
+```
+
+<details>
+<summary>Advanced config — agent override, GitLab, other agents, loop-monitor</summary>
+
+To override the detected agent, edit `loop.env`:
+
+```bash
+LOOP_AGENT=codex           # or: gemini, aider, custom
+LOOP_AGENT_MODEL=o4-mini   # optional model override
+```
+
+Or re-bootstrap with an explicit agent:
+
+```bash
+LOOP_AGENT=gemini ./install.sh --bootstrap
+```
+
+For GitLab, Jira+GitLab, loop-monitor integration, and full configuration reference —
+see [docs/quick-start.md](docs/quick-start.md).
+
+</details>
 
 ## How a feature flows through Loop
 

--- a/install.sh
+++ b/install.sh
@@ -87,6 +87,63 @@ bootstrap_check_tools() {
     [ "$ok" = "true" ]
 }
 
+# Detect the first available agent CLI and write LOOP_AGENT to loop.env.
+# Returns 1 if no agent is found.
+bootstrap_detect_agent() {
+    local env_file="$LOOP_ROOT/loop.env"
+    local detected=""
+    local _agent
+
+    for _agent in claude codex gemini aider; do
+        if command -v "$_agent" >/dev/null 2>&1; then
+            detected="$_agent"
+            break
+        fi
+    done
+
+    if [ -z "$detected" ]; then
+        cat >&2 <<'ERR'
+[agent] ERROR: No supported agent CLI found in PATH.
+        Install one of the following, then re-run --bootstrap:
+          - claude   https://docs.anthropic.com/en/docs/claude-code
+          - codex    https://github.com/openai/codex
+          - gemini   https://github.com/google-gemini/gemini-cli
+          - aider    https://aider.chat
+
+        To override: LOOP_AGENT=<name> ./install.sh --bootstrap
+ERR
+        return 1
+    fi
+
+    echo "[agent] Detected: $detected"
+
+    # Write or update LOOP_AGENT in loop.env
+    if [ -f "$env_file" ]; then
+        if grep -q '^LOOP_AGENT=' "$env_file"; then
+            # Replace existing value
+            python3 - "$env_file" "$detected" <<'PY'
+import sys, re
+path, agent = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    content = f.read()
+content = re.sub(r'^LOOP_AGENT=.*$', f'LOOP_AGENT="{agent}"', content, flags=re.MULTILINE)
+with open(path, 'w') as f:
+    f.write(content)
+PY
+            echo "[agent] Updated LOOP_AGENT=\"$detected\" in loop.env"
+        else
+            echo "LOOP_AGENT=\"$detected\"" >> "$env_file"
+            echo "[agent] Appended LOOP_AGENT=\"$detected\" to loop.env"
+        fi
+    else
+        echo "LOOP_AGENT=\"$detected\"" > "$env_file"
+        echo "[agent] Created loop.env with LOOP_AGENT=\"$detected\""
+    fi
+
+    echo "[agent] To override: LOOP_AGENT=<other> ./install.sh --bootstrap"
+    echo "        Available: claude, codex, gemini, aider"
+}
+
 # Write loop.env from loop.env.example (skips if already exists).
 # Substitutes ${HOME} with the actual home directory for launchd/cron safety.
 bootstrap_write_env() {
@@ -291,6 +348,7 @@ bootstrap_pipeline() {
 
     bootstrap_check_tools || return 1
     bootstrap_write_env
+    bootstrap_detect_agent || return 1
     bootstrap_write_projects_yaml
     bootstrap_chmod_scripts
     bootstrap_register_services
@@ -308,16 +366,246 @@ Log paths:
   Reconciler: $log_dir/loop-reconciler.log
   Digest:     $log_dir/loop-digest.log
 
-To add your first project:
-  $0 /path/to/your/project [--auto]
+Next step:
+  $0 /path/to/your/project
 
-To verify scanner is running:
-  tail -f $log_dir/loop-scanner.log
+To check health:
+  $0 status
 
 DONE
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Status subcommand — one-shot health check
+# ─────────────────────────────────────────────────────────────────────────────
+
+status_check() {
+    local all_ok=true
+    local env_file="$LOOP_ROOT/loop.env"
+
+    echo "Loop Status"
+    echo "─────────────────────────────────────────────────"
+
+    # 1. loop.env present + LOOP_AGENT set
+    if [ -f "$env_file" ]; then
+        local agent_val
+        agent_val=$(grep '^LOOP_AGENT=' "$env_file" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"')
+        if [ -n "$agent_val" ]; then
+            echo "  [ok]  loop.env present, LOOP_AGENT=$agent_val"
+        else
+            echo "  [!!]  loop.env present but LOOP_AGENT not set"
+            all_ok=false
+        fi
+    else
+        echo "  [!!]  loop.env not found — run: ./install.sh --bootstrap"
+        all_ok=false
+        agent_val=""
+    fi
+
+    # 2. Agent CLI in PATH
+    local _detected_agent=""
+    if [ -f "$env_file" ]; then
+        _detected_agent=$(grep '^LOOP_AGENT=' "$env_file" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"')
+    fi
+    if [ -n "$_detected_agent" ]; then
+        if command -v "$_detected_agent" >/dev/null 2>&1; then
+            echo "  [ok]  agent CLI '$_detected_agent' in PATH"
+        else
+            echo "  [!!]  agent CLI '$_detected_agent' not found in PATH"
+            all_ok=false
+        fi
+    else
+        local _found_agent=""
+        local _a
+        for _a in claude codex gemini aider; do
+            if command -v "$_a" >/dev/null 2>&1; then
+                _found_agent="$_a"
+                break
+            fi
+        done
+        if [ -n "$_found_agent" ]; then
+            echo "  [ok]  agent CLI '$_found_agent' in PATH (LOOP_AGENT not set)"
+        else
+            echo "  [!!]  no agent CLI found (claude/codex/gemini/aider)"
+            all_ok=false
+        fi
+    fi
+
+    # 3. gh auth status
+    if command -v gh >/dev/null 2>&1; then
+        if gh auth status >/dev/null 2>&1; then
+            echo "  [ok]  gh authenticated"
+        else
+            echo "  [!!]  gh not authenticated — run: gh auth login"
+            all_ok=false
+        fi
+    else
+        echo "  [!!]  gh CLI not found"
+        all_ok=false
+    fi
+
+    # 4. Scanner running
+    local scanner_running=false
+    if [ "$(uname -s)" = "Darwin" ]; then
+        if launchctl list 2>/dev/null | grep -q "com.user.loop-scanner"; then
+            echo "  [ok]  scanner running (launchd)"
+            scanner_running=true
+        else
+            echo "  [!!]  scanner not running — run: ./install.sh --bootstrap"
+            all_ok=false
+        fi
+    else
+        if crontab -l 2>/dev/null | grep -q "loop-scanner"; then
+            echo "  [ok]  scanner registered (cron)"
+            scanner_running=true
+        else
+            echo "  [!!]  scanner not registered — run: ./install.sh --bootstrap"
+            all_ok=false
+        fi
+    fi
+
+    # 5. Reconciler running
+    if [ "$(uname -s)" = "Darwin" ]; then
+        if launchctl list 2>/dev/null | grep -q "com.user.loop-reconciler"; then
+            echo "  [ok]  reconciler running (launchd)"
+        else
+            echo "  [!!]  reconciler not running — run: ./install.sh --bootstrap"
+            all_ok=false
+        fi
+    else
+        if crontab -l 2>/dev/null | grep -q "loop-reconciler"; then
+            echo "  [ok]  reconciler registered (cron)"
+        else
+            echo "  [!!]  reconciler not registered — run: ./install.sh --bootstrap"
+            all_ok=false
+        fi
+    fi
+
+    # 6. Latest scanner tick within 2x POLL_INTERVAL (default: 5 min → 10 min window)
+    local log_dir
+    log_dir=$(bootstrap_resolve_log_dir)
+    local scanner_log="$log_dir/loop-scanner.log"
+    if [ -f "$scanner_log" ]; then
+        local poll_interval=300
+        if [ -f "$env_file" ]; then
+            local _pi
+            _pi=$(grep '^POLL_INTERVAL=' "$env_file" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"')
+            [ -n "$_pi" ] && poll_interval="$_pi"
+        fi
+        local threshold=$(( poll_interval * 2 ))
+        local last_modified
+        last_modified=$(python3 -c "import os,time; print(int(time.time()-os.path.getmtime('$scanner_log')))" 2>/dev/null || echo "9999")
+        if [ "$last_modified" -le "$threshold" ] 2>/dev/null; then
+            echo "  [ok]  scanner last tick ${last_modified}s ago (within ${threshold}s window)"
+        else
+            echo "  [!!]  scanner last tick ${last_modified}s ago — expected within ${threshold}s"
+            all_ok=false
+        fi
+    elif $scanner_running; then
+        echo "  [--]  scanner log not found yet (may not have ticked)"
+    fi
+
+    # 7. Registered projects accessible
+    if [ -f "$PROJECTS_YAML" ] && command -v python3 >/dev/null 2>&1; then
+        local slugs
+        slugs=$(python3 -c "
+import yaml, sys
+with open('$PROJECTS_YAML') as f:
+    data = yaml.safe_load(f) or {}
+for p in (data.get('projects') or []):
+    print(p.get('slug','') + '|' + p.get('repo','') + '|' + p.get('root',''))
+" 2>/dev/null || true)
+        if [ -z "$slugs" ]; then
+            echo "  [--]  no projects registered"
+        else
+            while IFS='|' read -r _slug _repo _root; do
+                [ -z "$_slug" ] && continue
+                if [ -n "$_root" ] && [ ! -d "$_root" ]; then
+                    echo "  [!!]  project '$_slug': root '$_root' not accessible"
+                    all_ok=false
+                elif [ -n "$_repo" ] && ! gh repo view "$_repo" >/dev/null 2>&1; then
+                    echo "  [!!]  project '$_slug': repo '$_repo' not accessible via gh"
+                    all_ok=false
+                else
+                    echo "  [ok]  project '$_slug' (${_repo:-?})"
+                fi
+            done <<< "$slugs"
+        fi
+    else
+        echo "  [--]  config/projects.yaml not found — no projects registered"
+    fi
+
+    echo "─────────────────────────────────────────────────"
+    if $all_ok; then
+        echo "  All checks passed."
+        return 0
+    else
+        echo "  One or more checks failed. See above."
+        return 1
+    fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Smoke test — kick scanner once after project add, wait for slug in output
+# ─────────────────────────────────────────────────────────────────────────────
+
+smoke_test_scanner() {
+    local slug="$1"
+    local log_dir
+    log_dir=$(bootstrap_resolve_log_dir)
+    local scanner_log="$log_dir/loop-scanner.log"
+    local scan_script="$LOOP_ROOT/scanner/scanner.sh"
+    local timeout_secs=30
+
+    echo
+    echo "[smoke] Kicking scanner once to verify it picks up '$slug'..."
+
+    # Run one scan in background, capturing output
+    local scan_out="$log_dir/smoke-test-$slug.log"
+    mkdir -p "$log_dir"
+
+    if [ ! -x "$scan_script" ]; then
+        echo "[smoke] Scanner not executable — skipping smoke test"
+        return 0
+    fi
+
+    "$scan_script" --once >"$scan_out" 2>&1 &
+    local scan_pid=$!
+
+    local elapsed=0
+    local found=false
+    while [ $elapsed -lt $timeout_secs ]; do
+        if grep -q "$slug" "$scan_out" 2>/dev/null; then
+            found=true
+            break
+        fi
+        if ! kill -0 $scan_pid 2>/dev/null; then
+            # scanner finished — check one final time
+            grep -q "$slug" "$scan_out" 2>/dev/null && found=true
+            break
+        fi
+        sleep 2
+        elapsed=$(( elapsed + 2 ))
+    done
+
+    # Clean up background process if still running
+    kill $scan_pid 2>/dev/null || true
+    wait $scan_pid 2>/dev/null || true
+
+    if $found; then
+        local now
+        now=$(date '+%H:%M:%S')
+        echo "[smoke] Scanner picked up '$slug' at $now"
+    else
+        echo "[smoke] WARNING: scanner did not pick up '$slug' in ${timeout_secs}s"
+        echo "        See $scanner_log"
+    fi
+    rm -f "$scan_out"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+
+STATUS_MODE=false
 
 for arg in "$@"; do
     case "$arg" in
@@ -330,9 +618,15 @@ for arg in "$@"; do
             exit 0
             ;;
         -h|--help) sed -n '1,20p' "$0"; exit 0 ;;
+        status) STATUS_MODE=true ;;
         *) PROJECT_PATH="$arg" ;;
     esac
 done
+
+if $STATUS_MODE; then
+    status_check
+    exit $?
+fi
 
 if $BOOTSTRAP_MODE; then
     bootstrap_pipeline
@@ -341,6 +635,8 @@ fi
 
 if [ -z "$PROJECT_PATH" ]; then
     echo "Usage: $0 <project-path> [--auto]" >&2
+    echo "       $0 --bootstrap" >&2
+    echo "       $0 status" >&2
     exit 2
 fi
 PROJECT_PATH="$(cd "$PROJECT_PATH" && pwd)"
@@ -361,6 +657,14 @@ DEFAULT_BRANCH=$(git -C "$PROJECT_PATH" symbolic-ref refs/remotes/origin/HEAD 2>
 DEFAULT_SLUG=$(basename "$PROJECT_PATH" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
 DEFAULT_PREFIX=$(echo "$DEFAULT_SLUG" | tr '[:lower:]' '[:upper:]' | cut -c1-3)
 DEFAULT_NAME=$(basename "$PROJECT_PATH")
+
+# --auto is now the default when git root is detectable; fall back to interactive
+# if auto-detect fails (e.g., git remote not found).
+if ! $AUTO_MODE; then
+    if git -C "$PROJECT_PATH" remote get-url origin >/dev/null 2>&1; then
+        AUTO_MODE=true
+    fi
+fi
 
 if $AUTO_MODE; then
     SLUG="$DEFAULT_SLUG"
@@ -632,6 +936,12 @@ if [ -f "$SCANNER_LOCK" ]; then
 else
     echo "[scanner] not running — will pick up $SLUG when it starts"
 fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 7. Smoke test — kick scanner and verify it sees the new slug
+# ─────────────────────────────────────────────────────────────────────────────
+
+smoke_test_scanner "$SLUG"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Done

--- a/install.sh
+++ b/install.sh
@@ -88,11 +88,40 @@ bootstrap_check_tools() {
 }
 
 # Detect the first available agent CLI and write LOOP_AGENT to loop.env.
+# If LOOP_AGENT is already set in the environment, honour it without probing PATH.
 # Returns 1 if no agent is found.
 bootstrap_detect_agent() {
     local env_file="$LOOP_ROOT/loop.env"
     local detected=""
     local _agent
+
+    # Honour explicit env override — do not probe PATH when the caller already
+    # knows which agent to use.
+    if [ -n "${LOOP_AGENT:-}" ]; then
+        detected="$LOOP_AGENT"
+        echo "[agent] Using LOOP_AGENT from environment: $detected"
+        if [ -f "$env_file" ]; then
+            if grep -q '^LOOP_AGENT=' "$env_file"; then
+                python3 - "$env_file" "$detected" <<'PY'
+import sys, re
+path, agent = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    content = f.read()
+content = re.sub(r'^LOOP_AGENT=.*$', f'LOOP_AGENT="{agent}"', content, flags=re.MULTILINE)
+with open(path, 'w') as f:
+    f.write(content)
+PY
+                echo "[agent] Updated LOOP_AGENT=\"$detected\" in loop.env"
+            else
+                echo "LOOP_AGENT=\"$detected\"" >> "$env_file"
+                echo "[agent] Appended LOOP_AGENT=\"$detected\" to loop.env"
+            fi
+        else
+            echo "LOOP_AGENT=\"$detected\"" > "$env_file"
+            echo "[agent] Created loop.env with LOOP_AGENT=\"$detected\""
+        fi
+        return 0
+    fi
 
     for _agent in claude codex gemini aider; do
         if command -v "$_agent" >/dev/null 2>&1; then
@@ -494,7 +523,9 @@ status_check() {
         fi
         local threshold=$(( poll_interval * 2 ))
         local last_modified
-        last_modified=$(python3 -c "import os,time; print(int(time.time()-os.path.getmtime('$scanner_log')))" 2>/dev/null || echo "9999")
+        last_modified=$(scanner_log="$scanner_log" python3 -c \
+            "import os,time; p=os.environ['scanner_log']; print(int(time.time()-os.path.getmtime(p)))" \
+            2>/dev/null || echo "9999")
         if [ "$last_modified" -le "$threshold" ] 2>/dev/null; then
             echo "  [ok]  scanner last tick ${last_modified}s ago (within ${threshold}s window)"
         else
@@ -596,11 +627,17 @@ smoke_test_scanner() {
         local now
         now=$(date '+%H:%M:%S')
         echo "[smoke] Scanner picked up '$slug' at $now"
+        rm -f "$scan_out"
     else
+        # Persist the captured output to the scanner log so the path we show
+        # the user actually contains the diagnostic information.
+        if [ -s "$scan_out" ]; then
+            cat "$scan_out" >> "$scanner_log"
+        fi
+        rm -f "$scan_out"
         echo "[smoke] WARNING: scanner did not pick up '$slug' in ${timeout_secs}s"
         echo "        See $scanner_log"
     fi
-    rm -f "$scan_out"
 }
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/install-bootstrap-detect.bats
+++ b/tests/install-bootstrap-detect.bats
@@ -1,0 +1,242 @@
+#!/usr/bin/env bats
+# tests/install-bootstrap-detect.bats — tests for bootstrap agent auto-detect in install.sh
+#
+# Verifies that:
+#   - bootstrap with each of claude/codex/gemini/aider available picks the right one
+#   - bootstrap with no agent found exits non-zero with a useful error message
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    # Isolated temp directory for each test
+    export TEST_HOME="$BATS_TMPDIR/home-$$"
+    mkdir -p "$TEST_HOME"
+
+    # Fake bin directory for mocking agent CLIs
+    export MOCK_BIN="$BATS_TMPDIR/bin-$$"
+    mkdir -p "$MOCK_BIN"
+
+    # Isolated loop.env location — use a temp LOOP_ROOT
+    export FAKE_LOOP_ROOT="$BATS_TMPDIR/loop-root-$$"
+    mkdir -p "$FAKE_LOOP_ROOT/config"
+    cp "$REPO_ROOT/loop.env.example" "$FAKE_LOOP_ROOT/"
+    touch "$FAKE_LOOP_ROOT/config/projects.example.yaml"
+
+    # Stub out heavy bootstrap functions — we only want to test agent detect
+    # We do this by sourcing install.sh with the right env substitutions
+    export AGENT_DETECT_ONLY=1
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/home-$$" "$BATS_TMPDIR/bin-$$" "$BATS_TMPDIR/loop-root-$$"
+    unset TEST_HOME MOCK_BIN FAKE_LOOP_ROOT AGENT_DETECT_ONLY
+}
+
+# Helper: create a fake agent binary in MOCK_BIN
+make_fake_agent() {
+    local name="$1"
+    printf '#!/usr/bin/env bash\necho "%s mock"\n' "$name" > "$MOCK_BIN/$name"
+    chmod +x "$MOCK_BIN/$name"
+}
+
+# Helper: run bootstrap_detect_agent in an isolated subshell with controlled PATH
+run_detect_agent() {
+    local mock_path="$1"
+    local loop_env="$FAKE_LOOP_ROOT/loop.env"
+    rm -f "$loop_env"
+    cp "$FAKE_LOOP_ROOT/loop.env.example" "$loop_env"
+
+    # Source only the bootstrap_detect_agent function from install.sh
+    # and run it in a controlled environment
+    bash - <<SHELL
+set -euo pipefail
+PATH="$mock_path:\$PATH"
+LOOP_ROOT="$FAKE_LOOP_ROOT"
+$(grep -A 60 '^bootstrap_detect_agent()' "$REPO_ROOT/install.sh" | \
+  awk '/^bootstrap_detect_agent\(\)/{found=1} found{print} found && /^\}$/{exit}')
+bootstrap_detect_agent
+SHELL
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Agent detection — each agent in isolation
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Helper: extract bootstrap_detect_agent function body from install.sh
+_extract_detect_func() {
+    awk '
+        /^bootstrap_detect_agent\(\)/ { found=1; depth=0 }
+        found {
+            for(i=1;i<=length($0);i++) {
+                c=substr($0,i,1)
+                if(c=="{") depth++
+                if(c=="}") depth--
+            }
+            print
+            if(depth==0 && NR>1) { found=0 }
+        }
+    ' "$REPO_ROOT/install.sh"
+}
+
+# Helper: run bootstrap_detect_agent with only the specified agents "available".
+# Uses a command() override to intercept command -v calls for agent names.
+# Keeps system PATH for tools like python3, grep etc.
+run_detect_only_agents() {
+    local available_agents=("$@")
+    local loop_env="$FAKE_LOOP_ROOT/loop.env"
+
+    # Build a space-separated list for the subshell
+    local agents_list="${available_agents[*]}"
+
+    local func_body
+    func_body=$(_extract_detect_func)
+
+    bash -c "
+set -euo pipefail
+LOOP_ROOT=\"$FAKE_LOOP_ROOT\"
+
+# Override 'command' to control which agents are 'found'
+# Only the agents in _AVAIL_AGENTS are reported as available
+_AVAIL_AGENTS=\" ${agents_list} \"
+command() {
+    if [ \"\${1:-}\" = \"-v\" ]; then
+        local name=\"\${2:-}\"
+        case \"\$name\" in
+            claude|codex|gemini|aider)
+                if [[ \"\$_AVAIL_AGENTS\" == *\" \$name \"* ]]; then
+                    echo \"/mock/\$name\"
+                    return 0
+                else
+                    return 1
+                fi
+                ;;
+        esac
+    fi
+    builtin command \"\$@\"
+}
+export -f command 2>/dev/null || true
+
+${func_body}
+bootstrap_detect_agent
+"
+    local rc=$?
+    return $rc
+}
+
+@test "bootstrap_detect_agent: detects 'claude' when only claude is in PATH" {
+    local loop_env="$FAKE_LOOP_ROOT/loop.env"
+    rm -f "$loop_env"
+    cp "$FAKE_LOOP_ROOT/loop.env.example" "$loop_env"
+
+    run_detect_only_agents "claude"
+    grep -q 'LOOP_AGENT="claude"' "$loop_env"
+}
+
+@test "bootstrap_detect_agent: detects 'codex' when only codex is in PATH" {
+    local loop_env="$FAKE_LOOP_ROOT/loop.env"
+    rm -f "$loop_env"
+    cp "$FAKE_LOOP_ROOT/loop.env.example" "$loop_env"
+
+    run_detect_only_agents "codex"
+    grep -q 'LOOP_AGENT="codex"' "$loop_env"
+}
+
+@test "bootstrap_detect_agent: detects 'gemini' when only gemini is in PATH" {
+    local loop_env="$FAKE_LOOP_ROOT/loop.env"
+    rm -f "$loop_env"
+    cp "$FAKE_LOOP_ROOT/loop.env.example" "$loop_env"
+
+    run_detect_only_agents "gemini"
+    grep -q 'LOOP_AGENT="gemini"' "$loop_env"
+}
+
+@test "bootstrap_detect_agent: detects 'aider' when only aider is in PATH" {
+    local loop_env="$FAKE_LOOP_ROOT/loop.env"
+    rm -f "$loop_env"
+    cp "$FAKE_LOOP_ROOT/loop.env.example" "$loop_env"
+
+    run_detect_only_agents "aider"
+    grep -q 'LOOP_AGENT="aider"' "$loop_env"
+}
+
+@test "bootstrap_detect_agent: prefers claude over codex when both present" {
+    local loop_env="$FAKE_LOOP_ROOT/loop.env"
+    rm -f "$loop_env"
+    cp "$FAKE_LOOP_ROOT/loop.env.example" "$loop_env"
+
+    run_detect_only_agents "claude" "codex"
+    grep -q 'LOOP_AGENT="claude"' "$loop_env"
+}
+
+@test "bootstrap_detect_agent: exits non-zero when no agent found" {
+    local loop_env="$FAKE_LOOP_ROOT/loop.env"
+    rm -f "$loop_env"
+    cp "$FAKE_LOOP_ROOT/loop.env.example" "$loop_env"
+
+    local func_body
+    func_body=$(_extract_detect_func)
+
+    # Pass empty list — no agents available
+    run bash -c "
+set -euo pipefail
+LOOP_ROOT=\"$FAKE_LOOP_ROOT\"
+_AVAIL_AGENTS=\"  \"
+command() {
+    if [ \"\${1:-}\" = \"-v\" ]; then
+        local name=\"\${2:-}\"
+        case \"\$name\" in
+            claude|codex|gemini|aider) return 1 ;;
+        esac
+    fi
+    builtin command \"\$@\"
+}
+export -f command 2>/dev/null || true
+${func_body}
+bootstrap_detect_agent 2>&1
+"
+    [ "$status" -ne 0 ]
+}
+
+@test "bootstrap_detect_agent: prints actionable error when no agent found" {
+    local loop_env="$FAKE_LOOP_ROOT/loop.env"
+    rm -f "$loop_env"
+    cp "$FAKE_LOOP_ROOT/loop.env.example" "$loop_env"
+
+    local func_body
+    func_body=$(_extract_detect_func)
+
+    run bash -c "
+LOOP_ROOT=\"$FAKE_LOOP_ROOT\"
+_AVAIL_AGENTS=\"  \"
+command() {
+    if [ \"\${1:-}\" = \"-v\" ]; then
+        local name=\"\${2:-}\"
+        case \"\$name\" in
+            claude|codex|gemini|aider) return 1 ;;
+        esac
+    fi
+    builtin command \"\$@\"
+}
+export -f command 2>/dev/null || true
+${func_body}
+bootstrap_detect_agent 2>&1
+"
+    [[ "$output" == *"claude"* ]]
+    [[ "$output" == *"codex"* ]]
+    [[ "$output" == *"gemini"* ]]
+    [[ "$output" == *"aider"* ]]
+}
+
+@test "bootstrap_detect_agent: updates existing LOOP_AGENT line in loop.env" {
+    local loop_env="$FAKE_LOOP_ROOT/loop.env"
+    # Simulate already having claude set
+    printf 'LOOP_AGENT="claude"\n' > "$loop_env"
+
+    # Only make codex available
+    run_detect_only_agents "codex"
+
+    # Should now have codex (the only available agent)
+    grep -q 'LOOP_AGENT="codex"' "$loop_env"
+    # Should not have duplicate lines
+    [ "$(grep -c 'LOOP_AGENT=' "$loop_env")" -eq 1 ]
+}

--- a/tests/install-bootstrap-detect.bats
+++ b/tests/install-bootstrap-detect.bats
@@ -240,3 +240,76 @@ bootstrap_detect_agent 2>&1
     # Should not have duplicate lines
     [ "$(grep -c 'LOOP_AGENT=' "$loop_env")" -eq 1 ]
 }
+
+@test "bootstrap_detect_agent: honours LOOP_AGENT env var without probing PATH" {
+    local loop_env="$FAKE_LOOP_ROOT/loop.env"
+    rm -f "$loop_env"
+    cp "$FAKE_LOOP_ROOT/loop.env.example" "$loop_env"
+
+    local func_body
+    func_body=$(_extract_detect_func)
+
+    # LOOP_AGENT=gemini is set in the env; no agent CLIs are available in PATH.
+    # The function should write gemini to loop.env and exit 0 without failing.
+    run bash -c "
+set -euo pipefail
+LOOP_ROOT=\"$FAKE_LOOP_ROOT\"
+LOOP_AGENT=\"gemini\"
+export LOOP_AGENT
+
+# Override command -v so no agent CLIs appear in PATH
+command() {
+    if [ \"\${1:-}\" = \"-v\" ]; then
+        local name=\"\${2:-}\"
+        case \"\$name\" in
+            claude|codex|gemini|aider) return 1 ;;
+        esac
+    fi
+    builtin command \"\$@\"
+}
+export -f command 2>/dev/null || true
+
+${func_body}
+bootstrap_detect_agent
+"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"gemini"* ]]
+    grep -q 'LOOP_AGENT="gemini"' "$loop_env"
+}
+
+@test "bootstrap_detect_agent: LOOP_AGENT env overrides a different agent already in loop.env" {
+    local loop_env="$FAKE_LOOP_ROOT/loop.env"
+    # loop.env already has claude
+    printf 'LOOP_AGENT="claude"\n' > "$loop_env"
+
+    local func_body
+    func_body=$(_extract_detect_func)
+
+    # LOOP_AGENT=aider is in the environment; claude is not in PATH either.
+    run bash -c "
+set -euo pipefail
+LOOP_ROOT=\"$FAKE_LOOP_ROOT\"
+LOOP_AGENT=\"aider\"
+export LOOP_AGENT
+
+command() {
+    if [ \"\${1:-}\" = \"-v\" ]; then
+        local name=\"\${2:-}\"
+        case \"\$name\" in
+            claude|codex|gemini|aider) return 1 ;;
+        esac
+    fi
+    builtin command \"\$@\"
+}
+export -f command 2>/dev/null || true
+
+${func_body}
+bootstrap_detect_agent
+"
+    [ "$status" -eq 0 ]
+    grep -q 'LOOP_AGENT="aider"' "$loop_env"
+    # Should not have duplicate lines
+    local count
+    count=$(grep -c 'LOOP_AGENT=' "$loop_env")
+    [ "$count" -eq 1 ]
+}

--- a/tests/install-status.bats
+++ b/tests/install-status.bats
@@ -1,0 +1,196 @@
+#!/usr/bin/env bats
+# tests/install-status.bats — tests for the 'status' subcommand in install.sh
+#
+# Verifies that:
+#   - status exits 0 when all checks pass
+#   - status exits non-zero and prints checklist items when checks fail
+#   - each check (loop.env, agent CLI, gh auth, scanner, reconciler) is reported
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    # Fake LOOP_ROOT for isolation
+    export FAKE_LOOP_ROOT="$BATS_TMPDIR/loop-root-$$"
+    mkdir -p "$FAKE_LOOP_ROOT/config"
+
+    # Fake bin dir for mocking commands
+    export MOCK_BIN="$BATS_TMPDIR/bin-$$"
+    mkdir -p "$MOCK_BIN"
+
+    # Default: healthy loop.env
+    cat > "$FAKE_LOOP_ROOT/loop.env" <<'ENV'
+LOOP_AGENT="claude"
+LOOP_LOG_DIR=""
+ENV
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/loop-root-$$" "$BATS_TMPDIR/bin-$$"
+    unset FAKE_LOOP_ROOT MOCK_BIN
+}
+
+# Helper: create a fake binary in MOCK_BIN that exits 0
+make_fake_cmd() {
+    local name="$1"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$MOCK_BIN/$name"
+    chmod +x "$MOCK_BIN/$name"
+}
+
+# Helper: create a fake binary in MOCK_BIN that exits with given code
+make_fake_cmd_exit() {
+    local name="$1" code="$2"
+    printf '#!/usr/bin/env bash\nexit %d\n' "$code" > "$MOCK_BIN/$name"
+    chmod +x "$MOCK_BIN/$name"
+}
+
+# Extract status_check + helpers from install.sh for isolated testing
+extract_status_check() {
+    # Extract bootstrap_resolve_log_dir and status_check functions
+    awk '
+        /^bootstrap_resolve_log_dir\(\)/ { found=1; depth=0 }
+        /^status_check\(\)/ { found=1; depth=0 }
+        found {
+            print
+            for(i=1;i<=length($0);i++) {
+                c=substr($0,i,1)
+                if(c=="{") depth++
+                if(c=="}") depth--
+            }
+            if(found && depth==0 && NR>1) { found=0; print "" }
+        }
+    ' "$REPO_ROOT/install.sh"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# status: loop.env checks
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "status: reports ok for loop.env with LOOP_AGENT set" {
+    make_fake_cmd "claude"
+    make_fake_cmd "gh"
+    # gh auth status mock
+    cat > "$MOCK_BIN/gh" <<'BASH'
+#!/usr/bin/env bash
+if [ "${1:-}" = "auth" ] && [ "${2:-}" = "status" ]; then exit 0; fi
+if [ "${1:-}" = "repo" ] && [ "${2:-}" = "view" ]; then exit 0; fi
+exit 0
+BASH
+    chmod +x "$MOCK_BIN/gh"
+
+    run bash - <<SHELL
+PATH="$MOCK_BIN"
+LOOP_ROOT="$FAKE_LOOP_ROOT"
+PROJECTS_YAML="$FAKE_LOOP_ROOT/config/projects.yaml"
+uname() { echo "Linux"; }
+crontab() {
+    if [ "\$1" = "-l" ]; then
+        echo "*/5 * * * * scanner.sh # loop-scanner"
+        echo "*/15 * * * * reconciler.sh # loop-reconciler"
+    fi
+}
+export -f uname crontab 2>/dev/null || true
+$(extract_status_check)
+status_check
+SHELL
+
+    [[ "$output" == *"loop.env"* ]] || [[ "$output" == *"LOOP_AGENT=claude"* ]]
+}
+
+@test "status: exits non-zero when loop.env is missing" {
+    rm -f "$FAKE_LOOP_ROOT/loop.env"
+    make_fake_cmd "gh"
+
+    run bash - <<SHELL
+PATH="$MOCK_BIN"
+LOOP_ROOT="$FAKE_LOOP_ROOT"
+PROJECTS_YAML="$FAKE_LOOP_ROOT/config/projects.yaml"
+$(extract_status_check)
+status_check
+SHELL
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"loop.env"* ]]
+}
+
+@test "status: exits non-zero when LOOP_AGENT not set in loop.env" {
+    # loop.env exists but no LOOP_AGENT
+    printf '# empty\nLOOP_LOG_DIR=""\n' > "$FAKE_LOOP_ROOT/loop.env"
+    make_fake_cmd "gh"
+
+    run bash - <<SHELL
+PATH="$MOCK_BIN"
+LOOP_ROOT="$FAKE_LOOP_ROOT"
+PROJECTS_YAML="$FAKE_LOOP_ROOT/config/projects.yaml"
+$(extract_status_check)
+status_check
+SHELL
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"LOOP_AGENT"* ]]
+}
+
+@test "status: exits non-zero when agent CLI not in PATH" {
+    # loop.env says claude, but claude not in PATH
+    cat > "$FAKE_LOOP_ROOT/loop.env" <<'ENV'
+LOOP_AGENT="claude"
+ENV
+    make_fake_cmd "gh"
+
+    run bash - <<SHELL
+PATH="$MOCK_BIN"
+LOOP_ROOT="$FAKE_LOOP_ROOT"
+PROJECTS_YAML="$FAKE_LOOP_ROOT/config/projects.yaml"
+$(extract_status_check)
+status_check
+SHELL
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"claude"* ]]
+}
+
+@test "status: reports failure when gh not authenticated" {
+    make_fake_cmd "claude"
+    # gh auth status fails
+    cat > "$MOCK_BIN/gh" <<'BASH'
+#!/usr/bin/env bash
+if [ "${1:-}" = "auth" ] && [ "${2:-}" = "status" ]; then exit 1; fi
+exit 0
+BASH
+    chmod +x "$MOCK_BIN/gh"
+
+    run bash - <<SHELL
+PATH="$MOCK_BIN"
+LOOP_ROOT="$FAKE_LOOP_ROOT"
+PROJECTS_YAML="$FAKE_LOOP_ROOT/config/projects.yaml"
+$(extract_status_check)
+status_check
+SHELL
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"gh"* ]]
+}
+
+@test "status: prints checklist with ok/fail markers" {
+    rm -f "$FAKE_LOOP_ROOT/loop.env"
+
+    run bash - <<SHELL
+PATH="$MOCK_BIN"
+LOOP_ROOT="$FAKE_LOOP_ROOT"
+PROJECTS_YAML="$FAKE_LOOP_ROOT/config/projects.yaml"
+$(extract_status_check)
+status_check
+SHELL
+
+    # Should contain checklist markers
+    [[ "$output" == *"[ok]"* ]] || [[ "$output" == *"[!!]"* ]] || [[ "$output" == *"[--]"* ]]
+}
+
+@test "status: ./install.sh status subcommand is reachable" {
+    # Verify the install.sh accepts 'status' as a positional arg
+    run bash -n "$REPO_ROOT/install.sh"
+    [ "$status" -eq 0 ]
+
+    grep -q 'status)' "$REPO_ROOT/install.sh"
+    grep -q 'STATUS_MODE=true' "$REPO_ROOT/install.sh"
+    grep -q 'status_check' "$REPO_ROOT/install.sh"
+}


### PR DESCRIPTION
## Summary

- `install.sh --bootstrap` now auto-detects agent CLI (`claude`/`codex`/`gemini`/`aider`) and writes `LOOP_AGENT` to `loop.env` automatically — no manual file editing required for the happy path
- `install.sh /path/to/repo` defaults to `--auto` when git remote is detectable; drops to interactive only if auto-detect fails
- After project registration, kicks scanner once and polls 30s to confirm it picked up the slug (smoke test)
- New `./install.sh status` subcommand prints a `[ok]/[!!]` checklist (loop.env, agent CLI, gh auth, scanner/reconciler running, last tick freshness, projects accessible) and exits 0 if all pass
- README Install section leads with the 3-command sequence; advanced config in a collapsible `<details>` block
- 15 new bats tests: 8 for bootstrap agent detection, 7 for status subcommand

## Test plan

- [ ] `bats tests/install-bootstrap-detect.bats` — all 8 pass
- [ ] `bats tests/install-status.bats` — all 7 pass
- [ ] `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — no syntax errors
- [ ] `shellcheck -S warning lib/*.sh scripts/*.sh scanner/*.sh install.sh` — no warnings
- [ ] `./install.sh --bootstrap` with `claude` in PATH: writes `LOOP_AGENT="claude"` to loop.env
- [ ] `./install.sh --bootstrap` with no agent: exits 1 with list of what to install
- [ ] `./install.sh /path/to/repo` (no `--auto`): auto-detects and registers without prompts
- [ ] `./install.sh status`: prints checklist, exits 0 when healthy

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)