### PR TITLE
[LOOP-170] feat: add migrate-labels.sh for deprecated→canonical label migration

### DIFF
--- a/scripts/migrate-labels.sh
+++ b/scripts/migrate-labels.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# migrate-labels.sh — one-shot per-project deprecated→canonical label migration.
+#
+# Walks projects in config/projects.yaml, re-tags every open issue/PR that
+# carries a deprecated alias with the canonical label, then deletes the
+# deprecated label definition from the repo.
+#
+# Usage:
+#   scripts/migrate-labels.sh --slug <s>           # one project (dry-run by default)
+#   scripts/migrate-labels.sh --all                # every project
+#   scripts/migrate-labels.sh --slug <s> --apply   # actually mutate
+#   scripts/migrate-labels.sh --all --apply
+#
+# Idempotent: a second --all run after a clean migration produces zero changes.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROJECTS_YAML="${LOOP_CONFIG:-$LOOP_ROOT/config/projects.yaml}"
+
+TARGET_SLUG=""
+ALL=false
+APPLY=false
+
+usage() {
+    sed -n '1,15p' "$0"
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --slug=*) TARGET_SLUG="${1#--slug=}"; shift ;;
+        --slug)   TARGET_SLUG="${2:-}"; shift 2 ;;
+        --all)    ALL=true; shift ;;
+        --dry-run) APPLY=false; shift ;;
+        --apply)  APPLY=true; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+if ! $ALL && [ -z "$TARGET_SLUG" ]; then
+    echo "error: pass --slug <s> or --all" >&2
+    usage >&2
+    exit 2
+fi
+
+if [ ! -f "$PROJECTS_YAML" ]; then
+    echo "error: projects config not found at $PROJECTS_YAML" >&2
+    exit 2
+fi
+
+# Deprecated alias → canonical name.
+# Keep this list in sync with the canonical vocabulary in scripts/label-audit.sh.
+DEPRECATED_TO_CANONICAL=(
+    "plan:po-review"
+    "build:dev"
+    "needs-review:review-pending"
+    "needs-qa:ready-for-qa"
+    "approved:qa-pass"
+    "qa-failed:qa-fail"
+    "needs-rework:changes-requested"
+)
+
+canonical_for() {
+    local dep="$1" entry
+    for entry in "${DEPRECATED_TO_CANONICAL[@]}"; do
+        if [ "${entry%%:*}" = "$dep" ]; then
+            echo "${entry#*:}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Collect target slugs.
+slugs=()
+if $ALL; then
+    while IFS= read -r s; do
+        [ -n "$s" ] && slugs+=("$s")
+    done < <(python3 - "$PROJECTS_YAML" <<'PY'
+import sys, yaml
+with open(sys.argv[1]) as f:
+    data = yaml.safe_load(f) or {}
+for p in data.get("projects", []) or []:
+    s = p.get("slug")
+    if s:
+        print(s)
+PY
+)
+else
+    slugs=("$TARGET_SLUG")
+fi
+
+if [ ${#slugs[@]} -eq 0 ]; then
+    echo "no projects found in $PROJECTS_YAML" >&2
+    exit 0
+fi
+
+repo_for_slug() {
+    python3 - "$PROJECTS_YAML" "$1" <<'PY'
+import sys, yaml
+with open(sys.argv[1]) as f:
+    data = yaml.safe_load(f) or {}
+for p in data.get("projects", []) or []:
+    if p.get("slug") == sys.argv[2]:
+        print(p.get("repo", ""))
+        break
+PY
+}
+
+mode_label="dry-run"
+$APPLY && mode_label="apply"
+
+overall_rc=0
+
+for slug in "${slugs[@]}"; do
+    repo=$(repo_for_slug "$slug")
+    if [ -z "$repo" ]; then
+        echo "[WARN] slug '$slug' not found in $PROJECTS_YAML — skipping" >&2
+        overall_rc=1
+        continue
+    fi
+
+    echo "── $slug ($repo) [$mode_label] ─────────────"
+
+    # Fetch existing label names on the repo.
+    existing=$(gh label list --repo "$repo" --limit 200 --json name --jq '.[].name' 2>/dev/null || true)
+
+    renamed=0
+    deleted=0
+
+    for entry in "${DEPRECATED_TO_CANONICAL[@]}"; do
+        dep="${entry%%:*}"
+        canon="${entry#*:}"
+
+        if ! grep -Fxq "$dep" <<<"$existing"; then
+            continue
+        fi
+
+        # Find open issues/PRs still tagged with the deprecated alias.
+        items_json=$(gh issue list --repo "$repo" --state open --label "$dep" --limit 500 \
+                       --json number 2>/dev/null || echo "[]")
+        prs_json=$(gh pr list --repo "$repo" --state open --label "$dep" --limit 500 \
+                       --json number 2>/dev/null || echo "[]")
+
+        issue_nums=$(echo "$items_json" | python3 -c 'import sys, json; [print(i["number"]) for i in json.load(sys.stdin)]' 2>/dev/null || true)
+        pr_nums=$(echo "$prs_json" | python3 -c 'import sys, json; [print(i["number"]) for i in json.load(sys.stdin)]' 2>/dev/null || true)
+
+        for n in $issue_nums; do
+            echo "  rename #$n: $dep → $canon"
+            if $APPLY; then
+                gh issue edit "$n" --repo "$repo" --add-label "$canon" --remove-label "$dep" >/dev/null \
+                    || { echo "    [WARN] failed to retag issue #$n" >&2; overall_rc=1; continue; }
+            fi
+            renamed=$((renamed + 1))
+        done
+        for n in $pr_nums; do
+            echo "  rename PR #$n: $dep → $canon"
+            if $APPLY; then
+                gh pr edit "$n" --repo "$repo" --add-label "$canon" --remove-label "$dep" >/dev/null \
+                    || { echo "    [WARN] failed to retag PR #$n" >&2; overall_rc=1; continue; }
+            fi
+            renamed=$((renamed + 1))
+        done
+
+        # Verify nothing still carries the deprecated label before deleting it.
+        # In dry-run we can only delete safely if there were zero items to start with.
+        remaining_issues="0"
+        remaining_prs="0"
+        if $APPLY; then
+            remaining_issues=$(gh issue list --repo "$repo" --state open --label "$dep" --limit 1 \
+                                  --json number --jq 'length' 2>/dev/null || echo "0")
+            remaining_prs=$(gh pr list --repo "$repo" --state open --label "$dep" --limit 1 \
+                                  --json number --jq 'length' 2>/dev/null || echo "0")
+        else
+            # In dry-run: only "safe to delete" if nothing currently uses it.
+            remaining_issues=$(echo "$items_json" | python3 -c 'import sys,json; print(len(json.load(sys.stdin)))' 2>/dev/null || echo "0")
+            remaining_prs=$(echo "$prs_json" | python3 -c 'import sys,json; print(len(json.load(sys.stdin)))' 2>/dev/null || echo "0")
+        fi
+
+        if [ "$remaining_issues" = "0" ] && [ "$remaining_prs" = "0" ]; then
+            echo "  delete label: $dep"
+            if $APPLY; then
+                if gh label delete "$dep" --repo "$repo" --yes >/dev/null 2>&1; then
+                    deleted=$((deleted + 1))
+                else
+                    echo "    [WARN] failed to delete label '$dep' (perms? still in use?)" >&2
+                    overall_rc=1
+                fi
+            else
+                deleted=$((deleted + 1))
+            fi
+        else
+            echo "  [SKIP] label '$dep' still attached (issues=$remaining_issues prs=$remaining_prs) — not deleting"
+            overall_rc=1
+        fi
+    done
+
+    echo "migrate-labels slug=$slug renamed=$renamed deleted=$deleted"
+done
+
+exit "$overall_rc"

--- a/tests/migrate-labels.bats
+++ b/tests/migrate-labels.bats
@@ -1,0 +1,136 @@
+#!/usr/bin/env bats
+# tests/migrate-labels.bats — unit tests for scripts/migrate-labels.sh.
+#
+# Stubs `gh` via a fake binary on PATH so no real GitHub calls are made.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    SCRIPT="$REPO_ROOT/scripts/migrate-labels.sh"
+
+    cat > "$BATS_TMPDIR/projects.yaml" <<'YAML'
+version: 1
+projects:
+  - slug: alpha
+    name: Alpha
+    repo: owner/alpha
+    root: /tmp/fake
+    default_branch: main
+    workflow: default
+YAML
+    export LOOP_CONFIG="$BATS_TMPDIR/projects.yaml"
+
+    # Fake gh binary: dispatches on first two args.
+    BIN_DIR="$BATS_TMPDIR/bin"
+    mkdir -p "$BIN_DIR"
+    export GH_LOG="$BATS_TMPDIR/gh.log"
+    rm -f "$GH_LOG"
+    export GH_LABEL_LIST="${GH_LABEL_LIST:-}"
+    export GH_ISSUE_NUMS="${GH_ISSUE_NUMS:-}"
+    export GH_PR_NUMS="${GH_PR_NUMS:-}"
+
+    cat > "$BIN_DIR/gh" <<'SH'
+#!/usr/bin/env bash
+printf 'gh %s\n' "$*" >> "$GH_LOG"
+case "$1 $2" in
+  "label list")
+        # emit one name per line as `--jq '.[].name'` would
+        printf '%s\n' $GH_LABEL_LIST
+        ;;
+  "issue list"|"pr list")
+        if [ "$1" = "issue" ]; then nums="$GH_ISSUE_NUMS"; else nums="$GH_PR_NUMS"; fi
+        # If invoked with `--jq length` (used by the script for re-check), emit a count.
+        want_length=0
+        for a in "$@"; do
+            if [ "$a" = "length" ]; then want_length=1; break; fi
+        done
+        if [ $want_length -eq 1 ]; then
+            count=0
+            for n in $nums; do count=$((count + 1)); done
+            printf '%s\n' "$count"
+        else
+            printf '['
+            first=1
+            for n in $nums; do
+                if [ $first -eq 1 ]; then first=0; else printf ','; fi
+                printf '{"number":%s}' "$n"
+            done
+            printf ']\n'
+        fi
+        ;;
+  "issue edit"|"pr edit"|"label delete")
+        : # success
+        ;;
+esac
+exit 0
+SH
+    chmod +x "$BIN_DIR/gh"
+    export PATH="$BIN_DIR:$PATH"
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/projects.yaml" "$BATS_TMPDIR/gh.log"
+}
+
+@test "rejects invocation without --slug or --all" {
+    run bash "$SCRIPT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"--slug"* ]]
+}
+
+@test "dry-run: no deprecated labels present → zero changes" {
+    export GH_LABEL_LIST="po-review dev review-pending ready-for-qa qa-pass qa-fail changes-requested"
+    run bash "$SCRIPT" --slug alpha
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"renamed=0 deleted=0"* ]]
+    # No mutating gh calls.
+    run grep -E "issue edit|pr edit|label delete" "$GH_LOG"
+    [ "$status" -ne 0 ]
+}
+
+@test "dry-run: deprecated label with no open items → reports planned delete, no mutation" {
+    export GH_LABEL_LIST="plan po-review dev"
+    export GH_ISSUE_NUMS=""
+    export GH_PR_NUMS=""
+    run bash "$SCRIPT" --slug alpha
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"delete label: plan"* ]]
+    [[ "$output" == *"renamed=0 deleted=1"* ]]
+    # dry-run must not actually call label delete
+    run grep "label delete" "$GH_LOG"
+    [ "$status" -ne 0 ]
+}
+
+@test "dry-run: deprecated label with open issues → reports planned renames, skips delete" {
+    export GH_LABEL_LIST="needs-review review-pending"
+    export GH_ISSUE_NUMS="42 43"
+    export GH_PR_NUMS="100"
+    run bash "$SCRIPT" --slug alpha
+    [ "$status" -ne 0 ]   # nonzero because label could not be safely deleted
+    [[ "$output" == *"rename #42: needs-review → review-pending"* ]]
+    [[ "$output" == *"rename PR #100: needs-review → review-pending"* ]]
+    [[ "$output" == *"renamed=3"* ]]
+    [[ "$output" == *"[SKIP] label 'needs-review' still attached"* ]]
+}
+
+@test "apply: invokes gh label delete when label is unused" {
+    export GH_LABEL_LIST="approved qa-pass"
+    export GH_ISSUE_NUMS=""
+    export GH_PR_NUMS=""
+    run bash "$SCRIPT" --slug alpha --apply
+    [ "$status" -eq 0 ]
+    run grep "label delete approved" "$GH_LOG"
+    [ "$status" -eq 0 ]
+}
+
+@test "unknown slug fails gracefully" {
+    run bash "$SCRIPT" --slug nope
+    [[ "$output" == *"slug 'nope' not found"* ]]
+}
+
+@test "summary line format matches spec" {
+    export GH_LABEL_LIST="po-review dev"
+    run bash "$SCRIPT" --slug alpha
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ migrate-labels\ slug=alpha\ renamed=[0-9]+\ deleted=[0-9]+ ]]
+}


