### PR TITLE
[LOOP] small-fixes batch — closes-regex widening (#200) + dep-state log clarity (#197)

### DIFF
--- a/lib/recovery.sh
+++ b/lib/recovery.sh
@@ -60,10 +60,14 @@ PY
         unresolved=""
         IFS=',' read -ra dep_arr <<< "$deps"
         for dep in "${dep_arr[@]}"; do
-            st=$(gh issue view "$dep" --repo "$repo" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
-            if [ "$st" != "CLOSED" ]; then
-                st=$(gh pr view "$dep" --repo "$repo" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+            # Try issue-view first; if the dep isn't an issue (returns empty
+            # JSON / non-zero), fall through to pr-view. Capture the actual
+            # state when present rather than the misleading 'UNKNOWN' (#197).
+            st=$(gh issue view "$dep" --repo "$repo" --json state --jq '.state' 2>/dev/null)
+            if [ -z "$st" ]; then
+                st=$(gh pr view "$dep" --repo "$repo" --json state --jq '.state' 2>/dev/null)
             fi
+            [ -z "$st" ] && st="MISSING"
             if [ "$st" = "CLOSED" ] || [ "$st" = "MERGED" ]; then
                 : # dep satisfied
             else
@@ -139,10 +143,14 @@ PY
         unresolved=""
         IFS=',' read -ra dep_arr <<< "$deps"
         for dep in "${dep_arr[@]}"; do
-            st=$(gh issue view "$dep" --repo "$repo" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
-            if [ "$st" != "CLOSED" ]; then
-                st=$(gh pr view "$dep" --repo "$repo" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+            # Try issue-view first; if the dep isn't an issue (returns empty
+            # JSON / non-zero), fall through to pr-view. Capture the actual
+            # state when present rather than the misleading 'UNKNOWN' (#197).
+            st=$(gh issue view "$dep" --repo "$repo" --json state --jq '.state' 2>/dev/null)
+            if [ -z "$st" ]; then
+                st=$(gh pr view "$dep" --repo "$repo" --json state --jq '.state' 2>/dev/null)
             fi
+            [ -z "$st" ] && st="MISSING"
             if [ "$st" = "CLOSED" ] || [ "$st" = "MERGED" ]; then
                 : # dep satisfied
             else

--- a/scripts/merge-handler.sh
+++ b/scripts/merge-handler.sh
@@ -131,9 +131,12 @@ if backend_pr_has_any_label "$REPO" "$PR_NUM" "release-pr"; then
     fi
 fi
 
-# Find all linked issues via "Closes #N" in PR body (handles multiple closes).
+# Find all linked issues via GitHub's auto-close keywords in PR body (#200).
+# Recognises closes/close/closed, fixes/fix/fixed, resolves/resolve/resolved
+# — same set GitHub uses natively for auto-close. Previous regex matched
+# only [Cc]loses?, so PRs using Fixes/Resolves left their issues open.
 LINKED_ISSUES=$(backend_pr_view "$REPO" "$PR_NUM" --json body --jq .body 2>/dev/null \
-    | python3 -c "import re,sys; print(' '.join(re.findall(r'[Cc]loses?\s+#(\d+)', sys.stdin.read() or '')))")
+    | python3 -c "import re,sys; print(' '.join(re.findall(r'(?:[Cc]los(?:e|es|ed)|[Ff]ix(?:|es|ed)|[Rr]esolv(?:e|es|ed))\s+#(\d+)', sys.stdin.read() or '')))")
 
 # Strip all pipeline-stage labels from the merged PR (issue #166).
 # Orthogonal labels (priority, semver:*, release-pr, safe-to-test, bug,


### PR DESCRIPTION
Two small additive fixes batched together.

Closes #200, closes #197.

## #200: merge-handler recognises Fixes/Resolves alongside Closes

`scripts/merge-handler.sh:135` regex was `[Cc]loses?\s+#(\d+)`. GitHub's native auto-close keywords are `closes/fixes/resolves` with their conjugations. PRs using `Fixes #N` left their issues open after merge (today's #192 was the canonical case — closed manually).

New regex matches the full vocabulary, with `(?:...)` non-capturing groups and a single capture for the issue number:
```
(?:[Cc]los(?:e|es|ed)|[Ff]ix(?:|es|ed)|[Rr]esolv(?:e|es|ed))\s+#(\d+)
```

Verified manual cases (positive + negative — "Fixes the regression in #178" does NOT match because the keyword and `#N` aren't directly adjacent).

## #197: dep-state lookup logs MISSING instead of UNKNOWN

`recovery_check_dependencies` previously swallowed gh exit codes with `|| echo UNKNOWN`, producing log lines like `still blocked by: #44 (UNKNOWN)` even when #44 was OPEN. Cause: the first issue-view succeeded (OPEN), the code unconditionally retried as a PR (failed because it's an issue), and `|| echo UNKNOWN` overwrote the original.

Fix: try issue-view first; fall through to pr-view only when issue-view is empty; tag MISSING when truly unfound.

Honest states now appear in logs (OPEN / CLOSED / MERGED / MISSING).