### PR TITLE
[LOOP-149] per-project agent/model override + cross-agent fallback chain

### DIFF
--- a/lib/config.sh
+++ b/lib/config.sh
@@ -77,6 +77,22 @@ for p in data.get("projects", []) or []:
         project_authors = p.get("allowed_authors") or global_authors
         authors_str = ",".join(str(a) for a in project_authors)
         print(f"ALLOWED_AUTHORS='{sh(authors_str)}'")
+        # per-project agent/model overrides (empty string means "use global")
+        project_agent = p.get("agent") or ""
+        print(f"_PROJECT_AGENT='{sh(project_agent)}'")
+        # _PROJECT_MODEL: explicit project-level 'model' key (distinct from the
+        # global default_model path used above for LOOP_AGENT_MODEL).
+        raw_project_model = p.get("model") or ""
+        print(f"_PROJECT_MODEL='{sh(raw_project_model)}'")
+        # fallback chain: serialise as newline-delimited "agent|model|cmd" records
+        fallback_entries = p.get("fallback") or []
+        fallback_lines = []
+        for entry in fallback_entries:
+            fa = entry.get("agent") or ""
+            fm = entry.get("model") or ""
+            fc = entry.get("cmd") or ""
+            fallback_lines.append(f"{fa}|{fm}|{fc}")
+        print(f"_PROJECT_FALLBACK='{sh(chr(10).join(fallback_lines))}'")
         # v1 fields
         print(f"WORKFLOW='{sh(workflow)}'")
         print(f"LOOP_LABEL_OVERRIDES='{sh(label_overrides)}'")
@@ -90,7 +106,7 @@ PY
         return 1
     fi
     eval "$out"
-    export NAME REPO ROOT DEFAULT_BRANCH COMMIT_PREFIX DEV_VALIDATION_CMD QA_VALIDATION_CMD QA_BROWSER_URL QA_TIMEOUT_SECONDS HANDLER_TIMEOUT_SECONDS MERGE_STRATEGY AUTO_REBASE BACKEND MAX_CONCURRENT_PRS LOOP_AGENT_MODEL ALLOWED_AUTHORS WORKFLOW LOOP_LABEL_OVERRIDES
+    export NAME REPO ROOT DEFAULT_BRANCH COMMIT_PREFIX DEV_VALIDATION_CMD QA_VALIDATION_CMD QA_BROWSER_URL QA_TIMEOUT_SECONDS HANDLER_TIMEOUT_SECONDS MERGE_STRATEGY AUTO_REBASE BACKEND MAX_CONCURRENT_PRS LOOP_AGENT_MODEL ALLOWED_AUTHORS WORKFLOW LOOP_LABEL_OVERRIDES _PROJECT_AGENT _PROJECT_MODEL _PROJECT_FALLBACK
 }
 
 # loop_list_slugs — print each project slug on its own line

--- a/lib/runner.sh
+++ b/lib/runner.sh
@@ -6,7 +6,17 @@
 #   "codex"    — OpenAI Codex CLI
 #   "gemini"   — Google Gemini CLI
 #   "aider"    — Aider
-#   "custom"   — Custom script (set LOOP_AGENT_CMD)
+#   "custom"   — Custom script (set LOOP_AGENT_CMD or per-project cmd:)
+#
+# Per-project overrides (set by loop_load_project via lib/config.sh):
+#   _PROJECT_AGENT    — overrides LOOP_AGENT for this project
+#   _PROJECT_MODEL    — overrides LOOP_AGENT_MODEL for this project
+#   _PROJECT_FALLBACK — newline-delimited "agent|model|cmd" fallback entries
+#
+# Fallback chain: on recoverable failure (auth error, rate limit, 5xx, network)
+# loop_run_agent walks the fallback list before surfacing the error.
+# Recoverable signals: 401, 403+auth, 429, 5xx, "rate limit", "timeout",
+#   "connection refused", "econnreset", "service unavailable".
 #
 # Usage (from other scripts):
 #   source "$LOOP_ROOT/lib/runner.sh"
@@ -16,22 +26,21 @@
 
 LOOP_AGENT="${LOOP_AGENT:-claude}"
 
