### PR TITLE
[LOOP] strip issue stage label after PR opens + lost-issues skip-when-PR-exists (#199)

### DIFF
--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -642,7 +642,19 @@ PY
 
     while IFS=$'\t' read -r num title; do
         [ -z "$num" ] && continue
-        log "[$repo] LOST issue #$num (no pipeline label): $title — observational, no mutation"
+
+        # Skip if the issue has an open PR closing it — work is on PR side
+        # (#199 producer-side: dev-handler now strips the issue's trigger
+        # label after opening the PR). Without this consumer-side gate,
+        # operator gets a Signal for every healthy in-flight ticket.
+        local _existing_pr
+        _existing_pr=$(backend_find_pr_for_issue "$repo" "$num" 2>/dev/null || echo "")
+        if [ -n "$_existing_pr" ]; then
+            log "[$repo] LOST issue #$num — skipping Signal: open PR #${_existing_pr} closes it (work in flight, no operator action needed)"
+            continue
+        fi
+
+        log "[$repo] LOST issue #$num (no pipeline label, no closing PR): $title — observational, no mutation"
 
         # Skip Signal if we already notified within the cool-down window.
         local repo_slug="${repo//\//-}"
@@ -657,7 +669,7 @@ PY
         fi
 
         $DRY_RUN && continue
-        loop_notify "Loop reconciler: $repo — issue #$num has no pipeline label. Operator: pick a trigger label (e.g. \`po-review\` or \`dev\`) or close as out-of-scope. Title: ${title}"
+        loop_notify "Loop reconciler: $repo — issue #$num has no pipeline label and no open PR closing it. Operator: pick a trigger label (e.g. \`po-review\` or \`dev\`) or close as out-of-scope. Title: ${title}"
         : > "$sentinel"
     done <<< "$lost"
 }

--- a/scripts/dev-handler.sh
+++ b/scripts/dev-handler.sh
@@ -216,7 +216,9 @@ if matches:
 " 2>/dev/null || true)
     if [ -z "$_dev_pr_num" ]; then
         log "WARN: no open PR found for issue #$ISSUE_NUM after dev agent — adding 'needs-clarification'"
-        backend_remove_label "$REPO" "$ISSUE_NUM" dev plan in-progress
+        # Strip every pipeline-stage label (canonical + deprecated) so the
+        # issue ends single-state with just needs-clarification (#199).
+        loop_strip_pipeline_labels "$REPO" "$ISSUE_NUM" >/dev/null || true
         backend_add_label "$REPO" "$ISSUE_NUM" needs-clarification
         loop_notify_human_required "$SLUG" "$ISSUE_NUM" needs-clarification "Dev agent finished without opening a PR"
     else
@@ -228,8 +230,13 @@ if matches:
             log "WARN: PR #$_dev_pr_num has no progression label after dev agent — adding '${_REVIEW_LABEL}'"
             backend_add_label "$REPO" "$_dev_pr_num" "$_REVIEW_LABEL"
         fi
-        # Strip both legacy and canonical issue-side names so the issue ends single-state
-        backend_remove_label "$REPO" "$ISSUE_NUM" "$LOOP_LABEL_NEEDS_REVIEW" "$LOOP_LABEL_DEPRECATED_REVIEW_PENDING" plan dev in-progress
+        # Strip every pipeline-stage label from the issue (#199 root-cause
+        # fix). Work has moved to PR side; reconciler should treat 'open
+        # issue with open closing PR + no stage label' as healthy. Single
+        # source of truth: lib/labels.sh::LOOP_PIPELINE_STAGE_LABELS covers
+        # both canonical and deprecated names so a future vocab addition
+        # propagates here automatically.
+        loop_strip_pipeline_labels "$REPO" "$ISSUE_NUM" >/dev/null || true
     fi
     cleanup_worktree
 else

