### PR TITLE
[LOOP-170] feat: migrate-labels.sh — deprecated→canonical GitHub label migration

### DIFF
--- a/scripts/migrate-labels.sh
+++ b/scripts/migrate-labels.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# migrate-labels.sh — one-shot deprecated→canonical GitHub label migration.
+#
+# Walks every project in config/projects.yaml (or one project via --slug),
+# re-tags every open issue/PR carrying a deprecated alias with the canonical
+# label, then deletes the deprecated label definition from the repo.
+#
+# Canonical and deprecated names come from lib/labels.sh (single source of
+# truth). Idempotent: a second --all run after a clean migration produces
+# zero changes and exits 0.
+#
+# Usage:
+#   scripts/migrate-labels.sh --slug <s>           # one project, dry-run
+#   scripts/migrate-labels.sh --all                # every project, dry-run
+#   scripts/migrate-labels.sh --slug <s> --apply   # mutate
+#   scripts/migrate-labels.sh --all --apply
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROJECTS_YAML="${LOOP_CONFIG:-$LOOP_ROOT/config/projects.yaml}"
+
+# shellcheck source=../lib/labels.sh
+source "$LOOP_ROOT/lib/labels.sh"
+
+TARGET_SLUG=""
+ALL=false
+APPLY=false
+
+usage() { sed -n '1,16p' "$0"; }
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --slug=*) TARGET_SLUG="${1#--slug=}"; shift ;;
+        --slug)   TARGET_SLUG="${2:-}"; shift 2 ;;
+        --all)    ALL=true; shift ;;
+        --dry-run) APPLY=false; shift ;;
+        --apply)  APPLY=true; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+if ! $ALL && [ -z "$TARGET_SLUG" ]; then
+    echo "error: pass --slug <s> or --all" >&2
+    usage >&2
+    exit 2
+fi
+
+if [ ! -f "$PROJECTS_YAML" ]; then
+    echo "error: projects config not found at $PROJECTS_YAML" >&2
+    exit 2
+fi
+
+slugs=()
+if $ALL; then
+    while IFS= read -r s; do
+        [ -n "$s" ] && slugs+=("$s")
+    done < <(python3 - "$PROJECTS_YAML" <<'PY'
+import sys, yaml
+with open(sys.argv[1]) as f:
+    data = yaml.safe_load(f) or {}
+for p in data.get("projects", []) or []:
+    s = p.get("slug")
+    if s:
+        print(s)
+PY
+)
+else
+    slugs=("$TARGET_SLUG")
+fi
+
+if [ ${#slugs[@]} -eq 0 ]; then
+    echo "no projects found in $PROJECTS_YAML" >&2
+    exit 0
+fi
+
+repo_for_slug() {
+    python3 - "$PROJECTS_YAML" "$1" <<'PY'
+import sys, yaml
+with open(sys.argv[1]) as f:
+    data = yaml.safe_load(f) or {}
+for p in data.get("projects", []) or []:
+    if p.get("slug") == sys.argv[2]:
+        print(p.get("repo", ""))
+        break
+PY
+}
+
+mode_label="dry-run"
+$APPLY && mode_label="apply"
+
+overall_rc=0
+
+for slug in "${slugs[@]}"; do
+    repo=$(repo_for_slug "$slug")
+    if [ -z "$repo" ]; then
+        echo "[WARN] slug '$slug' not found in $PROJECTS_YAML — skipping" >&2
+        overall_rc=1
+        continue
+    fi
+
+    echo "── $slug ($repo) [$mode_label] ─────────────"
+
+    existing=$(gh label list --repo "$repo" --limit 200 --json name --jq '.[].name' 2>/dev/null || true)
+
+    renamed=0
+    deleted=0
+
+    while IFS=' ' read -r dep canon; do
+        [ -z "$dep" ] && continue
+
+        if ! grep -Fxq "$dep" <<<"$existing"; then
+            continue
+        fi
+
+        items_json=$(gh issue list --repo "$repo" --state open --label "$dep" --limit 500 \
+                       --json number 2>/dev/null || echo "[]")
+        prs_json=$(gh pr list --repo "$repo" --state open --label "$dep" --limit 500 \
+                       --json number 2>/dev/null || echo "[]")
+
+        issue_nums=$(echo "$items_json" | python3 -c 'import sys, json; [print(i["number"]) for i in json.load(sys.stdin)]' 2>/dev/null || true)
+        pr_nums=$(echo "$prs_json" | python3 -c 'import sys, json; [print(i["number"]) for i in json.load(sys.stdin)]' 2>/dev/null || true)
+
+        for n in $issue_nums; do
+            echo "  rename #$n: $dep → $canon"
+            if $APPLY; then
+                if ! gh issue edit "$n" --repo "$repo" --add-label "$canon" --remove-label "$dep" >/dev/null; then
+                    echo "    [WARN] failed to retag issue #$n" >&2
+                    overall_rc=1
+                    continue
+                fi
+            fi
+            renamed=$((renamed + 1))
+        done
+        for n in $pr_nums; do
+            echo "  rename PR #$n: $dep → $canon"
+            if $APPLY; then
+                if ! gh pr edit "$n" --repo "$repo" --add-label "$canon" --remove-label "$dep" >/dev/null; then
+                    echo "    [WARN] failed to retag PR #$n" >&2
+                    overall_rc=1
+                    continue
+                fi
+            fi
+            renamed=$((renamed + 1))
+        done
+
+        # Re-check that nothing still carries the deprecated label before deleting it.
+        if $APPLY; then
+            remaining_issues=$(gh issue list --repo "$repo" --state open --label "$dep" --limit 1 \
+                                  --json number --jq 'length' 2>/dev/null || echo "0")
+            remaining_prs=$(gh pr list --repo "$repo" --state open --label "$dep" --limit 1 \
+                                  --json number --jq 'length' 2>/dev/null || echo "0")
+        else
+            remaining_issues=$(echo "$items_json" | python3 -c 'import sys,json; print(len(json.load(sys.stdin)))' 2>/dev/null || echo "0")
+            remaining_prs=$(echo "$prs_json" | python3 -c 'import sys,json; print(len(json.load(sys.stdin)))' 2>/dev/null || echo "0")
+        fi
+
+        if [ "$remaining_issues" = "0" ] && [ "$remaining_prs" = "0" ]; then
+            echo "  delete label: $dep"
+            if $APPLY; then
+                if gh label delete "$dep" --repo "$repo" --yes >/dev/null 2>&1; then
+                    deleted=$((deleted + 1))
+                else
+                    echo "    [WARN] failed to delete label '$dep' (perms? still in use?)" >&2
+                    overall_rc=1
+                fi
+            else
+                deleted=$((deleted + 1))
+            fi
+        else
+            echo "  [SKIP] label '$dep' still attached (issues=$remaining_issues prs=$remaining_prs) — not deleting"
+            overall_rc=1
+        fi
+    done <<EOF
+$LOOP_DEPRECATED_ALIAS_MAP
+EOF
+
+    echo "migrate-labels slug=$slug renamed=$renamed deleted=$deleted"
+done
+
+exit "$overall_rc"

--- a/tests/migrate-labels.bats
+++ b/tests/migrate-labels.bats
@@ -1,0 +1,140 @@
+#!/usr/bin/env bats
+# tests/migrate-labels.bats — unit tests for scripts/migrate-labels.sh.
+#
+# Stubs `gh` via a fake binary on PATH so no real GitHub calls are made.
+# Deprecated→canonical pairs come from lib/labels.sh.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    SCRIPT="$REPO_ROOT/scripts/migrate-labels.sh"
+
+    cat > "$BATS_TMPDIR/projects.yaml" <<'YAML'
+version: 1
+projects:
+  - slug: alpha
+    name: Alpha
+    repo: owner/alpha
+    root: /tmp/fake
+    default_branch: main
+    workflow: default
+YAML
+    export LOOP_CONFIG="$BATS_TMPDIR/projects.yaml"
+
+    BIN_DIR="$BATS_TMPDIR/bin"
+    mkdir -p "$BIN_DIR"
+    export GH_LOG="$BATS_TMPDIR/gh.log"
+    rm -f "$GH_LOG"
+    export GH_LABEL_LIST="${GH_LABEL_LIST:-}"
+    export GH_ISSUE_NUMS="${GH_ISSUE_NUMS:-}"
+    export GH_PR_NUMS="${GH_PR_NUMS:-}"
+
+    cat > "$BIN_DIR/gh" <<'SH'
+#!/usr/bin/env bash
+printf 'gh %s\n' "$*" >> "$GH_LOG"
+case "$1 $2" in
+  "label list")
+        printf '%s\n' $GH_LABEL_LIST
+        ;;
+  "issue list"|"pr list")
+        if [ "$1" = "issue" ]; then nums="$GH_ISSUE_NUMS"; else nums="$GH_PR_NUMS"; fi
+        want_length=0
+        for a in "$@"; do
+            if [ "$a" = "length" ]; then want_length=1; break; fi
+        done
+        if [ $want_length -eq 1 ]; then
+            count=0
+            for n in $nums; do count=$((count + 1)); done
+            printf '%s\n' "$count"
+        else
+            printf '['
+            first=1
+            for n in $nums; do
+                if [ $first -eq 1 ]; then first=0; else printf ','; fi
+                printf '{"number":%s}' "$n"
+            done
+            printf ']\n'
+        fi
+        ;;
+  "issue edit"|"pr edit"|"label delete")
+        : # success
+        ;;
+esac
+exit 0
+SH
+    chmod +x "$BIN_DIR/gh"
+    export PATH="$BIN_DIR:$PATH"
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/projects.yaml" "$BATS_TMPDIR/gh.log"
+}
+
+@test "rejects invocation without --slug or --all" {
+    run bash "$SCRIPT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"--slug"* ]]
+}
+
+@test "no deprecated labels present → zero changes, zero summary, exit 0" {
+    export GH_LABEL_LIST="needs-po needs-dev needs-review needs-qa qa-pass qa-fail blocked done"
+    run bash "$SCRIPT" --slug alpha
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"renamed=0 deleted=0"* ]]
+    run grep -E "issue edit|pr edit|label delete" "$GH_LOG"
+    [ "$status" -ne 0 ]
+}
+
+@test "dry-run: deprecated label with no open items → planned delete, no mutation" {
+    export GH_LABEL_LIST="plan needs-po needs-dev"
+    export GH_ISSUE_NUMS=""
+    export GH_PR_NUMS=""
+    run bash "$SCRIPT" --slug alpha
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"delete label: plan"* ]]
+    [[ "$output" == *"renamed=0 deleted=1"* ]]
+    run grep "label delete" "$GH_LOG"
+    [ "$status" -ne 0 ]
+}
+
+@test "dry-run: deprecated label with open items → planned renames, skips delete" {
+    export GH_LABEL_LIST="in-progress needs-dev"
+    export GH_ISSUE_NUMS="42 43"
+    export GH_PR_NUMS="100"
+    run bash "$SCRIPT" --slug alpha
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"rename #42: in-progress → needs-dev"* ]]
+    [[ "$output" == *"rename PR #100: in-progress → needs-dev"* ]]
+    [[ "$output" == *"renamed=3"* ]]
+    [[ "$output" == *"[SKIP] label 'in-progress' still attached"* ]]
+}
+
+@test "apply: invokes gh label delete when label is unused" {
+    export GH_LABEL_LIST="po-review needs-po"
+    export GH_ISSUE_NUMS=""
+    export GH_PR_NUMS=""
+    run bash "$SCRIPT" --slug alpha --apply
+    [ "$status" -eq 0 ]
+    run grep "label delete po-review" "$GH_LOG"
+    [ "$status" -eq 0 ]
+}
+
+@test "unknown slug fails gracefully" {
+    run bash "$SCRIPT" --slug nope
+    [[ "$output" == *"slug 'nope' not found"* ]]
+    [ "$status" -ne 0 ]
+}
+
+@test "summary line format matches spec" {
+    export GH_LABEL_LIST="needs-po needs-dev"
+    run bash "$SCRIPT" --slug alpha
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ migrate-labels\ slug=alpha\ renamed=[0-9]+\ deleted=[0-9]+ ]]
+}
+
+@test "idempotent: a second run after migration produces zero changes" {
+    export GH_LABEL_LIST="needs-po needs-dev needs-review needs-qa qa-pass qa-fail blocked done"
+    run bash "$SCRIPT" --slug alpha --apply
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"renamed=0 deleted=0"* ]]
+}


