### PR TITLE
[LOOP-161] reconcile-on-startup: GC orphaned /tmp/loop-worktree-* dirs

### DIFF
--- a/lib/recovery.sh
+++ b/lib/recovery.sh
@@ -9,6 +9,7 @@
 #   recovery_check_dependencies <slug>   — unblock when declared deps are merged
 #   recovery_check_stuck_labels <slug>   — strip timed-out operational labels
 #   recovery_prune_orphan_worktrees      — remove worktrees with no handler + no PR
+#   recovery_gc_stale_worktrees          — TTL-based GC of /tmp/loop-worktree-* dirs
 
 set -euo pipefail
 
@@ -381,4 +382,83 @@ recovery_prune_orphan_worktrees() {
             rm -rf "$wt_dir"
         fi
     done
+}
+
+# recovery_gc_stale_worktrees
+#
+# Last-resort garbage collector for /tmp/loop-worktree-* directories left
+# behind by crashed or SIGKILLed handlers. Independent of GitHub state — only
+# considers age and live process ownership.
+#
+# Skips a directory when:
+#   - Its mtime is younger than $LOOP_WORKTREE_TTL seconds (default 21600 = 6h)
+#   - lsof or fuser reports a live process holding any file under it
+#
+# Removes via `git worktree remove --force` (against $ROOT if set) and falls
+# back to `rm -rf`. Honors $DRY_RUN.
+#
+# The scan glob is overridable via $LOOP_WORKTREE_GC_GLOB (default
+# `/tmp/loop-worktree-*`) — this exists so tests can target an isolated
+# directory and never touch real worktrees.
+#
+# Prints the count of GC'd directories on stdout (for the reconcile summary
+# line). All progress messages go through log() to stderr.
+recovery_gc_stale_worktrees() {
+    local ttl="${LOOP_WORKTREE_TTL:-21600}"
+    local glob="${LOOP_WORKTREE_GC_GLOB:-/tmp/loop-worktree-*}"
+    local root="${ROOT:-}"
+    local now_sec gc_count=0
+    now_sec=$(date +%s)
+
+    log "[recovery] GC stale worktrees under ${glob} (ttl=${ttl}s)"
+
+    local wt_dir mtime age
+    for wt_dir in $glob/; do
+        [ -d "$wt_dir" ] || continue
+        wt_dir="${wt_dir%/}"
+
+        mtime=$(python3 -c "import os,sys; print(int(os.stat(sys.argv[1]).st_mtime))" "$wt_dir" 2>/dev/null || echo 0)
+        age=$(( now_sec - mtime ))
+        if [ "$age" -lt "$ttl" ]; then
+            log "[recovery] GC SKIP $wt_dir — within TTL (${age}s < ${ttl}s)"
+            continue
+        fi
+
+        if _recovery_worktree_has_live_owner "$wt_dir"; then
+            log "[recovery] GC SKIP $wt_dir — live process owns a file inside"
+            continue
+        fi
+
+        log "[recovery] GC REMOVE $wt_dir (age=${age}s, no live owner)"
+        if ${DRY_RUN:-false}; then
+            gc_count=$((gc_count + 1))
+            continue
+        fi
+
+        if [ -n "$root" ]; then
+            git -C "$root" worktree remove "$wt_dir" --force 2>/dev/null \
+                || rm -rf "$wt_dir"
+        else
+            rm -rf "$wt_dir"
+        fi
+        gc_count=$((gc_count + 1))
+    done
+
+    printf '%s\n' "$gc_count"
+}
+
+# Returns 0 if any live process holds an open handle inside $1, else 1.
+# Probes lsof first, then fuser; if neither is available, treats the dir as
+# unowned (the TTL alone gates removal in that case).
+_recovery_worktree_has_live_owner() {
+    local dir="$1"
+    if command -v lsof >/dev/null 2>&1; then
+        lsof +D "$dir" >/dev/null 2>&1 && return 0
+        return 1
+    fi
+    if command -v fuser >/dev/null 2>&1; then
+        fuser "$dir" >/dev/null 2>&1 && return 0
+        return 1
+    fi
+    return 1
 }

--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -1259,4 +1259,6 @@ else
     done < <(loop_list_slugs)
 fi
 
-log "=== reconciler done ==="
+orphans_gc=$(recovery_gc_stale_worktrees)
+
+log "=== reconciler done orphans_gc=${orphans_gc} ==="

--- a/tests/reconciler.bats
+++ b/tests/reconciler.bats
@@ -377,3 +377,61 @@ print(t.strftime('%Y-%m-%dT%H:%M:%SZ'))
     [ -d "$wt_dir" ]
     rm -rf "$wt_dir"
 }
