### PR TITLE
[LOOP-168] reconciler: rename deprecated labels via LOOP_DEPRECATED_ALIAS_MAP

### DIFF
--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -20,7 +20,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # shellcheck source=../lib/env.sh
 source "$LOOP_ROOT/lib/env.sh"
@@ -733,6 +733,75 @@ EOF
     fi
 }
 
+# --- Check: deprecated label aliases — rename to canonical ------------------
+# Iterates every alias declared in LOOP_DEPRECATED_ALIAS_MAP (lib/labels.sh).
+# For each open issue or PR carrying an alias, adds the canonical replacement
+# first and then removes the alias (additive-then-subtractive, never lossy).
+# Idempotent: a re-run on a clean repo issues zero label calls. Surfaces a
+# per-project `alias_renamed=N` line in the reconciler log.
+reconcile_alias_renames() {
+    local repo="$1"
+    log "[$repo] scanning open issues + PRs for deprecated label aliases"
+
+    local renamed=0 alias canonical
+
+    # Pull all open PRs once — we filter the cached list per alias.
+    local prs_json
+    prs_json=$(backend_list_open_prs_raw "$repo") || prs_json="[]"
+
+    while IFS= read -r alias; do
+        [ -z "$alias" ] && continue
+        canonical=$(loop_canonical_label "$alias")
+        # Skip self-mappings (defensive; map shouldn't contain them).
+        [ "$canonical" = "$alias" ] && continue
+
+        # Issues carrying $alias.
+        local issues_json issue_nums
+        issues_json=$(backend_list_open_issues_raw "$repo" "$alias") || issues_json="[]"
+        issue_nums=$(ISS="$issues_json" python3 -c '
+import json, os
+for i in json.loads(os.environ["ISS"]):
+    print(i["number"])
+' 2>/dev/null || echo "")
+
+        local num
+        for num in $issue_nums; do
+            log "[$repo] alias-rename issue #$num: $alias → $canonical"
+            $DRY_RUN || {
+                backend_add_label    "$repo" "$num" "$canonical" \
+                    || log "[$repo] WARN: failed to add $canonical to issue #$num"
+                backend_remove_label "$repo" "$num" "$alias" \
+                    || log "[$repo] WARN: failed to remove $alias from issue #$num"
+            }
+            renamed=$((renamed + 1))
+        done
+
+        # PRs carrying $alias (from the cached open-PRs list).
+        local pr_nums
+        pr_nums=$(PJSON="$prs_json" ALIAS="$alias" python3 -c '
+import json, os
+alias = os.environ["ALIAS"]
+for p in json.loads(os.environ["PJSON"]):
+    names = [l["name"] if isinstance(l, dict) else l for l in p.get("labels", [])]
+    if alias in names:
+        print(p["number"])
+' 2>/dev/null || echo "")
+
+        for num in $pr_nums; do
+            log "[$repo] alias-rename PR #$num: $alias → $canonical"
+            $DRY_RUN || {
+                backend_add_label    "$repo" "$num" "$canonical" \
+                    || log "[$repo] WARN: failed to add $canonical to PR #$num"
+                backend_remove_label "$repo" "$num" "$alias" \
+                    || log "[$repo] WARN: failed to remove $alias from PR #$num"
+            }
+            renamed=$((renamed + 1))
+        done
+    done < <(loop_deprecated_aliases)
+
+    log "[$repo] alias_renamed=$renamed"
+}
+
 # --- Check 10: orphaned in-progress issues (no live handler lock) --------------
 # An issue stuck with `in-progress` but no live dev-handler or po-handler process
 # will never self-recover — the EXIT trap added in the handlers handles normal
@@ -1346,6 +1415,7 @@ run_project() {
     log "=== $slug ($REPO) ==="
     reconcile_labels "$REPO"
     reconcile_synonym_labels "$REPO"
+    reconcile_alias_renames "$REPO"
     reconcile_lost_issues "$REPO"
     reconcile_duplicate_prs "$REPO"
     reconcile_obsolete_open_prs "$REPO"
@@ -1366,6 +1436,12 @@ run_project() {
     recovery_check_stuck_labels "$slug"
     recovery_prune_orphan_worktrees
 }
+
+# Test hook: when LOOP_RECONCILER_LIB_ONLY=1, return after defining functions
+# so bats files can source this script without triggering the main run.
+if [ "${LOOP_RECONCILER_LIB_ONLY:-0}" = "1" ]; then
+    return 0 2>/dev/null || exit 0
+fi
 
 acquire_lock
 

--- a/tests/reconciler-alias-rename.bats
+++ b/tests/reconciler-alias-rename.bats
@@ -1,0 +1,115 @@
+#!/usr/bin/env bats
+# tests/reconciler-alias-rename.bats — covers reconcile_alias_renames in
+# scanner/reconciler.sh (issue #168). Sources reconciler.sh in lib-only mode so
+# the main run is skipped, then exercises the function with stubbed backends.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export OPS_LOG="$BATS_TMPDIR/ops.log"
+    rm -f "$OPS_LOG"
+
+    export REPO="owner/test-repo"
+    export DRY_RUN=false
+
+    # Stubs must exist before sourcing reconciler.sh so subsequent function
+    # definitions inside the script don't shadow them. The script's own
+    # `backend_*` and `log` definitions live in libs we override after source.
+    LOOP_RECONCILER_LIB_ONLY=1
+    # Clear positional args — reconciler.sh has an arg parser at the top.
+    set --
+    # shellcheck source=../scanner/reconciler.sh
+    source "$REPO_ROOT/scanner/reconciler.sh"
+
+    # Now override library functions with test stubs.
+    backend_list_open_prs_raw() { echo "${MOCK_PRS_JSON:-[]}"; }
+    backend_list_open_issues_raw() {
+        local _repo="$1" lbl="$2"
+        local var="MOCK_ISSUES_${lbl//-/_}"
+        eval "echo \"\${$var:-[]}\""
+    }
+    backend_add_label()    { echo "add_label $2 $3"    >> "$OPS_LOG"; }
+    backend_remove_label() { echo "remove_label $2 $3" >> "$OPS_LOG"; }
+    log() { :; }
+}
+
+teardown() {
+    rm -rf "$LOOP_LOG_DIR" "$OPS_LOG" "$BATS_TMPDIR/log.out"
+}
+
+@test "reconcile_alias_renames: deprecated issue label → adds canonical, then removes alias" {
+    export MOCK_ISSUES_dev='[{"number":11,"labels":[{"name":"dev"}]}]'
+    export MOCK_PRS_JSON='[]'
+
+    run reconcile_alias_renames "$REPO"
+    [ "$status" -eq 0 ]
+
+    grep -q "add_label 11 needs-dev" "$OPS_LOG"
+    grep -q "remove_label 11 dev"    "$OPS_LOG"
+
+    # Additive precedes subtractive (never lossy).
+    local add_line rm_line
+    add_line=$(grep -n "add_label 11 needs-dev" "$OPS_LOG" | head -1 | cut -d: -f1)
+    rm_line=$(grep -n  "remove_label 11 dev"    "$OPS_LOG" | head -1 | cut -d: -f1)
+    [ "$add_line" -lt "$rm_line" ]
+}
+
+@test "reconcile_alias_renames: deprecated PR label → adds canonical, removes alias" {
+    export MOCK_PRS_JSON='[{"number":42,"labels":[{"name":"review-pending"}]}]'
+
+    run reconcile_alias_renames "$REPO"
+    [ "$status" -eq 0 ]
+
+    grep -q "add_label 42 needs-review"      "$OPS_LOG"
+    grep -q "remove_label 42 review-pending" "$OPS_LOG"
+}
+
+@test "reconcile_alias_renames: ticket already canonical is untouched" {
+    # Only canonical labels present; alias-keyed issue queries return [].
+    export MOCK_PRS_JSON='[{"number":21,"labels":[{"name":"needs-review"}]}]'
+
+    run reconcile_alias_renames "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -q "add_label"    "$OPS_LOG"
+    [ ! -s "$OPS_LOG" ] || ! grep -q "remove_label" "$OPS_LOG"
+}
+
+@test "reconcile_alias_renames: idempotent — second pass on clean repo is a no-op" {
+    export MOCK_PRS_JSON='[{"number":21,"labels":[{"name":"needs-review"}]}]'
+
+    run reconcile_alias_renames "$REPO"
+    [ "$status" -eq 0 ]
+    run reconcile_alias_renames "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -q "add_label"    "$OPS_LOG"
+    [ ! -s "$OPS_LOG" ] || ! grep -q "remove_label" "$OPS_LOG"
+}
+
+@test "reconcile_alias_renames: emits alias_renamed=N counter to log" {
+    export MOCK_ISSUES_dev='[{"number":11,"labels":[{"name":"dev"}]}]'
+    export MOCK_PRS_JSON='[{"number":42,"labels":[{"name":"review-pending"}]}]'
+
+    log() { echo "$*" >> "$BATS_TMPDIR/log.out"; }
+    rm -f "$BATS_TMPDIR/log.out"
+
+    run reconcile_alias_renames "$REPO"
+    [ "$status" -eq 0 ]
+    grep -q "alias_renamed=2" "$BATS_TMPDIR/log.out"
+}
+
+@test "reconcile_alias_renames: DRY_RUN performs no label mutations" {
+    export MOCK_ISSUES_dev='[{"number":11,"labels":[{"name":"dev"}]}]'
+    export MOCK_PRS_JSON='[]'
+    export DRY_RUN=true
+
+    run reconcile_alias_renames "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -q "add_label"    "$OPS_LOG"
+    [ ! -s "$OPS_LOG" ] || ! grep -q "remove_label" "$OPS_LOG"
+}


### PR DESCRIPTION
Closes #168

## Changes
- `scanner/reconciler.sh`: new `reconcile_alias_renames` check, wired into `run_project` after `reconcile_synonym_labels`. Iterates each alias in `LOOP_DEPRECATED_ALIAS_MAP` (sourced from `lib/labels.sh`). For each open issue carrying the alias (queried via `backend_list_open_issues_raw`) and each open PR carrying it (filtered from one cached `backend_list_open_prs_raw` call), it adds the canonical label first, then removes the deprecated one — additive-then-subtractive, never lossy. Surfaces `alias_renamed=N` per project in the reconciler log. Honors `DRY_RUN`.
- Same file: switched `SCRIPT_DIR` to use `${BASH_SOURCE[0]:-$0}` so the script can be sourced for unit tests, and added an early-return guard `LOOP_RECONCILER_LIB_ONLY=1` so tests can load the function library without firing the main run.
- `tests/reconciler-alias-rename.bats`: new bats file covering deprecated→canonical rename for issues and PRs (with strict order: add precedes remove); canonical-only ticket untouched; second invocation idempotent; `alias_renamed=N` counter emitted; `DRY_RUN=true` performs no mutations.

## Test Plan
- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` clean
- `bats tests/reconciler-alias-rename.bats` — 6/6 pass
- `bats tests/reconciler.bats` — existing suite still green
- Manual: run `scanner/reconciler.sh --dry-run --slug <slug>` against a repo with deprecated labels and confirm `alias-rename …` log lines appear plus `alias_renamed=N` summary; re-run and confirm `alias_renamed=0`.