-loop_run_agent() {
-    local prompt="$1"
-    local cwd="${2:-$(pwd)}"
+# _loop_invoke_agent <agent> <model> <cmd> <prompt> <cwd>
+# Invokes a single agent attempt. Writes stderr to a temp file so the caller
+# can inspect it for recoverable-signal patterns.
+# Returns the agent's exit code.
+_loop_invoke_agent() {
+    local agent="$1"
+    local model="$2"
+    local cmd="$3"
+    local prompt="$4"
+    local cwd="$5"
 
-    # If a full orchestrator is configured, use it (backward compat)
-    # --mode quick skips the planner's 1800s subtask cap — the dev prompt is
-    # already fully specified, so decomposition only adds latency and timeout risk.
-    if [ -n "${LOOP_ORCHESTRATOR:-}" ] && [ -x "${LOOP_ORCHESTRATOR}" ]; then
-        "$LOOP_ORCHESTRATOR" "$prompt" --mode quick --cwd "$cwd"
-        return $?
-    fi
-
-    case "$LOOP_AGENT" in
+    case "$agent" in
         claude)
             claude -p \
-                --model "${LOOP_AGENT_MODEL:-sonnet}" \
+                --model "${model:-sonnet}" \
                 --output-format text \
                 --dangerously-skip-permissions \
                 --cwd "$cwd" \
@@ -39,34 +48,140 @@ loop_run_agent() {
             ;;
         codex)
             (cd "$cwd" && codex \
-                --model "${LOOP_AGENT_MODEL:-o4-mini}" \
+                --model "${model:-o4-mini}" \
                 --approval-mode full-auto \
                 -q "$prompt")
             ;;
         gemini)
             (cd "$cwd" && gemini \
-                -m "${LOOP_AGENT_MODEL:-gemini-2.5-pro}" \
+                -m "${model:-gemini-2.5-pro}" \
                 --sandbox \
                 -p "$prompt")
             ;;
         aider)
             (cd "$cwd" && aider \
-                --model "${LOOP_AGENT_MODEL:-sonnet}" \
+                --model "${model:-sonnet}" \
                 --yes-always \
                 --message "$prompt")
             ;;
         custom)
-            if [ -z "${LOOP_AGENT_CMD:-}" ]; then
-                echo "ERROR: LOOP_AGENT=custom but LOOP_AGENT_CMD not set" >&2
+            if [ -z "${cmd:-}" ] && [ -z "${LOOP_AGENT_CMD:-}" ]; then
+                echo "ERROR: agent=custom but neither cmd nor LOOP_AGENT_CMD is set" >&2
                 return 2
             fi
-            eval "$LOOP_AGENT_CMD" "$prompt"
+            local _cmd="${cmd:-$LOOP_AGENT_CMD}"
+            eval "$_cmd" "$prompt"
             ;;
         *)
-            echo "ERROR: Unknown LOOP_AGENT='$LOOP_AGENT'. Use: claude, codex, gemini, aider, custom" >&2
+            echo "ERROR: Unknown agent='$agent'. Use: claude, codex, gemini, aider, custom" >&2
             return 2
             ;;
     esac