+
+# ---------------------------------------------------------------------------
+# recovery_gc_stale_worktrees — TTL-based GC of worktree dirs
+#
+# Tests scope the scan glob to $BATS_TMPDIR/loop-worktree-gc-* via
+# LOOP_WORKTREE_GC_GLOB so they never touch real /tmp/loop-worktree-*
+# directories owned by live handlers.
+# ---------------------------------------------------------------------------
+
+@test "recovery_gc_stale_worktrees: respects TTL — fresh dir is spared" {
+    local sandbox="$BATS_TMPDIR/gc-ttl-fresh"
+    rm -rf "$sandbox"; mkdir -p "$sandbox/loop-worktree-fresh"
+    export LOOP_WORKTREE_GC_GLOB="$sandbox/loop-worktree-*"
+    export LOOP_WORKTREE_TTL=21600
+
+    run recovery_gc_stale_worktrees
+    [ "$status" -eq 0 ]
+    local last_idx=$(( ${#lines[@]} - 1 ))
+    [ "${lines[$last_idx]}" = "0" ]
+    [ -d "$sandbox/loop-worktree-fresh" ]
+    rm -rf "$sandbox"
+    unset LOOP_WORKTREE_GC_GLOB LOOP_WORKTREE_TTL
+}
+
+@test "recovery_gc_stale_worktrees: removes stale dir past TTL" {
+    local sandbox="$BATS_TMPDIR/gc-ttl-stale"
+    rm -rf "$sandbox"; mkdir -p "$sandbox/loop-worktree-stale"
+    python3 -c "import os; os.utime('$sandbox/loop-worktree-stale', (0, 0))"
+    export LOOP_WORKTREE_GC_GLOB="$sandbox/loop-worktree-*"
+    export LOOP_WORKTREE_TTL=1
+
+    run recovery_gc_stale_worktrees
+    [ "$status" -eq 0 ]
+    local last_idx=$(( ${#lines[@]} - 1 ))
+    [ "${lines[$last_idx]}" = "1" ]
+    [ ! -d "$sandbox/loop-worktree-stale" ]
+    rm -rf "$sandbox"
+    unset LOOP_WORKTREE_GC_GLOB LOOP_WORKTREE_TTL
+}
+
+@test "recovery_gc_stale_worktrees: spares dir with live PID owner" {
+    local sandbox="$BATS_TMPDIR/gc-live-owner"
+    rm -rf "$sandbox"; mkdir -p "$sandbox/loop-worktree-live"
+    python3 -c "import os; os.utime('$sandbox/loop-worktree-live', (0, 0))"
+    export LOOP_WORKTREE_GC_GLOB="$sandbox/loop-worktree-*"
+    export LOOP_WORKTREE_TTL=1
+
+    # Stub the owner-probe to claim a live process holds the dir.
+    _recovery_worktree_has_live_owner() { return 0; }
+
+    run recovery_gc_stale_worktrees
+    [ "$status" -eq 0 ]
+    local last_idx=$(( ${#lines[@]} - 1 ))
+    [ "${lines[$last_idx]}" = "0" ]
+    [ -d "$sandbox/loop-worktree-live" ]
+    rm -rf "$sandbox"
+    unset LOOP_WORKTREE_GC_GLOB LOOP_WORKTREE_TTL
+}


### PR DESCRIPTION
Closes #161

## Changes
- Added `recovery_gc_stale_worktrees` in `lib/recovery.sh`: TTL-based last-resort GC for `/tmp/loop-worktree-*` directories left behind by crashed/SIGKILLed handlers. Independent of GitHub state — gates removal on age + live-process ownership only.
  - TTL via `LOOP_WORKTREE_TTL` (default 21600s = 6h)
  - Live-owner probe via `lsof +D` then `fuser` fallback
  - Removal via `git worktree remove --force` then `rm -rf` fallback
  - Honors `DRY_RUN`; prints GC count on stdout
  - Scan glob overridable via `LOOP_WORKTREE_GC_GLOB` (defaults to `/tmp/loop-worktree-*`) — exists so tests can target an isolated sandbox and never touch real worktrees
- `scanner/reconciler.sh`: invoke the GC after the per-project loop and surface the count in the final summary line as `orphans_gc=N`
- Bats coverage in `tests/reconciler.bats`: TTL respected, live-PID dir spared, stale dir removed

## Test Plan
- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh`
- `bats tests/reconciler.bats` — all 18 tests pass (3 new)
- `shellcheck -S warning lib/recovery.sh scanner/reconciler.sh` — clean
- Manual: `LOOP_WORKTREE_GC_GLOB=/tmp/sandbox-* LOOP_WORKTREE_TTL=1 ./scanner/reconciler.sh --dry-run` reports `orphans_gc=N` in the done line