### PR TITLE
[LOOP-160] feat: add reconcile-on-startup entrypoint

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -253,6 +253,25 @@ bootstrap_register_launchd() {
 
     local scanner_plist="$agents_dir/com.user.loop-scanner.plist"
     local reconciler_plist="$agents_dir/com.user.loop-reconciler.plist"
+    local reconcile_plist="$agents_dir/com.user.loop-reconcile.plist"
+
+    # One-shot startup audit (RunAtLoad). Installed before scanner so it
+    # fires once on agent load before the first scan tick.
+    if [ -f "$reconcile_plist" ]; then
+        echo "[launchd] com.user.loop-reconcile already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-reconcile.plist.template" > "$reconcile_plist"
+        if launchctl load "$reconcile_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-reconcile loaded (one-shot at load)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-reconcile (check Console.app)" >&2
+        fi
+    fi
 
     if [ -f "$scanner_plist" ]; then
         echo "[launchd] com.user.loop-scanner already registered — skipping"

--- a/scanner/reconcile.sh
+++ b/scanner/reconcile.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# reconcile.sh — one-shot startup audit of in-flight pipeline state.
+#
+# Runs once at launchd load (RunAtLoad), before the first scanner tick.
+# Iterates every project in config/projects.yaml and lists open issues +
+# PRs through the backend abstraction so downstream child issues can plug
+# in concrete drift / orphan / blocked checks.
+#
+# Today this entrypoint is intentionally observational: it counts what it
+# sees and emits a structured one-line summary so log aggregation can
+# track startup health. All mutation logic lives in scanner/reconciler.sh
+# (the recurring 15-min sweep) and will be incrementally subsumed via
+# follow-up child issues of epic #154.
+#
+# Modes:
+#   reconcile.sh                 # audit all projects
+#   reconcile.sh --slug <slug>   # limit to one project
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+# shellcheck source=../lib/config.sh
+source "$LOOP_ROOT/lib/config.sh"
+# shellcheck source=../lib/backends/backend.sh
+source "$LOOP_ROOT/lib/backends/backend.sh"
+
+LOG_FILE="${LOOP_LOG_DIR}/loop-reconcile.log"
+ONLY_SLUG=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --slug) ONLY_SLUG="$2"; shift 2 ;;
+        -h|--help) sed -n '1,20p' "$0"; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+log() {
+    local line; line="[$(date '+%Y-%m-%d %H:%M:%S')] [reconcile] $*"
+    if [ -t 2 ]; then
+        printf '%s\n' "$line" | tee -a "$LOG_FILE" >&2
+    else
+        printf '%s\n' "$line" >&2
+    fi
+}
+
+# Counters for the summary line. Concrete repair logic plugs in later;
+# today this entrypoint just observes and reports zero across the board.
+DRIFT_REPAIRED=0
+ORPHANS_GC=0
+BLOCKED_REPORTED=0
+
+audit_project() {
+    local slug="$1"
+    loop_load_project "$slug" || { log "skip $slug (config error)"; return 0; }
+    loop_load_backend
+
+    local issues_json prs_json issue_count pr_count
+    issues_json=$(backend_list_open_issues_raw "$REPO" "" 2>/dev/null || echo "[]")
+    prs_json=$(backend_list_open_prs_raw "$REPO" 2>/dev/null || echo "[]")
+    issue_count=$(printf '%s' "$issues_json" \
+        | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))' 2>/dev/null || echo 0)
+    pr_count=$(printf '%s' "$prs_json" \
+        | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))' 2>/dev/null || echo 0)
+
+    log "[$slug] $REPO: open_issues=$issue_count open_prs=$pr_count"
+}
+
+log "=== reconcile start (only_slug=${ONLY_SLUG:-<all>}) ==="
+
+if [ -n "$ONLY_SLUG" ]; then
+    audit_project "$ONLY_SLUG"
+else
+    while IFS= read -r slug; do
+        [ -z "$slug" ] && continue
+        audit_project "$slug"
+    done < <(loop_list_slugs)
+fi
+
+log "reconcile: drift_repaired=${DRIFT_REPAIRED} orphans_gc=${ORPHANS_GC} blocked_reported=${BLOCKED_REPORTED}"
+log "=== reconcile done ==="

--- a/templates/launchd/com.user.loop-reconcile.plist.template
+++ b/templates/launchd/com.user.loop-reconcile.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-reconcile</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/reconcile.sh</string>
+    </array>
+    <!-- One-shot audit at agent load, before the first scanner tick. -->
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-reconcile.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-reconcile.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Closes #160

## Changes
- New `scanner/reconcile.sh` — one-shot audit invoked at launchd load.
  Iterates every project in `config/projects.yaml` via the backend
  abstraction, lists open issues + PRs, and emits a structured one-line
  summary: `reconcile: drift_repaired=N orphans_gc=N blocked_reported=N`.
  Counters are placeholders for downstream child issues (#154 epic) that
  will plug in concrete drift / orphan-GC / blocked-report checks.
- New `templates/launchd/com.user.loop-reconcile.plist.template` with
  `RunAtLoad` true (no `StartInterval` — purely one-shot per agent load).
- `install.sh`: `bootstrap_register_launchd` now installs the new plist
  before the scanner so the audit runs before the first scan tick.
  Idempotent — skips if `com.user.loop-reconcile.plist` already exists.

Today this entrypoint is observational (no mutations); it intentionally
defers all repair logic to `scanner/reconciler.sh` and follow-up child
issues, per the issue's out-of-scope list.

## Test Plan
- [ ] `bash -n` and `shellcheck -S warning` are clean (matches CI).
- [ ] `./scanner/reconcile.sh` runs to completion on a configured host
      and writes a summary line to `~/.loop/logs/loop-reconcile.log`.
- [ ] `./scanner/reconcile.sh --slug <slug>` audits a single project.
- [ ] On a fresh `./install.sh --bootstrap`, the `loop-reconcile` plist
      is loaded and listed by `launchctl list | grep loop-reconcile`.
- [ ] Re-running `./install.sh --bootstrap` reports
      "com.user.loop-reconcile already registered — skipping".