+}
+
+# _loop_is_recoverable <stderr_text>
+# Returns 0 if the text contains a recoverable-signal pattern.
+_loop_is_recoverable() {
+    local text="$1"
+    echo "$text" | grep -qiE \
+        '(\b401\b|403[^0-9]*auth|auth[^0-9]*403|\b429\b|[^0-9]5[0-9]{2}[^0-9]|rate limit|timeout|connection refused|econnreset|service unavailable)'
+}
+
+# loop_run_agent <prompt> [cwd]
+# Runs the agent with per-project overrides and walks the fallback chain on
+# recoverable errors.
+loop_run_agent() {
+    local prompt="$1"
+    local cwd="${2:-$(pwd)}"
+
+    # Full orchestrator overrides everything (backward compat)
+    if [ -n "${LOOP_ORCHESTRATOR:-}" ] && [ -x "${LOOP_ORCHESTRATOR}" ]; then
+        "$LOOP_ORCHESTRATOR" "$prompt" --mode quick --cwd "$cwd"
+        return $?
+    fi
+
+    # Resolve effective agent/model from per-project override or global default
+    local eff_agent="${_PROJECT_AGENT:-${LOOP_AGENT:-claude}}"
+    local eff_model="${_PROJECT_MODEL:-${LOOP_AGENT_MODEL:-}}"
+    local eff_cmd=""
+
+    # Build fallback list: each entry is "agent|model|cmd"
+    # _PROJECT_FALLBACK is newline-delimited; empty means no fallbacks.
+    local fallback_list="${_PROJECT_FALLBACK:-}"
+
+    local attempt=0
+    local stderr_file
+    stderr_file="$(mktemp)"
+    # shellcheck disable=SC2064
+    trap "rm -f '$stderr_file'" RETURN
+
+    local cur_agent="$eff_agent"
+    local cur_model="$eff_model"
+    local cur_cmd="$eff_cmd"
+    local attempt_log=""
+
+    while true; do
+        attempt=$(( attempt + 1 ))
+        local label
+        if [ "$attempt" -eq 1 ]; then
+            label="primary"
+        else
+            label="fallback $((attempt - 1))"
+        fi
+
+        echo "loop_run_agent: attempt $attempt ($label): agent=${cur_agent} model=${cur_model:-<default>}" >&2
+
+        # Run agent; capture stderr separately while still streaming stdout
+        _loop_invoke_agent "$cur_agent" "$cur_model" "$cur_cmd" "$prompt" "$cwd" \
+            2> >(tee "$stderr_file" >&2)
+        local rc=$?
+
+        if [ $rc -eq 0 ]; then
+            echo "loop_run_agent: attempt $attempt ($label): ok" >&2
+            rm -f "$stderr_file"
+            trap - RETURN
+            return 0
+        fi
+
+        local stderr_tail
+        stderr_tail="$(tail -n 20 "$stderr_file" 2>/dev/null || true)"
+        attempt_log="${attempt_log}  attempt $attempt ($label) agent=${cur_agent} model=${cur_model:-<default>} exit=${rc}"$'\n'
+
+        if ! _loop_is_recoverable "$stderr_tail"; then
+            echo "loop_run_agent: attempt $attempt ($label): unrecoverable error (exit $rc), aborting chain" >&2
+            echo "loop_run_agent: summary of attempts:"$'\n'"${attempt_log}" >&2
+            rm -f "$stderr_file"
+            trap - RETURN
+            return $rc
+        fi
+
+        echo "loop_run_agent: attempt $attempt ($label): recoverable error (exit $rc), checking for next fallback" >&2
+
+        # Advance to next fallback entry
+        if [ -z "$fallback_list" ]; then
+            echo "loop_run_agent: no more fallbacks, chain exhausted" >&2
+            echo "loop_run_agent: summary of attempts:"$'\n'"${attempt_log}" >&2
+            rm -f "$stderr_file"
+            trap - RETURN
+            return $rc
+        fi
+
+        local next_entry
+        next_entry="$(echo "$fallback_list" | head -n1)"
+        fallback_list="$(echo "$fallback_list" | tail -n +2)"
+
+        local next_agent next_model next_cmd
+        next_agent="$(echo "$next_entry" | cut -d'|' -f1)"
+        next_model="$(echo "$next_entry" | cut -d'|' -f2)"
+        next_cmd="$(echo "$next_entry" | cut -d'|' -f3)"
+
+        # Empty fields mean "use previous / global default"
+        [ -n "$next_agent" ] && cur_agent="$next_agent" || cur_agent="${LOOP_AGENT:-claude}"
+        cur_model="$next_model"
+        cur_cmd="$next_cmd"
+
+        echo "loop_run_agent: trying fallback $((attempt)): agent=${cur_agent} model=${cur_model:-<default>}" >&2
+    done
 }
 
 # loop_run_senior_agent <prompt> <cwd>
