### PR TITLE
[LOOP-185] notify: fire-and-forget alert on needs-clarification/blocked

### DIFF
--- a/lib/notify.sh
+++ b/lib/notify.sh
@@ -5,3 +5,65 @@
 loop_notify() {
     [ -n "${LOOP_NOTIFY:-}" ] && eval "$LOOP_NOTIFY" "$1" || true
 }
+
+# loop_notify_human_required <slug> <number> <label> [reason]
+# Fire-and-forget operator notification when an issue lands on a human-decision
+# label (needs-clarification / blocked). Opt-in: silent no-op when
+# LOOP_NOTIFY_CHANNEL is unset. Dedup state file under
+# $LOOP_LOG_DIR/notified/<slug>-<number>-<label> stores today's UTC date — same
+# day skips re-fire, next day re-pings (covers parked tickets that linger).
+# Errors in the underlying notifier are caught so a missing signal-cli/curl
+# never aborts the calling handler.
+loop_notify_human_required() {
+    local slug="$1" number="$2" label="$3" reason="${4:-}"
+    [ -n "${LOOP_NOTIFY_CHANNEL:-}" ] || return 0
+
+    local today state_dir state_file
+    today=$(date -u +%Y-%m-%d)
+    state_dir="${LOOP_LOG_DIR:-${HOME}/.loop/logs}/notified"
+    state_file="${state_dir}/${slug}-${number}-${label}"
+    mkdir -p "$state_dir" 2>/dev/null || return 0
+
+    if [ -f "$state_file" ] && [ "$(cat "$state_file" 2>/dev/null)" = "$today" ]; then
+        return 0
+    fi
+
+    (
+        local repo="${REPO:-}" title="" url="" last_comment=""
+        if [ -n "$repo" ] && command -v backend_issue_view >/dev/null 2>&1; then
+            title=$(backend_issue_view "$repo" "$number" --json title --jq .title 2>/dev/null || echo "")
+            url=$(backend_issue_view "$repo" "$number" --json url --jq .url 2>/dev/null || echo "")
+            last_comment=$(backend_issue_view "$repo" "$number" --json comments \
+                --jq '[.comments[]?] | last | .body // ""' 2>/dev/null || echo "")
+        fi
+        [ -z "$url" ] && [ -n "$repo" ] && url="https://github.com/${repo}/issues/${number}"
+        if [ "${#last_comment}" -gt 400 ]; then
+            last_comment="${last_comment:0:400}…"
+        fi
+
+        local msg="🚧 [${slug}] #${number} ${label}: ${title:-(no title)}
+${url}
+Reason: ${reason:-${label}}"
+        if [ -n "$last_comment" ]; then
+            msg="${msg}
+Last comment: ${last_comment}"
+        fi
+        loop_notify "$msg"
+    ) >/dev/null 2>&1 || {
+        if declare -F log >/dev/null 2>&1; then
+            log "notify_human_required failed for ${slug}#${number} (${label})"
+        fi
+    }
+
+    echo "$today" > "$state_file" 2>/dev/null || true
+    return 0
+}
+
+# loop_notify_human_required_clear <slug> <number> <label>
+# Removes the dedup file so a future re-transition to the same label re-notifies.
+# Call wherever the human-decision label is stripped from an issue.
+loop_notify_human_required_clear() {
+    local slug="$1" number="$2" label="$3"
+    rm -f "${LOOP_LOG_DIR:-${HOME}/.loop/logs}/notified/${slug}-${number}-${label}" 2>/dev/null || true
+    return 0
+}

--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -24,6 +24,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # shellcheck source=../lib/env.sh
 source "$LOOP_ROOT/lib/env.sh"
+# shellcheck source=../lib/notify.sh
+source "$LOOP_ROOT/lib/notify.sh"
 # shellcheck source=../lib/config.sh
 source "$LOOP_ROOT/lib/config.sh"
 # shellcheck source=../lib/backends/backend.sh
@@ -479,6 +481,7 @@ PY
             $DRY_RUN && continue
             backend_remove_label "$repo" "$num" "$state" \
                 || log "[$repo] failed to relabel issue #$num"
+            loop_notify_human_required_clear "${SLUG:-${repo##*/}}" "$num" "$state"
             backend_add_label "$repo" "$num" dev \
                 || log "[$repo] failed to add dev label to issue #$num"
             backend_comment_issue "$repo" "$num" \
@@ -1011,6 +1014,8 @@ ${last_20}
         for issue_num in $linked_issues; do
             backend_add_label "$repo" "$issue_num" needs-clarification \
                 || log "[$repo] WARN: failed to add needs-clarification to issue#$issue_num"
+            loop_notify_human_required "${SLUG:-${repo##*/}}" "$issue_num" needs-clarification \
+                "QA failure on PR #${pr_num} escalated"
         done
 
         loop_notify "Loop reconciler: $repo — PR#$pr_num QA failure escalated to needs-clarification (run=$run_id)"

