### PR TITLE
[LOOP] extract loop_label_is_trigger to lib/workflow.sh — share + cache (#209)

### DIFF
--- a/lib/workflow.sh
+++ b/lib/workflow.sh
@@ -66,6 +66,35 @@ print(canon)
 PY
 }
 
+# loop_label_is_trigger <slug> <kind> <label>
+# Returns 0 if <label> is one of the project's workflow trigger labels for
+# <kind> (issue|pr), 1 otherwise. Empty slug returns 1 (caller-side opt-out
+# gate). Used by reconciler check functions that rewrite labels and must
+# not strip a live trigger or apply a dead one.
+#
+# Caches the trigger sets per (slug, kind) within one process via
+# _LOOP_TRIGGER_CACHE_<slug>_<kind> environment vars to avoid re-querying
+# the workflow YAML for every label check (each loop_polled_labels call
+# spawns python3 + reads a YAML).
+loop_label_is_trigger() {
+    local slug="$1" kind="$2" label="$3"
+    [ -z "$slug" ] && return 1
+
+    local cache_var="_LOOP_TRIGGER_CACHE_${slug//[^A-Za-z0-9]/_}_${kind}"
+    local set
+    set="${!cache_var:-__UNSET__}"
+    if [ "$set" = "__UNSET__" ]; then
+        set=$(loop_polled_labels "$slug" "$kind" 2>/dev/null || echo "")
+        # Encode "empty result" distinctly so we don't re-query forever.
+        [ -z "$set" ] && set="__EMPTY__"
+        printf -v "$cache_var" '%s' "$set"
+        export "$cache_var"
+    fi
+
+    [ "$set" = "__EMPTY__" ] && return 1
+    printf '%s\n' "$set" | grep -qxF "$label"
+}
+
 # loop_polled_labels <slug> <target>
 # target = "issue" or "pr". Returns one label per line.
 loop_polled_labels() {

--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -757,43 +757,21 @@ reconcile_synonym_labels() {
     log "[$repo] scanning open issues + PRs for synonym labels"
     local renamed=0 entry from to
 
-    # Workflow-aware gating: build the set of trigger labels actually used by
-    # this project's workflow. We must NOT rename a label that IS a trigger
-    # for this project (would strip a live label), and we must NOT rename TO
-    # a label that is NOT a trigger for this project (would apply a dead
-    # label). Without this, projects on workflow=current end up with their
-    # canonical triggers rewritten to default-workflow names — observed on
-    # pa-scanner: review-pending → needs-review starved 5 PRs for 24h.
-    local issue_triggers="" pr_triggers=""
-    if [ -n "$slug" ]; then
-        issue_triggers=$(loop_polled_labels "$slug" issue 2>/dev/null || echo "")
-        pr_triggers=$(loop_polled_labels "$slug" pr 2>/dev/null || echo "")
-    fi
-    _is_trigger_for_kind() {
-        # _is_trigger_for_kind <label> <issue|pr>
-        local _label="$1" _kind="$2" _set
-        case "$_kind" in
-            issue) _set="$issue_triggers" ;;
-            pr)    _set="$pr_triggers" ;;
-            *)     return 1 ;;
-        esac
-        [ -z "$_set" ] && return 1
-        printf '%s\n' "$_set" | grep -qxF "$_label"
-    }
+    # Workflow-aware gating: don't rewrite a label that IS a workflow
+    # trigger for this project (would strip a live label), and don't
+    # rewrite TO a label that is NOT a trigger here (would apply a dead
+    # label). Shared helper in lib/workflow.sh — see #209.
 
     for entry in "${LOOP_SYNONYM_MAP[@]}"; do
         from="${entry%%:*}"; to="${entry##*:}"
 
         for kind in issue pr; do
-            # Skip rename for this kind if `from` is a live trigger for the
-            # project's workflow (don't strip canonical labels) or if `to`
-            # is not a trigger (don't apply dead labels).
             if [ -n "$slug" ]; then
-                if _is_trigger_for_kind "$from" "$kind"; then
+                if loop_label_is_trigger "$slug" "$kind" "$from"; then
                     log "[$repo] synonym skip ($kind, $slug): '$from' is a workflow trigger here"
                     continue
                 fi
-                if ! _is_trigger_for_kind "$to" "$kind"; then
+                if ! loop_label_is_trigger "$slug" "$kind" "$to"; then
                     log "[$repo] synonym skip ($kind, $slug): '$to' is not a workflow trigger here"
                     continue
                 fi
