### PR TITLE
[LOOP] reconciler: agent-distress detector — surface meta-bug language (#203)

### DIFF
--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -1615,6 +1615,114 @@ PY
     return 0
 }
 
+# --- Check: agent self-diagnosis — surface meta-bug language in comments -----
+# Closes #203. Agents (PO/dev/review/qa) sometimes write meta-bug language in
+# their own PR/issue comments — "reconciler keeps stripping", "human action
+# required", etc. The anomaly detector (#195) catches BEHAVIOR (label flip
+# rate); this check catches NARRATIVE.
+#
+# Mines comments authored by ALLOWED_AUTHORS (agents post as the operator),
+# bounded to tickets updated in the last LOOP_DISTRESS_WINDOW hours.
+#
+# Configurable env:
+#   LOOP_DISTRESS_WINDOW_HOURS   default 1
+#   LOOP_DISTRESS_NOTIFY_HOURS   default 24  (per-ticket cool-down)
+#   LOOP_DISTRESS_STATE_DIR      default /tmp/loop-distress-notified
+#   LOOP_DISTRESS_PHRASES_FILE   optional path to a custom phrase list
+#                                (one regex per line; defaults built-in)
+reconcile_agent_distress() {
+    local repo="$1"
+    log "[$repo] agent-distress detector: scanning recent comments"
+
+    local window_hours="${LOOP_DISTRESS_WINDOW_HOURS:-1}"
+    local notify_hours="${LOOP_DISTRESS_NOTIFY_HOURS:-24}"
+    local state_dir="${LOOP_DISTRESS_STATE_DIR:-/tmp/loop-distress-notified}"
+    local phrases_file="${LOOP_DISTRESS_PHRASES_FILE:-}"
+    mkdir -p "$state_dir"
+
+    local default_phrases='reconciler keeps
+reconciler is.*looping
+pipeline is.*looping
+human action required
+no progress (after|since)
+[0-9]+\+? cycles
+ping[ -]?pong
+pathology
+stuck cycle
+operator: investigate
+manually fix the reconciler'
+
+    local phrases
+    if [ -n "$phrases_file" ] && [ -f "$phrases_file" ]; then
+        phrases=$(cat "$phrases_file")
+    else
+        phrases="$default_phrases"
+    fi
+
+    local since
+    since=$(date -u -v "-${window_hours}H" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+            || date -u -d "${window_hours} hours ago" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+            || echo "")
+    [ -z "$since" ] && { log "[$repo] agent-distress: cannot compute window cutoff"; return 0; }
+
+    local recent_json
+    recent_json=$(gh search issues --repo "$repo" --updated ">=$since" --state open \
+                  --limit 50 --json number 2>/dev/null || echo "[]")
+    local recent_nums
+    recent_nums=$(printf '%s' "$recent_json" | jq -r '.[].number // empty' 2>/dev/null || echo "")
+    [ -z "$recent_nums" ] && { log "[$repo] agent-distress: no recently-updated tickets"; return 0; }
+
+    local now_epoch; now_epoch=$(date +%s)
+    local cool_down_seconds=$(( notify_hours * 3600 ))
+
+    local num
+    for num in $recent_nums; do
+        local comments_json
+        comments_json=$(gh issue view "$num" --repo "$repo" --json comments 2>/dev/null \
+                        || echo "{\"comments\":[]}")
+
+        local matched
+        matched=$(PHRASES="$phrases" AUTHORS="${ALLOWED_AUTHORS:-svv2014}" \
+                  python3 -c '
+import json, os, re, sys
+data = json.load(sys.stdin)
+authors = set(os.environ["AUTHORS"].split(","))
+patterns = [re.compile(p, re.IGNORECASE) for p in os.environ["PHRASES"].splitlines() if p.strip()]
+for c in data.get("comments", [])[-10:]:
+    author = (c.get("author") or {}).get("login", "")
+    if author not in authors:
+        continue
+    body = c.get("body") or ""
+    for p in patterns:
+        m = p.search(body)
+        if m:
+            print(m.group(0)[:80])
+            sys.exit(0)
+' <<< "$comments_json" 2>/dev/null || echo "")
+
+        [ -z "$matched" ] && continue
+
+        local repo_slug="${repo//\//-}"
+        local sentinel="$state_dir/${repo_slug}-${num}"
+        if [ -f "$sentinel" ]; then
+            local mtime; mtime=$(stat -f %m "$sentinel" 2>/dev/null || stat -c %Y "$sentinel" 2>/dev/null || echo 0)
+            local age=$(( now_epoch - mtime ))
+            if [ "$age" -lt "$cool_down_seconds" ]; then
+                log "[$repo] agent-distress: #$num matched '$matched' — Signal cooled-down (${age}s ago)"
+                continue
+            fi
+        fi
+
+        log "[$repo] AGENT-DISTRESS: #$num — agent comment matched '$matched'"
+        $DRY_RUN && continue
+        loop_notify "Loop reconciler: $repo — agent posted distress on #$num: '$matched'. Likely pipeline pathology the agent recognises but cannot fix. Operator: investigate. URL: https://github.com/${repo}/issues/${num}" \
+            || true
+        : > "$sentinel"
+    done
+
+    return 0
+}
+
 run_project() {
     local slug="$1"
     loop_load_project "$slug" || { log "skip $slug (config error)"; return 0; }
@@ -1642,6 +1750,7 @@ run_project() {
     reconcile_qa_failures "$REPO"
     reconcile_pr_label_audit "$REPO"
     reconcile_anomalies "$REPO"
+    reconcile_agent_distress "$REPO"
     reconcile_author_gated "$slug" "$REPO"
     reconcile_closed_issue_labels "$REPO"
     recovery_check_dependencies "$slug"

--- a/tests/agent-distress.bats
+++ b/tests/agent-distress.bats
@@ -1,0 +1,152 @@
+#!/usr/bin/env bats
+# tests/agent-distress.bats — coverage for reconcile_agent_distress (#203).
+#
+# Verifies: distress phrases in agent comments → Signal once with cool-down;
+# non-distress comments / non-agent authors → no Signal; observational only.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export OPS_LOG="$BATS_TMPDIR/ops.log"
+    rm -f "$OPS_LOG"
+
+    export LOOP_DISTRESS_STATE_DIR="$BATS_TMPDIR/distress-notified-$$"
+    rm -rf "$LOOP_DISTRESS_STATE_DIR"
+
+    export ALLOWED_AUTHORS="testagent"
+    export REPO="owner/test-repo"
+    export DRY_RUN=false
+    export LOG_FILE="$LOOP_LOG_DIR/loop-reconciler.log"
+
+    export LOOP_RECONCILER_LIB_ONLY=1
+    # shellcheck source=../scanner/reconciler.sh
+    source "$REPO_ROOT/scanner/reconciler.sh"
+
+    loop_notify() { echo "loop_notify $*" >> "$OPS_LOG"; }
+
+    # Stub gh: search returns the candidate set; issue view returns fixture.
+    gh() {
+        if [ "$1" = "search" ] && [ "$2" = "issues" ]; then
+            cat "${GH_SEARCH_FIXTURE:-/dev/null}"
+            return 0
+        fi
+        if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+            cat "${GH_VIEW_FIXTURE:-/dev/null}"
+            return 0
+        fi
+        return 0
+    }
+    export -f gh
+}
+
+teardown() {
+    rm -rf "$LOOP_DISTRESS_STATE_DIR" "$OPS_LOG" "$LOG_FILE"
+    unset GH_SEARCH_FIXTURE GH_VIEW_FIXTURE
+}
+
+write_search_fixture() {
+    GH_SEARCH_FIXTURE="$BATS_TMPDIR/search.json"
+    cat > "$GH_SEARCH_FIXTURE" <<'JSON'
+[{"number": 42}]
+JSON
+    export GH_SEARCH_FIXTURE
+}
+
+write_view_with_distress() {
+    GH_VIEW_FIXTURE="$BATS_TMPDIR/view-distress.json"
+    cat > "$GH_VIEW_FIXTURE" <<'JSON'
+{"comments": [
+    {"author": {"login": "testagent"}, "body": "PO: pipeline reconciler keeps stripping the dev label every 20 minutes. Human action required."}
+]}
+JSON
+    export GH_VIEW_FIXTURE
+}
+
+write_view_no_distress() {
+    GH_VIEW_FIXTURE="$BATS_TMPDIR/view-clean.json"
+    cat > "$GH_VIEW_FIXTURE" <<'JSON'
+{"comments": [
+    {"author": {"login": "testagent"}, "body": "PO: tracker decomposed into 3 child issues."}
+]}
+JSON
+    export GH_VIEW_FIXTURE
+}
+
+write_view_distress_wrong_author() {
+    GH_VIEW_FIXTURE="$BATS_TMPDIR/view-wrong-author.json"
+    cat > "$GH_VIEW_FIXTURE" <<'JSON'
+{"comments": [
+    {"author": {"login": "external-user"}, "body": "Why does the reconciler keep stripping my labels?? Human action required please."}
+]}
+JSON
+    export GH_VIEW_FIXTURE
+}
+
+@test "agent posts distress phrase: Signal fires once" {
+    write_search_fixture
+    write_view_with_distress
+
+    run reconcile_agent_distress "$REPO"
+    [ "$status" -eq 0 ]
+
+    grep -q "^loop_notify .*#42.*reconciler keeps" "$OPS_LOG"
+}
+
+@test "agent posts non-distress: no Signal" {
+    write_search_fixture
+    write_view_no_distress
+
+    run reconcile_agent_distress "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -q "^loop_notify" "$OPS_LOG"
+}
+
+@test "non-agent author posts distress phrase: no Signal (only ALLOWED_AUTHORS count)" {
+    write_search_fixture
+    write_view_distress_wrong_author
+
+    run reconcile_agent_distress "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -q "^loop_notify" "$OPS_LOG"
+}
+
+@test "cool-down: second tick within window does NOT re-Signal" {
+    write_search_fixture
+    write_view_with_distress
+
+    reconcile_agent_distress "$REPO"
+    local notifies1
+    notifies1=$(grep -c "^loop_notify" "$OPS_LOG" 2>/dev/null || echo 0)
+    [ "$notifies1" -eq 1 ]
+
+    reconcile_agent_distress "$REPO"
+    local notifies2
+    notifies2=$(grep -c "^loop_notify" "$OPS_LOG" 2>/dev/null || echo 0)
+    [ "$notifies2" -eq 1 ]
+}
+
+@test "DRY_RUN=true: detect but do not Signal" {
+    write_search_fixture
+    write_view_with_distress
+    DRY_RUN=true
+
+    reconcile_agent_distress "$REPO"
+
+    [ ! -s "$OPS_LOG" ] || ! grep -q "^loop_notify" "$OPS_LOG"
+    DRY_RUN=false
+}
+
+@test "no recently-updated tickets: no-op, no error" {
+    GH_SEARCH_FIXTURE="$BATS_TMPDIR/empty-search.json"
+    echo "[]" > "$GH_SEARCH_FIXTURE"
+    export GH_SEARCH_FIXTURE
+
+    run reconcile_agent_distress "$REPO"
+    [ "$status" -eq 0 ]
+    [ ! -s "$OPS_LOG" ]
+}


### PR DESCRIPTION
Closes #203.

Complement to #195: that catches BEHAVIOR (label flip rate); this catches NARRATIVE (agents writing 'reconciler keeps stripping', 'human action required', etc.). Would have flagged ppl-study#421 after the first PO comment instead of cycle 7.

Per-tick: `gh search issues --updated >X` for the candidate set, then per ticket `gh issue view --json comments` (last 10). Filter to ALLOWED_AUTHORS, regex-match a built-in distress phrase list (overridable via LOOP_DISTRESS_PHRASES_FILE).

Observational only. Per-ticket cool-down. 6 bats cases pass; all 39 reconciler tests green.