--- a/scripts/dev-handler.sh
+++ b/scripts/dev-handler.sh
@@ -73,6 +73,7 @@ if [ "$retries" -ge "$MAX_RETRIES" ]; then
     log "issue #$ISSUE_NUM already failed ${retries}x — labeling blocked"
     backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
     backend_add_label "$REPO" "$ISSUE_NUM" blocked
+    loop_notify_human_required "$SLUG" "$ISSUE_NUM" blocked "Dev failed ${retries}x"
     exit 0
 fi
 
@@ -217,6 +218,7 @@ if matches:
         log "WARN: no open PR found for issue #$ISSUE_NUM after dev agent — adding 'needs-clarification'"
         backend_remove_label "$REPO" "$ISSUE_NUM" dev plan in-progress
         backend_add_label "$REPO" "$ISSUE_NUM" needs-clarification
+        loop_notify_human_required "$SLUG" "$ISSUE_NUM" needs-clarification "Dev agent finished without opening a PR"
     else
         log "belt-and-braces: found PR #$_dev_pr_num for issue #$ISSUE_NUM"
         if ! backend_pr_has_any_label "$REPO" "$_dev_pr_num" \
@@ -238,6 +240,7 @@ else
     if [ "$n" -ge "$MAX_RETRIES" ]; then
         backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
         backend_add_label "$REPO" "$ISSUE_NUM" blocked
+        loop_notify_human_required "$SLUG" "$ISSUE_NUM" blocked "Dev agent failed after $MAX_RETRIES attempts"
         _fail_body_file=$(mktemp /tmp/loop-fail-XXXXXX.md)
         {
             echo "Automated dev cycle failed ${MAX_RETRIES} times. Needs human review."

--- a/scripts/dev-rework-handler.sh
+++ b/scripts/dev-rework-handler.sh
@@ -99,6 +99,7 @@ _block_linked_issue() {
     backend_comment_issue "$REPO" "$LINKED_ISSUE" \
         "🚫 Blocked: automated rework failed ${MAX_RETRIES} times on PR #${PR_NUM}. Needs human review." \
         2>/dev/null || true
+    loop_notify_human_required "$SLUG" "$LINKED_ISSUE" blocked "Rework failed ${MAX_RETRIES}x on PR #${PR_NUM}"
 }
 
 SENIOR_ESCALATION_MARKER="Escalating to senior-dev for one final attempt"
@@ -126,6 +127,7 @@ _block_linked_issue_senior_failed() {
     backend_comment_issue "$REPO" "$LINKED_ISSUE" \
         "Senior-dev attempt also failed. Marking blocked for human review." \
         2>/dev/null || true
+    loop_notify_human_required "$SLUG" "$LINKED_ISSUE" blocked "Senior-dev escalation also failed on PR #${PR_NUM}"
 }
 
 if [ "$retries" -ge "$MAX_RETRIES" ]; then

--- a/scripts/po-handler.sh
+++ b/scripts/po-handler.sh
@@ -81,6 +81,7 @@ if [ "$retries" -ge "$MAX_RETRIES" ]; then
     backend_remove_label "$REPO" "$ISSUE_NUM" "$_po_trigger"
     backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
     backend_add_label "$REPO" "$ISSUE_NUM" needs-clarification
+    loop_notify_human_required "$SLUG" "$ISSUE_NUM" needs-clarification "PO failed ${retries}x"
     exit 0
 fi
 
@@ -352,6 +353,7 @@ else
         backend_add_label "$REPO" "$ISSUE_NUM" needs-clarification
         _post_failure_comment issue "$ISSUE_NUM" "PO agent" "$n" "$MAX_RETRIES"
         loop_notify "❌ [$SLUG] #$ISSUE_NUM ${LOOP_LABEL_DEPRECATED_PO_REVIEW} failed: agent failed after $MAX_RETRIES attempts"
+        loop_notify_human_required "$SLUG" "$ISSUE_NUM" needs-clarification "PO agent failed after $MAX_RETRIES attempts"
     else
         backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
         backend_add_label "$REPO" "$ISSUE_NUM" "$_po_trigger"

--- a/tests/notify_human_required.bats
+++ b/tests/notify_human_required.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+# tests/notify_human_required.bats — coverage for loop_notify_human_required.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/loop-notify-test-$$"
+    mkdir -p "$LOOP_LOG_DIR"
+    export NOTIFY_LOG="$BATS_TMPDIR/loop-notify-msgs-$$"
+    : > "$NOTIFY_LOG"
+    # shellcheck source=../lib/notify.sh
+    source "$REPO_ROOT/lib/notify.sh"
+
+    # Override loop_notify so the test captures messages instead of evaluating
+    # the LOOP_NOTIFY command fragment.
+    loop_notify() { printf '%s\n' "$1" >> "$NOTIFY_LOG"; }
+
+    # Stub backend_issue_view so the helper has title/url/comment data.
+    backend_issue_view() {
+        local field
+        for field in "$@"; do
+            case "$field" in
+                title)    echo "Sample issue title"; return 0 ;;
+                url)      echo "https://example.test/issue/1"; return 0 ;;
+                comments) echo ""; return 0 ;;
+            esac
+        done
+        echo ""
+    }
+    export -f backend_issue_view 2>/dev/null || true
+}
+
+teardown() {
+    rm -rf "$LOOP_LOG_DIR" "$NOTIFY_LOG"
+}
+
+@test "fires once on first transition" {
+    export LOOP_NOTIFY_CHANNEL="signal"
+    loop_notify_human_required "demo" 42 needs-clarification "ambiguous spec"
+    [ -s "$NOTIFY_LOG" ]
+    grep -q "demo" "$NOTIFY_LOG"
+    grep -q "#42" "$NOTIFY_LOG"
+    grep -q "needs-clarification" "$NOTIFY_LOG"
+    [ -f "$LOOP_LOG_DIR/notified/demo-42-needs-clarification" ]
+}
+
+@test "second tick same day is a no-op" {
+    export LOOP_NOTIFY_CHANNEL="signal"
+    loop_notify_human_required "demo" 7 blocked "first"
+    local first_count
+    first_count=$(wc -l < "$NOTIFY_LOG")
+    loop_notify_human_required "demo" 7 blocked "second"
+    local second_count
+    second_count=$(wc -l < "$NOTIFY_LOG")
+    [ "$first_count" = "$second_count" ]
+}
+
+@test "missing LOOP_NOTIFY_CHANNEL is silent" {
+    unset LOOP_NOTIFY_CHANNEL
+    run loop_notify_human_required "demo" 9 blocked "no channel"
+    [ "$status" -eq 0 ]
+    [ ! -s "$NOTIFY_LOG" ]
+    [ ! -f "$LOOP_LOG_DIR/notified/demo-9-blocked" ]
+}
+
+@test "notifier failure does not exit caller" {
+    export LOOP_NOTIFY_CHANNEL="signal"
+    # Make the underlying notifier fail hard.
+    loop_notify() { return 7; }
+    set -e
+    loop_notify_human_required "demo" 11 blocked "notifier broken"
+    local rc=$?
+    [ "$rc" -eq 0 ]
+    # Caller continues running afterwards.
+    echo "still alive"
+}
+
+@test "clear removes dedup file so future transition re-fires" {
+    export LOOP_NOTIFY_CHANNEL="signal"
+    loop_notify_human_required "demo" 5 blocked "first"
+    [ -f "$LOOP_LOG_DIR/notified/demo-5-blocked" ]
+    loop_notify_human_required_clear "demo" 5 blocked
+    [ ! -f "$LOOP_LOG_DIR/notified/demo-5-blocked" ]
+    loop_notify_human_required "demo" 5 blocked "second"
+    [ "$(wc -l < "$NOTIFY_LOG")" -ge 2 ]
+}


