### PR TITLE
docs: refresh for v0.2.0 — smart QA, 3-command onboarding, label vocab

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,10 @@ see [docs/quick-start.md](docs/quick-start.md).
 4. **Review handler** sends the diff back to an AI agent for an
    approve/reject decision. On approve → `needs-qa`. On reject →
    `needs-rework` and back to step 3.
-5. **QA handler** runs the project's `validation_cmd` (your `npm test`,
-   `make`, whatever). On pass → `qa-pass`. On fail → `qa-fail` →
-   dev-rework.
+5. **QA handler** runs four-phase smart QA: verifies acceptance criteria,
+   creates targeted tests, runs regression on touched modules, then runs
+   the project's `validation_cmd`. Posts a structured `### QA verification`
+   comment. On pass → `qa-pass`. On fail → `qa-fail` → dev-rework.
 6. **Merge handler** squash-merges, closes the linked issue, records a
    bounty event, triggers the judge for a PR scorecard.
 7. **Reconciler** runs every 15 minutes to clean up stuck states,
@@ -219,10 +220,12 @@ versioned (currently `1.0`).
 
 ## Status
 
-`v0.1.0` — initial public release. The pipeline is production-tested
-internally and has driven hundreds of merges across multiple repos. The
-public release introduces workflow-as-config and a versioned bounty API
-contract; both are first-class commitments going forward.
+`v0.2.0` — production-tested across multiple repos. Introduces four-phase
+smart QA (AC verification, targeted test creation, module regression,
+`validation_cmd`), 3-command onboarding with agent auto-detect, and
+automated release PRs with tag + publish on merge. The pipeline,
+workflow-as-config, and the versioned bounty API are first-class
+commitments going forward.
 
 [Roadmap](ROADMAP.md) tracks what's next: spec-blind validator stage,
 domain specialist agents (frontend / backend / data / devops), expanded

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -120,8 +120,8 @@ systemctl enable --now loop-scanner
 # Interactive (prompts for repo, branch, validation commands)
 ./install.sh /path/to/your/project
 
-# Non-interactive (auto-detects from git remote)
-./install.sh --auto /path/to/your/project
+# Non-interactive (auto-detects everything from git remote)
+./install.sh /path/to/your/project --auto
 ```
 
 `install.sh` will:
@@ -129,24 +129,28 @@ systemctl enable --now loop-scanner
 2. Create Loop labels on the GitHub repo
 3. Enable auto-merge and delete-branch-on-merge
 4. Copy issue/PR templates into the repo
+5. Run a smoke test confirming the scanner picks up the new project
 
 ---
 
 ## 5. Verify the Pipeline
 
 ```bash
-# 1. Confirm the scanner can read your project config
-bash scanner/scanner.sh --once
+# 1. Overall health (scanner running, gh auth, projects registered)
+./install.sh status
 
-# 2. Create a test issue
+# 2. Dry-run: confirm the scanner can read your project config
+bash scanner/scanner.sh --dry-run
+
+# 3. Create a test issue
 gh issue create --repo owner/your-repo \
     --title "Test Loop pipeline" \
     --label dev
 
-# 3. Watch the logs
+# 4. Watch the logs
 tail -f /tmp/loop-scanner.log
 
-# 4. Confirm the issue transitions through the label lifecycle:
+# 5. Confirm the issue transitions through the label lifecycle:
 #    dev → in-progress → review-pending → in-review → ready-for-qa → qa-pass → done
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,8 +77,8 @@ actual work.
 | `dev-handler.sh` | `dev` (or workflow-equivalent) on issue | Implements in worktree, opens PR, labels `needs-review` |
 | `review-handler.sh` | `needs-review` on PR | AI reviewer reads diff, approves or requests changes |
 | `dev-rework-handler.sh` | `needs-rework` or `qa-fail` on PR | Re-runs dev agent with rework context |
