### PR TITLE
[LOOP-162] reconcile-on-startup: subsume #127 issue↔PR label-drift repair

### DIFF
--- a/lib/reconcile_drift.sh
+++ b/lib/reconcile_drift.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# lib/reconcile_drift.sh — issue↔PR label drift detection (subsumes #127).
+#
+# Detects the cases enumerated in #127: an open PR whose pipeline label has
+# advanced past the linked issue's pipeline label (or vice versa). Repairs
+# unambiguously where the PR carries a single mapped pipeline label;
+# otherwise flags the issue with `needs-clarification` for human triage.
+#
+# Mapping (PR label → expected issue label), expressed in canonical form
+# per lib/labels.sh:
+#
+#   PR has  in-dev        →  issue must be  in-dev
+#   PR has  needs-dev     →  issue must be  in-dev
+#   PR has  needs-review  →  issue must be  needs-review
+#   PR has  in-review     →  issue must be  needs-review
+#   PR has  needs-qa      →  issue must be  needs-review
+#
+# Inputs (function-scoped):
+#   $REPO must be set by the caller (loop_load_project).
+#   Backend functions backend_list_open_prs_raw / backend_list_open_issues_raw
+#   / backend_*_label / backend_comment_issue must be loaded.
+#
+# Outputs (caller-visible globals, incremented in place):
+#   DRIFT_REPAIRED      — issues whose label was corrected
+#   BLOCKED_REPORTED    — issues flagged needs-clarification due to
+#                         ambiguous PR state (multiple mapped pipeline
+#                         labels active simultaneously)
+#
+# Honours $DRY_RUN: in dry-run mode, counters still advance but no
+# mutations are performed.
+
+if [ "${_LOOP_RECONCILE_DRIFT_LOADED:-0}" = "1" ]; then
+    return 0 2>/dev/null || true
+fi
+_LOOP_RECONCILE_DRIFT_LOADED=1
+
+# Drift mapping table: "<pr_canonical> <expected_issue_canonical>" per line.
+# Kept here (not in lib/labels.sh) because it is policy, not vocabulary.
+_LOOP_DRIFT_MAP=$(cat <<'EOF'
+in-dev in-dev
+needs-dev in-dev
+needs-review needs-review
+in-review needs-review
+needs-qa needs-review
+EOF
+)
+
+# Read JSON-encoded PR and issue lists, emit one drift record per offending
+# linked issue. Output (TAB-separated):
+#   <issue_num>\t<verdict>\t<expected>\t<current>\t<pr_num>
+# verdict ∈ {repair, ambiguous}
+_loop_drift_classify() {
+    local prs_json="$1" issues_json="$2"
+    PJSON="$prs_json" IJSON="$issues_json" \
+        DRIFT_MAP="$_LOOP_DRIFT_MAP" \
+        python3 - <<'PY'
+import json, os, re
+
+prs = json.loads(os.environ['PJSON'])
+issues = json.loads(os.environ['IJSON'])
+
+mapping = {}
+for line in os.environ['DRIFT_MAP'].splitlines():
+    line = line.strip()
+    if not line: continue
+    k, v = line.split()
+    mapping[k] = v
+
+# Alias normalisation mirrors LOOP_DEPRECATED_ALIAS_MAP in lib/labels.sh.
+ALIAS = {
+    "review-pending":    "needs-review",
+    "needs-rework":      "needs-dev",
+    "changes-requested": "needs-dev",
+    "in-rework":         "in-dev",
+}
+def canon(name): return ALIAS.get(name, name)
+
+issue_by_num = {i['number']: i for i in issues}
+closes_re = re.compile(
+    r'(?:clos(?:e|es|ed)|fix(?:|es|ed)|resolv(?:e|es|ed))\s+#(\d+)', re.I)
+
+map_keys = set(mapping.keys())
+map_vals = set(mapping.values())
+
+for pr in prs:
+    pr_labels = {canon(l['name']) if isinstance(l, dict) else canon(l)
+                 for l in pr.get('labels', [])}
+    pr_keys = pr_labels & map_keys
+    if not pr_keys:
+        continue
+    expected_set = {mapping[k] for k in pr_keys}
+
+    body = pr.get('body') or ''
+    for n in {int(m) for m in closes_re.findall(body)}:
+        iss = issue_by_num.get(n)
+        if not iss: continue
+        iss_labels = {canon(l['name']) if isinstance(l, dict) else canon(l)
+                      for l in iss.get('labels', [])}
+        if iss_labels & {"needs-clarification", "blocked", "done"}:
+            continue
+        cur_pipe = sorted(iss_labels & map_vals)
+        cur_str = ','.join(cur_pipe) if cur_pipe else '<none>'
+
+        if len(expected_set) > 1:
+            print(f"{n}\tambiguous\t{','.join(sorted(expected_set))}\t{cur_str}\t{pr['number']}")
+            continue
+
+        expected = next(iter(expected_set))
+        if expected in iss_labels:
+            continue
+        print(f"{n}\trepair\t{expected}\t{cur_str}\t{pr['number']}")
+PY
+}
+
+# Public: run drift detection for $REPO. Mutates DRIFT_REPAIRED and
+# BLOCKED_REPORTED globals; never returns non-zero on individual failures.
+reconcile_drift_run() {
+    local repo="${REPO:?REPO not set}"
+    local prs_json issues_json
+    prs_json=$(backend_list_open_prs_raw "$repo" 2>/dev/null || echo "[]")
+    issues_json=$(backend_list_open_issues_raw "$repo" "" 2>/dev/null || echo "[]")
+
+    local records
+    records=$(_loop_drift_classify "$prs_json" "$issues_json") || records=""
+    [ -z "$records" ] && return 0
+
+    local issue_num verdict expected current pr_num current_label
+    while IFS=$'\t' read -r issue_num verdict expected current pr_num; do
+        [ -z "$issue_num" ] && continue
+        case "$verdict" in
+            repair)
+                if declare -F log >/dev/null; then
+                    log "[$repo] DRIFT issue #$issue_num: PR#$pr_num implies '$expected', issue has '$current' — repairing"
+                fi
+                DRIFT_REPAIRED=$((DRIFT_REPAIRED + 1))
+                ${DRY_RUN:-false} && continue
+                if [ "$current" != "<none>" ]; then
+                    IFS=',' read -r -a _cur_arr <<< "$current"
+                    for current_label in "${_cur_arr[@]}"; do
+                        [ "$current_label" = "$expected" ] && continue
+                        backend_remove_label "$repo" "$issue_num" "$current_label" 2>/dev/null || true
+                    done
+                fi
+                backend_add_label "$repo" "$issue_num" "$expected" 2>/dev/null || true
+                ;;
+            ambiguous)
+                if declare -F log >/dev/null; then
+                    log "[$repo] DRIFT-AMBIGUOUS issue #$issue_num: PR#$pr_num maps to {$expected} — needs-clarification"
+                fi
+                BLOCKED_REPORTED=$((BLOCKED_REPORTED + 1))
+                ${DRY_RUN:-false} && continue
+                backend_add_label "$repo" "$issue_num" needs-clarification 2>/dev/null || true
+                backend_comment_issue "$repo" "$issue_num" \
+                    "Reconciler: linked PR #$pr_num carries conflicting pipeline labels mapping to multiple expected issue states ({$expected}). Manual triage required." \
+                    2>/dev/null || true
+                ;;
+        esac
+    done <<< "$records"
+}

