### PR TITLE
[LOOP] reconcile_lost_issues: observational only — no auto-mutation (root-cause fix for label ping-pong)

### DIFF
--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -586,8 +586,23 @@ reconcile_worktrees() {
 LOOP_PIPELINE_LABELS=$(loop_pipeline_tracked_labels_string)
 
 reconcile_lost_issues() {
+    # Observational, NOT mutating. Previously this function applied po-review
+    # to any issue it considered "lost" — but that fought every other writer
+    # within the same tick (alias-rename, synonym-rename, recovery_check_*,
+    # etc.) and could be wrong on stale data (GitHub's read-after-write
+    # consistency window for gh issue edit → gh issue list is non-zero).
+    #
+    # Concrete failure: today on suprun.ca#10 the cycle was alias-rename
+    # writes po-review → needs-po, lost-issues' next gh-fetch in the same
+    # tick missed the update OR labels.sh's pipeline-label set was stale,
+    # lost-issues re-applied po-review, alias-rename re-renamed, ...
+    # 41+ comments, infinite ping-pong.
+    #
+    # Now: log + notify only. The operator (Signal) decides whether the
+    # issue is genuinely abandoned vs. mid-transition. No mutation = no
+    # tick-level coordination needed = no fights with other checks.
     local repo="$1"
-    log "[$repo] scanning for lost issues (no pipeline label)"
+    log "[$repo] scanning for lost issues (no pipeline label) — observational"
 
     local all_open_json
     all_open_json=$(gh issue list --repo "$repo" --state open --limit 200 --json number,title,labels 2>/dev/null || echo "[]")
@@ -609,16 +624,36 @@ PY
         return 0
     fi
 
+    # Per-(repo,issue) cool-down so we don't spam Signal on every tick for
+    # the same lost ticket. State file is touched once we've notified; the
+    # next notification fires only after LOOP_LOST_NOTIFY_HOURS (default 24)
+    # have elapsed.
+    local cool_down_dir="${LOOP_LOST_STATE_DIR:-/tmp/loop-lost-notified}"
+    local cool_down_hours="${LOOP_LOST_NOTIFY_HOURS:-24}"
+    mkdir -p "$cool_down_dir"
+    local cool_down_seconds=$(( cool_down_hours * 3600 ))
+    local now_epoch
+    now_epoch=$(date +%s)
+
     while IFS=$'\t' read -r num title; do
         [ -z "$num" ] && continue
-        log "[$repo] LOST issue #$num (no pipeline label): $title — routing to ${LOOP_LABEL_DEPRECATED_PO_REVIEW}"
+        log "[$repo] LOST issue #$num (no pipeline label): $title — observational, no mutation"
+
+        # Skip Signal if we already notified within the cool-down window.
+        local repo_slug="${repo//\//-}"
+        local sentinel="$cool_down_dir/${repo_slug}-${num}"
+        if [ -f "$sentinel" ]; then
+            local mtime; mtime=$(stat -f %m "$sentinel" 2>/dev/null || stat -c %Y "$sentinel" 2>/dev/null || echo 0)
+            local age=$(( now_epoch - mtime ))
+            if [ "$age" -lt "$cool_down_seconds" ]; then
+                log "[$repo] LOST issue #$num — Signal cooled-down (last notified ${age}s ago)"
+                continue
+            fi
+        fi
+
         $DRY_RUN && continue
-        backend_add_label "$repo" "$num" "$LOOP_LABEL_DEPRECATED_PO_REVIEW" \
-            || log "[$repo] WARN: failed to add ${LOOP_LABEL_DEPRECATED_PO_REVIEW} to issue #$num"
-        backend_comment_issue "$repo" "$num" \
-            "Reconciler: issue had no pipeline label — routed back to \`${LOOP_LABEL_DEPRECATED_PO_REVIEW}\` for triage." \
-            || true
-        loop_notify "Loop reconciler: $repo — issue #$num had no pipeline label; sent to ${LOOP_LABEL_DEPRECATED_PO_REVIEW}: $title"
+        loop_notify "Loop reconciler: $repo — issue #$num has no pipeline label. Operator: pick a trigger label (e.g. \`po-review\` or \`dev\`) or close as out-of-scope. Title: ${title}"
+        : > "$sentinel"
     done <<< "$lost"
 }
 


### PR DESCRIPTION
## Root cause of today's repeated label ping-pong incidents

Today we patched three separate label-vocabulary drift bugs (#207, #208, #213). All three made the symptoms go away briefly, then a different version of the same ping-pong reappeared. The structural cause was untouched: **`reconcile_lost_issues` is the only reconciler check that mutates state based on a single tick's snapshot, without corroboration**. Every other writer (alias-rename, synonym-rename, recovery_check_*) has gating (workflow triggers, deps satisfied, retry-counter-exhausted, timeout-based). lost-issues has none.

Within one tick, lost-issues runs **after** alias-rename + synonym-rename (which legitimately rewrite labels). Three converging failure modes:

1. **GitHub eventual consistency** — alias-rename's mutation may not yet be visible to lost-issues' subsequent `gh issue list` in the same tick → false-classifies the issue as "no pipeline label."
2. **Stale label-set constants** (today's #207) — needs-po was canonical but `LOOP_PIPELINE_LABELS` didn't include it for weeks → even after a successful rename, lost-issues didn't recognize the result.
3. **Bootstrap drift** (today's #213) — `LOOP_REQUIRED_LABELS` missed needs-po → repo didn't have the label defined → alias-rename's add silently failed → issue ended bare → lost-issues re-routed.

Each subsystem patch made the *current* failure mode go away, but the next eventual-consistency hiccup or future label addition would re-trigger the same class of bug. The fix has to address the writer, not its inputs.

## Change

`reconcile_lost_issues` becomes **observational only**:

- Log "LOST issue #N — observational, no mutation"
- Signal-notify the operator once per (repo, issue), with a 24h cool-down
- Operator applies a trigger label (or closes the issue) — manual decision

No auto-`backend_add_label`. No auto-comment on the issue. No fights with other reconciler writers.

## Behavioural change

Tickets filed without a pipeline label no longer auto-routed to po-review. **This is intentional** — the auto-routing was the bug. The operator-in-the-loop decision was free in practice today (every routing was followed by an operator triage anyway).

Configurable env vars:
- `LOOP_LOST_NOTIFY_HOURS` (default 24)
- `LOOP_LOST_STATE_DIR` (default /tmp/loop-lost-notified)

## Why this matches Symphony's design

Yesterday's discussion: deterministic checks should surface anomalies to operator, not auto-decide. Symphony's reconcile loop is a state machine that reports; humans (or the higher-level claim machine) act. Loop's other checks already follow this; lost-issues was the outlier.

## Verification

- `bash -n scanner/reconciler.sh` clean
- Live test after merge: suprun.ca#10 will receive ONE Signal notification on next tick, then no further mutations until 24h pass or operator labels it
- Bats coverage deferred per #210 (sourceability blocker)