### PR TITLE
[LOOP-183] po-handler: auto-decompose epics with complete AC

### DIFF
--- a/scripts/po-handler.sh
+++ b/scripts/po-handler.sh
@@ -36,6 +36,27 @@ MAX_RETRIES=2
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [po-handler] $*" | tee -a "$LOG_FILE"; }
 
+# _po_has_complete_ac <body>
+# Returns 0 iff the body has a non-empty `## Acceptance` or
+# `## Acceptance Criteria` section with at least one `- [ ]`/`- [x]` checkbox
+# item between the heading and the next `## ` heading (or EOF). Returns 1
+# otherwise. Callers must check the exit code, not stdout.
+_po_has_complete_ac() {
+    BODY="${1:-}" python3 <<'PY'
+import os, re, sys
+body = os.environ.get('BODY', '')
+m = re.search(r'(?im)^##\s+Acceptance(?:\s+Criteria)?\s*$', body)
+if not m:
+    sys.exit(1)
+rest = body[m.end():]
+nxt = re.search(r'(?m)^##\s+\S', rest)
+section = rest[:nxt.start()] if nxt else rest
+if re.search(r'(?m)^\s*-\s*\[[ xX]\]', section):
+    sys.exit(0)
+sys.exit(1)
+PY
+}
+
 SLUG="${LOOP_SLUG:-}"
 ISSUE_NUM="${LOOP_ISSUE_NUMBER:-}"
 ISSUE_TITLE="${LOOP_ISSUE_TITLE:-}"