--- a/tests/lost-issues-observational.bats
+++ b/tests/lost-issues-observational.bats
@@ -40,11 +40,13 @@ setup() {
 
     # Override stubbed-out functions AFTER sourcing so they win over any
     # real implementation pulled in via lib/*.
-    backend_add_label()      { echo "backend_add_label $*"      >> "$OPS_LOG"; }
-    backend_remove_label()   { echo "backend_remove_label $*"   >> "$OPS_LOG"; }
-    backend_comment_issue()  { echo "backend_comment_issue $*"  >> "$OPS_LOG"; }
-    backend_comment_pr()     { echo "backend_comment_pr $*"     >> "$OPS_LOG"; }
-    loop_notify()            { echo "loop_notify $*"            >> "$OPS_LOG"; }
+    backend_add_label()         { echo "backend_add_label $*"         >> "$OPS_LOG"; }
+    backend_remove_label()      { echo "backend_remove_label $*"      >> "$OPS_LOG"; }
+    backend_comment_issue()     { echo "backend_comment_issue $*"     >> "$OPS_LOG"; }
+    backend_comment_pr()        { echo "backend_comment_pr $*"        >> "$OPS_LOG"; }
+    loop_notify()               { echo "loop_notify $*"               >> "$OPS_LOG"; }
+    # Default: no closing PR. Tests that need one set BACKEND_PR_FOR_ISSUE.
+    backend_find_pr_for_issue() { echo "${BACKEND_PR_FOR_ISSUE:-}"; }
 
     # Mock gh: only the `gh issue list` call inside reconcile_lost_issues
     # needs a return value. Read fixture from $GH_FIXTURE.
@@ -60,7 +62,7 @@ setup() {
 
 teardown() {
     rm -rf "$LOOP_LOST_STATE_DIR" "$OPS_LOG"
-    unset GH_FIXTURE
+    unset GH_FIXTURE BACKEND_PR_FOR_ISSUE
 }
 
 # Helper: fixture for an issue with no pipeline labels at all.
@@ -163,4 +165,20 @@ JSON
     [ ! -d "$LOOP_LOST_STATE_DIR" ] || [ -z "$(ls "$LOOP_LOST_STATE_DIR" 2>/dev/null)" ]
 
     DRY_RUN=false
+}
+
+@test "lost issue WITH open closing PR: skipped silently — no Signal (#199 producer/consumer pair)" {
+    write_fixture_unlabelled_issue
+    BACKEND_PR_FOR_ISSUE=99   # closing PR exists
+
+    run reconcile_lost_issues "$REPO"
+    [ "$status" -eq 0 ]
+
+    # No mutating ops AND no notification — operator already sees the PR.
+    ! grep -q "^backend_add_label"     "$OPS_LOG" 2>/dev/null
+    ! grep -q "^backend_comment_issue" "$OPS_LOG" 2>/dev/null
+    ! grep -q "^loop_notify"           "$OPS_LOG" 2>/dev/null
+
+    # No sentinel either — we'll re-evaluate freshly next tick.
+    [ ! -f "$LOOP_LOST_STATE_DIR/owner-test-repo-42" ]
 }


### PR DESCRIPTION
Closes #199.

Producer/consumer pair that closes the structural gap behind multiple recovery_check_dependencies / lost-issues ping-pong incidents.

## Producer (dev-handler)
Replaces the hardcoded post-PR label-strip list (`plan dev in-progress`) with a call to `loop_strip_pipeline_labels`, which uses `LOOP_PIPELINE_STAGE_LABELS` from lib/labels.sh — covers both canonical (needs-po/needs-dev/in-po/in-dev) and deprecated names. Future vocab additions propagate automatically.

## Consumer (reconcile_lost_issues)
After producer-side strip, the issue legitimately has no pipeline label until the PR merges. The lost-issues check now skips the Signal notification when `backend_find_pr_for_issue` reports an open closing PR — work is healthily on PR side.

## Tests
tests/lost-issues-observational.bats grows from 5 to 6 cases. New case asserts: lost issue + open closing PR → no Signal, no sentinel.

All 299 bats tests pass (none regressed).