@@ -81,44 +196,17 @@ loop_run_senior_agent() {
         return $?
     fi
 
-    case "$LOOP_AGENT" in
-        claude)
-            claude -p \
-                --model "${LOOP_SENIOR_MODEL:-${LOOP_AGENT_MODEL:-sonnet}}" \
-                --output-format text \
-                --dangerously-skip-permissions \
-                --cwd "$cwd" \
-                "$prompt"
-            ;;
-        codex)
-            (cd "$cwd" && codex \
-                --model "${LOOP_SENIOR_MODEL:-${LOOP_AGENT_MODEL:-o4-mini}}" \
-                --approval-mode full-auto \
-                -q "$prompt")
-            ;;
-        gemini)
-            (cd "$cwd" && gemini \
-                -m "${LOOP_SENIOR_MODEL:-${LOOP_AGENT_MODEL:-gemini-2.5-pro}}" \
-                --sandbox \
-                -p "$prompt")
-            ;;
-        aider)
-            (cd "$cwd" && aider \
-                --model "${LOOP_SENIOR_MODEL:-${LOOP_AGENT_MODEL:-sonnet}}" \
-                --yes-always \
-                --message "$prompt")
-            ;;
-        custom)
-            echo "WARNING: LOOP_AGENT=custom does not support model override; proceeding without --model flag" >&2
-            if [ -z "${LOOP_AGENT_CMD:-}" ]; then
-                echo "ERROR: LOOP_AGENT=custom but LOOP_AGENT_CMD not set" >&2
-                return 2
-            fi
-            eval "$LOOP_AGENT_CMD" "$prompt"
-            ;;
-        *)
-            echo "ERROR: Unknown LOOP_AGENT='$LOOP_AGENT'. Use: claude, codex, gemini, aider, custom" >&2
-            return 2
-            ;;
-    esac
+    # For the senior agent, override the model with LOOP_SENIOR_MODEL if set.
+    # Per-project agent is still honoured; model escalation applies on top.
+    local save_project_model="${_PROJECT_MODEL:-}"
+    local senior_model="${LOOP_SENIOR_MODEL:-${_PROJECT_MODEL:-${LOOP_AGENT_MODEL:-}}}"
+    _PROJECT_MODEL="$senior_model"
+    export _PROJECT_MODEL
+
+    loop_run_agent "$prompt" "$cwd"
+    local rc=$?
+
+    _PROJECT_MODEL="$save_project_model"
+    export _PROJECT_MODEL
+    return $rc
 }

--- a/loop.env.example
+++ b/loop.env.example
@@ -14,6 +14,22 @@ LOOP_AGENT="claude"
 #   claude: sonnet, codex: o4-mini, gemini: gemini-2.5-pro, aider: sonnet
 # LOOP_AGENT_MODEL="sonnet"
 
+# Per-project agent/model overrides — set these in config/projects.yaml, NOT here.
+# The fields below are the *global* defaults; per-project values (agent:, model:,
+# fallback:) in projects.yaml take precedence and are loaded by loop_load_project.
+# Supported agent values: claude, codex, gemini, aider, custom
+#
+# Example projects.yaml entry with overrides:
+#   - name: My Project
+#     slug: myproject
+#     repo: owner/myproject
+#     agent: codex            # optional; falls back to LOOP_AGENT
+#     model: gpt-5.5          # optional; falls back to LOOP_AGENT_MODEL or per-agent default
+#     fallback:
+#       - { agent: claude, model: sonnet }
+#       - { agent: gemini, model: gemini-2.5-pro }
+#       - { agent: custom, cmd: "ollama run gemma4:e4b" }
+
 # Senior/escalated model (optional). Used by loop_run_senior_agent() for hard problems
 # that warrant a more capable model. Defaults to LOOP_AGENT_MODEL when unset (no escalation).
 # claude default: claude-opus-4-7

