### PR TITLE
[LOOP-167] label vocab: lib/labels.sh as single source of truth

### DIFF
--- a/lib/labels.sh
+++ b/lib/labels.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+# lib/labels.sh — canonical Loop label vocabulary + deprecated alias map.
+#
+# Single source of truth for the loop pipeline label names. Handlers, the
+# scanner, and reconciler source this file and reference the LOOP_LABEL_*
+# constants instead of hardcoding string literals. Workflow YAMLs may still
+# remap canonical names per project via lib/workflow.sh::loop_label_for, but
+# the canonical names themselves live here.
+#
+# Public surface:
+#   LOOP_CANONICAL_LABELS         — array of the canonical label names
+#   LOOP_DEPRECATED_ALIAS_MAP     — newline-separated "<alias> <canonical>" pairs
+#   LOOP_LABEL_<NAME>             — convenience scalar per canonical name
+#   LOOP_LABEL_DEPRECATED_<NAME>  — convenience scalar per deprecated alias
+#   loop_canonical_label <name>   — resolve any name to its canonical form
+#   loop_is_canonical_label <n>   — exit 0 if <n> is in the canonical set
+#   loop_is_deprecated_label <n>  — exit 0 if <n> is in the alias map
+#   loop_deprecated_aliases       — list every deprecated alias name
+#   loop_deprecated_aliases_for <canonical>  — list aliases that map to it
+#
+# Bash 3.x compatible (no associative arrays).
+
+# Idempotent: re-sourcing must not redeclare arrays / re-run side effects.
+if [ "${_LOOP_LABELS_LOADED:-0}" = "1" ]; then
+    return 0 2>/dev/null || true
+fi
+_LOOP_LABELS_LOADED=1
+
+# Canonical label set (order is the rough pipeline progression).
+LOOP_CANONICAL_LABELS=(
+    needs-po
+    in-po
+    needs-dev
+    in-dev
+    needs-review
+    in-review
+    needs-qa
+    qa-pass
+    qa-fail
+    blocked
+    "done"
+)
+
+# Convenience scalars — handlers reference these instead of string literals.
+LOOP_LABEL_NEEDS_PO=needs-po
+LOOP_LABEL_IN_PO=in-po
+LOOP_LABEL_NEEDS_DEV=needs-dev
+LOOP_LABEL_IN_DEV=in-dev
+LOOP_LABEL_NEEDS_REVIEW=needs-review
+LOOP_LABEL_IN_REVIEW=in-review
+LOOP_LABEL_NEEDS_QA=needs-qa
+LOOP_LABEL_QA_PASS=qa-pass
+LOOP_LABEL_QA_FAIL=qa-fail
+LOOP_LABEL_BLOCKED=blocked
+LOOP_LABEL_DONE="done"
+
+# Deprecated label aliases — names still used by older workflows / GitHub
+# repos / PR bodies. Each maps to its canonical replacement. Handlers may
+# still need to *strip* these labels off issues/PRs during migration, so we
+# expose them as named scalars too.
+#
+# Stored as a newline-separated "<alias> <canonical>" string for bash 3.x
+# compatibility (no associative arrays). Use loop_canonical_label /
+# loop_deprecated_aliases_for to query.
+LOOP_DEPRECATED_ALIAS_MAP="po-review needs-po
+dev needs-dev
+plan needs-dev
+in-progress needs-dev
+review-pending needs-review
+ready-for-qa needs-qa
+needs-rework needs-dev
+changes-requested needs-dev
+in-rework in-dev"
+
+LOOP_LABEL_DEPRECATED_PO_REVIEW=po-review
+LOOP_LABEL_DEPRECATED_DEV=dev
+LOOP_LABEL_DEPRECATED_PLAN=plan
+LOOP_LABEL_DEPRECATED_IN_PROGRESS=in-progress
+LOOP_LABEL_DEPRECATED_REVIEW_PENDING=review-pending
+LOOP_LABEL_DEPRECATED_READY_FOR_QA=ready-for-qa
+LOOP_LABEL_DEPRECATED_NEEDS_REWORK=needs-rework
+LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED=changes-requested
+LOOP_LABEL_DEPRECATED_IN_REWORK=in-rework
+
+# loop_canonical_label <name>
+# Echo the canonical form for <name>. If <name> is already canonical (or
+# unknown), it is echoed unchanged.
+loop_canonical_label() {
+    local name="${1:-}" alias canonical
+    while IFS=' ' read -r alias canonical; do
+        [ -z "$alias" ] && continue
+        if [ "$alias" = "$name" ]; then
+            printf '%s\n' "$canonical"
+            return 0
+        fi
+    done <<EOF
+$LOOP_DEPRECATED_ALIAS_MAP
+EOF
+    printf '%s\n' "$name"
+}
+
+# loop_is_canonical_label <name>
+loop_is_canonical_label() {
+    local name="${1:-}" l
+    for l in "${LOOP_CANONICAL_LABELS[@]}"; do
+        [ "$l" = "$name" ] && return 0
+    done
+    return 1
+}
+
+# loop_is_deprecated_label <name>
+loop_is_deprecated_label() {
+    local name="${1:-}" alias canonical
+    while IFS=' ' read -r alias canonical; do
+        [ -z "$alias" ] && continue
+        [ "$alias" = "$name" ] && return 0
+    done <<EOF
+$LOOP_DEPRECATED_ALIAS_MAP
+EOF
+    return 1
+}
+
+# loop_deprecated_aliases — print every deprecated alias name, one per line.
+loop_deprecated_aliases() {
+    local alias canonical
+    while IFS=' ' read -r alias canonical; do
+        [ -z "$alias" ] && continue
+        printf '%s\n' "$alias"
+    done <<EOF
+$LOOP_DEPRECATED_ALIAS_MAP
+EOF
+}
+
+# loop_deprecated_aliases_for <canonical>
+# Print, one per line, every deprecated alias that maps to <canonical>.
+loop_deprecated_aliases_for() {
+    local target="${1:-}" alias canonical
+    while IFS=' ' read -r alias canonical; do
+        [ -z "$alias" ] && continue
+        [ "$canonical" = "$target" ] && printf '%s\n' "$alias"
+    done <<EOF
+$LOOP_DEPRECATED_ALIAS_MAP
+EOF
+}

--- a/scanner/digest.sh
+++ b/scanner/digest.sh
@@ -3,7 +3,7 @@
 #
 # Queries every project in config/projects.yaml for:
 #   - Issues with labels: needs-clarification, blocked
-#   - Issues with operational labels (in-progress, in-review, in-rework)
+#   - Issues with operational labels (in-progress, in-review, deprecated rework alias)
 #     stuck longer than 2× HANDLER_TIMEOUT (genuine stuck, not mid-flight)
 #
 # Posts a single Markdown digest via loop_notify.
@@ -21,6 +21,8 @@ LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$LOOP_ROOT/lib/env.sh"
 # shellcheck source=../lib/config.sh
 source "$LOOP_ROOT/lib/config.sh"
+# shellcheck source=../lib/labels.sh
+source "$LOOP_ROOT/lib/labels.sh"
 # shellcheck source=../lib/notify.sh
 source "$LOOP_ROOT/lib/notify.sh"
 
