### PR TITLE
[LOOP-152] fix: drop unsupported --cwd flag in claude branch

### DIFF
--- a/lib/runner.sh
+++ b/lib/runner.sh
@@ -39,12 +39,11 @@ _loop_invoke_agent() {
 
     case "$agent" in
         claude)
-            claude -p \
+            (cd "$cwd" && claude -p \
                 --model "${model:-sonnet}" \
                 --output-format text \
                 --dangerously-skip-permissions \
-                --cwd "$cwd" \
-                "$prompt"
+                "$prompt")
             ;;
         codex)
             (cd "$cwd" && codex \

--- a/tests/runner-fallback.bats
+++ b/tests/runner-fallback.bats
@@ -155,3 +155,26 @@ SH
     grep -q "claude"            "$ATTEMPTS_LOG"
     grep -q "custom-local-model" "$ATTEMPTS_LOG"
 }
+
+@test "claude branch never passes --cwd flag (regression of LOOP-29 / LOOP-152)" {
+    # Stub records full argv so we can assert no --cwd is passed.
+    cat > "$STUB_DIR/claude" <<'STUB'
+#!/usr/bin/env bash
+echo "claude $*" >> "$ATTEMPTS_LOG"
+exit 0
+STUB
+    chmod +x "$STUB_DIR/claude"
+
+    export LOOP_AGENT="claude"
+    unset _PROJECT_FALLBACK
+
+    run loop_run_agent "do something" "$BATS_TMPDIR"
+    [ "$status" -eq 0 ]
+    ! grep -q -- "--cwd" "$ATTEMPTS_LOG"
+
+    rm -f "$ATTEMPTS_LOG"
+
+    run loop_run_senior_agent "do something" "$BATS_TMPDIR"
+    [ "$status" -eq 0 ]
+    ! grep -q -- "--cwd" "$ATTEMPTS_LOG"
+}


### PR DESCRIPTION
Closes #152.

## Summary

LOOP-29 originally removed `--cwd` from the claude branch (`claude -p` does not accept it). The LOOP-149 refactor that introduced `_loop_invoke_agent` re-added the flag, so every claude invocation in default config was failing with `error: unknown option '--cwd'`.

This affects **both** `loop_run_agent` and `loop_run_senior_agent`, since both delegate to `_loop_invoke_agent` — broader than the issue body described.

## Change

`lib/runner.sh` claude branch: subshell `(cd "$cwd" && claude -p ...)` instead of the unsupported flag, mirroring LOOP-29.

## Test

Added regression test in `tests/runner-fallback.bats` asserting `--cwd` never appears in the claude argv for either entry point.

```
$ bats tests/runner-fallback.bats
1..8
ok 8 claude branch never passes --cwd flag (regression of LOOP-29 / LOOP-152)
```

All 8 runner-fallback tests pass.