### PR DESCRIPTION
Closes #185

## Changes
- `lib/notify.sh`: new `loop_notify_human_required <slug> <number> <label> <reason>` helper.
  - Silent no-op when `LOOP_NOTIFY_CHANNEL` is unset (opt-in per AC).
  - Dedup state file `${LOOP_LOG_DIR}/notified/<slug>-<number>-<label>` storing today's UTC date — same day skips, next day re-fires (handles "stale label parked overnight").
  - Body wrapped in subshell + `|| true` so missing signal-cli/curl never aborts the caller; failure logged via `log` if defined.
  - Notification body: title (via `backend_issue_view --json title`), URL, applied label, reason, last comment truncated to 400 chars.
- Companion `loop_notify_human_required_clear` to drop the dedup file when the label is removed (used by reconciler unblock path).
- Wired into add-label sites: `po-handler.sh` (×2), `dev-handler.sh` (×3), `dev-rework-handler.sh` (`_block_linked_issue`, `_block_linked_issue_senior_failed`), `scanner/reconciler.sh` (QA-fail escalation issue side, plus `_clear` on unblock relabel).
- Reconciler now sources `lib/notify.sh` directly (env.sh only redefines plain `loop_notify`).
- `tests/notify_human_required.bats`: 5 cases — fires on first transition, second tick is a no-op, missing channel is silent, notifier failure does not exit caller, clear re-arms future fire.

## Test Plan
- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh`
- `shellcheck -S warning lib/notify.sh scripts/po-handler.sh scripts/dev-handler.sh scripts/dev-rework-handler.sh scanner/reconciler.sh`
- `bats tests/notify_human_required.bats tests/handlers.bats tests/reconciler.bats`
- Sanity-check: run `LOOP_NOTIFY_CHANNEL=signal LOOP_NOTIFY='echo NOTIFY:'` with a fake handler invocation to confirm message format and dedup file creation.