### PR TITLE
[LOOP-129] reconciler: strip issue-only labels from open PRs

### DIFF
--- a/lib/labels.sh
+++ b/lib/labels.sh
@@ -218,3 +218,26 @@ loop_pipeline_stage_labels_csv() {
     local IFS=','
     echo "${LOOP_PIPELINE_STAGE_LABELS[*]}"
 }
+
+# Issue-only labels — should never appear on a PR. Some are pipeline triggers
+# whose handlers expect to run against an issue (and would misfire on a PR);
+# others are taxonomy markers (`tracker`, `epic`) that classify issues only.
+# Reconciler strips any of these found on an open PR. Includes deprecated
+# aliases of the trigger labels so a stale `dev`/`po-review`/`plan` on a PR
+# also gets cleaned up.
+LOOP_ISSUE_ONLY_LABELS=(
+    needs-po
+    needs-dev
+    tracker
+    epic
+    needs-clarification
+    po-review
+    dev
+    plan
+)
+
+# loop_issue_only_labels_csv — emit the issue-only label set as a CSV string.
+loop_issue_only_labels_csv() {
+    local IFS=','
+    echo "${LOOP_ISSUE_ONLY_LABELS[*]}"
+}

--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -1404,6 +1404,56 @@ PY
     done <<< "$stale"
 }
 
