### PR TITLE
[LOOP] reconciler: consolidate LOOP_PIPELINE_LABELS to lib/labels.sh single source of truth

### DIFF
--- a/lib/labels.sh
+++ b/lib/labels.sh
@@ -219,6 +219,31 @@ loop_pipeline_stage_labels_csv() {
     echo "${LOOP_PIPELINE_STAGE_LABELS[*]}"
 }
 
+# Tracked labels — every label that means "this ticket is part of the Loop
+# pipeline at all," including terminal states. Superset of LOOP_PIPELINE_STAGE_LABELS
+# plus blocked/done (terminal) and tracker (epic taxonomy). Used by
+# reconcile_lost_issues to detect issues with NO pipeline label at all (so
+# they can be routed back to po-review for triage).
+#
+# DO NOT use this for strip-on-close — use LOOP_PIPELINE_STAGE_LABELS for
+# that, since blocked/done/tracker must be preserved.
+LOOP_PIPELINE_TRACKED_LABELS=(
+    "${LOOP_PIPELINE_STAGE_LABELS[@]}"
+    blocked
+    "done"
+    tracker
+)
+
+# loop_pipeline_tracked_labels_string — space-separated string of every tracked
+# label. Single source of truth for reconcile_lost_issues' detection set.
+# Replaces the hardcoded LOOP_PIPELINE_LABELS string in scanner/reconciler.sh
+# (which drifted twice: missed needs-po/in-po/needs-dev/in-dev when the vocab
+# migration landed in #167/#188 → fixed in #207; now consolidated here so any
+# future label addition propagates automatically).
+loop_pipeline_tracked_labels_string() {
+    echo "${LOOP_PIPELINE_TRACKED_LABELS[*]}"
+}
+
 # Issue-only labels — should never appear on a PR. Some are pipeline triggers
 # whose handlers expect to run against an issue (and would misfire on a PR);
 # others are taxonomy markers (`tracker`, `epic`) that classify issues only.

--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -578,7 +578,12 @@ reconcile_worktrees() {
 # Open issues that have no Loop pipeline label at all are invisible to the
 # scanner and all handlers. Detect them and send back to the PO trigger so
 # the PO agent can triage (re-spec, close, cancel, or upgrade to epic).
-LOOP_PIPELINE_LABELS="${LOOP_LABEL_DEPRECATED_PO_REVIEW} ${LOOP_LABEL_DEPRECATED_PLAN} ${LOOP_LABEL_DEPRECATED_DEV} ${LOOP_LABEL_DEPRECATED_IN_PROGRESS} ${LOOP_LABEL_DEPRECATED_REVIEW_PENDING} ${LOOP_LABEL_NEEDS_PO} ${LOOP_LABEL_IN_PO} ${LOOP_LABEL_NEEDS_DEV} ${LOOP_LABEL_IN_DEV} ${LOOP_LABEL_NEEDS_REVIEW} ${LOOP_LABEL_IN_REVIEW} ${LOOP_LABEL_NEEDS_QA} ${LOOP_LABEL_DEPRECATED_READY_FOR_QA} ${LOOP_LABEL_DEPRECATED_IN_REWORK} ${LOOP_LABEL_DEPRECATED_NEEDS_REWORK} ${LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED} needs-clarification ${LOOP_LABEL_BLOCKED} ${LOOP_LABEL_QA_FAIL} ${LOOP_LABEL_QA_PASS} ${LOOP_LABEL_DONE} tracker"
+# Single source of truth: lib/labels.sh exports LOOP_PIPELINE_TRACKED_LABELS
+# and the loop_pipeline_tracked_labels_string helper. Previously this was a
+# hardcoded string here that drifted twice: missed needs-po/in-po/needs-dev/
+# in-dev when the vocab migration landed in #167/#188, fixed in #207, now
+# consolidated so any future label addition propagates from one place.
+LOOP_PIPELINE_LABELS=$(loop_pipeline_tracked_labels_string)
 
 reconcile_lost_issues() {
     local repo="$1"


### PR DESCRIPTION
## Summary

Same vocabulary-migration drift hit us four times today in different files (#192, #205, #207, #199) — each addition during the migration era shipped without checking every other place referencing the same vocab.

Process fix: `lib/labels.sh` now owns the canonical pipeline-tracked-label set. `scanner/reconciler.sh`'s hardcoded `LOOP_PIPELINE_LABELS` string is replaced with a call to a new `loop_pipeline_tracked_labels_string` helper. Future label additions propagate from one place.

## Two distinct sets, both in lib/labels.sh

| Set | Use | Contents |
|---|---|---|
| `LOOP_PIPELINE_STAGE_LABELS` (existing) | strip-on-close | everything in-flight, excludes `blocked`/`done`/`tracker` |
| `LOOP_PIPELINE_TRACKED_LABELS` (new) | "is in the pipeline?" detection | stage + `blocked` + `done` + `tracker` |

## Verification

```
$ source lib/labels.sh
$ loop_pipeline_tracked_labels_string
needs-po in-po needs-dev in-dev needs-review in-review needs-qa qa-pass qa-fail needs-clarification po-review dev plan in-progress review-pending ready-for-qa needs-rework changes-requested in-rework blocked done tracker
```

Same labels as the post-#207 hardcoded string. No behavioural change; refactor only.

## Why

Drift costs went up steeply today: the migration introduced the new canonicals (`needs-po`/`needs-dev`/etc.), but multiple consumers kept their own hardcoded copies of "what counts as a pipeline label". Each one was a separate bug, each one had real impact (suprun.ca#10 ping-ponged 15 times because of one missing entry). One place to edit > four places to remember.