-| `qa-handler.sh` | `needs-qa` on PR | Runs project's `validation_cmd`; passes/fails |
-| `merge-handler.sh` | `qa-pass` on PR | Squash-merges, closes linked issue, records bounty |
+| `qa-handler.sh` | `needs-qa` on PR | Four-phase smart QA: AC verification, targeted test creation, module regression, `validation_cmd`; posts structured `### QA verification` comment; applies `qa-pass` or `qa-fail` |
+| `merge-handler.sh` | `qa-pass` on PR | Squash-merges, closes linked issue, records bounty; if PR carries `release-pr` label, tags the merged commit and publishes a GitHub release |
 
 Each handler also has a short-name alias (`builder.sh`, `planner.sh`,
 `reviewer.sh`, `reviser.sh`, `tester.sh`, `merger.sh`) that is a thin
@@ -233,6 +233,7 @@ loop/
 │   ├── reviewer.sh                 thin alias → review-handler.sh
 │   ├── tester.sh                   thin alias → qa-handler.sh
 │   ├── merger.sh                   thin alias → merge-handler.sh
+│   ├── auto-release-pr.sh          open/update a "chore: release vX.Y.Z" PR; merge-handler tags + publishes
 │   ├── adopt.sh                    heuristic label-mapping for existing repos
 │   ├── judge.sh                    AI judge — runs after merge
 │   ├── bounty-board.sh             leaderboard CLI

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,16 +4,18 @@
 
 - `gh` CLI authenticated: `gh auth status`
 - `python3` with `pyyaml`: `python3 -c "import yaml"`
-- `claude` CLI installed: `claude --version`
+- One of: `claude`, `codex`, `gemini`, or `aider` CLI installed and on PATH
 - A GitHub repo you want to automate
 
-## Step 1 — Clone and configure
+## Step 1 — Clone and bootstrap
+
+Bootstrap auto-detects your agent and writes `loop.env`. No manual editing
+required for the happy path.
 
 ```bash
 git clone https://github.com/svv2014/loop.git
 cd loop
-cp loop.env.example loop.env
-# Edit loop.env — set log directory and optional integrations
+./install.sh --bootstrap
 ```
 
 ## Step 2 — Add your project
@@ -42,24 +44,19 @@ The dev handler instructs the agent to read this file before every task.
 
 ## Step 4 — Start the scanner
 
-```bash
-# Foreground (testing)
-bash scanner/scanner.sh
-
-# Cron (production)
-echo "*/5 * * * * $(pwd)/scanner/scanner.sh --once" | crontab -
-
-# Optional: reconciler (fixes stuck states)
-echo "*/15 * * * * $(pwd)/scanner/reconciler.sh" | crontab -
-```
-
-## Step 5 — Dry run
+`--bootstrap` registers the scanner and reconciler automatically (launchd
+on macOS, cron on Linux). To start them manually or for testing:
 
 ```bash
+# Foreground (testing / dry-run)
 bash scanner/scanner.sh --dry-run
-```
 
-Shows every event that would be emitted without acting.
+# macOS — restart launchd service
+launchctl kickstart -k gui/$(id -u)/com.user.loop-scanner
+
+# Linux — restart cron wrapper or systemd unit
+systemctl --user restart loop-scanner
+```
 
 ## Step 6 — Create an issue
 

--- a/docs/label-lifecycle.md
+++ b/docs/label-lifecycle.md
@@ -44,7 +44,7 @@ in-review
   │                   │ qa-handler validates (or QA workflow for Loop repo)
   │                   ├── pass ──► approved (qa-pass) ──► merge-handler ──► merged + branch deleted
   │                   │
-  │                   └── fail ──► qa-failed (qa-fail) (requires human or re-dev)
+  │                   └── fail ──► qa-fail (qa-failed) (requires human or re-dev)
   │
   └── reject ──► needs-rework (changes-requested) (back to dev-handler with feedback)
 ```
@@ -69,7 +69,18 @@ Both the new canonical name and its deprecated alias trigger the same event.
 - `done` — issue closed, PR merged. No further events.
 - `blocked` — needs human attention. No automation until a human removes the label.
 - `needs-clarification` — waiting on issue author.