@@ -844,24 +822,7 @@ reconcile_alias_renames() {
     # projects (ppl-study, NTC, vrefm-classifier, pa-scanner) — same class of
     # bug as #192/#193 caught in the synonym renamer.
     #
-    # Build the set of live trigger labels from this project's workflow YAML.
-    # For each candidate rename: skip if `alias` IS a live trigger here, OR
-    # if `canonical` is NOT a trigger here.
-    local issue_triggers="" pr_triggers=""
-    if [ -n "$slug" ]; then
-        issue_triggers=$(loop_polled_labels "$slug" issue 2>/dev/null || echo "")
-        pr_triggers=$(loop_polled_labels "$slug" pr 2>/dev/null || echo "")
-    fi
-    _alias_is_trigger_for_kind() {
-        local _label="$1" _kind="$2" _set
-        case "$_kind" in
-            issue) _set="$issue_triggers" ;;
-            pr)    _set="$pr_triggers" ;;
-            *)     return 1 ;;
-        esac
-        [ -z "$_set" ] && return 1
-        printf '%s\n' "$_set" | grep -qxF "$_label"
-    }
+    # Workflow-aware gating via the shared helper in lib/workflow.sh (#209).
 
     # Pull all open PRs once — we filter the cached list per alias.
     local prs_json