### PR DESCRIPTION
Closes #170

## Changes
- Adds `scripts/migrate-labels.sh`, a one-shot migrator that walks projects in `config/projects.yaml` and brings their GitHub label sets in line with the canonical Loop vocabulary.
- Deprecated→canonical pairs are sourced from `lib/labels.sh` (`LOOP_DEPRECATED_ALIAS_MAP`) — no duplicated map, single source of truth.
- Accepts `--slug <s>` or `--all`, dry-run by default; `--apply` performs mutations.
- For each present deprecated alias: lists every open issue/PR carrying it, re-tags them with the canonical name (`gh issue edit` / `gh pr edit`), then re-checks and only calls `gh label delete` if zero items still reference it. Partial runs are safe.
- Emits the per-project summary line `migrate-labels slug=<s> renamed=N deleted=N` exactly as the AC requires.
- Idempotent: a clean second `--all` run produces `renamed=0 deleted=0` and exits 0.
- Tests in `tests/migrate-labels.bats` (8 cases) stub `gh` via a fake binary on PATH and cover arg validation, dry-run vs apply, the "still-attached → skip delete" branch, idempotency, and the summary line format.

## Test Plan
- [ ] `bash -n scripts/migrate-labels.sh` and `shellcheck -S warning scripts/migrate-labels.sh` clean (verified locally + matches CI)
- [ ] `bats tests/migrate-labels.bats` → 8/8 pass
- [ ] On a sandbox repo with `plan` / `dev` / `in-progress` labels, run `scripts/migrate-labels.sh --slug <s>` (dry-run) and confirm the planned renames + deletes look right
- [ ] Re-run with `--apply` and confirm deprecated labels are gone and tickets carry canonical labels
- [ ] Run `--all` again afterwards: should report `renamed=0 deleted=0` and exit 0