### PR TITLE
[LOOP-164] reconciler: surface author-gated tickets via digest + status counter

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -566,6 +566,19 @@ for p in (data.get('projects') or []):
         echo "  [--]  config/projects.yaml not found — no projects registered"
     fi
 
+    # 8. Author-gate digest — counter populated by reconciler each tick
+    local agated_dir="$log_dir/author-gated"
+    if [ -d "$agated_dir" ]; then
+        local total_gated=0 _f _n
+        for _f in "$agated_dir"/*.count; do
+            [ -f "$_f" ] || continue
+            _n=$(tr -d '[:space:]' < "$_f" 2>/dev/null || echo 0)
+            [ -n "$_n" ] || _n=0
+            total_gated=$(( total_gated + _n ))
+        done
+        echo "  [--]  author_gated_pending=$total_gated"
+    fi
+
     echo "─────────────────────────────────────────────────"
     if $all_ok; then
         echo "  All checks passed."

--- a/lib/author_gate.sh
+++ b/lib/author_gate.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# lib/author_gate.sh — author-gate digest helpers for the reconciler.
+#
+# When ALLOWED_AUTHORS is configured for a project, the scanner silently
+# skips any issue/PR opened by an author outside that allow-list. Operators
+# have no easy way to see what is parked. This helper produces a structured
+# one-line-per-ticket summary and a per-slug counter that `loop status`
+# surfaces as `author_gated_pending=N`.
+#
+# Tickets carrying the `operator-approved` label are treated as bypassed
+# (handled by the sibling override-label issue) and are excluded from the
+# digest.
+
+# State directory holding per-slug counter files. Defaults under LOOP_LOG_DIR
+# but can be overridden in tests.
+: "${LOOP_AUTHOR_GATED_DIR:=${LOOP_LOG_DIR:-/tmp}/author-gated}"
+
+# author_gate_state_dir
+# Echo the directory used to persist per-slug counters.
+author_gate_state_dir() {
+    printf '%s\n' "$LOOP_AUTHOR_GATED_DIR"
+}
+
+# author_gate_count_file <slug>
+author_gate_count_file() {
+    printf '%s/%s.count\n' "$LOOP_AUTHOR_GATED_DIR" "$1"
+}
+
+# author_gate_pending_total
+# Sum the pending counts across every slug. Empty / missing dir → 0.
+author_gate_pending_total() {
+    local total=0 f n
+    [ -d "$LOOP_AUTHOR_GATED_DIR" ] || { echo 0; return 0; }
+    for f in "$LOOP_AUTHOR_GATED_DIR"/*.count; do
+        [ -f "$f" ] || continue
+        n=$(tr -d '[:space:]' < "$f" 2>/dev/null || echo 0)
+        [ -n "$n" ] || n=0
+        total=$(( total + n ))
+    done
+    echo "$total"
+}
+
+# reconcile_author_gated <slug> <repo>
+# Emits one structured log line per gated ticket and writes the count to a
+# state file consumed by `loop status`. Dedup is per (slug, number) so an
+# entry that appears in both the issues and PRs query (shared numbering) is
+# only reported once. Requires globals: ALLOWED_AUTHORS, log().
+reconcile_author_gated() {
+    local slug="$1" repo="$2"
+
+    mkdir -p "$LOOP_AUTHOR_GATED_DIR"
+    local count_file
+    count_file=$(author_gate_count_file "$slug")
+
+    if [ -z "${ALLOWED_AUTHORS:-}" ]; then
+        # No gate configured — clear any stale counter and exit.
+        echo 0 > "$count_file"
+        return 0
+    fi
+
+    log "[$repo] scanning author-gated tickets (allow-list=${ALLOWED_AUTHORS})"
+
+    local issues_json prs_json
+    issues_json=$(gh issue list --repo "$repo" --state open --limit 200 \
+        --json number,title,labels,author,createdAt 2>/dev/null || echo "[]")
+    prs_json=$(gh pr list --repo "$repo" --state open --limit 200 \
+        --json number,title,labels,author,createdAt 2>/dev/null || echo "[]")
+
+    local digest
+    digest=$(SLUG="$slug" ALLOWED="$ALLOWED_AUTHORS" \
+             ISSUES="$issues_json" PRS="$prs_json" python3 - <<'PY'
+import json, os, datetime as dt
+
+slug = os.environ['SLUG']
+allowed = {a.strip() for a in os.environ['ALLOWED'].split(',') if a.strip()}
+issues = json.loads(os.environ['ISSUES'] or '[]')
+prs = json.loads(os.environ['PRS'] or '[]')
+now = dt.datetime.now(dt.timezone.utc)
+
+seen = set()
+lines = []
+for items in (issues, prs):
+    for it in items:
+        num = it.get('number')
+        if num is None:
+            continue
+        key = (slug, num)
+        if key in seen:
+            continue
+        author_obj = it.get('author') or {}
+        author = author_obj.get('login') or author_obj.get('name') or ''
+        if not author or author in allowed:
+            continue
+        labels = {
+            (l.get('name') if isinstance(l, dict) else l)
+            for l in (it.get('labels') or [])
+        }
+        if 'operator-approved' in labels:
+            continue
+        try:
+            ts = dt.datetime.fromisoformat(
+                (it.get('createdAt') or '').replace('Z', '+00:00'))
+            age_h = max(0, int((now - ts).total_seconds() // 3600))
+        except Exception:
+            age_h = 0
+        title = (it.get('title') or '').replace('\n', ' ').strip()[:80]
+        seen.add(key)
+        lines.append(
+            f"author_gated: slug={slug} num={num} author={author} "
+            f"age={age_h}h title={title}")
+
+for line in lines:
+    print(line)
+PY
+)
+
+    local count=0
+    if [ -n "$digest" ]; then
+        while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            log "$line"
+            count=$(( count + 1 ))
+        done <<< "$digest"
+    fi
+
+    echo "$count" > "$count_file"
+    log "[$repo] author_gated_pending=$count (slug=$slug)"
+}

--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -30,6 +30,8 @@ source "$LOOP_ROOT/lib/config.sh"
 source "$LOOP_ROOT/lib/backends/backend.sh"
 # shellcheck source=../lib/recovery.sh
 source "$LOOP_ROOT/lib/recovery.sh"
+# shellcheck source=../lib/author_gate.sh
+source "$LOOP_ROOT/lib/author_gate.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-reconciler.log"
 LOCK_FILE="/tmp/loop-reconciler.lock"
@@ -1224,6 +1226,7 @@ run_project() {
     reconcile_stale_base "$REPO"
     reconcile_stale_blocked_issues "$REPO"
     reconcile_qa_failures "$REPO"
+    reconcile_author_gated "$slug" "$REPO"
     recovery_check_dependencies "$slug"
     reconcile_worktrees "$slug" "$REPO"
     recovery_check_stuck_labels "$slug"

--- a/tests/author_gated.bats
+++ b/tests/author_gated.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+# tests/author_gated.bats — unit tests for lib/author_gate.sh
+#
+# Stubs gh as a shell function so no real GitHub calls are made. Covers:
+#   - dedup per (slug, number) when an entry surfaces in both queries
+#   - counter file written for `loop status` consumption
+#   - operator-approved label bypasses the gate
+#   - empty ALLOWED_AUTHORS short-circuits to count=0
+#   - allow-listed authors are excluded
+#   - author_gate_pending_total sums per-slug counters
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    export LOOP_AUTHOR_GATED_DIR="$BATS_TMPDIR/author-gated"
+    mkdir -p "$LOOP_LOG_DIR" "$LOOP_AUTHOR_GATED_DIR"
+
+    export LOG_LINES="$BATS_TMPDIR/log.out"
+    : > "$LOG_LINES"
+
+    # Capture log output for assertions.
+    log() { printf '%s\n' "$*" >> "$LOG_LINES"; }
+    export -f log
+
+    # gh stub: returns canned JSON keyed off the subcommand.
+    # GH_ISSUES_JSON / GH_PRS_JSON drive the responses.
+    gh() {
+        case "$1" in
+            issue) printf '%s' "${GH_ISSUES_JSON:-[]}" ;;
+            pr)    printf '%s' "${GH_PRS_JSON:-[]}"    ;;
+            *)     return 0 ;;
+        esac
+    }
+    export -f gh
+
+    # shellcheck source=../lib/author_gate.sh
+    source "$REPO_ROOT/lib/author_gate.sh"
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/author-gated" \
+           "$BATS_TMPDIR/log.out" 2>/dev/null || true
+    unset -f log gh 2>/dev/null || true
+}
+
+@test "reconcile_author_gated: emits one line per gated ticket and writes count" {
+    export ALLOWED_AUTHORS="alice,bob"
+    export GH_ISSUES_JSON='[
+        {"number": 10, "title": "Outsider issue", "labels": [],
+         "author": {"login": "mallory"}, "createdAt": "2026-04-29T00:00:00Z"},
+        {"number": 11, "title": "Bob issue",     "labels": [],
+         "author": {"login": "bob"},     "createdAt": "2026-04-29T00:00:00Z"}
+    ]'
+    export GH_PRS_JSON='[
+        {"number": 20, "title": "Outsider PR",   "labels": [],
+         "author": {"login": "eve"},     "createdAt": "2026-04-29T00:00:00Z"}
+    ]'
+
+    run reconcile_author_gated "alpha" "owner/alpha"
+    [ "$status" -eq 0 ]
+
+    grep -q "author_gated: slug=alpha num=10 author=mallory" "$LOG_LINES"
+    grep -q "author_gated: slug=alpha num=20 author=eve"     "$LOG_LINES"
+    ! grep -q "author_gated: .* num=11 "                     "$LOG_LINES"
+
+    [ "$(cat "$LOOP_AUTHOR_GATED_DIR/alpha.count")" = "2" ]
+}
+
+@test "reconcile_author_gated: dedups (slug, number) across issues + PRs" {
+    export ALLOWED_AUTHORS="alice"
+    # Same number 42 appears in both queries (impossible on GH, but we still
+    # protect the digest from double-emitting on edge-case backends).
+    export GH_ISSUES_JSON='[
+        {"number": 42, "title": "dup", "labels": [],
+         "author": {"login": "mallory"}, "createdAt": "2026-04-29T00:00:00Z"}
+    ]'
+    export GH_PRS_JSON='[
+        {"number": 42, "title": "dup", "labels": [],
+         "author": {"login": "mallory"}, "createdAt": "2026-04-29T00:00:00Z"}
+    ]'
+
+    run reconcile_author_gated "beta" "owner/beta"
+    [ "$status" -eq 0 ]
+
+    [ "$(grep -c "num=42" "$LOG_LINES")" = "1" ]
+    [ "$(cat "$LOOP_AUTHOR_GATED_DIR/beta.count")" = "1" ]
+}
+
+@test "reconcile_author_gated: operator-approved label bypasses the gate" {
+    export ALLOWED_AUTHORS="alice"
+    export GH_ISSUES_JSON='[
+        {"number": 5, "title": "approved",
+         "labels": [{"name":"operator-approved"}],
+         "author": {"login": "mallory"}, "createdAt": "2026-04-29T00:00:00Z"}
+    ]'
+    export GH_PRS_JSON='[]'
+
+    run reconcile_author_gated "alpha" "owner/alpha"
+    [ "$status" -eq 0 ]
+
+    ! grep -q "num=5" "$LOG_LINES"
+    [ "$(cat "$LOOP_AUTHOR_GATED_DIR/alpha.count")" = "0" ]
+}
+
+@test "reconcile_author_gated: empty ALLOWED_AUTHORS short-circuits to count=0" {
+    export ALLOWED_AUTHORS=""
+    export GH_ISSUES_JSON='[
+        {"number": 9, "title": "anything",
+         "labels": [], "author": {"login": "mallory"},
+         "createdAt": "2026-04-29T00:00:00Z"}
+    ]'
+    export GH_PRS_JSON='[]'
+
+    run reconcile_author_gated "alpha" "owner/alpha"
+    [ "$status" -eq 0 ]
+
+    ! grep -q "author_gated:" "$LOG_LINES"
+    [ "$(cat "$LOOP_AUTHOR_GATED_DIR/alpha.count")" = "0" ]
+}
+
+@test "author_gate_pending_total: sums per-slug counters" {
+    echo 3 > "$LOOP_AUTHOR_GATED_DIR/alpha.count"
+    echo 5 > "$LOOP_AUTHOR_GATED_DIR/beta.count"
+    echo 0 > "$LOOP_AUTHOR_GATED_DIR/gamma.count"
+
+    run author_gate_pending_total
+    [ "$status" -eq 0 ]
+    [ "$output" = "8" ]
+}
+
+@test "author_gate_pending_total: missing dir returns 0" {
+    rm -rf "$LOOP_AUTHOR_GATED_DIR"
+    run author_gate_pending_total
+    [ "$status" -eq 0 ]
+    [ "$output" = "0" ]
+}


### PR DESCRIPTION
Closes #164

## Changes

- New `lib/author_gate.sh` helper:
  - `reconcile_author_gated <slug> <repo>` queries open issues + PRs whose author is not in `ALLOWED_AUTHORS` and which lack the `operator-approved` bypass label, then logs one structured line per ticket: `author_gated: slug=<s> num=<N> author=<a> age=<h>h title=<t>`. Dedup is keyed on `(slug, number)` so a ticket cannot double-emit within a single run.
  - Per-slug counter file under `${LOOP_LOG_DIR}/author-gated/<slug>.count`.
  - `author_gate_pending_total` aggregator for CLI consumers.
- `scanner/reconciler.sh` sources the helper and invokes `reconcile_author_gated` once per project per tick.
- `install.sh status` (i.e. `loop status`) now prints `author_gated_pending=N` summed across all slug counters so operators see at a glance how many tickets are parked behind the allow-list.
- `tests/author_gated.bats` — 6 cases covering dedup, counter file, `operator-approved` bypass, empty allow-list short-circuit, and the total aggregator.

The Loop Monitor dashboard tab consumes the same `author_gated:` log line — no monitor-side change required (per the issue's scope note). The companion `operator-approved` honoring change is tracked in the sibling child issue and explicitly out of scope here.

## Test Plan

- [x] `bash -n` clean across `lib/*.sh scripts/*.sh scanner/*.sh install.sh`
- [x] `shellcheck -S warning` clean on touched files
- [x] `bats tests/author_gated.bats` — 6/6 passing
- [ ] On a project with `ALLOWED_AUTHORS` set, run `./scanner/reconciler.sh --slug <slug>` and confirm `author_gated:` lines appear in `~/.loop/logs/loop-reconciler.log`
- [ ] Run `./install.sh status` and confirm an `author_gated_pending=N` line is printed