@@ -104,6 +125,26 @@ _po_label_cleanup() {
 trap '_po_label_cleanup' EXIT TERM INT
 
 ISSUE_BODY=$(backend_issue_view "$REPO" "$ISSUE_NUM" --json body --jq .body 2>/dev/null || echo "")
+
+# Auto-decompose gate: if the issue carries the literal `epic` label AND its
+# body has a populated Acceptance / Acceptance Criteria section (≥1 checkbox),
+# instruct the PO agent to take Path D directly. This skips the
+# needs-clarification round-trip on already-well-specified epics.
+_PO_AUTO_DECOMPOSE_DIRECTIVE=""
+if backend_issue_has_any_label "$REPO" "$ISSUE_NUM" epic 2>/dev/null \
+    && _po_has_complete_ac "$ISSUE_BODY"; then
+    log "auto-decompose gate: issue #$ISSUE_NUM is epic+AC — directing agent to Path D"
+    _PO_AUTO_DECOMPOSE_DIRECTIVE="
+--- AUTO-DECOMPOSE DIRECTIVE ---
+This issue carries the 'epic' label and has a populated Acceptance Criteria
+section with at least one checkbox item. Treat it as operator-approved.
+You MUST take Path D (UPGRADE TO EPIC / decompose into child issues).
+Do NOT apply 'needs-clarification'. Only escalate to needs-clarification or
+blocked if scope is architecturally ambiguous or requires an external
+decision (budget, third-party API, etc.) that the AC do not resolve.
+--- END DIRECTIVE ---
+"
+fi
 
 # Extract the true original body — strips any existing ## Original brief section
 # so re-triaging an already-expanded issue doesn't nest markers.
@@ -235,7 +276,7 @@ If CLAUDE.md is missing or empty, proceed with the issue text alone and note the
 You have been given GitHub issue #${ISSUE_NUM}: ${ISSUE_TITLE}
 URL: ${ISSUE_URL}
 
-${_MR_PREAMBLE}Current body:
+${_MR_PREAMBLE}${_PO_AUTO_DECOMPOSE_DIRECTIVE}Current body:
 ${ISSUE_BODY}
 
 Recent comments (most recent last) — may include human steering, blocker context from prior dev attempts, or supplementary scope:

--- a/tests/po-auto-decompose.bats
+++ b/tests/po-auto-decompose.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+# tests/po-auto-decompose.bats — unit tests for _po_has_complete_ac.
+#
+# Exercises the AC-detection helper in scripts/po-handler.sh that gates the
+# auto-decompose Path D route for epic-labeled issues. The helper returns 0
+# when the body contains a non-empty Acceptance / Acceptance Criteria section
+# with at least one checkbox item, and 1 otherwise. Callers check exit code,
+# not stdout.
+
+# Inline replication of the helper from scripts/po-handler.sh so the test
+# does not need to source the full handler (which pulls in env/backends).
+_po_has_complete_ac() {
+    BODY="${1:-}" python3 <<'PY'
+import os, re, sys
+body = os.environ.get('BODY', '')
+m = re.search(r'(?im)^##\s+Acceptance(?:\s+Criteria)?\s*$', body)
+if not m:
+    sys.exit(1)
+rest = body[m.end():]
+nxt = re.search(r'(?m)^##\s+\S', rest)
+section = rest[:nxt.start()] if nxt else rest
+if re.search(r'(?m)^\s*-\s*\[[ xX]\]', section):
+    sys.exit(0)
+sys.exit(1)
+PY
+}
+
+@test "epic body with populated Acceptance Criteria → exit 0" {
+    body="$(printf '## Objective\nDo X\n\n## Acceptance Criteria\n- [ ] item one\n- [ ] item two\n')"
+    run _po_has_complete_ac "$body"
+    [ "$status" -eq 0 ]
+}
+
+@test "epic body with populated Acceptance heading (no Criteria word) → exit 0" {
+    body="$(printf '## Acceptance\n- [ ] one thing\n')"
+    run _po_has_complete_ac "$body"
+    [ "$status" -eq 0 ]
+}
+
+@test "checked checkbox also counts as complete → exit 0" {
+    body="$(printf '## Acceptance\n- [x] already done\n')"
+    run _po_has_complete_ac "$body"
+    [ "$status" -eq 0 ]
+}
+
+@test "missing AC section → exit 1" {
+    body="$(printf '## Objective\nNo acceptance here\n')"
+    run _po_has_complete_ac "$body"
+    [ "$status" -eq 1 ]
+}
+
+@test "AC section with zero checkbox items → exit 1" {
+    body="$(printf '## Acceptance Criteria\n\nSome prose but no checkboxes.\n')"
+    run _po_has_complete_ac "$body"
+    [ "$status" -eq 1 ]
+}
+
+@test "empty body → exit 1" {
+    run _po_has_complete_ac ""
+    [ "$status" -eq 1 ]
+}
+
+@test "AC section ends at next ## heading — checkboxes outside don't count" {
+    body="$(printf '## Acceptance Criteria\n\nNo boxes here.\n\n## Notes\n- [ ] this should not count\n')"
+    run _po_has_complete_ac "$body"
+    [ "$status" -eq 1 ]
+}
+
+@test "AC section followed by another section with its own checkboxes → exit 0" {
+    body="$(printf '## Acceptance\n- [ ] real ac item\n\n## Notes\n- [ ] unrelated\n')"
+    run _po_has_complete_ac "$body"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #183

## Changes

- `scripts/po-handler.sh`: new `_po_has_complete_ac <body>` helper (inline python heredoc, exit-code contract — 0 if AC heading exists with at least one `- [ ]`/`- [x]` checkbox before the next `## ` heading or EOF; 1 otherwise).
- `scripts/po-handler.sh`: added an auto-decompose gate that runs after the issue body is fetched. When the issue carries the literal `epic` label AND `_po_has_complete_ac` returns 0, the prompt receives an `--- AUTO-DECOMPOSE DIRECTIVE ---` block instructing the PO agent to take Path D (UPGRADE TO EPIC / decompose into child issues) and forbidding the `needs-clarification` escalation unless scope is architecturally ambiguous or requires an external decision.
- Non-epic issues and epics without AC see no prompt change → existing PO triage behavior is preserved.
- `tests/po-auto-decompose.bats`: 8 cases covering the helper — populated AC, alternate `## Acceptance` heading, checked boxes, missing section, empty section, empty body, scoping to the AC section only, and AC followed by another section with its own boxes.

## Test Plan

- [x] `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — passes.
- [x] `shellcheck -S warning scripts/po-handler.sh` — clean.
- [x] `bats tests/po-auto-decompose.bats` — 8/8 pass.
- [ ] Pipeline: trigger PO on a synthetic epic-labeled issue with AC checkboxes; confirm log line `auto-decompose gate: ... directing agent to Path D` and that the agent does not apply `needs-clarification`.
- [ ] Pipeline: trigger PO on an epic-labeled issue without AC; confirm gate does NOT fire and existing E (needs-clarification) path remains reachable.
- [ ] Pipeline: trigger PO on a non-epic issue with AC; confirm gate does NOT fire (epic label is the precondition).