--- a/tests/runner-fallback.bats
+++ b/tests/runner-fallback.bats
@@ -1,0 +1,157 @@
+#!/usr/bin/env bats
+# tests/runner-fallback.bats — unit tests for lib/runner.sh fallback chain.
+#
+# All agent CLIs are stubbed; no real network or CLI is required.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    # Stub directory that overrides real agent CLIs
+    STUB_DIR="$BATS_TMPDIR/stubs"
+    mkdir -p "$STUB_DIR"
+
+    # Attempt log: each stub records its invocation
+    ATTEMPTS_LOG="$BATS_TMPDIR/attempts.log"
+    rm -f "$ATTEMPTS_LOG"
+    export ATTEMPTS_LOG
+
+    # Export env expected by runner.sh
+    export LOOP_AGENT="claude"
+    unset LOOP_AGENT_CMD LOOP_ORCHESTRATOR LOOP_SENIOR_MODEL LOOP_AGENT_MODEL
+    unset _PROJECT_AGENT _PROJECT_MODEL _PROJECT_FALLBACK
+
+    # Prepend stubs to PATH
+    export PATH="$STUB_DIR:$PATH"
+
+    # shellcheck source=../lib/runner.sh
+    source "$REPO_ROOT/lib/runner.sh"
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/stubs" "$BATS_TMPDIR/attempts.log" 2>/dev/null || true
+    unset LOOP_AGENT LOOP_AGENT_CMD LOOP_AGENT_MODEL LOOP_ORCHESTRATOR
+    unset _PROJECT_AGENT _PROJECT_MODEL _PROJECT_FALLBACK ATTEMPTS_LOG
+}
+
+# ─── Stub helpers ────────────────────────────────────────────────────────────
+
+# make_stub <name> <exit_code> [stderr_message]
+# Creates an executable stub in $STUB_DIR that logs its name and exits with
+# the given code, optionally printing a message to stderr.
+make_stub() {
+    local name="$1"
+    local exit_code="$2"
+    local stderr_msg="${3:-}"
+    cat > "$STUB_DIR/$name" <<STUB
+#!/usr/bin/env bash
+echo "$name" >> "\$ATTEMPTS_LOG"
+${stderr_msg:+echo "$stderr_msg" >&2}
+exit $exit_code
+STUB
+    chmod +x "$STUB_DIR/$name"
+}
+
+# ─── Tests ───────────────────────────────────────────────────────────────────
+
+@test "primary success — no fallback attempted, exit 0" {
+    make_stub claude 0
+    export LOOP_AGENT="claude"
+    unset _PROJECT_FALLBACK
+
+    run loop_run_agent "do something" "$BATS_TMPDIR"
+    [ "$status" -eq 0 ]
+    # Only one attempt
+    [ "$(wc -l < "$ATTEMPTS_LOG")" -eq 1 ]
+    grep -q "claude" "$ATTEMPTS_LOG"
+}
+
+@test "primary recoverable error (401) — first fallback runs and succeeds, exit 0" {
+    make_stub claude  1 "HTTP 401 Unauthorized"
+    make_stub codex   0
+    export LOOP_AGENT="claude"
+    export _PROJECT_FALLBACK="codex||"
+
+    run loop_run_agent "do something" "$BATS_TMPDIR"
+    [ "$status" -eq 0 ]
+    [ "$(wc -l < "$ATTEMPTS_LOG")" -eq 2 ]
+    grep -q "claude" "$ATTEMPTS_LOG"
+    grep -q "codex"  "$ATTEMPTS_LOG"
+}
+
+@test "two consecutive recoverable errors — third agent (gemini) succeeds, exit 0" {
+    make_stub claude 1 "rate limit exceeded"
+    make_stub codex  1 "429 Too Many Requests"
+    make_stub gemini 0
+    export LOOP_AGENT="claude"
+    export _PROJECT_FALLBACK="$(printf 'codex||\ngemini||')"
+
+    run loop_run_agent "do something" "$BATS_TMPDIR"
+    [ "$status" -eq 0 ]
+    [ "$(wc -l < "$ATTEMPTS_LOG")" -eq 3 ]
+    grep -q "claude" "$ATTEMPTS_LOG"
+    grep -q "codex"  "$ATTEMPTS_LOG"
+    grep -q "gemini" "$ATTEMPTS_LOG"
+}
+
+@test "primary unrecoverable error (no signal pattern) — no fallback, error propagated" {
+    make_stub claude 1 "SyntaxError: unexpected token"
+    make_stub codex  0
+    export LOOP_AGENT="claude"
+    export _PROJECT_FALLBACK="codex||"
+
+    run loop_run_agent "do something" "$BATS_TMPDIR"
+    [ "$status" -ne 0 ]
+    # Only the primary was invoked; codex fallback must NOT run
+    [ "$(wc -l < "$ATTEMPTS_LOG")" -eq 1 ]
+    grep -q "claude" "$ATTEMPTS_LOG"
+    ! grep -q "codex" "$ATTEMPTS_LOG"
+}
+
+@test "all fallbacks exhausted — final non-zero exit propagated with summary" {
+    make_stub claude 1 "503 Service Unavailable"
+    make_stub codex  1 "503 Service Unavailable"
+    make_stub gemini 1 "connection refused"
+    export LOOP_AGENT="claude"
+    export _PROJECT_FALLBACK="$(printf 'codex||\ngemini||')"
+
+    run loop_run_agent "do something" "$BATS_TMPDIR"
+    [ "$status" -ne 0 ]
+    [ "$(wc -l < "$ATTEMPTS_LOG")" -eq 3 ]
+    # Summary line must mention attempts
+    [[ "$output" == *"attempt"* ]]
+}
+
+@test "no agent/model/fallback in project — uses global LOOP_AGENT, no chain" {
+    make_stub claude 0
+    export LOOP_AGENT="claude"
+    unset _PROJECT_AGENT _PROJECT_MODEL _PROJECT_FALLBACK
+
+    run loop_run_agent "do something" "$BATS_TMPDIR"
+    [ "$status" -eq 0 ]
+    [ "$(wc -l < "$ATTEMPTS_LOG")" -eq 1 ]
+    grep -q "claude" "$ATTEMPTS_LOG"
+}
+
+@test "agent: custom fallback runs the configured cmd" {
+    # Primary agent fails recoverably; fallback uses custom cmd (a stub script)
+    make_stub claude 1 "timeout: connection timed out"
+
+    # Custom command is a script that logs and exits 0
+    local custom_script="$BATS_TMPDIR/my-local-model.sh"
+    cat > "$custom_script" <<'SH'
+#!/usr/bin/env bash
+echo "custom-local-model" >> "$ATTEMPTS_LOG"
+exit 0
+SH
+    chmod +x "$custom_script"
+
+    export LOOP_AGENT="claude"
+    # fallback entry: agent=custom, model="", cmd=<path>
+    export _PROJECT_FALLBACK="custom||${custom_script}"
+
+    run loop_run_agent "do something" "$BATS_TMPDIR"
+    [ "$status" -eq 0 ]
+    [ "$(wc -l < "$ATTEMPTS_LOG")" -eq 2 ]
+    grep -q "claude"            "$ATTEMPTS_LOG"
+    grep -q "custom-local-model" "$ATTEMPTS_LOG"
+}


