### PR TITLE
[LOOP] test: lost-issues observational behaviour + fix LIB_ONLY hook ordering

### DIFF
--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -45,15 +45,20 @@ STALE_PR_HOURS="${LOOP_STALE_PR_HOURS:-24}"
 DRY_RUN=false
 ONLY_SLUG=""
 
-while [ $# -gt 0 ]; do
-    case "$1" in
-        --dry-run) DRY_RUN=true; shift ;;
-        --slug)    ONLY_SLUG="$2"; shift 2 ;;
-        -h|--help)
-            sed -n '1,20p' "$0"; exit 0 ;;
-        *) echo "unknown arg: $1" >&2; exit 2 ;;
-    esac
-done
+# Test hook: when LOOP_RECONCILER_LIB_ONLY=1 is set, skip the arg-parser
+# (which would reject the bats-injected $0/$@) and skip the main run at
+# the bottom — we only want function definitions for unit tests.
+if [ "${LOOP_RECONCILER_LIB_ONLY:-0}" != "1" ]; then
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --dry-run) DRY_RUN=true; shift ;;
+            --slug)    ONLY_SLUG="$2"; shift 2 ;;
+            -h|--help)
+                sed -n '1,20p' "$0"; exit 0 ;;
+            *) echo "unknown arg: $1" >&2; exit 2 ;;
+        esac
+    done
+fi
 
 mkdir -p "$(dirname "$LOG_FILE")"
 

--- a/tests/lost-issues-observational.bats
+++ b/tests/lost-issues-observational.bats
@@ -1,0 +1,166 @@
+#!/usr/bin/env bats
+# tests/lost-issues-observational.bats — coverage for reconcile_lost_issues.
+#
+# Verifies the post-#214 behaviour:
+#   - LOST issues trigger a Signal notification (loop_notify called)
+#   - LOST issues DO NOT mutate state (no backend_add_label, no
+#     backend_comment_issue) — this was the root cause of every label
+#     ping-pong incident on 2026-05-01 (suprun#10 41 comments,
+#     ppl-study#421 80 comments).
+#   - Per-(repo, issue) cool-down suppresses a second Signal within
+#     LOOP_LOST_NOTIFY_HOURS.
+#
+# Sourcing pattern: set LOOP_RECONCILER_LIB_ONLY=1 so reconciler.sh
+# defines functions and returns without acquiring locks or running main.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Per-test cool-down dir so test runs are isolated.
+    export LOOP_LOST_STATE_DIR="$BATS_TMPDIR/lost-notified-$$"
+    rm -rf "$LOOP_LOST_STATE_DIR"
+
+    # Operations log: every backend_add_label / backend_comment_issue /
+    # loop_notify call records a line. Tests assert on the contents.
+    export OPS_LOG="$BATS_TMPDIR/ops.log"
+    rm -f "$OPS_LOG"
+
+    # Globals reconciler.sh expects to exist at top-level scope.
+    export REPO="owner/test-repo"
+    export DRY_RUN=false
+
+    # Library-only mode: source reconciler.sh without running main.
+    export LOOP_RECONCILER_LIB_ONLY=1
+
+    # shellcheck source=../scanner/reconciler.sh
+    source "$REPO_ROOT/scanner/reconciler.sh"
+
+    # Override stubbed-out functions AFTER sourcing so they win over any
+    # real implementation pulled in via lib/*.
+    backend_add_label()      { echo "backend_add_label $*"      >> "$OPS_LOG"; }
+    backend_remove_label()   { echo "backend_remove_label $*"   >> "$OPS_LOG"; }
+    backend_comment_issue()  { echo "backend_comment_issue $*"  >> "$OPS_LOG"; }
+    backend_comment_pr()     { echo "backend_comment_pr $*"     >> "$OPS_LOG"; }
+    loop_notify()            { echo "loop_notify $*"            >> "$OPS_LOG"; }
+
+    # Mock gh: only the `gh issue list` call inside reconcile_lost_issues
+    # needs a return value. Read fixture from $GH_FIXTURE.
+    gh() {
+        if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+            cat "${GH_FIXTURE:-/dev/null}"
+            return 0
+        fi
+        return 0
+    }
+    export -f gh
+}
+
+teardown() {
+    rm -rf "$LOOP_LOST_STATE_DIR" "$OPS_LOG"
+    unset GH_FIXTURE
+}
+
+# Helper: fixture for an issue with no pipeline labels at all.
+write_fixture_unlabelled_issue() {
+    GH_FIXTURE="$BATS_TMPDIR/fixture-unlabelled.json"
+    cat > "$GH_FIXTURE" <<'JSON'
+[
+    {"number": 42, "title": "Test ticket without pipeline label", "labels": [{"name": "p2-medium"}]}
+]
+JSON
+    export GH_FIXTURE
+}
+
+# Helper: fixture for an issue WITH a pipeline label (should not be lost).
+write_fixture_labelled_issue() {
+    GH_FIXTURE="$BATS_TMPDIR/fixture-labelled.json"
+    cat > "$GH_FIXTURE" <<'JSON'
+[
+    {"number": 99, "title": "Healthy ticket", "labels": [{"name": "needs-po"}, {"name": "p1-high"}]}
+]
+JSON
+    export GH_FIXTURE
+}
+
+# ─── Tests ───────────────────────────────────────────────────────────────────
+
+@test "lost issue: notifies operator (Signal) but does NOT mutate state" {
+    write_fixture_unlabelled_issue
+
+    run reconcile_lost_issues "$REPO"
+    [ "$status" -eq 0 ]
+
+    # Mutation must NOT happen — this is the root-cause fix for the ping-pong.
+    ! grep -q "^backend_add_label"     "$OPS_LOG"
+    ! grep -q "^backend_comment_issue" "$OPS_LOG"
+
+    # Operator notification IS expected.
+    grep -q "^loop_notify .*#42" "$OPS_LOG"
+    grep -q "Test ticket without pipeline label" "$OPS_LOG"
+}
+
+@test "labelled issue: no notification, no mutation (not lost)" {
+    write_fixture_labelled_issue
+
+    run reconcile_lost_issues "$REPO"
+    [ "$status" -eq 0 ]
+
+    # Nothing happens for a healthy ticket.
+    [ ! -s "$OPS_LOG" ] || ! grep -qE "^(backend_add_label|backend_comment_issue|loop_notify)" "$OPS_LOG"
+}
+
+@test "lost issue cool-down: second tick within window does NOT re-notify" {
+    write_fixture_unlabelled_issue
+
+    # Tick 1 — should notify.
+    reconcile_lost_issues "$REPO"
+    local notifies_after_1
+    notifies_after_1=$(grep -c "^loop_notify" "$OPS_LOG" || echo 0)
+    [ "$notifies_after_1" -eq 1 ]
+
+    # Tick 2 — within LOOP_LOST_NOTIFY_HOURS (default 24h); cool-down kicks in.
+    reconcile_lost_issues "$REPO"
+    local notifies_after_2
+    notifies_after_2=$(grep -c "^loop_notify" "$OPS_LOG" || echo 0)
+    [ "$notifies_after_2" -eq 1 ]   # still 1 — second tick was suppressed
+}
+
+@test "lost issue cool-down: re-notifies after the window expires" {
+    write_fixture_unlabelled_issue
+
+    # Tick 1 — notify and create the sentinel.
+    reconcile_lost_issues "$REPO"
+
+    # Backdate the sentinel beyond the cool-down window so the next tick
+    # treats it as expired.
+    local repo_slug="${REPO//\//-}"
+    local sentinel="$LOOP_LOST_STATE_DIR/${repo_slug}-42"
+    [ -f "$sentinel" ]
+    # Set mtime to 25h ago (default LOOP_LOST_NOTIFY_HOURS=24).
+    touch -t "$(date -v-25H '+%Y%m%d%H%M' 2>/dev/null || date -d '25 hours ago' '+%Y%m%d%H%M')" "$sentinel"
+
+    # Tick 2 — should notify again.
+    reconcile_lost_issues "$REPO"
+    local notifies
+    notifies=$(grep -c "^loop_notify" "$OPS_LOG" || echo 0)
+    [ "$notifies" -eq 2 ]
+}
+
+@test "DRY_RUN=true: still classifies but does nothing — no notify, no sentinel" {
+    write_fixture_unlabelled_issue
+    DRY_RUN=true
+
+    run reconcile_lost_issues "$REPO"
+    [ "$status" -eq 0 ]
+
+    # No mutating ops, no notification, no sentinel created.
+    ! grep -q "^backend_add_label"     "$OPS_LOG" 2>/dev/null
+    ! grep -q "^backend_comment_issue" "$OPS_LOG" 2>/dev/null
+    ! grep -q "^loop_notify"           "$OPS_LOG" 2>/dev/null
+    [ ! -d "$LOOP_LOST_STATE_DIR" ] || [ -z "$(ls "$LOOP_LOST_STATE_DIR" 2>/dev/null)" ]
+
+    DRY_RUN=false
+}