+# --- Check: PR label audit — strip issue-only labels from open PRs ---------
+# Pipeline-trigger labels (`needs-po`, `needs-dev`, plus deprecated aliases)
+# and taxonomy labels (`tracker`, `epic`, `needs-clarification`) belong on
+# issues only. If applied to a PR by mistake, scanner/handler logic may
+# misfire. For each open PR carrying any issue-only label, strip the labels
+# and post one combined comment per PR per run.
+reconcile_pr_label_audit() {
+    local repo="$1"
+    log "[$repo] auditing open PRs for issue-only labels"
+
+    local prs_json
+    prs_json=$(backend_list_open_prs_raw "$repo")
+
+    local hits
+    hits=$(PRS="$prs_json" ISSUE_ONLY="$(loop_issue_only_labels_csv)" python3 - <<'PY'
+import json, os
+prs = json.loads(os.environ['PRS'])
+issue_only = set(os.environ['ISSUE_ONLY'].split(','))
+for pr in prs:
+    labels = {l['name'] for l in pr.get('labels', [])}
+    bad = labels & issue_only
+    if bad:
+        print(f"{pr['number']}\t{','.join(sorted(bad))}")
+PY
+)
+
+    if [ -z "$hits" ]; then
+        log "[$repo] no PRs carrying issue-only labels"
+        return 0
+    fi
+
+    local num bad
+    while IFS=$'\t' read -r num bad; do
+        [ -z "$num" ] && continue
+        log "[$repo] PR-LABEL-AUDIT PR#$num strip issue-only: $bad"
+        if $DRY_RUN; then
+            continue
+        fi
+        local label
+        local IFS_ORIG="$IFS"
+        IFS=','
+        for label in $bad; do
+            backend_remove_label "$repo" "$num" "$label" >/dev/null 2>&1 || true
+        done
+        IFS="$IFS_ORIG"
+        backend_comment_pr "$repo" "$num" \
+            "Reconciler: removed issue-only label(s): ${bad}. These trigger issue-side handlers and can misfire on PRs."
+    done <<< "$hits"
+}
+
 run_project() {
     local slug="$1"
     loop_load_project "$slug" || { log "skip $slug (config error)"; return 0; }
@@ -1429,6 +1479,7 @@ run_project() {
     reconcile_stale_base "$REPO"
     reconcile_stale_blocked_issues "$REPO"
     reconcile_qa_failures "$REPO"
+    reconcile_pr_label_audit "$REPO"
     reconcile_author_gated "$slug" "$REPO"
     reconcile_closed_issue_labels "$REPO"
     recovery_check_dependencies "$slug"

--- a/tests/reconciler-pr-label-audit.bats
+++ b/tests/reconciler-pr-label-audit.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+# tests/reconciler-pr-label-audit.bats — covers reconcile_pr_label_audit in
+# scanner/reconciler.sh (issue #129). Sources reconciler.sh in lib-only mode
+# so the main run is skipped, then exercises the function with stubbed
+# backends.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export OPS_LOG="$BATS_TMPDIR/ops.log"
+    rm -f "$OPS_LOG"
+
+    export REPO="owner/test-repo"
+    export DRY_RUN=false
+
+    LOOP_RECONCILER_LIB_ONLY=1
+    set --
+    # shellcheck source=../scanner/reconciler.sh
+    source "$REPO_ROOT/scanner/reconciler.sh"
+
+    backend_list_open_prs_raw() { echo "${MOCK_PRS_JSON:-[]}"; }
+    backend_remove_label()      { echo "remove_label $2 $3" >> "$OPS_LOG"; }
+    backend_comment_pr()        { echo "comment_pr $2 $3"   >> "$OPS_LOG"; }
+    log() { :; }
+}
+
+teardown() {
+    rm -rf "$LOOP_LOG_DIR" "$OPS_LOG"
+}
+
+@test "reconcile_pr_label_audit: PR with only stage labels is untouched" {
+    export MOCK_PRS_JSON='[{"number":50,"labels":[{"name":"needs-review"}]},{"number":51,"labels":[{"name":"in-review"}]}]'
+
+    run reconcile_pr_label_audit "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -q "remove_label" "$OPS_LOG"
+    [ ! -s "$OPS_LOG" ] || ! grep -q "comment_pr"   "$OPS_LOG"
+}
+
+@test "reconcile_pr_label_audit: PR carrying tracker is stripped with a comment" {
+    export MOCK_PRS_JSON='[{"number":75,"labels":[{"name":"needs-review"},{"name":"tracker"}]}]'
+
+    run reconcile_pr_label_audit "$REPO"
+    [ "$status" -eq 0 ]
+
+    grep -q "remove_label 75 tracker" "$OPS_LOG"
+    grep -q "comment_pr 75"           "$OPS_LOG"
+    grep -q "issue-only label(s): tracker" "$OPS_LOG"
+}
+
+@test "reconcile_pr_label_audit: PR with two issue-only labels gets one combined comment" {
+    export MOCK_PRS_JSON='[{"number":80,"labels":[{"name":"dev"},{"name":"epic"}]}]'
+
+    run reconcile_pr_label_audit "$REPO"
+    [ "$status" -eq 0 ]
+
+    grep -q "remove_label 80 dev"  "$OPS_LOG"
+    grep -q "remove_label 80 epic" "$OPS_LOG"
+
+    # Exactly one comment, listing both labels (sorted).
+    local comments
+    comments=$(grep -c "^comment_pr 80" "$OPS_LOG")
+    [ "$comments" -eq 1 ]
+    grep -q "issue-only label(s): dev,epic" "$OPS_LOG"
+}
+
+@test "reconcile_pr_label_audit: idempotent — clean PR set produces no ops" {
+    export MOCK_PRS_JSON='[{"number":90,"labels":[{"name":"needs-review"}]}]'
+
+    run reconcile_pr_label_audit "$REPO"
+    [ "$status" -eq 0 ]
+    run reconcile_pr_label_audit "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -q "remove_label" "$OPS_LOG"
+    [ ! -s "$OPS_LOG" ] || ! grep -q "comment_pr"   "$OPS_LOG"
+}
+
+@test "reconcile_pr_label_audit: DRY_RUN performs no mutations" {
+    export MOCK_PRS_JSON='[{"number":75,"labels":[{"name":"tracker"}]}]'
+    export DRY_RUN=true
+
+    run reconcile_pr_label_audit "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -q "remove_label" "$OPS_LOG"
+    [ ! -s "$OPS_LOG" ] || ! grep -q "comment_pr"   "$OPS_LOG"
+}


### PR DESCRIPTION
Closes #129

## Changes
- `lib/labels.sh`: new `LOOP_ISSUE_ONLY_LABELS` array (canonical triggers `needs-po`, `needs-dev`, taxonomy `tracker`/`epic`/`needs-clarification`, plus deprecated aliases `po-review`/`dev`/`plan`) and `loop_issue_only_labels_csv` helper.
- `scanner/reconciler.sh`: new `reconcile_pr_label_audit <repo>` check, wired into `run_project` after `reconcile_qa_failures`. For each open PR carrying any issue-only label, strips the labels via `backend_remove_label` and posts one combined `backend_comment_pr` per PR per run. Honours `$DRY_RUN`; idempotent on a clean PR set.
- `tests/reconciler-pr-label-audit.bats`: 5 cases — clean stage-only PR untouched, single `tracker` stripped with comment, two issue-only labels combined into one comment, idempotent re-run, DRY_RUN no-op.

## Test Plan
- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh`
- `shellcheck -S warning lib/labels.sh scanner/reconciler.sh`
- `bats tests/reconciler-pr-label-audit.bats tests/labels.bats tests/reconciler-alias-rename.bats` — all pass
- Manually verify: a `--dry-run` reconciler tick against a project where a PR carries `tracker` logs the planned strip and posts no mutation; without dry-run, the label is removed and one comment is posted.