--- a/scanner/reconcile.sh
+++ b/scanner/reconcile.sh
@@ -26,8 +26,11 @@ source "$LOOP_ROOT/lib/env.sh"
 source "$LOOP_ROOT/lib/config.sh"
 # shellcheck source=../lib/backends/backend.sh
 source "$LOOP_ROOT/lib/backends/backend.sh"
+# shellcheck source=../lib/reconcile_drift.sh
+source "$LOOP_ROOT/lib/reconcile_drift.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-reconcile.log"
+DRY_RUN="${DRY_RUN:-false}"
 ONLY_SLUG=""
 
 while [ $# -gt 0 ]; do
@@ -69,6 +72,10 @@ audit_project() {
         | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))' 2>/dev/null || echo 0)
 
     log "[$slug] $REPO: open_issues=$issue_count open_prs=$pr_count"
+
+    # Issue↔PR label-drift repair (subsumes #127). Updates DRIFT_REPAIRED
+    # / BLOCKED_REPORTED in place; honours $DRY_RUN.
+    reconcile_drift_run || log "[$slug] drift run failed (continuing)"
 }
 
 log "=== reconcile start (only_slug=${ONLY_SLUG:-<all>}) ==="

--- a/tests/reconcile_drift.bats
+++ b/tests/reconcile_drift.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+# tests/reconcile_drift.bats — unit tests for lib/reconcile_drift.sh.
+#
+# Backend functions are stubbed so no real GitHub calls are made. Covers:
+#   repair: PR has needs-review, issue still has in-dev → relabel issue
+#   repair: PR has in-dev, issue still has needs-review → relabel issue
+#   ambiguous: PR carries conflicting mapped labels → needs-clarification
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+
+    export OPS_LOG="$BATS_TMPDIR/ops.log"
+    rm -f "$OPS_LOG"
+
+    export REPO="owner/test-repo"
+    export DRY_RUN=false
+
+    backend_list_open_prs_raw()    { echo "${MOCK_PRS_JSON:-[]}"; }
+    backend_list_open_issues_raw() { echo "${MOCK_ISSUES_JSON:-[]}"; }
+    backend_remove_label()         { echo "remove_label $2 $3" >> "$OPS_LOG"; }
+    backend_add_label()            { echo "add_label $2 $3"    >> "$OPS_LOG"; }
+    backend_comment_issue()        { echo "comment_issue $2"   >> "$OPS_LOG"; }
+    log()                          { :; }
+
+    export -f backend_list_open_prs_raw backend_list_open_issues_raw \
+              backend_remove_label backend_add_label backend_comment_issue log
+
+    # shellcheck source=../lib/reconcile_drift.sh
+    source "$REPO_ROOT/lib/reconcile_drift.sh"
+
+    DRIFT_REPAIRED=0
+    BLOCKED_REPORTED=0
+}
+
+@test "repair: PR needs-review while issue still in-dev → relabel issue to needs-review" {
+    export MOCK_PRS_JSON='[{"number":42,"body":"Closes #100","labels":[{"name":"needs-review"}]}]'
+    export MOCK_ISSUES_JSON='[{"number":100,"labels":[{"name":"in-dev"}]}]'
+
+    reconcile_drift_run
+
+    [ "$DRIFT_REPAIRED" -eq 1 ]
+    [ "$BLOCKED_REPORTED" -eq 0 ]
+    grep -qx "remove_label 100 in-dev" "$OPS_LOG"
+    grep -qx "add_label 100 needs-review" "$OPS_LOG"
+}
+
+@test "repair: PR in-dev (deprecated alias in-rework on PR) while issue lacks any pipeline label → add in-dev" {
+    # PR has the deprecated alias 'in-rework' which canonicalises to in-dev.
+    # Issue carries no mapped pipeline label (only an unrelated meta label).
+    export MOCK_PRS_JSON='[{"number":7,"body":"Resolves #200","labels":[{"name":"in-rework"}]}]'
+    export MOCK_ISSUES_JSON='[{"number":200,"labels":[{"name":"p1-high"}]}]'
+
+    reconcile_drift_run
+
+    [ "$DRIFT_REPAIRED" -eq 1 ]
+    [ "$BLOCKED_REPORTED" -eq 0 ]
+    grep -qx "add_label 200 in-dev" "$OPS_LOG"
+    # Nothing to strip — issue had no mapped pipeline label.
+    ! grep -q "^remove_label 200" "$OPS_LOG"
+}
+
+@test "ambiguous: PR carries needs-review + in-dev simultaneously → needs-clarification on issue" {
+    export MOCK_PRS_JSON='[{"number":9,"body":"Fixes #300","labels":[{"name":"needs-review"},{"name":"in-dev"}]}]'
+    export MOCK_ISSUES_JSON='[{"number":300,"labels":[{"name":"in-dev"}]}]'
+
+    reconcile_drift_run
+
+    [ "$BLOCKED_REPORTED" -eq 1 ]
+    [ "$DRIFT_REPAIRED" -eq 0 ]
+    grep -qx "add_label 300 needs-clarification" "$OPS_LOG"
+    grep -q "^comment_issue 300" "$OPS_LOG"
+}
+
+@test "no-op: issue label already aligned with PR → no mutations" {
+    export MOCK_PRS_JSON='[{"number":11,"body":"Closes #400","labels":[{"name":"needs-review"}]}]'
+    export MOCK_ISSUES_JSON='[{"number":400,"labels":[{"name":"needs-review"}]}]'
+
+    reconcile_drift_run
+
+    [ "$DRIFT_REPAIRED" -eq 0 ]
+    [ "$BLOCKED_REPORTED" -eq 0 ]
+    [ ! -s "$OPS_LOG" ]
+}
+
+@test "skip: issue carrying needs-clarification is left for human triage" {
+    export MOCK_PRS_JSON='[{"number":13,"body":"Closes #500","labels":[{"name":"needs-review"}]}]'
+    export MOCK_ISSUES_JSON='[{"number":500,"labels":[{"name":"in-dev"},{"name":"needs-clarification"}]}]'
+
+    reconcile_drift_run
+
+    [ "$DRIFT_REPAIRED" -eq 0 ]
+    [ "$BLOCKED_REPORTED" -eq 0 ]
+    [ ! -s "$OPS_LOG" ]
+}
+
+@test "dry-run: counters advance but no mutations happen" {
+    export DRY_RUN=true
+    export MOCK_PRS_JSON='[{"number":15,"body":"Closes #600","labels":[{"name":"needs-review"}]}]'
+    export MOCK_ISSUES_JSON='[{"number":600,"labels":[{"name":"in-dev"}]}]'
+
+    reconcile_drift_run
+
+    [ "$DRIFT_REPAIRED" -eq 1 ]
+    [ ! -s "$OPS_LOG" ]
+}


