### PR TITLE
[LOOP] fix: _autopull_loop must return 0 — set -e killed reconciler when HEAD unchanged

### DIFF
--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -1545,7 +1545,10 @@ _autopull_loop() {
     before=$(git -C "$LOOP_ROOT" rev-parse HEAD 2>/dev/null || echo "")
     git -C "$LOOP_ROOT" pull --ff-only origin main --quiet 2>/dev/null || return 0
     after=$(git -C "$LOOP_ROOT" rev-parse HEAD 2>/dev/null || echo "")
-    [ "$before" != "$after" ] && log "auto-pull: updated $before → $after"
+    if [ "$before" != "$after" ]; then
+        log "auto-pull: updated $before → $after"
+    fi
+    return 0
 }
 $DRY_RUN || _autopull_loop
 


### PR DESCRIPTION
## Summary

`scanner/reconciler.sh::_autopull_loop` ended with:
```
[ "$before" != "$after" ] && log "auto-pull: updated $before → $after"
```

When `git pull --ff-only` made no change (i.e. nothing to pull), `before == after`, the conditional returns 1, the function inherits exit status 1, and `set -euo pipefail` (top of file) kills the entire script before any reconcile_* check runs. The lock-file EXIT trap fires, then the script exits 1.

## Impact

The reconciler has been silently exiting on every launchd tick for ~2 hours since the most recent merge to main (PR #193, 2026-05-01 01:37). Symptoms:

- `launchctl print gui/$UID/com.user.loop-reconciler` → `last exit code = 1`
- `loop-reconciler.log` last entry at 01:37; nothing for 8+ launchd retries since
- All downstream handlers idle (no events emitted from reconciler-driven paths)
- New project (suprun.ca) added to projects.yaml during the window — never bootstrapped (no labels created on the repo, no events for issue #10)

The bug is deterministic: it triggers on the first reconciler tick after the last merge and stays triggered until something else merges main. Working all day was an artifact of frequent merges; the bug surfaced as soon as merge cadence stopped.

## Fix

Replace the `&&` short-circuit with `if/then` and add explicit `return 0`:

```bash
if [ "$before" != "$after" ]; then
    log "auto-pull: updated $before → $after"
fi
return 0
```

No behavior change in the happy path; only fixes the silent exit when nothing was pulled.

## Verification

- `bash -n scanner/reconciler.sh` clean
- Reproduced locally with `env -i HOME=$HOME PATH=... bash -x reconciler.sh` showing the script exits right after `_autopull_loop` returns when `before == after`
- After fix, manual run + launchd kickstart both proceed past the autopull and run the project loop

## Priority

p0-critical — the entire reconciler-driven pipeline is currently stalled. Recommend admin-merge.