### PR DESCRIPTION
## Summary

5 bats cases pinning the post-#214 contract for `reconcile_lost_issues`:

1. **Lost issue → notifies, no mutation.** `loop_notify` called; `backend_add_label` and `backend_comment_issue` NOT called. This is the root-cause assertion that would have caught the pre-#214 ping-pong on first review.
2. **Labelled issue → no action.**
3. **Cool-down within window** → second tick suppressed.
4. **Cool-down after window** → re-notifies.
5. **DRY_RUN=true** → full no-op; no sentinel created.

## Side fix in reconciler.sh

Moved the `LOOP_RECONCILER_LIB_ONLY=1` test hook to before the top-level argument parser. The hook existed at line 1614 — too late. The arg parser at line 48 saw bats's injected `$0`/`$@` as "unknown arg" and exited 2 before any function definition was reached. Wrapping the parser in the LIB_ONLY guard fixes this and unblocks bats coverage for the rest of #210's follow-up work.

## Test output

```
$ bats tests/lost-issues-observational.bats
1..5
ok 1 lost issue: notifies operator (Signal) but does NOT mutate state
ok 2 labelled issue: no notification, no mutation (not lost)
ok 3 lost issue cool-down: second tick within window does NOT re-notify
ok 4 lost issue cool-down: re-notifies after the window expires
ok 5 DRY_RUN=true: still classifies but does nothing — no notify, no sentinel
```

Closes part of #210 — reconciler.sh is now genuinely sourceable from tests.