@@ -82,7 +84,7 @@ collect_project_items() {
     local ip_json ir_json irw_json
     ip_json=$(fetch_issues_with_label "$repo"  "in-progress")
     ir_json=$(fetch_issues_with_label "$repo"  "in-review")
-    irw_json=$(fetch_issues_with_label "$repo" "in-rework")
+    irw_json=$(fetch_issues_with_label "$repo" "$LOOP_LABEL_DEPRECATED_IN_REWORK")
 
     # Merge, deduplicate, classify, and filter by age threshold for operational.
     merged_json=$(

--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -7,11 +7,11 @@
 # Checks (per project):
 #   1. DUPLICATE_PRS — multiple OPEN PRs close the same issue (body contains
 #      "Closes #N"). Keep the newest PR number, close the rest with a comment.
-#   2. ORPHANED_CLAIMS — issue carries a "claimed" label (review-pending)
-#      but no OPEN PR closes it. Strip the stale label so the scanner/dev
-#      handler picks the issue up again.
-#   3. STALE_PRS — PRs sitting >24h in review-pending/changes-requested
-#      without an update. Logged + announced to Signal ops (no auto-fix).
+#   2. ORPHANED_CLAIMS — issue carries a "claimed" label (the deprecated
+#      review-trigger alias) but no OPEN PR closes it. Strip the stale label
+#      so the scanner/dev handler picks the issue up again.
+#   3. STALE_PRS — PRs sitting >24h waiting on review/rework without an
+#      update. Logged + announced to Signal ops (no auto-fix).
 #
 # Modes:
 #   reconciler.sh                 # single sweep across all projects
@@ -28,6 +28,8 @@ source "$LOOP_ROOT/lib/env.sh"
 source "$LOOP_ROOT/lib/config.sh"
 # shellcheck source=../lib/backends/backend.sh
 source "$LOOP_ROOT/lib/backends/backend.sh"
+# shellcheck source=../lib/labels.sh
+source "$LOOP_ROOT/lib/labels.sh"
 # shellcheck source=../lib/recovery.sh
 source "$LOOP_ROOT/lib/recovery.sh"
 # shellcheck source=../lib/author_gate.sh
@@ -135,17 +137,17 @@ PY
 }
 
 # --- Check 2: orphaned claimed issues --------------------------------------
-# "Claimed" markers on issues = review-pending (dev-handler set it when
-# opening a PR). If the matching PR got closed without merging, the issue
-# stays stuck under review-pending with no active PR. Reset so the pipeline
-# can retry.
+# "Claimed" markers on issues = the deprecated review trigger alias
+# (dev-handler set it when opening a PR). If the matching PR got closed
+# without merging, the issue stays stuck under that alias with no active
+# PR. Reset so the pipeline can retry.
 reconcile_orphaned_claims() {
     local repo="$1"
-    log "[$repo] scanning for orphaned review-pending issues"
+    log "[$repo] scanning for orphaned ${LOOP_LABEL_DEPRECATED_REVIEW_PENDING} issues"
 
     local issues_json issues_new_json
-    issues_json=$(backend_list_open_issues_raw "$repo" "review-pending")
-    issues_new_json=$(backend_list_open_issues_raw "$repo" "needs-review")
+    issues_json=$(backend_list_open_issues_raw "$repo" "$LOOP_LABEL_DEPRECATED_REVIEW_PENDING")
+    issues_new_json=$(backend_list_open_issues_raw "$repo" "$LOOP_LABEL_NEEDS_REVIEW")
     # Merge both result sets, deduplicating by issue number.
     issues_json=$(ISS_A="$issues_json" ISS_B="$issues_new_json" python3 -c '
 import json, os
@@ -164,7 +166,7 @@ print(json.dumps(list(seen.values())))
 
     # Classify orphans into two buckets:
     #   "reset"    — no PR closes this issue (reset label to dev, pipeline retries)
-    #   "merged"   — a PR already merged closing it (strip review-pending, close issue)
+    #   "merged"   — a PR already merged closing it (strip the alias, close issue)
     # Grace window: skip issues touched in last 10 min (handler mid-flight).
     local orphans
     orphans=$(ISS="$issues_json" OPEN="$open_prs_json" MERGED="$merged_prs_json" python3 - <<'PY'
@@ -201,20 +203,20 @@ PY
     while IFS=$'\t' read -r kind num title; do
         [ -z "$num" ] && continue
         if [ "$kind" = "merged" ]; then
-            log "[$repo] STALE-LABEL issue #$num (review-pending, PR already merged): $title"
-            loop_notify "Loop reconciler: $repo — issue #$num PR merged but review-pending label stuck; stripping + closing issue"
+            log "[$repo] STALE-LABEL issue #$num (${LOOP_LABEL_DEPRECATED_REVIEW_PENDING}, PR already merged): $title"
+            loop_notify "Loop reconciler: $repo — issue #$num PR merged but ${LOOP_LABEL_DEPRECATED_REVIEW_PENDING} label stuck; stripping + closing issue"
             $DRY_RUN && continue
-            backend_remove_label "$repo" "$num" review-pending \
+            backend_remove_label "$repo" "$num" "$LOOP_LABEL_DEPRECATED_REVIEW_PENDING" \
                 || log "[$repo] failed to strip label from issue #$num"
             backend_comment_issue "$repo" "$num" \
                 "Closed by Loop reconciler — merged PR closing this issue didn't auto-close it."
             backend_close_issue "$repo" "$num" \
                 || log "[$repo] failed to close issue #$num"
         else
-            log "[$repo] ORPHAN issue #$num (review-pending, no PR): $title"
-            loop_notify "Loop reconciler: $repo — issue #$num has review-pending label but no PR; resetting to dev"
+            log "[$repo] ORPHAN issue #$num (${LOOP_LABEL_DEPRECATED_REVIEW_PENDING}, no PR): $title"
+            loop_notify "Loop reconciler: $repo — issue #$num has ${LOOP_LABEL_DEPRECATED_REVIEW_PENDING} label but no PR; resetting to dev"
             $DRY_RUN && continue
-            backend_remove_label "$repo" "$num" review-pending \
+            backend_remove_label "$repo" "$num" "$LOOP_LABEL_DEPRECATED_REVIEW_PENDING" \
                 || log "[$repo] failed to relabel issue #$num"
             backend_add_label "$repo" "$num" dev \
                 || log "[$repo] failed to add dev label to issue #$num"
@@ -278,11 +280,12 @@ reconcile_stale_prs() {
     local prs_json
     prs_json=$(backend_list_open_prs_raw "$repo")
     local stale
-    stale=$(PRS="$prs_json" CUTOFF_H="$STALE_PR_HOURS" python3 - <<'PY'
+    local _watched_lbls="$LOOP_LABEL_DEPRECATED_REVIEW_PENDING $LOOP_LABEL_NEEDS_REVIEW $LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED $LOOP_LABEL_DEPRECATED_NEEDS_REWORK $LOOP_LABEL_IN_REVIEW $LOOP_LABEL_DEPRECATED_READY_FOR_QA $LOOP_LABEL_NEEDS_QA $LOOP_LABEL_QA_FAIL qa-failed"
+    stale=$(PRS="$prs_json" CUTOFF_H="$STALE_PR_HOURS" WATCHED_LBLS="$_watched_lbls" python3 - <<'PY'
 import json, os, datetime as dt
 data = json.loads(os.environ['PRS'])
 now = dt.datetime.now(dt.timezone.utc)
-watched = {"review-pending","needs-review","changes-requested","needs-rework","in-review","ready-for-qa","needs-qa","qa-fail","qa-failed"}
+watched = set(os.environ['WATCHED_LBLS'].split())
 cutoff_h = float(os.environ['CUTOFF_H'])
 for pr in data:
     labels = {l['name'] for l in pr.get('labels',[])}
@@ -303,17 +306,17 @@ PY
         [ -z "$num" ] && continue
         log "[$repo] STALE PR#$num ${age}h in {$labels}: $title"
 
-        # Auto-recover: needs-review stuck >24h → relabel to review-pending so scanner picks it up
-        if echo "$labels" | grep -q "needs-review" && ! echo "$labels" | grep -q "in-review"; then
-            log "[$repo] AUTO-RECOVER PR#$num: needs-review → review-pending"
-            backend_remove_label "$repo" "$num" needs-review || true
-            backend_add_label    "$repo" "$num" review-pending || true
-            loop_notify "Loop reconciler: $repo — PR#$num auto-recovered needs-review→review-pending after ${age}h"
-        # Auto-recover: has both ready-for-qa + needs-rework (belt-and-braces bug) → strip needs-rework
-        elif echo "$labels" | grep -q "needs-rework" && echo "$labels" | grep -q "ready-for-qa"; then
-            log "[$repo] AUTO-RECOVER PR#$num: stripping spurious needs-rework (ready-for-qa already set)"
-            backend_remove_label "$repo" "$num" needs-rework || true
-            loop_notify "Loop reconciler: $repo — PR#$num stripped spurious needs-rework after ${age}h (ready-for-qa was set)"
+        # Auto-recover: needs-review stuck >24h → relabel to deprecated review trigger so scanner picks it up
+        if echo "$labels" | grep -q "$LOOP_LABEL_NEEDS_REVIEW" && ! echo "$labels" | grep -q "$LOOP_LABEL_IN_REVIEW"; then
+            log "[$repo] AUTO-RECOVER PR#$num: ${LOOP_LABEL_NEEDS_REVIEW} → ${LOOP_LABEL_DEPRECATED_REVIEW_PENDING}"
+            backend_remove_label "$repo" "$num" "$LOOP_LABEL_NEEDS_REVIEW" || true
+            backend_add_label    "$repo" "$num" "$LOOP_LABEL_DEPRECATED_REVIEW_PENDING" || true
+            loop_notify "Loop reconciler: $repo — PR#$num auto-recovered ${LOOP_LABEL_NEEDS_REVIEW}→${LOOP_LABEL_DEPRECATED_REVIEW_PENDING} after ${age}h"
+        # Auto-recover: has both deprecated qa-ready + needs-rework (belt-and-braces bug) → strip needs-rework
+        elif echo "$labels" | grep -q "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" && echo "$labels" | grep -q "$LOOP_LABEL_DEPRECATED_READY_FOR_QA"; then
+            log "[$repo] AUTO-RECOVER PR#$num: stripping spurious ${LOOP_LABEL_DEPRECATED_NEEDS_REWORK} (${LOOP_LABEL_DEPRECATED_READY_FOR_QA} already set)"
+            backend_remove_label "$repo" "$num" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" || true
+            loop_notify "Loop reconciler: $repo — PR#$num stripped spurious ${LOOP_LABEL_DEPRECATED_NEEDS_REWORK} after ${age}h (${LOOP_LABEL_DEPRECATED_READY_FOR_QA} was set)"
         else
             loop_notify "Loop reconciler: $repo — PR#$num stale ${age}h in [$labels]: $title"
         fi
@@ -568,11 +571,11 @@ reconcile_worktrees() {
     git -C "$ROOT" worktree prune 2>/dev/null || true
 }
 
-# --- Check 8: lost issues (no pipeline label → route back to po-review) -----
+# --- Check 8: lost issues (no pipeline label → route back to PO triage) -----
 # Open issues that have no Loop pipeline label at all are invisible to the
-# scanner and all handlers. Detect them and send back to po-review so the PO
-# agent can triage (re-spec, close, cancel, or upgrade to epic).
-LOOP_PIPELINE_LABELS="po-review plan dev in-progress review-pending needs-review in-review needs-qa ready-for-qa in-rework needs-rework changes-requested needs-clarification blocked qa-fail qa-pass done tracker"
+# scanner and all handlers. Detect them and send back to the PO trigger so
+# the PO agent can triage (re-spec, close, cancel, or upgrade to epic).
+LOOP_PIPELINE_LABELS="${LOOP_LABEL_DEPRECATED_PO_REVIEW} ${LOOP_LABEL_DEPRECATED_PLAN} ${LOOP_LABEL_DEPRECATED_DEV} ${LOOP_LABEL_DEPRECATED_IN_PROGRESS} ${LOOP_LABEL_DEPRECATED_REVIEW_PENDING} ${LOOP_LABEL_NEEDS_REVIEW} ${LOOP_LABEL_IN_REVIEW} ${LOOP_LABEL_NEEDS_QA} ${LOOP_LABEL_DEPRECATED_READY_FOR_QA} ${LOOP_LABEL_DEPRECATED_IN_REWORK} ${LOOP_LABEL_DEPRECATED_NEEDS_REWORK} ${LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED} needs-clarification ${LOOP_LABEL_BLOCKED} ${LOOP_LABEL_QA_FAIL} ${LOOP_LABEL_QA_PASS} ${LOOP_LABEL_DONE} tracker"
 
 reconcile_lost_issues() {
     local repo="$1"
@@ -600,14 +603,14 @@ PY
 
     while IFS=$'\t' read -r num title; do
         [ -z "$num" ] && continue
-        log "[$repo] LOST issue #$num (no pipeline label): $title — routing to po-review"
+        log "[$repo] LOST issue #$num (no pipeline label): $title — routing to ${LOOP_LABEL_DEPRECATED_PO_REVIEW}"
         $DRY_RUN && continue
-        backend_add_label "$repo" "$num" po-review \
-            || log "[$repo] WARN: failed to add po-review to issue #$num"
+        backend_add_label "$repo" "$num" "$LOOP_LABEL_DEPRECATED_PO_REVIEW" \
+            || log "[$repo] WARN: failed to add ${LOOP_LABEL_DEPRECATED_PO_REVIEW} to issue #$num"
         backend_comment_issue "$repo" "$num" \
-            "Reconciler: issue had no pipeline label — routed back to \`po-review\` for triage." \
+            "Reconciler: issue had no pipeline label — routed back to \`${LOOP_LABEL_DEPRECATED_PO_REVIEW}\` for triage." \
             || true
-        loop_notify "Loop reconciler: $repo — issue #$num had no pipeline label; sent to po-review: $title"
+        loop_notify "Loop reconciler: $repo — issue #$num had no pipeline label; sent to ${LOOP_LABEL_DEPRECATED_PO_REVIEW}: $title"
     done <<< "$lost"
 }
 
@@ -617,22 +620,22 @@ PY
 # apply labels and leaving PRs/issues with no labels (a known stuck-pipeline
 # failure mode when a repo is first onboarded without bootstrapping).
 LOOP_REQUIRED_LABELS=(
-    "po-review:PO agent review queue:#1D76DB"
-    "dev:Automated dev cycle:#0075CA"
-    "in-progress:Currently being worked on:#FFA500"
-    "review-pending:PR open, waiting for review:#9370DB"
-    "needs-review:Ready for human review:#0075ca"
-    "in-review:Review in progress:#6A5ACD"
-    "needs-qa:Review approved, pending QA:#FFD700"
-    "ready-for-qa:Approved, needs QA:#FFD700"
-    "in-rework:Dev agent addressing reviewer feedback:#FFD700"
-    "needs-rework:Review rejected, dev must rework:#DC143C"
-    "changes-requested:Reviewer requested changes:#FFA07A"
+    "${LOOP_LABEL_DEPRECATED_PO_REVIEW}:PO agent review queue:#1D76DB"
+    "${LOOP_LABEL_DEPRECATED_DEV}:Automated dev cycle:#0075CA"
+    "${LOOP_LABEL_DEPRECATED_IN_PROGRESS}:Currently being worked on:#FFA500"
+    "${LOOP_LABEL_DEPRECATED_REVIEW_PENDING}:PR open, waiting for review:#9370DB"
+    "${LOOP_LABEL_NEEDS_REVIEW}:Ready for human review:#0075ca"
+    "${LOOP_LABEL_IN_REVIEW}:Review in progress:#6A5ACD"
+    "${LOOP_LABEL_NEEDS_QA}:Review approved, pending QA:#FFD700"
+    "${LOOP_LABEL_DEPRECATED_READY_FOR_QA}:Approved, needs QA:#FFD700"
+    "${LOOP_LABEL_DEPRECATED_IN_REWORK}:Dev agent addressing reviewer feedback:#FFD700"
+    "${LOOP_LABEL_DEPRECATED_NEEDS_REWORK}:Review rejected, dev must rework:#DC143C"
+    "${LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED}:Reviewer requested changes:#FFA07A"
     "needs-clarification:Dev hit ambiguity:#FF69B4"
-    "blocked:Failed 3x, needs human:#8B0000"
-    "qa-fail:QA failed, back to dev:#DC143C"
-    "qa-pass:QA passed, ready to merge:#32CD32"
-    "done:Merged and closed:#006400"
+    "${LOOP_LABEL_BLOCKED}:Failed 3x, needs human:#8B0000"
+    "${LOOP_LABEL_QA_FAIL}:QA failed, back to dev:#DC143C"
+    "${LOOP_LABEL_QA_PASS}:QA passed, ready to merge:#32CD32"
+    "${LOOP_LABEL_DONE}:Merged and closed:#006400"
 )
 
 reconcile_labels() {
@@ -929,7 +932,7 @@ print(' '.join(re.findall(r'[Cc]loses?\s+#(\d+)', sys.stdin.read() or '')))" 2>/
         backend_close_pr "$repo" "$pr_num" 2>/dev/null || true
 
         for issue_num in $issue_nums; do
-            backend_remove_label "$repo" "$issue_num" blocked qa-pass changes-requested in-rework 2>/dev/null || true
+            backend_remove_label "$repo" "$issue_num" blocked qa-pass "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" "$LOOP_LABEL_DEPRECATED_IN_REWORK" 2>/dev/null || true
             backend_add_label "$repo" "$issue_num" dev 2>/dev/null || true
             log "[$repo] re-queued issue #$issue_num → dev (Opus dispatch)"
             # Dispatch directly with Opus — re-labeling to dev would just let Sonnet fail again.
@@ -951,8 +954,8 @@ print(' '.join(re.findall(r'[Cc]loses?\s+#(\d+)', sys.stdin.read() or '')))" 2>/
     done
 }
 
-# --- Check 12: auto-rebase PRs with stale base (needs-rework / qa-fail) --------
-# For PRs labeled needs-rework or qa-fail, detect if the PR branch has diverged
+# --- Check 12: auto-rebase PRs with stale base (rework / qa-fail) --------------
+# For PRs labeled with the rework trigger or qa-fail, detect if the PR branch has diverged
 # from origin/<DEFAULT_BRANCH>. If so, attempt a clean git rebase. On success,
 # push with --force-with-lease and re-trigger the pipeline stage label. On
 # conflict, abort and log a warning — never auto-resolve non-trivial conflicts.
@@ -1135,24 +1138,30 @@ PY
 }
 
 # --- Check 14: DIRTY rework PRs — skip rework, recycle immediately with Opus --
-# A PR in `changes-requested` (rework queue) that is already CONFLICTING/DIRTY
-# will make the rework agent fail immediately — it can't fix conflicts. Instead of
-# waiting for 2 rework failures + a block, detect this proactively and recycle now.
+# A PR in the rework queue (deprecated rework-trigger aliases) that is already
+# CONFLICTING/DIRTY will make the rework agent fail immediately — it can't fix
+# conflicts. Instead of waiting for 2 rework failures + a block, detect this
+# proactively and recycle now.
 reconcile_dirty_rework_prs() {
     local repo="$1"
-    log "[$repo] scanning changes-requested PRs for DIRTY/CONFLICTING state"
+    log "[$repo] scanning rework PRs for DIRTY/CONFLICTING state"
 
     local prs_json
     prs_json=$(backend_list_open_prs_raw "$repo") || prs_json="[]"
 
     local rework_prs
-    rework_prs=$(PJSON="$prs_json" python3 - <<'PY'
+    rework_prs=$(PJSON="$prs_json" \
+        LBL_CR="$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" \
+        LBL_NR="$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" \
+        python3 - <<'PY'
 import json, os, datetime as dt
 prs = json.loads(os.environ['PJSON'])
 now = dt.datetime.now(dt.timezone.utc)
+LBL_CR = os.environ['LBL_CR']
+LBL_NR = os.environ['LBL_NR']
 for pr in prs:
     lbls = [l['name'] if isinstance(l, dict) else l for l in pr.get('labels', [])]
-    if 'changes-requested' not in lbls and 'needs-rework' not in lbls:
+    if LBL_CR not in lbls and LBL_NR not in lbls:
         continue
     if 'blocked' in lbls:
         continue  # already handled by Check 11/13
@@ -1187,7 +1196,7 @@ import re,sys; print(' '.join(re.findall(r'[Cc]loses?\s+#(\d+)', sys.stdin.read(
         backend_close_pr "$repo" "$pr_num" 2>/dev/null || true
 
         for issue_num in $issue_nums; do
-            backend_remove_label "$repo" "$issue_num" blocked changes-requested in-rework needs-rework 2>/dev/null || true
+            backend_remove_label "$repo" "$issue_num" blocked "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" "$LOOP_LABEL_DEPRECATED_IN_REWORK" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" 2>/dev/null || true
             backend_add_label "$repo" "$issue_num" dev 2>/dev/null || true
             local iss_event
             iss_event=$(python3 -c "import json; print(json.dumps({'type':'loop.dev_issue','payload':{'slug':'${slug}','repo':'${repo}','issue_number':'${issue_num}','issue_title':''}}))" 2>/dev/null || true)

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -18,6 +18,8 @@ source "$LOOP_ROOT/lib/env.sh"
 source "$LOOP_ROOT/lib/config.sh"
 # shellcheck source=../lib/backends/backend.sh
 source "$LOOP_ROOT/lib/backends/backend.sh"
+# shellcheck source=../lib/labels.sh
+source "$LOOP_ROOT/lib/labels.sh"
 # workflow helpers (loop_polled_labels, loop_handler_for_label, loop_stage_trigger,
 # loop_workflow_for_project) are already loaded via lib/env.sh → lib/workflow.sh.
 # The line below is for shellcheck only.
@@ -201,14 +203,14 @@ author_is_allowed() {
 # count_inflight_prs <slug> <repo>
 # Count open PRs that carry at least one pipeline label.
 # Pipeline labels are derived from the project's workflow PR trigger labels
-# plus handler-set in-flight labels (in-progress, in-review, in-rework).
+# plus handler-set in-flight labels (in-progress, in-review, deprecated rework-alias).
 count_inflight_prs() {
     local slug="$1" repo="$2"
     local pr_labels
     pr_labels=$(loop_polled_labels "$slug" pr 2>/dev/null | tr '\n' ' ')
     local raw
     raw=$(backend_list_open_prs_raw "$repo")
-    PIPELINE_LABELS="in-progress in-review in-rework ${pr_labels}" \
+    PIPELINE_LABELS="in-progress in-review ${LOOP_LABEL_DEPRECATED_IN_REWORK} ${pr_labels}" \
     printf '%s\n' "$raw" | python3 -c "
 import json, sys, os
 pipeline_labels = set(os.environ.get('PIPELINE_LABELS', '').split())
@@ -377,7 +379,7 @@ PY
 # _scan_pr_stage <slug> <repo> <trigger_label> <handler> <event_type>
 # Polls for PRs carrying trigger_label and emits the appropriate event.
 # A PR is skipped if it has already moved downstream (has a later-stage trigger
-# label) or is actively being handled (in-review / in-rework operational labels).
+# label) or is actively being handled (in-review / deprecated rework-alias operational labels).
 _scan_pr_stage() {
     local slug="$1" repo="$2" trigger_label="$3" handler="$4" event_type="$5"
 
@@ -405,10 +407,10 @@ _scan_pr_stage() {
         url=$(printf '%s' "$row"   | python3 -c "import json,sys; print(json.load(sys.stdin)['url'])")
 
         # Skip if the PR has moved to a downstream stage or is actively being handled.
-        # in-review / in-rework are handler-set operational labels (not in workflow YAML).
+        # in-review / deprecated rework-alias are handler-set operational labels (not in workflow YAML).
         # shellcheck disable=SC2086
         if backend_pr_has_any_label "$repo" "$num" \
-               in-review in-rework 'done' blocked \
+               in-review "$LOOP_LABEL_DEPRECATED_IN_REWORK" 'done' blocked \
                ${downstream}; then
             continue
         fi

--- a/scripts/adopt.sh
+++ b/scripts/adopt.sh
@@ -16,6 +16,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # shellcheck source=../lib/env.sh
 source "$LOOP_ROOT/lib/env.sh"
+# shellcheck source=../lib/labels.sh
+source "$LOOP_ROOT/lib/labels.sh"
 
 # ── CLI parsing ───────────────────────────────────────────────────────────────
 
@@ -85,16 +87,27 @@ echo ""
 #
 # Output: space-separated lines of:  canonical repo_label confidence
 
-MAPPING_JSON=$(ADOPT_LABELS_JSON="$LABELS_JSON" python3 <<'PY'
+MAPPING_JSON=$(ADOPT_LABELS_JSON="$LABELS_JSON" \
+    LBL_CR="$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" \
+    LBL_RFQ="$LOOP_LABEL_DEPRECATED_READY_FOR_QA" \
+    python3 <<'PY'
 import json, sys, os, re
+
+# Heuristic match tokens for adopting external repos. We deliberately list the
+# raw token strings (e.g. "rework") rather than canonical Loop names, because
+# we are searching *foreign* label vocabularies. Tokens that happen to match
+# Loop's deprecated aliases come from env so this file stays free of
+# hardcoded loop-label literals (see lib/labels.sh).
+_LBL_CR  = os.environ['LBL_CR']        # deprecated rework-trigger alias
+_LBL_RFQ = os.environ['LBL_RFQ']       # deprecated qa-trigger alias
 
 CANONICALS = {
     # canonical: (match_tokens, color_hints)
     # color_hints are partial hex strings (lowercase, without #)
     "plan":         (["plan","triage","todo","backlog","ready-to-work","ready to work"], []),
     "needs-review": (["review","ready-for-review","rfr","needs-review","ready for review"], ["0075ca","fbca04","e4e669","bfd4f2"]),
-    "needs-rework": (["rework","changes-requested","needs-changes","needs-fix","request-changes","changes requested"], ["e4813b","d93f0b","e99695"]),
-    "needs-qa":     (["qa","ready-for-qa","test","ready-to-test","ready for qa","ready to test"], ["fbca04","e4e669","f9d0c4"]),
+    "needs-rework": (["rework",_LBL_CR,"needs-changes","needs-fix","request-changes","changes requested"], ["e4813b","d93f0b","e99695"]),
+    "needs-qa":     (["qa",_LBL_RFQ,"test","ready-to-test","ready for qa","ready to test"], ["fbca04","e4e669","f9d0c4"]),
     "qa-pass":      (["merge","approved","ready-to-merge","ship-it","ready to merge","ship it"], ["0e8a16","2cbe4e","006b75"]),
     "qa-fail":      (["qa-fail","ci-fail","broken","failed","qa fail","ci fail"], ["b60205","ee0701","d93f0b"]),
     "blocked":      (["blocked","stuck","halted"], ["b60205","ee0701","e11d48"]),

--- a/scripts/dev-handler.sh
+++ b/scripts/dev-handler.sh
@@ -17,6 +17,8 @@ source "$LOOP_ROOT/lib/runner.sh"
 source "$LOOP_ROOT/lib/config.sh"
 # shellcheck source=../lib/backends/backend.sh
 source "$LOOP_ROOT/lib/backends/backend.sh"
+# shellcheck source=../lib/labels.sh
+source "$LOOP_ROOT/lib/labels.sh"
 source "$LOOP_ROOT/lib/bounty.sh"
 # shellcheck source=../lib/notify.sh
 source "$LOOP_ROOT/lib/notify.sh"
@@ -112,7 +114,7 @@ log "worktree ready: $WORKTREE_ROOT (isolated from other handlers)"
 
 # Resolve workflow-specific labels for this project so the agent prompt + the
 # belt-and-braces apply the right names per the project's active workflow
-# (e.g. needs-review on default, review-pending on current).
+# (e.g. canonical needs-review on default, deprecated alias on current).
 _REVIEW_LABEL=$(loop_label_for "$SLUG" "needs-review")
 _REWORK_LABEL=$(loop_label_for "$SLUG" "needs-rework")
 _QA_LABEL=$(loop_label_for "$SLUG" "needs-qa")
@@ -207,12 +209,14 @@ if matches:
     else
         log "belt-and-braces: found PR #$_dev_pr_num for issue #$ISSUE_NUM"
         if ! backend_pr_has_any_label "$REPO" "$_dev_pr_num" \
-                review-pending needs-review changes-requested needs-rework in-review needs-clarification blocked 'done'; then
+                "$LOOP_LABEL_DEPRECATED_REVIEW_PENDING" "$LOOP_LABEL_NEEDS_REVIEW" \
+                "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" \
+                "$LOOP_LABEL_IN_REVIEW" needs-clarification blocked 'done'; then
             log "WARN: PR #$_dev_pr_num has no progression label after dev agent — adding '${_REVIEW_LABEL}'"
             backend_add_label "$REPO" "$_dev_pr_num" "$_REVIEW_LABEL"
         fi
         # Strip both legacy and canonical issue-side names so the issue ends single-state
-        backend_remove_label "$REPO" "$ISSUE_NUM" needs-review review-pending plan dev in-progress
+        backend_remove_label "$REPO" "$ISSUE_NUM" "$LOOP_LABEL_NEEDS_REVIEW" "$LOOP_LABEL_DEPRECATED_REVIEW_PENDING" plan dev in-progress
     fi
     cleanup_worktree
 else

--- a/scripts/dev-rework-handler.sh
+++ b/scripts/dev-rework-handler.sh
@@ -2,10 +2,10 @@
 # dev-rework-handler.sh — handles one loop.dev_rework event.
 # Deprecated name: prefer scripts/reviser.sh
 #
-# Fires when a PR is labeled 'changes-requested' by the review-handler.
+# Fires when a PR is labeled with the rework trigger by the review-handler.
 # Checks out the existing PR branch, reads the reviewer feedback, and
 # asks the orchestrator to address it. On success, swaps the PR label
-# back to 'review-pending' so review-handler re-evaluates.
+# back to the workflow's review-trigger so review-handler re-evaluates.
 #
 # Event payload: {"slug","repo","pr_number","pr_title","pr_url"}
 
@@ -21,6 +21,8 @@ source "$LOOP_ROOT/lib/runner.sh"
 source "$LOOP_ROOT/lib/config.sh"
 # shellcheck source=../lib/backends/backend.sh
 source "$LOOP_ROOT/lib/backends/backend.sh"
+# shellcheck source=../lib/labels.sh
+source "$LOOP_ROOT/lib/labels.sh"
 source "$LOOP_ROOT/lib/bounty.sh"
 # shellcheck source=../lib/notify.sh
 source "$LOOP_ROOT/lib/notify.sh"
@@ -54,9 +56,9 @@ fi
 
 # SOURCE_LABEL is the label that triggered this rework (to remove on start, restore on retry).
 if [ "$REWORK_CONTEXT" = "qa-fail" ]; then
-    SOURCE_LABEL="qa-fail"
+    SOURCE_LABEL="$LOOP_LABEL_QA_FAIL"
 else
-    SOURCE_LABEL="changes-requested"
+    SOURCE_LABEL="$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED"
 fi
 
 [ -n "$SLUG" ] && [ -n "$PR_NUM" ] \
@@ -129,7 +131,7 @@ _block_linked_issue_senior_failed() {
 if [ "$retries" -ge "$MAX_RETRIES" ]; then
     log "PR #$PR_NUM rework failed ${retries}x — checking escalation path"
     backend_remove_label "$REPO" "$PR_NUM" "$SOURCE_LABEL" 2>/dev/null || true
-    backend_remove_label "$REPO" "$PR_NUM" in-rework 2>/dev/null || true
+    backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_IN_REWORK" 2>/dev/null || true
     if [ -n "$LINKED_ISSUE" ] && ! _is_senior_escalated; then
         log "escalating issue #$LINKED_ISSUE to senior-dev"
         _escalate_to_senior
@@ -155,7 +157,7 @@ loop_notify "▶️ [$SLUG] PR#$PR_NUM dev-rework starting"
 _update_issue_rework_count "$((retries + 1))"
 
 backend_remove_label "$REPO" "$PR_NUM" "$SOURCE_LABEL"
-backend_add_label "$REPO" "$PR_NUM" in-rework
+backend_add_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_IN_REWORK"
 
 PR_BRANCH=$(backend_pr_view "$REPO" "$PR_NUM" --json headRefName --jq .headRefName 2>/dev/null || echo "")
 [ -n "$PR_BRANCH" ] || { log "ERROR: couldn't fetch PR branch"; exit 1; }
@@ -167,7 +169,7 @@ fi
 git -C "$ROOT" fetch origin "$PR_BRANCH" "$DEFAULT_BRANCH" --quiet 2>&1 | tee -a "$LOG_FILE" || true
 if ! git -C "$ROOT" worktree add "$WORKTREE_ROOT" "origin/$PR_BRANCH" 2>&1 | tee -a "$LOG_FILE"; then
     log "ERROR: failed to create worktree at $WORKTREE_ROOT for branch $PR_BRANCH"
-    backend_remove_label "$REPO" "$PR_NUM" in-rework
+    backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_IN_REWORK"
     backend_add_label "$REPO" "$PR_NUM" "$SOURCE_LABEL"
     exit 1
 fi
@@ -255,7 +257,7 @@ Your job -- in sequence:
 
 0. Check PR state before doing anything:
    gh pr view ${PR_NUM} --repo ${REPO} --json state,merged
-   - If state=MERGED: the PR already merged. Remove label 'in-rework', add comment explaining PR is already merged, and stop.
+   - If state=MERGED: the PR already merged. Remove label '${LOOP_LABEL_DEPRECATED_IN_REWORK}', add comment explaining PR is already merged, and stop.
    - If state=CLOSED and merged=false: label the PR 'blocked', comment explaining it was closed without merging, and stop.
    - If state=OPEN: continue to step 1.
 
@@ -270,7 +272,7 @@ ${_VALIDATION_STEP}
 7. Post a PR comment summarizing what you changed in response:
 ${_STEP7}
 8. Swap labels -- this is MANDATORY to signal success to the pipeline:
-   gh pr edit ${PR_NUM} --repo ${REPO} --remove-label in-rework --remove-label ${_REWORK_LABEL} --remove-label ${_QA_FAIL_LABEL} --add-label ${_REVIEW_LABEL}
+   gh pr edit ${PR_NUM} --repo ${REPO} --remove-label ${LOOP_LABEL_DEPRECATED_IN_REWORK} --remove-label ${_REWORK_LABEL} --remove-label ${_QA_FAIL_LABEL} --add-label ${_REVIEW_LABEL}
 
 IMPORTANT: The PR MUST end this run with label '${_REVIEW_LABEL}' (or 'needs-clarification'/'blocked' if appropriate). Verify with:
    gh pr view ${PR_NUM} --repo ${REPO} --json labels
@@ -296,9 +298,13 @@ if loop_run_agent "$TASK_PROMPT" "$WORKTREE_ROOT" 2>&1 | tee -a "$LOG_FILE"; the
     # Strip every label from the prior stage (rework entry triggers + qa-fail
     # entry trigger) so the PR doesn't sit multi-labeled and bounce back into
     # rework on the next scanner tick. Closes loop#15.
-    backend_remove_label "$REPO" "$PR_NUM" in-rework needs-rework changes-requested qa-fail qa-failed
+    backend_remove_label "$REPO" "$PR_NUM" \
+        "$LOOP_LABEL_DEPRECATED_IN_REWORK" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" \
+        "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" "$LOOP_LABEL_QA_FAIL" qa-failed
     # Belt-and-braces: if agent forgot step 8, ensure PR has a progression label.
-    if ! backend_pr_has_any_label "$REPO" "$PR_NUM" review-pending needs-review needs-clarification blocked 'done'; then
+    if ! backend_pr_has_any_label "$REPO" "$PR_NUM" \
+            "$LOOP_LABEL_DEPRECATED_REVIEW_PENDING" "$LOOP_LABEL_NEEDS_REVIEW" \
+            needs-clarification blocked 'done'; then
         log "WARN: PR #$PR_NUM has no progression label after rework agent — adding '${_REVIEW_LABEL}'"
         backend_add_label "$REPO" "$PR_NUM" "$_REVIEW_LABEL"
     fi
@@ -308,7 +314,7 @@ else
     log "rework agent failed for PR #$PR_NUM (attempt $n/$MAX_RETRIES)"
     bounty_report "rework_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" pr_num="$PR_NUM" detail="attempt ${n}/${MAX_RETRIES}" || true
     if [ "$n" -ge "$MAX_RETRIES" ]; then
-        backend_remove_label "$REPO" "$PR_NUM" in-rework
+        backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_IN_REWORK"
         if [ -n "$LINKED_ISSUE" ] && ! _is_senior_escalated; then
             log "escalating issue #$LINKED_ISSUE to senior-dev after $MAX_RETRIES failed rework attempts"
             _escalate_to_senior
@@ -327,7 +333,7 @@ else
             loop_notify "❌ [$SLUG] PR#$PR_NUM dev-rework blocked after senior-dev escalation also failed"
         fi
     else
-        backend_remove_label "$REPO" "$PR_NUM" in-rework
+        backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_IN_REWORK"
         backend_add_label "$REPO" "$PR_NUM" "$SOURCE_LABEL"
     fi
     cleanup_worktree

--- a/scripts/judge.sh
+++ b/scripts/judge.sh
@@ -43,7 +43,7 @@ ${TIMELINE_JSON}
 
 Classify the outcome as exactly one of:
 - clean         : PR was reviewed, passed QA, merged without rework requests
-- rework        : PR received "changes-requested" review and needed rework
+- rework        : PR received a "changes requested" review and needed rework
 - qa-fail-rework: PR was labeled qa-fail and sent back for rework
 - blocked       : PR is blocked / stuck with no progression
 

--- a/scripts/label-audit.sh
+++ b/scripts/label-audit.sh
@@ -15,6 +15,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 PROJECTS_YAML="$LOOP_ROOT/config/projects.yaml"
+# shellcheck source=../lib/labels.sh
+source "$LOOP_ROOT/lib/labels.sh"
 
 TARGET_SLUG=""
 FIX_MODE=false
@@ -31,31 +33,32 @@ for arg in "$@"; do
     esac
 done
 
-# Canonical pipeline labels (name|color|description)
+# Canonical pipeline labels (name|color|description). Names sourced from
+# lib/labels.sh so this stays in sync with the canonical/deprecated split.
 CANONICAL_LABELS=(
-    "po-review|1D76DB|PO agent expands rough idea into full spec"
-    "dev|0075CA|Issue ready for automated dev cycle"
-    "in-progress|FFA500|Currently being worked on by dev agent"
-    "in-review|6A5ACD|Reviewer is looking at it"
-    "review-pending|9370DB|PR open, waiting for automated review"
-    "ready-for-qa|FFD700|Approved, needs QA validation"
-    "qa-pass|32CD32|QA passed, ready to merge"
-    "qa-fail|DC143C|QA failed, back to dev for rework"
-    "changes-requested|FFA07A|Reviewer requested changes"
-    "blocked|8B0000|Failed 3x, needs human"
+    "${LOOP_LABEL_DEPRECATED_PO_REVIEW}|1D76DB|PO agent expands rough idea into full spec"
+    "${LOOP_LABEL_DEPRECATED_DEV}|0075CA|Issue ready for automated dev cycle"
+    "${LOOP_LABEL_DEPRECATED_IN_PROGRESS}|FFA500|Currently being worked on by dev agent"
+    "${LOOP_LABEL_IN_REVIEW}|6A5ACD|Reviewer is looking at it"
+    "${LOOP_LABEL_DEPRECATED_REVIEW_PENDING}|9370DB|PR open, waiting for automated review"
+    "${LOOP_LABEL_DEPRECATED_READY_FOR_QA}|FFD700|Approved, needs QA validation"
+    "${LOOP_LABEL_QA_PASS}|32CD32|QA passed, ready to merge"
+    "${LOOP_LABEL_QA_FAIL}|DC143C|QA failed, back to dev for rework"
+    "${LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED}|FFA07A|Reviewer requested changes"
+    "${LOOP_LABEL_BLOCKED}|8B0000|Failed 3x, needs human"
     "needs-clarification|FF69B4|Dev hit ambiguity"
-    "done|006400|Merged and closed"
+    "${LOOP_LABEL_DONE}|006400|Merged and closed"
 )
 
-# Build lookup set of canonical names (and known aliases added by additive label rename)
-KNOWN_LABELS=(
-    po-review dev plan in-progress build
-    review-pending needs-review in-review
-    ready-for-qa needs-qa
-    qa-pass approved
-    qa-fail qa-failed
-    changes-requested needs-rework
-    blocked needs-clarification "done"
+# Build lookup set of canonical names + every deprecated alias the project
+# may still carry (handlers strip these as part of the migration).
+KNOWN_LABELS=("${LOOP_CANONICAL_LABELS[@]}")
+while IFS= read -r _alias; do
+    [ -n "$_alias" ] && KNOWN_LABELS+=("$_alias")
+done < <(loop_deprecated_aliases)
+KNOWN_LABELS+=(
+    build approved qa-failed
+    needs-clarification
     bug enhancement question documentation duplicate wontfix invalid
 )
 

--- a/scripts/merge-handler.sh
+++ b/scripts/merge-handler.sh
@@ -88,8 +88,8 @@ if ! backend_merge_pr "$REPO" "$PR_NUM" "$STRATEGY_FLAG" 2>&1 | tee -a "$LOG_FIL
         *CONFLICTING*|*DIRTY*)
             log "merge failed due to conflict — routing to dev-rework"
             bounty_report "merge_conflict" model="${LOOP_AGENT_MODEL:-sonnet}" role=merge project="$SLUG" pr_num="$PR_NUM" || true
-            backend_remove_label "$REPO" "$PR_NUM" qa-pass ready-for-qa
-            backend_add_label "$REPO" "$PR_NUM" changes-requested
+            backend_remove_label "$REPO" "$PR_NUM" qa-pass "$LOOP_LABEL_DEPRECATED_READY_FOR_QA"
+            backend_add_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED"
             backend_comment_pr "$REPO" "$PR_NUM" \
                 "Merge blocked by conflicts with \`${DEFAULT_BRANCH}\`. Routing back to dev-rework to rebase and resolve."
             exit 0

--- a/scripts/merge-handler.sh
+++ b/scripts/merge-handler.sh
@@ -14,6 +14,8 @@ source "$LOOP_ROOT/lib/env.sh"
 source "$LOOP_ROOT/lib/config.sh"
 # shellcheck source=../lib/backends/backend.sh
 source "$LOOP_ROOT/lib/backends/backend.sh"
+# shellcheck source=../lib/labels.sh
+source "$LOOP_ROOT/lib/labels.sh"
 source "$LOOP_ROOT/lib/bounty.sh"
 # shellcheck source=../lib/notify.sh
 source "$LOOP_ROOT/lib/notify.sh"
@@ -67,8 +69,8 @@ case "$MERGE_STATE" in
     *CONFLICTING*|*DIRTY*)
         log "PR #${PR_NUM} is CONFLICTING — bouncing to dev-rework (no retry loop)"
         bounty_report "merge_conflict" model="${LOOP_AGENT_MODEL:-sonnet}" role=merge project="$SLUG" pr_num="$PR_NUM" || true
-        backend_remove_label "$REPO" "$PR_NUM" qa-pass ready-for-qa
-        backend_add_label "$REPO" "$PR_NUM" changes-requested
+        backend_remove_label "$REPO" "$PR_NUM" qa-pass "$LOOP_LABEL_DEPRECATED_READY_FOR_QA"
+        backend_add_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED"
         backend_comment_pr "$REPO" "$PR_NUM" \
             "Merge blocked by conflicts with \`${DEFAULT_BRANCH}\`. Routing back to dev-rework to rebase and resolve."
         exit 0
@@ -262,6 +264,8 @@ BOUNTY_RECORD=$(REPO="$REPO" PR_NUM="$PR_NUM" SLUG="$SLUG" \
     LOOP_AGENT_MODEL="${LOOP_AGENT_MODEL:-unknown}" \
     LINKED_ISSUE="$FIRST_LINKED_ISSUE" \
     PR_TITLE="$PR_TITLE" \
+    LOOP_LBL_CR="$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" \
+    LOOP_LBL_NR="$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" \
     python3 <<'PY'
 import json, os, subprocess, datetime
 
@@ -282,9 +286,11 @@ raw = subprocess.run(
 ).stdout.strip()
 labels_added = json.loads(raw) if raw else []
 
+_LBL_CR = os.environ['LOOP_LBL_CR']
+_LBL_NR = os.environ['LOOP_LBL_NR']
 qa_fail    = bool({'qa-fail', 'qa-failed'} & set(labels_added))
-cr_labeled = bool({'changes-requested', 'needs-rework'} & set(labels_added))
-rework_count = (labels_added.count('changes-requested') + labels_added.count('needs-rework') +
+cr_labeled = bool({_LBL_CR, _LBL_NR} & set(labels_added))
+rework_count = (labels_added.count(_LBL_CR) + labels_added.count(_LBL_NR) +
                 labels_added.count('qa-fail') + labels_added.count('qa-failed'))
 
 if qa_fail:

--- a/scripts/po-handler.sh
+++ b/scripts/po-handler.sh
@@ -4,10 +4,11 @@
 #
 # Event payload: {"slug","repo","issue_number","issue_title","issue_url"}
 #
-# Takes a rough "[IDEA]" issue labeled 'po-review', invokes a Product Owner
-# agent that expands the body into a full spec (goal, acceptance criteria,
-# file scope, dependencies), rewrites the issue body, and swaps the label
-# from 'po-review' to 'dev' so the scanner picks it up next tick.
+# Takes a rough "[IDEA]" issue labeled with the workflow's PO trigger,
+# invokes a Product Owner agent that expands the body into a full spec
+# (goal, acceptance criteria, file scope, dependencies), rewrites the issue
+# body, and swaps the label to the dev trigger so the scanner picks it up
+# next tick.
 
 set -euo pipefail
 
@@ -21,6 +22,8 @@ source "$LOOP_ROOT/lib/runner.sh"
 source "$LOOP_ROOT/lib/config.sh"
 # shellcheck source=../lib/backends/backend.sh
 source "$LOOP_ROOT/lib/backends/backend.sh"
+# shellcheck source=../lib/labels.sh
+source "$LOOP_ROOT/lib/labels.sh"
 # shellcheck source=../lib/bounty.sh
 source "$LOOP_ROOT/lib/bounty.sh"
 # shellcheck source=../lib/notify.sh
@@ -57,8 +60,8 @@ fi
 loop_load_project "$SLUG" || { log "ERROR: unknown slug '$SLUG'"; exit 2; }
 loop_load_backend
 
-_po_trigger=$(loop_label_for "$SLUG" "po-review")
-_REWORK_LABEL=$(loop_label_for "$SLUG" "needs-rework")
+_po_trigger=$(loop_label_for "$SLUG" "$LOOP_LABEL_DEPRECATED_PO_REVIEW")
+_REWORK_LABEL=$(loop_label_for "$SLUG" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK")
 
 # Per-issue lock — PO writes only to one issue's body and labels, so two PO
 # workers on different issues in the same project are safe in parallel. The
@@ -83,14 +86,14 @@ fi
 
 log "po: slug=$SLUG repo=$REPO issue=#$ISSUE_NUM attempt=$((retries + 1))/$MAX_RETRIES"
 bounty_report "po_start" model="${LOOP_AGENT_MODEL:-sonnet}" role=po project="$SLUG" issue_num="$ISSUE_NUM" || true
-loop_notify "▶️ [$SLUG] #$ISSUE_NUM po-review starting"
+loop_notify "▶️ [$SLUG] #$ISSUE_NUM ${LOOP_LABEL_DEPRECATED_PO_REVIEW} starting"
 
 # Claim so scanner doesn't re-emit: strip workflow trigger label before adding in-progress
 # so the issue never carries both simultaneously.
 backend_remove_label "$REPO" "$ISSUE_NUM" "$_po_trigger"
 backend_add_label "$REPO" "$ISSUE_NUM" in-progress
 
-# Safety net: restore to po-review if killed or set -e fires before explicit cleanup.
+# Safety net: restore the workflow PO trigger if killed or set -e fires before explicit cleanup.
 _IN_PROGRESS_CLAIMED=1
 _po_label_cleanup() {
     [ "${_IN_PROGRESS_CLAIMED:-0}" = "1" ] || return 0
@@ -331,7 +334,7 @@ if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
     _IN_PROGRESS_CLAIMED=0  # disarm trap — success path handles cleanup
     log "po agent succeeded for #$ISSUE_NUM"
     bounty_report "po_done" model="${LOOP_AGENT_MODEL:-sonnet}" role=po project="$SLUG" issue_num="$ISSUE_NUM" || true
-    loop_notify "✅ [$SLUG] #$ISSUE_NUM po-review done"
+    loop_notify "✅ [$SLUG] #$ISSUE_NUM ${LOOP_LABEL_DEPRECATED_PO_REVIEW} done"
     retry_clear
     backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
     # Belt-and-braces: if agent forgot to apply progression label, add 'dev' as safe default.
@@ -348,7 +351,7 @@ else
         backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
         backend_add_label "$REPO" "$ISSUE_NUM" needs-clarification
         _post_failure_comment issue "$ISSUE_NUM" "PO agent" "$n" "$MAX_RETRIES"
-        loop_notify "❌ [$SLUG] #$ISSUE_NUM po-review failed: agent failed after $MAX_RETRIES attempts"
+        loop_notify "❌ [$SLUG] #$ISSUE_NUM ${LOOP_LABEL_DEPRECATED_PO_REVIEW} failed: agent failed after $MAX_RETRIES attempts"
     else
         backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
         backend_add_label "$REPO" "$ISSUE_NUM" "$_po_trigger"

--- a/scripts/qa-handler.sh
+++ b/scripts/qa-handler.sh
@@ -20,6 +20,8 @@ source "$LOOP_ROOT/lib/runner.sh"
 source "$LOOP_ROOT/lib/config.sh"
 # shellcheck source=../lib/backends/backend.sh
 source "$LOOP_ROOT/lib/backends/backend.sh"
+# shellcheck source=../lib/labels.sh
+source "$LOOP_ROOT/lib/labels.sh"
 source "$LOOP_ROOT/lib/bounty.sh"
 # shellcheck source=../lib/notify.sh
 source "$LOOP_ROOT/lib/notify.sh"
@@ -66,9 +68,9 @@ bounty_report "qa_start" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$S
 PR_STATE=$(backend_pr_view "$REPO" "$PR_NUM" --json state --jq .state 2>/dev/null || echo "")
 case "$PR_STATE" in
     MERGED|CLOSED)
-        log "PR #$PR_NUM is already $PR_STATE — skipping QA, removing needs-qa"
-        backend_remove_label "$REPO" "$PR_NUM" needs-qa
-        backend_remove_label "$REPO" "$PR_NUM" ready-for-qa
+        log "PR #$PR_NUM is already $PR_STATE — skipping QA, removing $LOOP_LABEL_NEEDS_QA"
+        backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_NEEDS_QA"
+        backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_READY_FOR_QA"
         exit 0
         ;;
 esac
@@ -101,7 +103,7 @@ You are performing four-phase smart QA on pull request #${PR_NUM}.
 
 1. Check PR state:
    gh pr view ${PR_NUM} --repo ${REPO} --json state,merged
-   If state=MERGED or state=CLOSED: remove labels 'ready-for-qa' and 'needs-qa',
+   If state=MERGED or state=CLOSED: remove labels '${LOOP_LABEL_DEPRECATED_READY_FOR_QA}' and '${LOOP_LABEL_NEEDS_QA}',
    leave a comment "PR already closed/merged — QA skipped.", and stop.
 
 2. Fetch PR details and diff:
@@ -207,10 +209,10 @@ Post the comment:
 Then apply the label:
 
 If qa-pass:
-   gh pr edit ${PR_NUM} --repo ${REPO} --remove-label needs-qa --remove-label ready-for-qa --remove-label qa-failed --remove-label qa-fail --add-label ${_QA_PASS_LABEL}
+   gh pr edit ${PR_NUM} --repo ${REPO} --remove-label ${LOOP_LABEL_NEEDS_QA} --remove-label ${LOOP_LABEL_DEPRECATED_READY_FOR_QA} --remove-label qa-failed --remove-label qa-fail --add-label ${_QA_PASS_LABEL}
 
 If qa-fail:
-   gh pr edit ${PR_NUM} --repo ${REPO} --remove-label needs-qa --remove-label ready-for-qa --remove-label approved --remove-label qa-pass --remove-label qa-fail --add-label ${_QA_FAIL_LABEL}
+   gh pr edit ${PR_NUM} --repo ${REPO} --remove-label ${LOOP_LABEL_NEEDS_QA} --remove-label ${LOOP_LABEL_DEPRECATED_READY_FOR_QA} --remove-label approved --remove-label qa-pass --remove-label qa-fail --add-label ${_QA_FAIL_LABEL}
 
 IMPORTANT: You MUST finish by applying either '${_QA_PASS_LABEL}' or '${_QA_FAIL_LABEL}'. The pipeline
 stalls if neither is applied. Verify with:
@@ -225,8 +227,8 @@ rm -f "$_PROMPT_FILE"
 if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
     log "qa agent finished for PR #$PR_NUM"
     loop_notify "✅ [$SLUG] PR#$PR_NUM qa done"
-    backend_remove_label "$REPO" "$PR_NUM" needs-qa
-    backend_remove_label "$REPO" "$PR_NUM" ready-for-qa
+    backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_NEEDS_QA"
+    backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_READY_FOR_QA"
 
     # Report the actual outcome based on which label the agent applied.
     if backend_pr_has_any_label "$REPO" "$PR_NUM" qa-pass "$_QA_PASS_LABEL"; then
@@ -249,8 +251,8 @@ else
     log "qa agent failed for PR #$PR_NUM"
     bounty_report "qa_fail" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$SLUG" pr_num="$PR_NUM" || true
     loop_notify "❌ [$SLUG] PR#$PR_NUM qa failed: agent error"
-    backend_remove_label "$REPO" "$PR_NUM" needs-qa
-    backend_remove_label "$REPO" "$PR_NUM" ready-for-qa
+    backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_NEEDS_QA"
+    backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_READY_FOR_QA"
     backend_remove_label "$REPO" "$PR_NUM" approved
     backend_remove_label "$REPO" "$PR_NUM" qa-pass
     backend_remove_label "$REPO" "$PR_NUM" qa-fail

--- a/scripts/review-handler.sh
+++ b/scripts/review-handler.sh
@@ -6,7 +6,7 @@
 #
 # Flow: label PR 'in-review' → invoke orchestrator with reviewer prompt →
 # agent reviews diff + PR body against the issue being closed →
-# applies 'needs-qa' on approve or 'needs-rework' on reject.
+# applies 'needs-qa' on approve or the workflow's rework label on reject.
 
 set -euo pipefail
 
@@ -20,6 +20,8 @@ source "$LOOP_ROOT/lib/runner.sh"
 source "$LOOP_ROOT/lib/config.sh"
 # shellcheck source=../lib/backends/backend.sh
 source "$LOOP_ROOT/lib/backends/backend.sh"
+# shellcheck source=../lib/labels.sh
+source "$LOOP_ROOT/lib/labels.sh"
 source "$LOOP_ROOT/lib/bounty.sh"
 # shellcheck source=../lib/notify.sh
 source "$LOOP_ROOT/lib/notify.sh"
@@ -86,9 +88,9 @@ retry_clear() { rm -f "$RETRY_FILE"; }
 retries=$(retry_count)
 if [ "$retries" -ge "$MAX_RETRIES" ]; then
     log "PR #$PR_NUM already failed review ${retries}x — labeling ${_REWORK_LABEL}"
-    backend_remove_label "$REPO" "$PR_NUM" needs-review
-    backend_remove_label "$REPO" "$PR_NUM" review-pending
-    backend_remove_label "$REPO" "$PR_NUM" in-review
+    backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_NEEDS_REVIEW"
+    backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_REVIEW_PENDING"
+    backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_IN_REVIEW"
     backend_remove_label "$REPO" "$PR_NUM" "$_REWORK_LABEL"
     backend_add_label "$REPO" "$PR_NUM" "$_REWORK_LABEL"
     exit 0
@@ -98,9 +100,9 @@ log "review: slug=$SLUG repo=$REPO pr=#$PR_NUM attempt=$((retries + 1))/$MAX_RET
 bounty_report "review_start" model="${LOOP_AGENT_MODEL:-sonnet}" role=reviewer project="$SLUG" pr_num="$PR_NUM" || true
 loop_notify "▶️ [$SLUG] PR#$PR_NUM review starting"
 
-backend_remove_label "$REPO" "$PR_NUM" needs-review
-backend_remove_label "$REPO" "$PR_NUM" review-pending
-backend_add_label "$REPO" "$PR_NUM" in-review
+backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_NEEDS_REVIEW"
+backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_REVIEW_PENDING"
+backend_add_label "$REPO" "$PR_NUM" "$LOOP_LABEL_IN_REVIEW"
 
 _BACKEND_CLI_NOTE=$(backend_cli_note)
 
@@ -163,9 +165,12 @@ if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
     backend_remove_label "$REPO" "$PR_NUM" in-review
     # Belt-and-braces: if agent forgot to apply a decision label, default to rework
     # (workflow-resolved) so the PR doesn't silently disappear from the pipeline.
-    if ! backend_pr_has_any_label "$REPO" "$PR_NUM" needs-qa ready-for-qa needs-rework changes-requested blocked 'done'; then
+    if ! backend_pr_has_any_label "$REPO" "$PR_NUM" \
+            "$LOOP_LABEL_NEEDS_QA" "$LOOP_LABEL_DEPRECATED_READY_FOR_QA" \
+            "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" \
+            blocked 'done'; then
         log "WARN: PR #$PR_NUM has no decision label after review agent — defaulting to '${_REWORK_LABEL}'"
-        backend_remove_label "$REPO" "$PR_NUM" needs-rework changes-requested
+        backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED"
         backend_add_label "$REPO" "$PR_NUM" "$_REWORK_LABEL"
     fi
 else

--- a/scripts/senior-dev-handler.sh
+++ b/scripts/senior-dev-handler.sh
@@ -18,6 +18,8 @@ source "$LOOP_ROOT/lib/runner.sh"
 source "$LOOP_ROOT/lib/config.sh"
 # shellcheck source=../lib/backends/backend.sh
 source "$LOOP_ROOT/lib/backends/backend.sh"
+# shellcheck source=../lib/labels.sh
+source "$LOOP_ROOT/lib/labels.sh"
 source "$LOOP_ROOT/lib/bounty.sh"
 # shellcheck source=../lib/notify.sh
 source "$LOOP_ROOT/lib/notify.sh"
@@ -103,7 +105,7 @@ if ! git -C "$ROOT" worktree add "$WORKTREE_ROOT" "origin/$DEFAULT_BRANCH" 2>&1 
 fi
 log "worktree ready: $WORKTREE_ROOT (isolated from other handlers)"
 
-REVIEW_LABEL=$(loop_stage_trigger "$SLUG" review pr 2>/dev/null || echo review-pending)
+REVIEW_LABEL=$(loop_stage_trigger "$SLUG" review pr 2>/dev/null || echo "$LOOP_LABEL_DEPRECATED_REVIEW_PENDING")
 
 TASK_PROMPT=$(cat <<EOF
 You are the Senior Developer for ${NAME} (slug: ${SLUG}).
@@ -151,7 +153,7 @@ $( [ -n "$DEV_VALIDATION_CMD" ] && echo "4. Run validation: ${DEV_VALIDATION_CMD
 <what QA should verify>' \\
      --label ${REVIEW_LABEL}
 8. On your own issue — this step is MANDATORY to signal success to the pipeline:
-   gh issue edit ${ISSUE_NUM} --repo ${REPO} --remove-label in-progress --remove-label senior-dev --remove-label plan --remove-label needs-review --remove-label review-pending --add-label ${REVIEW_LABEL}
+   gh issue edit ${ISSUE_NUM} --repo ${REPO} --remove-label in-progress --remove-label senior-dev --remove-label plan --remove-label needs-review --remove-label ${LOOP_LABEL_DEPRECATED_REVIEW_PENDING} --add-label ${REVIEW_LABEL}
 
 IMPORTANT: The issue MUST end this run with label '${REVIEW_LABEL}' (or 'needs-clarification' if blocked). Verify with:
    gh issue view ${ISSUE_NUM} --repo ${REPO} --json labels
@@ -194,11 +196,13 @@ if matches:
     else
         log "belt-and-braces: found PR #$_senior_pr_num for issue #$ISSUE_NUM"
         if ! backend_pr_has_any_label "$REPO" "$_senior_pr_num" \
-                review-pending needs-review changes-requested needs-rework in-review needs-clarification blocked 'done'; then
+                "$LOOP_LABEL_DEPRECATED_REVIEW_PENDING" "$LOOP_LABEL_NEEDS_REVIEW" \
+                "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" \
+                "$LOOP_LABEL_IN_REVIEW" needs-clarification blocked 'done'; then
             log "WARN: PR #$_senior_pr_num has no progression label after senior-dev agent — adding '${REVIEW_LABEL}'"
             backend_add_label "$REPO" "$_senior_pr_num" "$REVIEW_LABEL"
         fi
-        backend_remove_label "$REPO" "$ISSUE_NUM" needs-review review-pending plan senior-dev in-progress
+        backend_remove_label "$REPO" "$ISSUE_NUM" "$LOOP_LABEL_NEEDS_REVIEW" "$LOOP_LABEL_DEPRECATED_REVIEW_PENDING" plan senior-dev in-progress
     fi
     cleanup_worktree
 else

--- a/tests/labels.bats
+++ b/tests/labels.bats
@@ -1,0 +1,101 @@
+#!/usr/bin/env bats
+# tests/labels.bats — verify lib/labels.sh canonical set + deprecated alias map.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    # shellcheck source=../lib/labels.sh
+    source "$REPO_ROOT/lib/labels.sh"
+}
+
+@test "canonical set has the expected 11 names" {
+    [ "${#LOOP_CANONICAL_LABELS[@]}" -eq 11 ]
+    local expected="needs-po in-po needs-dev in-dev needs-review in-review needs-qa qa-pass qa-fail blocked done"
+    local actual="${LOOP_CANONICAL_LABELS[*]}"
+    [ "$actual" = "$expected" ]
+}
+
+@test "convenience scalars match the canonical names" {
+    [ "$LOOP_LABEL_NEEDS_PO"     = "needs-po" ]
+    [ "$LOOP_LABEL_IN_PO"        = "in-po" ]
+    [ "$LOOP_LABEL_NEEDS_DEV"    = "needs-dev" ]
+    [ "$LOOP_LABEL_IN_DEV"       = "in-dev" ]
+    [ "$LOOP_LABEL_NEEDS_REVIEW" = "needs-review" ]
+    [ "$LOOP_LABEL_IN_REVIEW"    = "in-review" ]
+    [ "$LOOP_LABEL_NEEDS_QA"     = "needs-qa" ]
+    [ "$LOOP_LABEL_QA_PASS"      = "qa-pass" ]
+    [ "$LOOP_LABEL_QA_FAIL"      = "qa-fail" ]
+    [ "$LOOP_LABEL_BLOCKED"      = "blocked" ]
+    [ "$LOOP_LABEL_DONE"         = "done" ]
+}
+
+@test "every deprecated alias resolves to a canonical label" {
+    local alias canonical
+    while IFS= read -r alias; do
+        [ -z "$alias" ] && continue
+        canonical=$(loop_canonical_label "$alias")
+        run loop_is_canonical_label "$canonical"
+        [ "$status" -eq 0 ] || {
+            echo "alias '$alias' resolved to non-canonical '$canonical'" >&2
+            return 1
+        }
+    done < <(loop_deprecated_aliases)
+}
+
+@test "deprecated aliases match the spec" {
+    [ "$(loop_canonical_label po-review)"          = "needs-po" ]
+    [ "$(loop_canonical_label dev)"                = "needs-dev" ]
+    [ "$(loop_canonical_label plan)"               = "needs-dev" ]
+    [ "$(loop_canonical_label in-progress)"        = "needs-dev" ]
+    [ "$(loop_canonical_label review-pending)"     = "needs-review" ]
+    [ "$(loop_canonical_label ready-for-qa)"       = "needs-qa" ]
+    [ "$(loop_canonical_label needs-rework)"       = "needs-dev" ]
+    [ "$(loop_canonical_label changes-requested)"  = "needs-dev" ]
+    [ "$(loop_canonical_label in-rework)"          = "in-dev" ]
+}
+
+@test "loop_canonical_label echoes unknown names unchanged" {
+    [ "$(loop_canonical_label some-random-label)" = "some-random-label" ]
+}
+
+@test "loop_canonical_label echoes canonical names unchanged" {
+    local l
+    for l in "${LOOP_CANONICAL_LABELS[@]}"; do
+        [ "$(loop_canonical_label "$l")" = "$l" ]
+    done
+}
+
+@test "loop_is_canonical_label distinguishes canonical from deprecated" {
+    run loop_is_canonical_label needs-review
+    [ "$status" -eq 0 ]
+    run loop_is_canonical_label review-pending
+    [ "$status" -ne 0 ]
+}
+
+@test "loop_is_deprecated_label flags every alias and rejects canonicals" {
+    local alias l
+    while IFS= read -r alias; do
+        [ -z "$alias" ] && continue
+        run loop_is_deprecated_label "$alias"
+        [ "$status" -eq 0 ]
+    done < <(loop_deprecated_aliases)
+    for l in "${LOOP_CANONICAL_LABELS[@]}"; do
+        run loop_is_deprecated_label "$l"
+        [ "$status" -ne 0 ]
+    done
+}
+
+@test "loop_deprecated_aliases_for lists all aliases pointing at a canonical" {
+    local out
+    out=$(loop_deprecated_aliases_for needs-dev | sort | tr '\n' ' ')
+    [[ "$out" == *"dev"* ]]
+    [[ "$out" == *"plan"* ]]
+    [[ "$out" == *"in-progress"* ]]
+    [[ "$out" == *"needs-rework"* ]]
+    [[ "$out" == *"changes-requested"* ]]
+}
+
+@test "lib/labels.sh is idempotent when re-sourced" {
+    source "$REPO_ROOT/lib/labels.sh"
+    source "$REPO_ROOT/lib/labels.sh"
+    [ "${#LOOP_CANONICAL_LABELS[@]}" -eq 11 ]
+}


### PR DESCRIPTION
Closes #167

## Changes

- New **`lib/labels.sh`** exports the canonical Loop label vocabulary as the single source of truth:
  - `LOOP_CANONICAL_LABELS` — array of the 11 canonical names (`needs-po`, `in-po`, `needs-dev`, `in-dev`, `needs-review`, `in-review`, `needs-qa`, `qa-pass`, `qa-fail`, `blocked`, `done`)
  - `LOOP_DEPRECATED_ALIAS_MAP` — newline-separated `<alias> <canonical>` pairs (bash 3.x-compatible; no associative arrays)
  - Per-name scalars (`LOOP_LABEL_NEEDS_REVIEW`, `LOOP_LABEL_DEPRECATED_REVIEW_PENDING`, etc.) for handler use
  - Helpers: `loop_canonical_label`, `loop_is_canonical_label`, `loop_is_deprecated_label`, `loop_deprecated_aliases`, `loop_deprecated_aliases_for`
- Deprecated-alias mapping per the spec: `po-review`→`needs-po`; `dev`/`plan`/`in-progress`→`needs-dev`; `review-pending`→`needs-review`; `ready-for-qa`→`needs-qa`; `needs-rework`/`changes-requested`→`needs-dev`; `in-rework`→`in-dev`.
- Every handler under `scripts/` and every script under `scanner/` now sources `lib/labels.sh` and references the constants instead of hardcoded strings. After this PR, `grep -rE 'po-review|review-pending|ready-for-qa|in-rework|changes-requested' scripts/ scanner/` returns nothing.
- `scripts/label-audit.sh` and `scripts/adopt.sh` rebuild their canonical/known-alias lists from `lib/labels.sh` (adopt's heuristic match-token list passes the deprecated alias values via env into its embedded Python so the file itself stays free of literals).
- New **`tests/labels.bats`** (10 tests) asserts the canonical set is exactly the 11 expected names, every deprecated alias resolves to a canonical label, the deprecated-alias spec from the issue is preserved verbatim, and the file is idempotent on re-source.

Workflow YAMLs, `lib/backends/`, and `config/projects.yaml` were intentionally left untouched per the issue's "Out of scope" section.

## Test Plan

- [ ] `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` passes (verified locally).
- [ ] `shellcheck -S warning` on the same set passes (verified locally).
- [ ] `bats tests/labels.bats` — all 10 tests pass.
- [ ] `grep -rE 'po-review|review-pending|ready-for-qa|in-rework|changes-requested' scripts/ scanner/` returns nothing.
- [ ] Existing pipeline still routes events correctly (smoke-check on a project after merge): handlers still strip the deprecated trigger labels, scanner still skips PRs carrying the in-flight rework alias, reconciler still classifies orphaned issues by deprecated alias.