### PR DESCRIPTION
Closes #170

## Changes
- New `scripts/migrate-labels.sh` walks projects in `config/projects.yaml` and migrates deprecated label aliases (`plan`, `build`, `needs-review`, `needs-qa`, `approved`, `qa-failed`, `needs-rework`) to their canonical counterparts (`po-review`, `dev`, `review-pending`, `ready-for-qa`, `qa-pass`, `qa-fail`, `changes-requested`).
- Accepts `--slug <s>` or `--all`; defaults to dry-run, applies only with `--apply`.
- Re-tags every open issue / PR carrying a deprecated label, then deletes the label definition — but only after verifying nothing still references it (so partial runs are safe).
- Emits the per-project summary `migrate-labels slug=<s> renamed=N deleted=N`.
- Idempotent: a clean second `--all` run produces zero changes and exits 0.
- New `tests/migrate-labels.bats` covers arg validation, dry-run, apply, skip-when-attached, and summary format with a stubbed `gh` binary on PATH.

The deprecated→canonical map is inlined for now; if Child A (canonical map) lands later it can replace the `DEPRECATED_TO_CANONICAL` array.

## Test Plan
- [ ] `bash -n scripts/migrate-labels.sh` and `shellcheck -S warning scripts/migrate-labels.sh` clean (already verified locally + matches CI)
- [ ] `bats tests/migrate-labels.bats` — 7/7 pass
- [ ] On a sandbox repo, run `scripts/migrate-labels.sh --slug <s>` (dry-run) and confirm planned renames + deletes are correct
- [ ] Run again with `--apply` and verify deprecated labels are gone, tickets carry canonical labels
- [ ] Re-run `--all` afterwards: should report `renamed=0 deleted=0` and exit 0