### PR TITLE
[LOOP-169] workflows: switch to canonical label vocabulary + docs/labels.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,22 @@ projects.yaml schema, bounty event API, CLI flags, lock dir, log dir).
 - [LOOP-161] reconcile-on-startup: GC orphaned /tmp/loop-worktree-* dirs (#172)
 - [LOOP-164] reconciler: surface author-gated tickets via digest + status counter (#173)
 - [LOOP-163] author-gate: honour operator-approved label as per-ticket override (#177)
+- [LOOP-169] workflow YAMLs (`default`, `minimal`, `docs-only`) now reference
+  only the canonical label vocabulary defined in `lib/labels.sh`
+  (`needs-po`, `in-po`, `needs-dev`, `in-dev`, `needs-review`, `in-review`,
+  `needs-qa`, `qa-pass`, `qa-fail`, `blocked`, `done`). Deprecated synonyms
+  (`po-review`, `dev`, `plan`, `needs-rework`, `changes-requested`,
+  `merge-ready`, `ready-for-qa`, `review-pending`, `in-rework`,
+  `in-progress`) are no longer valid trigger names in the shipped workflows.
+- [LOOP-169] new `docs/labels.md` documents the canonical taxonomy, the
+  operator-set-vs-agent-set split, and the deprecated-alias mapping.
+
+### Migration
+- Existing tickets carrying deprecated labels are auto-renamed by
+  `reconcile_alias_renames` (shipped in #168) on the next reconciler tick;
+  per-project GitHub-side cleanup of the deprecated labels themselves is
+  handled by `scripts/migrate-labels.sh` (#170). No operator action is
+  required for projects on the shipped workflows.
 ## [0.2.0] - 2026-04-29
 
 ### Fixed

--- a/config/workflows/default.yaml
+++ b/config/workflows/default.yaml
@@ -1,8 +1,19 @@
-# Loop default workflow — clean canonical labels for new adopters.
+# Loop default workflow — canonical label vocabulary.
+#
+# Canonical labels (single source of truth: lib/labels.sh, docs/labels.md):
+#   needs-po, in-po, needs-dev, in-dev,
+#   needs-review, in-review,
+#   needs-qa, qa-pass, qa-fail,
+#   blocked, done
 #
 # Stages:
-#   po-review (issue) → dev (issue) → needs-review (PR) → needs-rework (PR) →
-#   needs-qa (PR) → qa-pass / qa-fail (PR) → merge → done
+#   needs-po (issue) → needs-dev (issue) → needs-review (PR) →
+#   {approve → needs-qa | reject → needs-dev (PR rework)} →
+#   qa-pass / qa-fail (PR) → merge → done
+#
+# Deprecated synonyms (po-review, dev, plan, in-progress, review-pending,
+# ready-for-qa, needs-rework, changes-requested, in-rework) are rewritten by
+# `reconcile_alias_renames` on the next reconciler tick — see lib/labels.sh.
 #
 # To use: in config/projects.yaml, set `workflow: default` for a project.
 # Per-project label overrides are supported via the `labels:` map.
@@ -13,18 +24,18 @@ version: 1
 name: default
 description: |
   Standard plan → review → QA → merge pipeline with PO expansion and
-  rework loop. Clean canonical label names; recommended for new repos.
+  rework loop. Canonical label names; recommended for new repos.
 
 issue_stages:
   - id: po
-    trigger_label: po-review
+    trigger_label: needs-po
     handler: po-handler
-    on_done: dev
+    on_done: needs-dev
     on_blocked: blocked
     on_clarification: needs-clarification
 
   - id: dev
-    trigger_label: dev
+    trigger_label: needs-dev
     handler: dev-handler
     on_done: needs-review
     on_failed_after_max: blocked
@@ -35,10 +46,10 @@ pr_stages:
     handler: review-handler
     decisions:
       approve: needs-qa
-      reject: needs-rework
+      reject: needs-dev
 
   - id: rework
-    trigger_label: needs-rework
+    trigger_label: needs-dev
     handler: dev-rework-handler
     on_done: needs-review
     on_failed_after_max: blocked

--- a/config/workflows/docs-only.yaml
+++ b/config/workflows/docs-only.yaml
@@ -1,22 +1,29 @@
 # Loop docs-only workflow — documentation and content change pipeline.
 #
 # Stages:
-#   plan (issue) → needs-review (PR) → done
+#   needs-dev (issue) → needs-review (PR) → qa-pass → done
 #
 # Skips QA. Use for documentation PRs, README updates, and other changes
 # where automated testing adds no value and human review is sufficient.
+# `qa-pass` is reused as the "approved, ready to merge" signal so the
+# canonical label vocabulary stays consistent across workflows (see
+# docs/labels.md and lib/labels.sh).
+#
+# Deprecated synonyms (dev, plan, needs-rework, merge-ready) are rewritten
+# by `reconcile_alias_renames` on the next reconciler tick.
 #
 # To use: in config/projects.yaml, set `workflow: docs-only`.
 
 version: 1
 name: docs-only
 description: |
-  Three-stage pipeline: plan → review → merge. No QA gate. For documentation
-  and content-only changes where human review is sufficient before merge.
+  Three-stage pipeline: needs-dev → review → merge. No QA gate. For
+  documentation and content-only changes where human review is sufficient
+  before merge.
 
 issue_stages:
-  - id: plan
-    trigger_label: dev
+  - id: dev
+    trigger_label: needs-dev
     handler: dev-handler
     on_done: needs-review
     on_failed_after_max: blocked
@@ -26,16 +33,16 @@ pr_stages:
     trigger_label: needs-review
     handler: review-handler
     decisions:
-      approve: merge-ready
-      reject: needs-rework
+      approve: qa-pass
+      reject: needs-dev
 
   - id: rework
-    trigger_label: needs-rework
+    trigger_label: needs-dev
     handler: dev-rework-handler
     on_done: needs-review
     on_failed_after_max: blocked
 
   - id: merge
-    trigger_label: merge-ready
+    trigger_label: qa-pass
     handler: merge-handler
     on_done: done

--- a/config/workflows/minimal.yaml
+++ b/config/workflows/minimal.yaml
@@ -1,8 +1,11 @@
 # Loop minimal workflow — solo-prototype pipeline.
 #
-# Skips review and QA. Issues labeled `plan` get implemented by the dev
+# Skips review and QA. Issues labeled `needs-dev` get implemented by the dev
 # handler, the resulting PR is merged automatically. Use for personal
 # projects or rapid prototypes where review/QA gates aren't useful.
+#
+# Canonical labels only (deprecated alias `dev` is auto-rewritten by the
+# reconciler — see lib/labels.sh and docs/labels.md).
 #
 # To use: in config/projects.yaml, set `workflow: minimal`.
 #
@@ -12,11 +15,11 @@
 version: 1
 name: minimal
 description: |
-  Two-stage pipeline: plan → merge. No review, no QA. For solo prototypes.
+  Two-stage pipeline: needs-dev → merge. No review, no QA. For solo prototypes.
 
 issue_stages:
-  - id: plan
-    trigger_label: dev
+  - id: dev
+    trigger_label: needs-dev
     handler: dev-handler
     on_done: needs-qa
     on_failed_after_max: blocked

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -1,0 +1,85 @@
+# Labels
+
+Loop drives every issue and PR through a label state machine. The vocabulary
+is small and intentionally so: every state has exactly one canonical name
+defined in `lib/labels.sh` (`LOOP_CANONICAL_LABELS`). Workflow YAMLs in
+`config/workflows/` reference only canonical names; older synonyms still in
+the wild are auto-renamed by the reconciler on its next tick.
+
+## Canonical taxonomy
+
+Eleven labels cover every Loop pipeline state.
+
+| Canonical label | Object | Triggers / role | Set by |
+|---|---|---|---|
+| `needs-po` | issue | Rough idea — PO handler will expand into a full spec | operator |
+| `in-po` | issue | PO handler has claimed the issue and is expanding the spec | agent (po-handler) |
+| `needs-dev` | issue / PR | Issue: queued for implementation. PR: review rejected, queued for rework. | operator (issue) / agent (PR, via review-handler reject) |
+| `in-dev` | issue / PR | Dev or rework handler has claimed the work | agent (dev-handler / dev-rework-handler) |
+| `needs-review` | PR | PR is open and waiting for code review | agent (dev-handler on PR open; dev-rework-handler on rework done) |
+| `in-review` | PR | Review handler has claimed the PR | agent (review-handler) |
+| `needs-qa` | PR | Review approved; queued for the QA gate | agent (review-handler on approve) |
+| `qa-pass` | PR | QA passed; queued for merge. Also used by docs-only workflow as the "approved, ready to merge" signal. | agent (qa-handler) / operator (manual override) |
+| `qa-fail` | PR | QA failed; queued for dev rework | agent (qa-handler) |
+| `blocked` | issue / PR | Terminal until a human intervenes | agent (after max retries) / operator |
+| `done` | issue / PR | Terminal — issue closed or PR merged | agent (merge-handler) |
+
+A handful of orthogonal labels (`needs-clarification`, `safe-to-test`, plus
+priority / semver / epic markers) are preserved as-is — they coexist with the
+state-machine labels and are never stripped on terminal transitions other
+than the strict pipeline-stage set in `LOOP_PIPELINE_STAGE_LABELS`.
+
+## Operator-set vs agent-set
+
+The taxonomy splits cleanly:
+
+- **Operator-set**: `needs-po`, `needs-dev` on issues, `blocked` (when
+  humans intervene), occasional `qa-pass` to force-merge.
+- **Agent-set**: every `in-*` claim label, every `needs-*` transition that a
+  handler emits on completion (`needs-review`, `needs-qa`), every terminal
+  outcome (`qa-pass`, `qa-fail`, `done`), and `blocked` after max retries.
+
+This split exists so handlers can race safely: only one party owns a given
+transition. Operators set the queue labels (`needs-po` / `needs-dev`) and
+nothing else; agents own the in-flight (`in-*`) and outcome states.
+
+## Deprecated alias table
+
+These names are still recognised in the wild — `lib/labels.sh::LOOP_DEPRECATED_ALIAS_MAP`
+is the source of truth, and `reconcile_alias_renames` (see #168) rewrites
+them on every reconciler tick. New code, new workflow YAMLs, and new
+handlers must reference the canonical name only.
+
+| Deprecated alias | Canonical replacement | Notes |
+|---|---|---|
+| `po-review` | `needs-po` | Old PO trigger label |
+| `dev` | `needs-dev` | Old dev trigger label |
+| `plan` | `needs-dev` | Old plan-stage trigger (minimal / docs-only) |
+| `in-progress` | `needs-dev` | Pre-canonical claim label; handler now uses `in-dev` |
+| `review-pending` | `needs-review` | Synonym for the review queue |
+| `ready-for-qa` | `needs-qa` | Synonym for the QA queue |
+| `needs-rework` | `needs-dev` | Rework collapses back into the dev queue (PR-side trigger) |
+| `changes-requested` | `needs-dev` | GitHub-style synonym for review rejection |
+| `in-rework` | `in-dev` | Pre-canonical claim label for rework; unified with dev claim |
+
+## Per-project label remapping
+
+Workflows reference canonical names, but a project can still rename a label
+on disk (for vocabulary preferences or to coexist with a pre-existing label
+scheme on the GitHub repo). Set the override under the project's `labels:`
+map in `config/projects.yaml`:
+
+```yaml
+projects:
+  - slug: example
+    repo: org/example
+    workflow: default
+    labels:
+      needs-dev: backlog          # canonical → project-local
+      needs-review: review-please
+```
+
+`lib/workflow.sh::loop_label_for` and `loop_polled_labels` apply the
+override transparently — handlers, the scanner, and the reconciler always
+work in canonical-label terms internally and only translate at the GitHub
+API boundary. No code changes are required to support a renamed label.

--- a/lib/workflow.sh
+++ b/lib/workflow.sh
@@ -226,7 +226,11 @@ seen_labels = set()
 all_handlers = []
 all_transitions = []  # (field_name, value)
 
+# Duplicate trigger_label check is per-section: issues and PRs are distinct
+# objects, so a label like `needs-dev` may legitimately trigger an issue
+# stage and a PR-rework stage in the same workflow.
 for section in ('issue_stages', 'pr_stages'):
+    section_labels = set()
     for s in wf.get(section, []) or []:
         stages_total += 1
         if 'id' not in s:
@@ -237,9 +241,10 @@ for section in ('issue_stages', 'pr_stages'):
             errors.append(f"{section}/{s.get('id','?')} missing 'handler'")
 
         lbl = s.get('trigger_label')
-        if lbl and lbl in seen_labels:
-            errors.append(f"duplicate trigger_label '{lbl}' in workflow")
+        if lbl and lbl in section_labels:
+            errors.append(f"duplicate trigger_label '{lbl}' within {section}")
         elif lbl:
+            section_labels.add(lbl)
             seen_labels.add(lbl)
 
         handler = s.get('handler')

--- a/tests/scanner.bats
+++ b/tests/scanner.bats
@@ -207,7 +207,7 @@ teardown() {
     unset LOOP_CONFIG
     run _pr_downstream_labels "test-slug" "needs-review"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"needs-rework"* ]]
+    [[ "$output" == *"needs-dev"* ]]
     [[ "$output" == *"needs-qa"* ]]
     [[ "$output" == *"qa-pass"* ]]
 }
@@ -217,7 +217,7 @@ teardown() {
     run _pr_downstream_labels "test-slug" "qa-pass"
     [ "$status" -eq 0 ]
     [[ "$output" != *"needs-review"* ]]
-    [[ "$output" != *"needs-rework"* ]]
+    [[ "$output" != *"needs-dev"* ]]
     [[ "$output" != *"needs-qa"* ]]
 }
 
@@ -254,22 +254,22 @@ projects:
 YAML
 }
 
-@test "workflow fixture: proj-default issue labels include po-review and dev" {
+@test "workflow fixture: proj-default issue labels include needs-po and needs-dev" {
     _write_fixture_config
     export LOOP_CONFIG="$BATS_TMPDIR/fixture.yaml"
     run loop_polled_labels "proj-default" issue
     [ "$status" -eq 0 ]
-    [[ "$output" == *"po-review"* ]]
-    [[ "$output" == *"dev"* ]]
+    [[ "$output" == *"needs-po"* ]]
+    [[ "$output" == *"needs-dev"* ]]
 }
 
-@test "workflow fixture: proj-minimal issue labels include dev but NOT po-review" {
+@test "workflow fixture: proj-minimal issue labels include needs-dev but NOT needs-po" {
     _write_fixture_config
     export LOOP_CONFIG="$BATS_TMPDIR/fixture.yaml"
     run loop_polled_labels "proj-minimal" issue
     [ "$status" -eq 0 ]
-    [[ "$output" == *"dev"* ]]
-    [[ "$output" != *"po-review"* ]]
+    [[ "$output" == *"needs-dev"* ]]
+    [[ "$output" != *"needs-po"* ]]
 }
 
 @test "workflow fixture: proj-default PR labels include needs-review, needs-qa, qa-pass" {
@@ -296,11 +296,11 @@ YAML
     export LOOP_CONFIG="$BATS_TMPDIR/fixture.yaml"
 
     local PLAN_ISSUE
-    PLAN_ISSUE='{"number":1,"title":"Fix thing","url":"http://gh/1","labels":["dev"],"author":"bot"}'
+    PLAN_ISSUE='{"number":1,"title":"Fix thing","url":"http://gh/1","labels":["needs-dev"],"author":"bot"}'
 
     backend_list_issues_with_label() {
         local _label="$2"
-        [ "$_label" = "dev" ] && printf '%s\n' "$PLAN_ISSUE"
+        [ "$_label" = "needs-dev" ] && printf '%s\n' "$PLAN_ISSUE"
         return 0
     }
     backend_list_prs_with_label()  { return 0; }

--- a/tests/workflow.bats
+++ b/tests/workflow.bats
@@ -120,7 +120,11 @@ YAML
     [[ "$output" == *"duplicate"* ]]
 }
 
-@test "validate: duplicate trigger_label across issue_stages and pr_stages fails" {
+@test "validate: same trigger_label across issue_stages and pr_stages is allowed" {
+    # Issues and PRs are distinct objects; one canonical label (e.g.
+    # `needs-dev`) may legitimately trigger both an issue stage and a
+    # PR-rework stage. The duplicate-trigger check is therefore scoped to
+    # a single section. See config/workflows/default.yaml and docs-only.yaml.
     cat > "$TEST_TMP/xdup.yaml" <<YAML
 version: 1
 name: xdup
@@ -136,8 +140,7 @@ pr_stages:
     on_done: done
 YAML
     run loop_workflow_validate "$TEST_TMP/xdup.yaml"
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"duplicate"* ]]
+    [ "$status" -eq 0 ]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/workflows-canonical.bats
+++ b/tests/workflows-canonical.bats
@@ -1,0 +1,117 @@
+#!/usr/bin/env bats
+# tests/workflows-canonical.bats — every label referenced by a shipped
+# workflow YAML must be a member of LOOP_CANONICAL_LABELS (or one of the
+# narrow set of orthogonal labels Loop allows in transition targets).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    # shellcheck source=../lib/labels.sh
+    source "$REPO_ROOT/lib/labels.sh"
+    # shellcheck source=../lib/workflow.sh
+    source "$REPO_ROOT/lib/workflow.sh"
+}
+
+# Walk a workflow YAML and emit every label it references — every
+# trigger_label and every transition target. One label per line.
+_workflow_labels() {
+    local yaml_path="$1"
+    YAML="$yaml_path" python3 - <<'PY'
+import os, sys, yaml
+
+with open(os.environ['YAML']) as f:
+    wf = yaml.safe_load(f) or {}
+
+labels = []
+for section in ('issue_stages', 'pr_stages'):
+    for stage in wf.get(section, []) or []:
+        lbl = stage.get('trigger_label')
+        if lbl:
+            labels.append(lbl)
+        for field in ('on_done', 'on_blocked', 'on_clarification',
+                      'on_failed_after_max', 'on_pass', 'on_fail'):
+            v = stage.get(field)
+            if v:
+                labels.append(v)
+        for v in (stage.get('decisions') or {}).values():
+            if v:
+                labels.append(v)
+
+for l in labels:
+    print(l)
+PY
+}
+
+# `needs-clarification` is the one orthogonal label that may appear as a
+# transition target — it's an out-of-band blocker (handler signal that the
+# issue author is needed) and intentionally not part of the canonical
+# pipeline state set in LOOP_CANONICAL_LABELS.
+_label_is_allowed() {
+    local label="$1"
+    [ "$label" = "needs-clarification" ] && return 0
+    loop_is_canonical_label "$label"
+}
+
+@test "default.yaml: every referenced label is canonical" {
+    local yaml="$REPO_ROOT/config/workflows/default.yaml"
+    [ -f "$yaml" ]
+    while IFS= read -r label; do
+        [ -z "$label" ] && continue
+        run _label_is_allowed "$label"
+        [ "$status" -eq 0 ] || {
+            echo "default.yaml references non-canonical label: '$label'" >&2
+            return 1
+        }
+    done < <(_workflow_labels "$yaml")
+}
+
+@test "minimal.yaml: every referenced label is canonical" {
+    local yaml="$REPO_ROOT/config/workflows/minimal.yaml"
+    [ -f "$yaml" ]
+    while IFS= read -r label; do
+        [ -z "$label" ] && continue
+        run _label_is_allowed "$label"
+        [ "$status" -eq 0 ] || {
+            echo "minimal.yaml references non-canonical label: '$label'" >&2
+            return 1
+        }
+    done < <(_workflow_labels "$yaml")
+}
+
+@test "docs-only.yaml: every referenced label is canonical" {
+    local yaml="$REPO_ROOT/config/workflows/docs-only.yaml"
+    [ -f "$yaml" ]
+    while IFS= read -r label; do
+        [ -z "$label" ] && continue
+        run _label_is_allowed "$label"
+        [ "$status" -eq 0 ] || {
+            echo "docs-only.yaml references non-canonical label: '$label'" >&2
+            return 1
+        }
+    done < <(_workflow_labels "$yaml")
+}
+
+@test "all shipped workflows pass loop_workflow_validate" {
+    for wf in default minimal docs-only; do
+        run loop_workflow_validate "$REPO_ROOT/config/workflows/${wf}.yaml"
+        [ "$status" -eq 0 ] || {
+            echo "loop_workflow_validate failed on ${wf}.yaml" >&2
+            return 1
+        }
+    done
+}
+
+@test "no deprecated alias appears as a workflow label" {
+    local deprecated
+    deprecated=$(loop_deprecated_aliases | tr '\n' '|' | sed 's/|$//')
+    for wf in default minimal docs-only; do
+        local yaml="$REPO_ROOT/config/workflows/${wf}.yaml"
+        while IFS= read -r label; do
+            [ -z "$label" ] && continue
+            if echo "$label" | grep -Eqx "$deprecated"; then
+                echo "${wf}.yaml uses deprecated label: '$label'" >&2
+                return 1
+            fi
+        done < <(_workflow_labels "$yaml")
+    done
+}


### PR DESCRIPTION
Closes #169

## Changes

- `config/workflows/{default,minimal,docs-only}.yaml` now reference only the
  canonical label vocabulary defined in `lib/labels.sh`: `needs-po`, `in-po`,
  `needs-dev`, `in-dev`, `needs-review`, `in-review`, `needs-qa`, `qa-pass`,
  `qa-fail`, `blocked`, `done`. Deprecated synonyms (`po-review`, `dev`,
  `plan`, `needs-rework`, `changes-requested`, `merge-ready`, `ready-for-qa`,
  `review-pending`, `in-rework`, `in-progress`) removed from the YAMLs.
- `docs/labels.md` (new): canonical taxonomy table with operator-vs-agent-set
  attribution, deprecated-alias mapping, and a note on per-project renaming
  via `loop_label_for` / `config/projects.yaml::labels`.
- `CHANGELOG.md` gets an `[Unreleased]` entry with a migration recipe
  (existing tickets are auto-renamed by `reconcile_alias_renames` from #168;
  per-project GitHub-side label cleanup is handled by `scripts/migrate-labels.sh`
  from #170 — no operator action required).
- `tests/workflows-canonical.bats` (new): for each shipped workflow YAML,
  asserts every referenced label (trigger + every transition target) is in
  `LOOP_CANONICAL_LABELS` (or the single allowed orthogonal label
  `needs-clarification`), and that no deprecated alias appears.
- `lib/workflow.sh`: duplicate-`trigger_label` check is now scoped per
  section (issue vs PR) instead of global. Issues and PRs are distinct
  objects, so `needs-dev` may legitimately trigger both an issue dev stage
  and a PR-rework stage in the same workflow — required by the canonical
  default and docs-only flows. `tests/workflow.bats` updated to assert the
  new behaviour.

## Test Plan

- [x] `bats tests/workflow.bats tests/labels.bats tests/workflows-canonical.bats` — 29/29 pass
- [x] `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — clean
- [x] `loop_workflow_validate` returns 0 for each of `default.yaml`,
  `minimal.yaml`, `docs-only.yaml`
- [ ] QA: confirm no in-flight ticket gets stranded — the next reconciler
  tick should rename any remaining deprecated labels (`reconcile_alias_renames`
  from #168) before the scanner re-emits events with the new triggers