### PR TITLE
[LOOP] docs: refresh reconciler check list + CHANGELOG for 2026-05-01/02 stability batch (#189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,75 @@ projects.yaml schema, bounty event API, CLI flags, lock dir, log dir).
 
 ## [Unreleased]
 
+### Reconciler stability + observability batch (2026-05-01 / 2026-05-02)
+
+A multi-PR sweep addressing root causes of label ping-pong, set -e
+foot-guns, vocab-migration drift, and lack of pathology visibility.
+The pipeline became dramatically more debuggable and self-healing in
+this batch.
+
+#### Fixed (writer correctness)
+- [#204] `_autopull_loop` returns 0 when no fast-forward — set -e was
+  killing the entire reconciler whenever no merge happened upstream.
+- [#206] `reconcile_alias_renames` is workflow-aware — stopped
+  stripping live trigger labels from `workflow: current` projects
+  (4 projects affected: ppl-study, NTC, vrefm-classifier, pa-scanner).
+- [#207, #208] `LOOP_PIPELINE_LABELS` consolidated into
+  `lib/labels.sh::LOOP_PIPELINE_TRACKED_LABELS`. Single source of
+  truth so vocab additions can't drift.
+- [#213] `LOOP_REQUIRED_LABELS` includes the canonical `needs-po`,
+  `in-po`, `needs-dev`, `in-dev` so freshly-onboarded repos bootstrap
+  them cleanly.
+- [#216] `merge-handler.sh` recognises `Fixes` / `Resolves` keywords
+  alongside `Closes` (matches GitHub's native auto-close vocabulary).
+- [#217] `_rename_label_on_target` is add-then-remove with early-
+  return on add-failure. No more label-less tickets when API flakes
+  mid-rename.
+- [#220] dev-handler strips the issue's stage trigger after opening a
+  closing PR via `loop_strip_pipeline_labels`; `reconcile_lost_issues`
+  skips Signal when an open PR closes the issue.
+- [#221] `reconcile_stale_base` ends with explicit `return 0`. Static
+  scan in `tests/reconciler-set-e-audit.bats` regression-guards every
+  `reconcile_*` / `recovery_*` function against the same trailing-
+  conditional `set -e` foot-gun.
+- [#222] `reconcile_synonym_labels` + `reconcile_alias_renames` →
+  thin wrappers over a shared `_reconcile_label_renames` helper. Net
+  49-line reduction; alias renamer also gains the atomic ordering
+  from #217 as a side effect.
+- [#225] PO Path D enforces a hard cap (`LOOP_PO_MAX_CHILDREN`,
+  default 4) and detects refactor-class epics (title/body keywords)
+  so their children are chained via `Depends on #N` for serial
+  processing — eliminates the merge-conflict storms on multi-file
+  refactors.
+
+#### Added (observability)
+- [#214] `reconcile_lost_issues` is observational only — Signal +
+  per-ticket cool-down, no auto-mutation. Eliminates the ping-pong
+  with `reconcile_alias_renames` that produced 41+ comments on a
+  single ticket.
+- [#218] `scanner.sh` installs a SIGHUP trap that reopens stdout/
+  stderr against `LOG_FILE`. Survives `logrotate copytruncate` /
+  `newsyslog R` without going silent.
+- [#223] `reconcile_anomalies` mines the reconciler log for tickets
+  touched more than threshold times within a window. Configurable
+  threshold (default 4), window (default 1h), cool-down (default 24h).
+- [#224] `reconcile_agent_distress` scans recent agent-authored
+  comments for narrative-pathology phrases (`reconciler keeps`,
+  `human action required`, `no progress after N cycles`). Built-in
+  phrase list overridable via `LOOP_DISTRESS_PHRASES_FILE`.
+
+#### Refactored
+- [#209, #219] `loop_label_is_trigger <slug> <kind> <label>` extracted
+  to `lib/workflow.sh` with per-(slug, kind) caching. Replaces two
+  duplicate copies of the gate in the reconciler.
+
+#### Tests added
+- 8 new bats files: `lost-issues-observational`, `rename-label-atomic`,
+  `label-is-trigger`, `scanner-log-sighup`, `reconciler-set-e-audit`,
+  `anomaly-detector`, `agent-distress`, `po-decomposition-instructions`.
+  39+ new cases covering writer contracts, observational invariants,
+  cool-downs, and prompt-text regression.
+
 
 ### Changed
 - [LOOP-160] feat: add reconcile-on-startup entrypoint (#171)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,15 +94,52 @@ Each handler:
 
 ### Reconciler (`scanner/reconciler.sh`)
 
-Every 15 minutes, sweeps for drift the scanner doesn't self-correct:
+Every 15 minutes, sweeps each configured project for drift the scanner
+doesn't self-correct. Two distinct classes of check:
 
+**Mutating checks** (corroboration-gated, never speculative):
+- Required-label bootstrap — creates any missing canonical Loop labels
+  on the repo (`needs-po`, `needs-dev`, `needs-review`, `needs-qa`, etc.)
+- Synonym + alias renames — rewrites deprecated label names to the
+  workflow's live trigger labels. Workflow-aware (won't strip a label
+  that IS a trigger for the project; won't apply one that isn't).
+  Atomic add-then-remove so add-failure preserves the original label.
 - Duplicate PRs (same `Closes #N`) — closes the older one
-- Orphaned `needs-review` issues (PR was closed without merging) —
-  resets to `dev`
-- Stale PRs (>24h with no movement) — notification only
-- Dependency unblock — parses `## Dependencies` section, re-labels
-  to `dev` once all referenced issues are closed
-- Missing-label routing — issues with no pipeline label get `po-review`
+- Obsolete open PRs (issue already closed by a merged PR) — closes
+  with reason
+- Dependency unblock — parses `blocked by #N`, `depends on #N`,
+  `## Dependencies` sections via `lib/dep_parser.sh`. Skips when an
+  open PR already closes the issue (work is on PR side, no requeue).
+- Stale-base auto-rebase — PRs whose base SHA diverged from main get
+  rebased automatically when conflict-free.
+- QA-failure transient retry vs repeated-failure clarification.
+- Conflict-blocked PR auto-recycle — closes a CONFLICTING PR and
+  re-queues the source issue to `dev`.
+- Orphaned in-progress reset — issue stuck `in-progress` >10 min with
+  no live handler lock → resets to `dev` (or canonical equivalent).
+- Closed-issue label scrub — strips stale pipeline labels off issues
+  closed in the last 7 days that the merge-handler didn't catch.
+- PR label audit — strips issue-only labels (`tracker`, `epic`,
+  `needs-clarification`) accidentally applied to PRs.
+
+**Observational checks** (Signal-only, no mutation):
+- Lost-issues detector — open issues with no pipeline label and no
+  closing PR get a Signal once per ticket per 24h cool-down. Operator
+  applies a trigger label or closes. Was the source of repeated label
+  ping-pong before #214 made it observational.
+- Anomaly detector — mines the reconciler's own log for ticket-level
+  pathology (one ticket touched ≥4 times within 1h). Threshold,
+  window, cool-down all tunable via env.
+- Agent-distress detector — scans agent-authored comments on
+  recently-updated tickets for narrative-pathology phrases ("reconciler
+  keeps", "human action required", "no progress after N cycles").
+  Surfaces to operator before the cycle escalates.
+- Author-gated digest — counts tickets skipped due to ALLOWED_AUTHORS
+  gate so an external user's request doesn't go silently unseen.
+
+The split between mutating and observational is intentional: mutators
+fight each other when they all run on the same ticket within one tick
+on stale data. Observational checks just report — operator decides.
 
 ### Lock layer (`lib/lock.sh`)
 
@@ -129,9 +166,12 @@ error). No-ops silently when unset. Concrete notifier scripts live in
 
 Loads `config/workflows/<name>.yaml`, applies project label overrides
 from `config/projects.yaml`. Public API: `loop_workflow_for_project`,
-`loop_label_for`, `loop_polled_labels`, `loop_handler_for_label`,
-`loop_workflow_validate`. Used by scanner and (selectively) by handlers
-to look up canonical-vs-actual label names.
+`loop_label_for`, `loop_polled_labels`, `loop_label_is_trigger`,
+`loop_handler_for_label`, `loop_workflow_validate`. Used by scanner
+and (selectively) by handlers to look up canonical-vs-actual label
+names. `loop_label_is_trigger` caches per-(slug, kind) trigger sets in
+env vars so a tick with many label candidates pays one workflow YAML
+read per project.
 
 ## Data flow on one feature
 


### PR DESCRIPTION
Closes #189.

Updates docs/architecture.md to reflect today's 19 reconciler checks (was listed as 5) split into mutating + observational classes. Adds CHANGELOG entry summarising the 11-PR stability sweep.