### PR TITLE
[LOOP] reconciler: anomaly detector — surface ticket-level pathology to operator (#195)

### DIFF
--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -1513,6 +1513,108 @@ PY
     done <<< "$hits"
 }
 
+# --- Check: anomaly detector — surface ping-pong / starvation tickets ----
+# Closes #195. Deterministic check that mines the reconciler's own log file
+# for label-flip-rate anomalies. When a single ticket appears in N or more
+# touch events within a window, Signal the operator once (cool-down per
+# ticket) so they can investigate before the ticket consumes more cycles.
+#
+# Mined patterns: alias-rename, synonym, UNBLOCK, LOST (post-#214 logged
+# but not auto-routed) — every reconciler check that *touches* a ticket.
+#
+# Configurable env:
+#   LOOP_ANOMALY_THRESHOLD     default 4   (touches in window → anomalous)
+#   LOOP_ANOMALY_WINDOW_HOURS  default 1
+#   LOOP_ANOMALY_NOTIFY_HOURS  default 24  (per-ticket Signal cool-down)
+#   LOOP_ANOMALY_STATE_DIR     default /tmp/loop-anomaly-notified
+reconcile_anomalies() {
+    local repo="$1"
+    log "[$repo] anomaly detector: scanning recent reconciler activity"
+
+    local threshold="${LOOP_ANOMALY_THRESHOLD:-4}"
+    local window_hours="${LOOP_ANOMALY_WINDOW_HOURS:-1}"
+    local notify_hours="${LOOP_ANOMALY_NOTIFY_HOURS:-24}"
+    local state_dir="${LOOP_ANOMALY_STATE_DIR:-/tmp/loop-anomaly-notified}"
+    mkdir -p "$state_dir"
+
+    [ -f "$LOG_FILE" ] || { log "[$repo] no reconciler log to mine"; return 0; }
+
+    # Mine the reconciler log: count touch-events per ticket within the
+    # window, emit "<num>\t<count>" for tickets crossing the threshold.
+    REPO_FOR_PY="$repo" THRESHOLD="$threshold" WIN_HOURS="$window_hours" \
+    LOG_FILE_PY="$LOG_FILE" python3 - <<'PY' | while IFS=$'\t' read -r num touches; do
+import os, re, sys, time
+from datetime import datetime
+
+repo = os.environ['REPO_FOR_PY']
+threshold = int(os.environ['THRESHOLD'])
+window_seconds = int(os.environ['WIN_HOURS']) * 3600
+cutoff = time.time() - window_seconds
+
+ts_re   = re.compile(r'^\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\]')
+repo_tag = f'[{repo}]'
+# Touch patterns this detector recognises:
+touch_re = re.compile(
+    r'(alias-rename (?:issue|PR) #\d+)'
+    r'|(synonym[^#]*#\d+)'
+    r'|(UNBLOCK (?:issue|PR) #\d+)'
+    r'|(LOST issue #\d+)'
+)
+num_re = re.compile(r'#(\d+)')
+counts = {}
+
+try:
+    with open(os.environ['LOG_FILE_PY'], 'r', errors='replace') as f:
+        for line in f:
+            tm = ts_re.match(line)
+            if tm:
+                try:
+                    epoch = datetime.strptime(tm.group(1), '%Y-%m-%d %H:%M:%S').timestamp()
+                except ValueError:
+                    continue
+                if epoch < cutoff:
+                    continue
+            else:
+                continue
+            if repo_tag not in line:
+                continue
+            if not touch_re.search(line):
+                continue
+            m = num_re.search(line)
+            if m:
+                counts[m.group(1)] = counts.get(m.group(1), 0) + 1
+except FileNotFoundError:
+    sys.exit(0)
+
+for num, count in counts.items():
+    if count >= threshold:
+        print(f"{num}\t{count}")
+PY
+        [ -z "$num" ] && continue
+        local repo_slug="${repo//\//-}"
+        local sentinel="$state_dir/${repo_slug}-${num}"
+        local cool_down_seconds=$(( notify_hours * 3600 ))
+        local now_epoch; now_epoch=$(date +%s)
+
+        if [ -f "$sentinel" ]; then
+            local mtime; mtime=$(stat -f %m "$sentinel" 2>/dev/null || stat -c %Y "$sentinel" 2>/dev/null || echo 0)
+            local age=$(( now_epoch - mtime ))
+            if [ "$age" -lt "$cool_down_seconds" ]; then
+                log "[$repo] anomaly: #$num touches=$touches in ${window_hours}h — Signal cooled-down (${age}s ago)"
+                continue
+            fi
+        fi
+
+        log "[$repo] ANOMALY: #$num — $touches reconciler touches in last ${window_hours}h (threshold=$threshold)"
+        $DRY_RUN && continue
+        loop_notify "Loop reconciler: $repo — issue/PR #$num was touched ${touches}× in the last ${window_hours}h. Likely a pipeline pathology (ping-pong, eventual-consistency drift, missing label, etc.). Operator: investigate. URL: https://github.com/${repo}/issues/${num}" \
+            || true
+        : > "$sentinel"
+    done
+
+    return 0
+}
+
 run_project() {
     local slug="$1"
     loop_load_project "$slug" || { log "skip $slug (config error)"; return 0; }
@@ -1539,6 +1641,7 @@ run_project() {
     reconcile_stale_blocked_issues "$REPO"
     reconcile_qa_failures "$REPO"
     reconcile_pr_label_audit "$REPO"
+    reconcile_anomalies "$REPO"
     reconcile_author_gated "$slug" "$REPO"
     reconcile_closed_issue_labels "$REPO"
     recovery_check_dependencies "$slug"

--- a/tests/anomaly-detector.bats
+++ b/tests/anomaly-detector.bats
@@ -1,0 +1,120 @@
+#!/usr/bin/env bats
+# tests/anomaly-detector.bats — coverage for reconcile_anomalies (#195).
+#
+# Verifies the post-#195 contract: deterministic mining of the reconciler
+# log for label-flip-rate anomalies; threshold-gated Signal with per-ticket
+# cool-down; observational only (no auto-mutation, like reconcile_lost_issues).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export OPS_LOG="$BATS_TMPDIR/ops.log"
+    rm -f "$OPS_LOG"
+
+    export LOOP_ANOMALY_STATE_DIR="$BATS_TMPDIR/anomaly-notified-$$"
+    rm -rf "$LOOP_ANOMALY_STATE_DIR"
+
+    # Make the threshold low so we can drive the test with a few log lines.
+    export LOOP_ANOMALY_THRESHOLD=3
+    export LOOP_ANOMALY_WINDOW_HOURS=1
+    export LOOP_ANOMALY_NOTIFY_HOURS=24
+
+    export REPO="owner/test-repo"
+    export DRY_RUN=false
+    export LOG_FILE="$LOOP_LOG_DIR/loop-reconciler.log"
+
+    export LOOP_RECONCILER_LIB_ONLY=1
+    # shellcheck source=../scanner/reconciler.sh
+    source "$REPO_ROOT/scanner/reconciler.sh"
+
+    loop_notify() { echo "loop_notify $*" >> "$OPS_LOG"; }
+}
+
+teardown() {
+    rm -rf "$LOOP_ANOMALY_STATE_DIR" "$OPS_LOG" "$LOG_FILE"
+}
+
+# Helper: write N synthetic touch lines for a ticket, all timestamped now.
+seed_touches() {
+    local num="$1" count="$2" pattern="${3:-alias-rename issue}"
+    local ts; ts="$(date '+%Y-%m-%d %H:%M:%S')"
+    : > "$LOG_FILE"
+    for ((i=0; i<count; i++)); do
+        echo "[${ts}] [reconciler] [$REPO] $pattern #$num: po-review → needs-po" >> "$LOG_FILE"
+    done
+}
+
+@test "anomaly threshold met: Signal fires once" {
+    seed_touches 42 3 "alias-rename issue"
+
+    run reconcile_anomalies "$REPO"
+    [ "$status" -eq 0 ]
+
+    grep -q "^loop_notify .*#42.*3×" "$OPS_LOG"
+}
+
+@test "below threshold: no Signal" {
+    seed_touches 42 2 "alias-rename issue"  # threshold=3, count=2
+
+    run reconcile_anomalies "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -q "^loop_notify" "$OPS_LOG"
+}
+
+@test "cool-down: second tick within window does NOT re-Signal" {
+    seed_touches 42 5 "alias-rename issue"
+
+    reconcile_anomalies "$REPO"
+    local notifies1
+    notifies1=$(grep -c "^loop_notify" "$OPS_LOG" 2>/dev/null || echo 0)
+    [ "$notifies1" -eq 1 ]
+
+    # Same log, run again — sentinel should suppress.
+    reconcile_anomalies "$REPO"
+    local notifies2
+    notifies2=$(grep -c "^loop_notify" "$OPS_LOG" 2>/dev/null || echo 0)
+    [ "$notifies2" -eq 1 ]
+}
+
+@test "observational only: zero backend mutations on anomaly" {
+    seed_touches 42 5 "alias-rename issue"
+
+    backend_add_label()    { echo "backend_add_label $*"    >> "$OPS_LOG"; }
+    backend_remove_label() { echo "backend_remove_label $*" >> "$OPS_LOG"; }
+    backend_comment_issue(){ echo "backend_comment_issue $*">> "$OPS_LOG"; }
+
+    reconcile_anomalies "$REPO"
+
+    grep -q "^loop_notify"             "$OPS_LOG"
+    ! grep -q "^backend_add_label"     "$OPS_LOG"
+    ! grep -q "^backend_remove_label"  "$OPS_LOG"
+    ! grep -q "^backend_comment_issue" "$OPS_LOG"
+}
+
+@test "DRY_RUN=true: detect but do not Signal" {
+    seed_touches 42 5 "alias-rename issue"
+    DRY_RUN=true
+
+    reconcile_anomalies "$REPO"
+
+    [ ! -s "$OPS_LOG" ] || ! grep -q "^loop_notify" "$OPS_LOG"
+    DRY_RUN=false
+}
+
+@test "different patterns count toward the same ticket's total" {
+    # Mix alias-rename + synonym + UNBLOCK touches on #42.
+    local ts; ts="$(date '+%Y-%m-%d %H:%M:%S')"
+    : > "$LOG_FILE"
+    echo "[${ts}] [reconciler] [$REPO] alias-rename issue #42: po-review → needs-po" >> "$LOG_FILE"
+    echo "[${ts}] [reconciler] [$REPO] synonym rename issue #42: review-pending → needs-review" >> "$LOG_FILE"
+    echo "[${ts}] [reconciler] [$REPO] UNBLOCK issue #42 (deps satisfied)" >> "$LOG_FILE"
+    # 3 touches with threshold=3 → trigger.
+
+    run reconcile_anomalies "$REPO"
+    [ "$status" -eq 0 ]
+    grep -q "^loop_notify .*#42" "$OPS_LOG"
+}


### PR DESCRIPTION
Closes #195.

Deterministic check that mines the reconciler log for tickets touched > threshold times within a window. Threshold breach → Signal operator once (per-ticket cool-down).

## Detection

- Patterns mined: `alias-rename`, `synonym`, `UNBLOCK`, `LOST`
- Defaults: LOOP_ANOMALY_THRESHOLD=4, LOOP_ANOMALY_WINDOW_HOURS=1, LOOP_ANOMALY_NOTIFY_HOURS=24
- Observational only — no auto-mutation. Same shape as #214's lost-issues fix.

## No LLM

Per #195's design: cheap, fast, auditable. Python log-tail (<1s per project per tick). Threshold + window tunable per operator preference.

## Test
6 new bats cases covering: threshold met / below / cool-down / no-mutation contract / DRY_RUN / cross-pattern counting. All 33 reconciler bats cases pass.