### PR TITLE
[LOOP] _rename_label_on_target: add-then-remove ordering (#198)

### DIFF
--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -730,18 +730,24 @@ LOOP_SYNONYM_MAP=(
 _rename_label_on_target() {
     # _rename_label_on_target <repo> <number> <kind> <from> <to>
     # kind: issue | pr
+    #
+    # Two-step rename, ordered add-THEN-remove (#198 fix). If the add fails
+    # (label not defined on repo, API rate limit, network flake), the
+    # original `from` label is preserved so the ticket retains SOMETHING
+    # the pipeline recognizes. The previous remove-then-add order could
+    # leave a ticket label-less when add failed mid-batch (observed on
+    # loop-monitor PRs #95/#88/#75, all empty-labelled simultaneously).
     local repo="$1" num="$2" kind="$3" from="$4" to="$5"
     if $DRY_RUN; then
         log "[$repo] DRY: would rename $kind #$num: $from → $to"
         return 0
     fi
-    if [ "$kind" = "pr" ]; then
-        backend_remove_label "$repo" "$num" "$from"
-        backend_add_label    "$repo" "$num" "$to"
-    else
-        backend_remove_label "$repo" "$num" "$from"
-        backend_add_label    "$repo" "$num" "$to"
+    if ! backend_add_label "$repo" "$num" "$to"; then
+        log "[$repo] WARN: rename $kind #$num: failed to add '$to' — keeping '$from'; will retry next tick"
+        return 1
     fi
+    backend_remove_label "$repo" "$num" "$from" \
+        || log "[$repo] WARN: rename $kind #$num: failed to remove '$from' (target now has both labels; reconciler will retry the cleanup)"
     log "[$repo] renamed $kind #$num: $from → $to"
 }
 

--- a/tests/rename-label-atomic.bats
+++ b/tests/rename-label-atomic.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+# tests/rename-label-atomic.bats — coverage for _rename_label_on_target.
+#
+# Verifies the post-#198 contract: add-then-remove ordering, with the
+# original label preserved on add-failure. Catches the loop-monitor
+# PR #95/#88/#75 empty-label regression.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export OPS_LOG="$BATS_TMPDIR/ops.log"
+    rm -f "$OPS_LOG"
+
+    export REPO="owner/test-repo"
+    export DRY_RUN=false
+    export LOOP_RECONCILER_LIB_ONLY=1
+
+    # shellcheck source=../scanner/reconciler.sh
+    source "$REPO_ROOT/scanner/reconciler.sh"
+
+    # Stubs override real backend after sourcing.
+    # Default: success. Tests can override per-case via $ADD_FAILS / $REMOVE_FAILS.
+    backend_add_label() {
+        echo "ADD $*" >> "$OPS_LOG"
+        if [ -n "${ADD_FAILS:-}" ] && [ "$3" = "$ADD_FAILS" ]; then
+            return 1
+        fi
+        return 0
+    }
+    backend_remove_label() {
+        echo "REMOVE $*" >> "$OPS_LOG"
+        if [ -n "${REMOVE_FAILS:-}" ] && [ "$3" = "$REMOVE_FAILS" ]; then
+            return 1
+        fi
+        return 0
+    }
+}
+
+teardown() {
+    rm -f "$OPS_LOG"
+    unset ADD_FAILS REMOVE_FAILS
+}
+
+@test "happy path: add canonical first, then remove alias (order matters)" {
+    run _rename_label_on_target "$REPO" 42 issue po-review needs-po
+    [ "$status" -eq 0 ]
+
+    # ADD must come before REMOVE in the ops log.
+    grep -n "^ADD .* needs-po"     "$OPS_LOG"
+    grep -n "^REMOVE .* po-review" "$OPS_LOG"
+    local add_line remove_line
+    add_line=$(grep -n "^ADD .* needs-po"     "$OPS_LOG" | head -1 | cut -d: -f1)
+    remove_line=$(grep -n "^REMOVE .* po-review" "$OPS_LOG" | head -1 | cut -d: -f1)
+    [ "$add_line" -lt "$remove_line" ]
+}
+
+@test "add failure: keeps the original label, does NOT call remove (regression guard)" {
+    ADD_FAILS=needs-po
+
+    run _rename_label_on_target "$REPO" 42 issue po-review needs-po
+    [ "$status" -eq 1 ]   # function reports failure
+
+    # ADD was attempted (and failed); REMOVE must NOT be called — otherwise
+    # the ticket would end up label-less.
+    grep -q "^ADD .* needs-po"        "$OPS_LOG"
+    ! grep -q "^REMOVE .* po-review"  "$OPS_LOG"
+}
+
+@test "remove failure: warns but doesn't error — both labels present (idempotent)" {
+    REMOVE_FAILS=po-review
+
+    run _rename_label_on_target "$REPO" 42 issue po-review needs-po
+    [ "$status" -eq 0 ]   # rename considered successful even with cleanup blip
+
+    # ADD succeeded; REMOVE attempted but failed — that's recoverable.
+    grep -q "^ADD .* needs-po"      "$OPS_LOG"
+    grep -q "^REMOVE .* po-review"  "$OPS_LOG"
+}
+
+@test "DRY_RUN=true: zero backend calls" {
+    DRY_RUN=true
+    run _rename_label_on_target "$REPO" 42 issue po-review needs-po
+    [ "$status" -eq 0 ]
+    [ ! -s "$OPS_LOG" ]
+    DRY_RUN=false
+}


### PR DESCRIPTION
Closes #198.

Today loop-monitor PRs #95/#88/#75 ended up label-less in the same minute — the synonym renamer ran and the remove-then-add order left them empty when the add-leg failed silently.

Switched to add-then-remove with an early-return on add-failure so the original label is preserved when anything goes wrong. tests/rename-label-atomic.bats pins all four cases (happy path, add-fail, remove-fail, dry-run).

4/4 bats pass.