### PR DESCRIPTION
Closes #149

## Changes

### `lib/config.sh`
- `loop_load_project` now exports three new variables from per-project YAML fields:
  - `_PROJECT_AGENT` — optional `agent:` key; empty means use global `LOOP_AGENT`
  - `_PROJECT_MODEL` — optional `model:` key (distinct from `default_model` path)
  - `_PROJECT_FALLBACK` — newline-delimited `agent|model|cmd` records from the `fallback:` list

### `lib/runner.sh`
- `loop_run_agent` now resolves effective agent/model from `_PROJECT_AGENT`/`_PROJECT_MODEL` before falling back to `LOOP_AGENT`/`LOOP_AGENT_MODEL`
- Added internal `_loop_invoke_agent` helper that dispatches all five agent backends (claude/codex/gemini/aider/custom) including per-entry `cmd:` for the custom backend
- Added `_loop_is_recoverable` that checks the last 20 lines of stderr for: `401`, `403+auth`, `429`, `5xx`, `rate limit`, `timeout`, `connection refused`, `econnreset`, `service unavailable`
- `loop_run_agent` walks the fallback list on recoverable errors, logging every attempt; surfaces immediately on unrecoverable errors; propagates non-zero exit when the chain is exhausted
- `loop_run_senior_agent` now delegates to `loop_run_agent` (with `_PROJECT_MODEL` temporarily set to the senior model) so it inherits fallback chain support

### `loop.env.example`
- Documented that `LOOP_AGENT`/`LOOP_AGENT_MODEL` are the global defaults; per-project `agent:`, `model:`, `fallback:` in `projects.yaml` take precedence

### `tests/runner-fallback.bats`
- 7 new bats tests covering all scenarios from the issue spec

## Test Plan
- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — all clean
- `shellcheck -S warning lib/*.sh scripts/*.sh scanner/*.sh install.sh` — no warnings
- `bats tests/runner-fallback.bats` — 7/7 pass
- `bats tests/config.bats` — 13/13 pass (no regressions)