### PR DESCRIPTION
Closes #162

## Changes
- New `lib/reconcile_drift.sh` exposes `reconcile_drift_run` — detects issue↔PR label drift per the mapping enumerated in #127:
  - PR `in-dev` / `needs-dev` → issue `in-dev`
  - PR `needs-review` / `in-review` / `needs-qa` → issue `needs-review`
  - Deprecated aliases (`review-pending`, `needs-rework`, `changes-requested`, `in-rework`) are canonicalised before comparison.
- Repairs unambiguously when the PR carries a single mapped pipeline label; if the PR carries conflicting mapped labels (multiple expected issue states), the linked issue gets `needs-clarification` plus an explanatory comment for human triage.
- Issues already carrying `needs-clarification` / `blocked` / `done` are skipped (operator owns them).
- `scanner/reconcile.sh` now sources the new module and calls `reconcile_drift_run` per project, so `DRIFT_REPAIRED` and `BLOCKED_REPORTED` populate the existing `drift_repaired=N ... blocked_reported=N` startup-summary line.
- Honours `$DRY_RUN`: counters still advance but no GitHub mutations are performed.

## Test Plan
- [x] `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — clean
- [x] `shellcheck -S warning lib/reconcile_drift.sh scanner/reconcile.sh` — clean
- [x] `bats tests/reconcile_drift.bats` — 6/6 pass (2 repair cases, 1 ambiguous-clarification case, plus no-op / skip-clarified / dry-run guards)
- [ ] QA: `scanner/reconcile.sh --slug <slug>` against a project with a known drift case prints `drift_repaired≥1` in the summary and the issue label is corrected.
- [ ] QA: a PR carrying both `needs-review` and `in-dev` produces `blocked_reported≥1` and the linked issue receives `needs-clarification`.

Once this lands, #127 can be closed (its runtime-only fallback is no longer needed since startup reconcile catches drift before the first scan tick).