@@ -874,9 +835,9 @@ reconcile_alias_renames() {
         [ "$canonical" = "$alias" ] && continue
 
         # Issues carrying $alias.
-        if [ -n "$slug" ] && _alias_is_trigger_for_kind "$alias" issue; then
+        if [ -n "$slug" ] && loop_label_is_trigger "$slug" issue "$alias"; then
             log "[$repo] alias-rename skip (issue, $slug): '$alias' is a workflow trigger here"
-        elif [ -n "$slug" ] && ! _alias_is_trigger_for_kind "$canonical" issue; then
+        elif [ -n "$slug" ] && ! loop_label_is_trigger "$slug" issue "$canonical"; then
             log "[$repo] alias-rename skip (issue, $slug): '$canonical' is not a workflow trigger here"
         else
             local issues_json issue_nums
@@ -901,9 +862,9 @@ for i in json.loads(os.environ["ISS"]):
         fi
 
         # PRs carrying $alias (from the cached open-PRs list).
-        if [ -n "$slug" ] && _alias_is_trigger_for_kind "$alias" pr; then
+        if [ -n "$slug" ] && loop_label_is_trigger "$slug" pr "$alias"; then
             log "[$repo] alias-rename skip (pr, $slug): '$alias' is a workflow trigger here"
-        elif [ -n "$slug" ] && ! _alias_is_trigger_for_kind "$canonical" pr; then
+        elif [ -n "$slug" ] && ! loop_label_is_trigger "$slug" pr "$canonical"; then
             log "[$repo] alias-rename skip (pr, $slug): '$canonical' is not a workflow trigger here"
         else
             local pr_nums num

--- a/tests/label-is-trigger.bats
+++ b/tests/label-is-trigger.bats
@@ -1,0 +1,184 @@
+#!/usr/bin/env bats
+# tests/label-is-trigger.bats — coverage for loop_label_is_trigger.
+#
+# Verifies the shared workflow-aware gate (extracted from duplicate copies
+# in reconcile_synonym_labels and reconcile_alias_renames per #209).
+#
+# Self-contained: synthesizes a temp workflow dir with two workflow YAMLs
+# so the test doesn't depend on the in-tree config/workflows/ files (some
+# of which are gitignored for local-only operator config).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+
+    # Synthetic workflow dir with two distinct workflows.
+    export LOOP_WORKFLOW_DIR="$BATS_TMPDIR/wf-$$"
+    mkdir -p "$LOOP_WORKFLOW_DIR"
+
+    cat > "$LOOP_WORKFLOW_DIR/canon.yaml" <<'YAML'
+version: 1
+name: canon
+issue_stages:
+  - id: po
+    trigger_label: needs-po
+    handler: po-handler
+  - id: dev
+    trigger_label: needs-dev
+    handler: dev-handler
+pr_stages:
+  - id: review
+    trigger_label: needs-review
+    handler: review-handler
+  - id: rework
+    trigger_label: needs-rework
+    handler: dev-rework-handler
+  - id: qa
+    trigger_label: needs-qa
+    handler: qa-handler
+  - id: merge
+    trigger_label: qa-pass
+    handler: merge-handler
+YAML
+
+    cat > "$LOOP_WORKFLOW_DIR/legacy.yaml" <<'YAML'
+version: 1
+name: legacy
+issue_stages:
+  - id: po
+    trigger_label: po-review
+    handler: po-handler
+  - id: dev
+    trigger_label: dev
+    handler: dev-handler
+pr_stages:
+  - id: review
+    trigger_label: review-pending
+    handler: review-handler
+  - id: rework
+    trigger_label: changes-requested
+    handler: dev-rework-handler
+  - id: qa
+    trigger_label: ready-for-qa
+    handler: qa-handler
+  - id: merge
+    trigger_label: qa-pass
+    handler: merge-handler
+YAML
+
+    cat > "$BATS_TMPDIR/fixture.yaml" <<'YAML'
+version: 1
+projects:
+  - slug: oncanon
+    name: Canon Workflow Project
+    repo: owner/canon-repo
+    root: /tmp/fake-canon
+    default_branch: main
+    workflow: canon
+  - slug: onlegacy
+    name: Legacy Workflow Project
+    repo: owner/legacy-repo
+    root: /tmp/fake-legacy
+    default_branch: main
+    workflow: legacy
+YAML
+    export LOOP_CONFIG="$BATS_TMPDIR/fixture.yaml"
+
+    # Clear any per-test cache pollution.
+    unset $(env | grep '^_LOOP_TRIGGER_CACHE_' | cut -d= -f1) 2>/dev/null || true
+
+    # shellcheck source=../lib/workflow.sh
+    source "$REPO_ROOT/lib/workflow.sh"
+}
+
+teardown() {
+    unset $(env | grep '^_LOOP_TRIGGER_CACHE_' | cut -d= -f1) 2>/dev/null || true
+    rm -rf "$LOOP_WORKFLOW_DIR" "$BATS_TMPDIR/fixture.yaml"
+}
+
+# canon workflow → needs-* canonical names
+@test "canon workflow: needs-po IS issue trigger" {
+    run loop_label_is_trigger oncanon issue needs-po
+    [ "$status" -eq 0 ]
+}
+
+@test "canon workflow: po-review is NOT issue trigger" {
+    run loop_label_is_trigger oncanon issue po-review
+    [ "$status" -eq 1 ]
+}
+
+@test "canon workflow: needs-review IS pr trigger" {
+    run loop_label_is_trigger oncanon pr needs-review
+    [ "$status" -eq 0 ]
+}
+
+@test "canon workflow: review-pending is NOT pr trigger" {
+    run loop_label_is_trigger oncanon pr review-pending
+    [ "$status" -eq 1 ]
+}
+
+# legacy workflow → po-review/dev/review-pending/changes-requested/ready-for-qa
+@test "legacy workflow: po-review IS issue trigger" {
+    run loop_label_is_trigger onlegacy issue po-review
+    [ "$status" -eq 0 ]
+}
+
+@test "legacy workflow: needs-po is NOT issue trigger" {
+    run loop_label_is_trigger onlegacy issue needs-po
+    [ "$status" -eq 1 ]
+}
+
+@test "legacy workflow: review-pending IS pr trigger" {
+    run loop_label_is_trigger onlegacy pr review-pending
+    [ "$status" -eq 0 ]
+}
+
+@test "legacy workflow: needs-review is NOT pr trigger" {
+    run loop_label_is_trigger onlegacy pr needs-review
+    [ "$status" -eq 1 ]
+}
+
+@test "qa-pass is shared trigger across both workflows" {
+    # The merge stage uses qa-pass in both — this is the legitimate overlap.
+    run loop_label_is_trigger oncanon   pr qa-pass
+    [ "$status" -eq 0 ]
+    run loop_label_is_trigger onlegacy pr qa-pass
+    [ "$status" -eq 0 ]
+}
+
+@test "empty slug: returns 1 (caller-side opt-out)" {
+    run loop_label_is_trigger "" issue needs-po
+    [ "$status" -eq 1 ]
+}
+
+@test "kind issue vs pr: same label is trigger on one but not the other" {
+    # In canon, needs-po is an ISSUE trigger but NOT a PR trigger.
+    run loop_label_is_trigger oncanon issue needs-po
+    [ "$status" -eq 0 ]
+    run loop_label_is_trigger oncanon pr needs-po
+    [ "$status" -eq 1 ]
+}
+
+@test "cache: a second call for the same (slug, kind) is served from cache" {
+    # Prime the cache.
+    loop_label_is_trigger oncanon issue needs-po
+
+    # Mutate the workflow YAML out-from-under us. If caching works, the
+    # cached value persists; the helper does NOT re-read the file.
+    cat > "$LOOP_WORKFLOW_DIR/canon.yaml" <<'YAML'
+version: 1
+name: canon
+issue_stages:
+  - id: po
+    trigger_label: completely-different-label
+    handler: po-handler
+pr_stages:
+  - id: review
+    trigger_label: also-different
+    handler: review-handler
+YAML
+
+    # Cache hit returns the original answer (still treats needs-po as trigger).
+    run loop_label_is_trigger oncanon issue needs-po
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #209.

Two reconciler functions had near-identical 12-line copies of the workflow-aware-gate helper (added in #193, copied in #206). Extracted to a shared `loop_label_is_trigger <slug> <kind> <label>` in lib/workflow.sh with per-(slug, kind) caching so a tick over many label candidates pays one workflow YAML read per project (not one per check).

12 new bats cases in tests/label-is-trigger.bats — covering both canonical (needs-*) and legacy (po-review/dev/review-pending/...) workflow trigger membership, kind disambiguation, shared triggers, empty-slug opt-out, and cache-hit-after-mutation. Self-contained fixture (synthesizes its own workflow YAMLs since some of the in-tree ones are gitignored).

All 23 existing+new bats cases green.