-- `qa-failed` (`qa-fail`) — waiting on human review of the QA failure.
+- `qa-fail` (`qa-failed`) — canonical failure label; waiting on human review. `qa-failed` is the deprecated alias.
+
+## QA handler — four-phase smart verification
+
+The QA handler (`scripts/qa-handler.sh`) performs four phases before reaching a verdict:
+
+1. **AC verification** — reads the issue body, checks each acceptance criterion against the diff
+2. **Targeted test creation** — writes tests for any AC that lacks coverage
+3. **Module regression** — runs existing tests for all modules touched by the PR
+4. **`validation_cmd`** — runs the project's configured validation command (e.g. `npm test`, `make`)
+
+The agent posts a structured `### QA verification` comment on the PR summarising each phase, then applies either `qa-pass` or `qa-fail`. Labels are resolved via `loop_label_for` so per-project overrides are respected.
 
 ## Loop repo (dogfooding)
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -6,11 +6,12 @@ Get from zero to your first merged PR.
 
 - `gh` CLI authenticated (`gh auth status`)
 - `python3` with `pyyaml` (`pip3 install pyyaml`)
-- `claude` CLI installed and authenticated
+- One of: `claude`, `codex`, `gemini`, or `aider` CLI installed and on PATH
 
 ## Step 1 — Clone and bootstrap
 
-Clone Loop and run the one-time setup.
+Clone Loop and run the one-time setup. Bootstrap auto-detects your agent
+and writes `loop.env` — no manual editing required for the happy path.
 
 ```bash
 git clone https://github.com/svv2014/loop.git
@@ -18,21 +19,19 @@ cd loop
 ./install.sh --bootstrap
 ```
 
-## Step 2 — Configure loop.env for Claude
+## Step 2 — Add a GitHub project
 
-Open `loop.env` (created by bootstrap) and set:
-
-```bash
-LOOP_AGENT=claude
-LOOP_AGENT_MODEL=sonnet
-```
-
-## Step 3 — Add a GitHub project
-
-Register your repo with the pipeline.
+Register your repo. This runs a smoke test to confirm the scanner picks
+up the project.
 
 ```bash
 ./install.sh /path/to/your-project
+```
+
+## Step 3 — Check pipeline health
+
+```bash
+./install.sh status
 ```
 
 ## Step 4 — Label an issue


### PR DESCRIPTION
Refreshes documentation to match the v0.2.0 release. No code changes — docs only.

## Changed files

- **README.md** — update Status section from v0.1.0 to v0.2.0; describe four-phase QA in the pipeline flow walkthrough
- **docs/quick-start.md** — reflect 3-command onboarding (bootstrap auto-detects agent; Step 2 is now project registration, Step 3 is `loop status`); remove stale "edit loop.env manually" step
- **docs/architecture.md** — update `qa-handler.sh` description to four-phase smart QA with `### QA verification` comment; update `merge-handler.sh` to mention tag + publish on `release-pr` merge; add `auto-release-pr.sh` to file layout
- **docs/label-lifecycle.md** — fix canonical label name: `qa-fail` (deprecated alias `qa-failed`); add four-phase QA section describing AC verification, targeted test creation, module regression, and `validation_cmd`; note `loop_label_for` resolution
- **docs/getting-started.md** — replace manual `cp loop.env.example loop.env` step with `./install.sh --bootstrap`; update prerequisites to list all supported agents (not just claude); simplify scanner start section to reference `--bootstrap` registration
- **docs/adoption.md** — fix `--auto` flag position (`./install.sh /path --auto`); add smoke test as step 5 of project registration; add `./install.sh status` as first verification step

## Invariants checked

- `bash -n` passes on `lib/*.sh scripts/*.sh scanner/*.sh install.sh`
- `shellcheck -S warning` passes on the same set
- No personal identifiers introduced (CI pattern: `vadim|/Users/vadim|openclaw|suprun`)
- No `lib/`, `scripts/`, `scanner/`, `tests/`, or CHANGELOG touched