### PR TITLE
[LOOP-163] author-gate: honour operator-approved label as per-ticket override

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,36 @@
+# Security notes
+
+For the full threat model and trust boundaries, see
+[`docs/security-model.md`](./security-model.md). This file documents
+narrow security-relevant operator contracts.
+
+## `operator-approved` label — per-ticket override of the author allow-list
+
+When `ALLOWED_AUTHORS` is configured for a project, the scanner silently
+skips any issue or PR whose author is not on the list. Applying the
+`operator-approved` label to a single ticket bypasses that check **for
+that ticket only**, leaving the allow-list intact as the default
+boundary.
+
+### Semantics
+
+- Scope is per-ticket. The label has no effect on sibling issues/PRs.
+- Removing the label restores normal author-gate behaviour on the next
+  scan tick.
+- Tickets carrying the label are excluded from the
+  `author_gated_pending` digest emitted by the reconciler — they are
+  considered approved, not parked.
+
+### Trust model
+
+The label is a **documentation/operator contract**, not an enforcement
+mechanism. Loop does not verify who applied the label. The label is
+meaningful only when applied by an allow-listed user; preventing
+untrusted users from applying it is the job of GitHub repository
+permissions (e.g. branch protection, restricting the
+`operator-approved` label to maintainers, or requiring write access to
+edit labels).
+
+If your repo permits arbitrary users to set labels, the override is
+worth nothing — treat label-application authority as part of your
+allow-list policy.

--- a/install.sh
+++ b/install.sh
@@ -922,6 +922,7 @@ labels_spec=(
     "changes-requested|FFA07A|[deprecated: use needs-rework] Reviewer requested changes"
     "needs-rework|FFA07A|Reviewer requested changes, needs rework"
     "blocked|8B0000|Failed 3x, needs human"
+    "operator-approved|2EA043|Override the author allow-list for this single ticket (see docs/security.md)"
     "needs-clarification|FF69B4|Dev hit ambiguity"
     "done|006400|Merged and closed"
     "semver:major|b60205|Bump major version on next release"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -176,10 +176,20 @@ _pr_downstream_labels() {
     echo "$result"
 }
 
-# author_is_allowed <author_login>
-# Returns 0 (true) if ALLOWED_AUTHORS is empty or contains the author.
+# author_is_allowed <author_login> [labels_space_separated]
+# Returns 0 (true) if any of the following holds:
+#   - ALLOWED_AUTHORS is empty (gate disabled)
+#   - the ticket carries the `operator-approved` label (per-ticket override)
+#   - the author appears in ALLOWED_AUTHORS
+# The label override is a documentation/operator contract — enforcement of who
+# may apply the label is done by GitHub repo permissions, not loop code.
+# See docs/security.md for the override semantics.
 author_is_allowed() {
     local author="$1"
+    local labels="${2:-}"
+    case " $labels " in
+        *" operator-approved "*) return 0 ;;
+    esac
     [ -z "${ALLOWED_AUTHORS:-}" ] && return 0
     local IFS=','
     for a in $ALLOWED_AUTHORS; do
@@ -268,7 +278,9 @@ _scan_issue_stage() {
         title=$(printf '%s' "$row"  | python3 -c "import json,sys; print(json.load(sys.stdin)['title'])")
         url=$(printf '%s' "$row"    | python3 -c "import json,sys; print(json.load(sys.stdin)['url'])")
         author=$(printf '%s' "$row" | python3 -c "import json,sys; print(json.load(sys.stdin).get('author',''))")
-        if ! author_is_allowed "$author"; then
+        local labels
+        labels=$(printf '%s' "$row" | python3 -c "import json,sys; print(' '.join(json.load(sys.stdin).get('labels') or []))")
+        if ! author_is_allowed "$author" "$labels"; then
             log "skip $event_type #$num: author '$author' not in ALLOWED_AUTHORS"
             continue
         fi
@@ -336,12 +348,13 @@ PY
     while IFS= read -r _row; do
         [ "$_emitted" -ge "$_slots" ] && break
         [ -z "$_row" ] && continue
-        local _num _title _url _author _unmet _evt
+        local _num _title _url _author _labels _unmet _evt
         _num=$(printf '%s' "$_row"    | python3 -c "import json,sys; print(json.load(sys.stdin)['number'])")
         _title=$(printf '%s' "$_row"  | python3 -c "import json,sys; print(json.load(sys.stdin)['title'])")
         _url=$(printf '%s' "$_row"    | python3 -c "import json,sys; print(json.load(sys.stdin)['url'])")
         _author=$(printf '%s' "$_row" | python3 -c "import json,sys; print(json.load(sys.stdin).get('author',''))")
-        if ! author_is_allowed "$_author"; then
+        _labels=$(printf '%s' "$_row" | python3 -c "import json,sys; print(' '.join(json.load(sys.stdin).get('labels') or []))")
+        if ! author_is_allowed "$_author" "$_labels"; then
             log "skip dev_issue #$_num: author '$_author' not in ALLOWED_AUTHORS"
             continue
         fi

--- a/tests/scanner.bats
+++ b/tests/scanner.bats
@@ -137,6 +137,34 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
+# author_is_allowed — author allow-list with operator-approved override
+# ---------------------------------------------------------------------------
+
+@test "author_is_allowed: allow-listed author passes" {
+    export ALLOWED_AUTHORS="alice,bob"
+    run author_is_allowed "alice" ""
+    [ "$status" -eq 0 ]
+}
+
+@test "author_is_allowed: outsider without override is rejected" {
+    export ALLOWED_AUTHORS="alice"
+    run author_is_allowed "mallory" "dev p2-medium"
+    [ "$status" -eq 1 ]
+}
+
+@test "author_is_allowed: operator-approved label bypasses gate for outsider" {
+    export ALLOWED_AUTHORS="alice"
+    run author_is_allowed "mallory" "dev operator-approved"
+    [ "$status" -eq 0 ]
+}
+
+@test "author_is_allowed: empty ALLOWED_AUTHORS lets everyone through" {
+    export ALLOWED_AUTHORS=""
+    run author_is_allowed "anyone" ""
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
 # issue_is_claimed — uses workflow-derived PR stage labels
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #163

## Changes
- `scanner/scanner.sh`: `author_is_allowed` now accepts an optional space-separated labels arg; presence of `operator-approved` short-circuits to allow. Both call sites (`_scan_issue_stage`, `_scan_dev_issue_stage`) extract `labels` from the row JSON and pass them through.
- `install.sh`: added `operator-approved` (green) to the bootstrap `labels_spec` so new projects pick it up automatically.
- `tests/scanner.bats`: added 4 unit tests covering `author_is_allowed` — allow-listed pass, outsider reject, outsider-with-override pass, empty allow-list pass.
- `docs/security.md` (new): brief operator-facing note on override semantics, scope, and the trust model (label is a contract; GitHub permissions are the enforcement layer).

The reconciler (`lib/author_gate.sh`) already excludes `operator-approved` tickets from the digest, so behaviour there is unchanged.

## Test Plan
- [ ] `bash -n` and `shellcheck -S warning` clean across `lib/*.sh scripts/*.sh scanner/*.sh install.sh`
- [ ] `bats tests/scanner.bats` — 4 new tests pass, existing tests unaffected
- [ ] `bats tests/author_gated.bats` still green (no changes to reconciler)
- [ ] In a project with `ALLOWED_AUTHORS=alice,bob`, an issue authored by `mallory` is silently skipped — adding `operator-approved` causes the next scan tick to dispatch it
- [ ] Removing the label restores the gate on the following tick