### PR TITLE
[LOOP] recovery: skip unblock when issue already has an open PR

### DIFF
--- a/lib/recovery.sh
+++ b/lib/recovery.sh
@@ -73,6 +73,26 @@ PY
         done
 
         if $all_closed; then
+            # Skip the unblock when an open PR already closes this issue. Work
+            # is in flight on the PR side (review/QA/merge); restoring the
+            # issue's `dev` trigger here causes the dev-handler to re-run and
+            # re-apply `blocked` on the next tick, producing a 20-min ping-pong
+            # observed on ppl-study #421 (7+ cycles, 80+ comments). Strip the
+            # stale `blocked` so the PR-side pipeline is unobstructed, but do
+            # not requeue dev.
+            local _existing_pr=""
+            _existing_pr=$(backend_find_pr_for_issue "$repo" "$num" 2>/dev/null || echo "")
+            if [ -n "$_existing_pr" ]; then
+                log "[$repo] UNBLOCK issue #$num (deps ${deps} satisfied) — open PR #${_existing_pr} found; stripping blocked only, NOT requeuing dev"
+                $DRY_RUN && continue
+                backend_remove_label "$repo" "$num" blocked \
+                    || log "[$repo] WARN: failed to remove blocked from issue #$num"
+                backend_comment_issue "$repo" "$num" \
+                    "Dependency ${deps//,/, #} is now closed/merged. PR #${_existing_pr} already in flight — stripping \`blocked\` so the PR pipeline can proceed; not re-running dev." \
+                    || log "[$repo] WARN: failed to comment on issue #$num"
+                continue
+            fi
+
             trigger_label=$(loop_label_for "$slug" "dev" 2>/dev/null) || trigger_label="dev"
             [ -z "$trigger_label" ] && trigger_label="dev"
             dep_list=$(DEP_NUMS="$deps" python3 -c "


### PR DESCRIPTION
Closes #190.

## Summary

Closes the 20-min reconciler-vs-handler ping-pong observed on **svv2014/ppl-study #421** (7+ cycles, 80+ issue comments — the PO agent itself diagnosed the loop and asked for human action). Same pattern reported on loop-monitor #47, #50.

## The loop

1. dev-handler runs → opens PR closing the issue → applies `blocked` (work moves to PR side)
2. `recovery_check_dependencies` sees `blocked` + declared deps closed → strips blocked, applies `dev`
3. dev-handler runs again on an issue that already has an open PR → re-applies `blocked`
4. ~20 min later, step (2) flips it back to `dev` → loop

The premise of recovery is *"this issue is parked waiting on upstream; upstream is done, so requeue dev"* — but once the issue's own PR exists, requeuing dev is wrong: work is already in review.

## Change

Before unblocking, call `backend_find_pr_for_issue`. If it returns an open PR:
- strip stale `blocked`
- **do not** add `dev`
- comment + log with the PR ref

When no PR exists, behaviour is unchanged.

## Verification

- `bash -n lib/recovery.sh` — clean
- Will be exercised on the next reconciler tick against the live ping-pong tickets
- Bats coverage deferred until reconciler.sh is refactored to be sourceable from tests (existing constraint, see PR #178 follow-up note)