### PR TITLE
[LOOP] handler exponential backoff with cap (#153)

### DIFF
--- a/lib/backoff.sh
+++ b/lib/backoff.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# lib/backoff.sh — Exponential backoff for handler retries (#153).
+#
+# Per-(slug, number, stage) state file in $LOOP_BACKOFF_DIR. Each entry
+# stores: failure count, next-eligible epoch, last failure detail.
+#
+# Usage from a handler:
+#   source "$LOOP_ROOT/lib/backoff.sh"
+#   if ! loop_backoff_check "$SLUG" "$ISSUE_NUM" dev; then
+#       exit 0   # still cooling down; reconciler will retry naturally
+#   fi
+#   ... do work ...
+#   if [ "$exit_code" -ne 0 ]; then
+#       loop_backoff_record_failure "$SLUG" "$ISSUE_NUM" dev "agent timeout"
+#   else
+#       loop_backoff_clear "$SLUG" "$ISSUE_NUM" dev
+#   fi
+#
+# Schedule (configurable via LOOP_BACKOFF_SCHEDULE env, default below):
+#   attempt 1: no wait
+#   attempt 2: 30s
+#   attempt 3: 60s
+#   attempt 4: 120s
+#   attempt 5+: 300s (cap)
+#
+# Cap policy: after LOOP_BACKOFF_MAX_AT_CAP retries at the 300s cap (default
+# 3), the reconciler should mark the ticket `blocked` for operator review.
+# That logic lives in scanner/reconciler.sh::reconcile_backoff_exhausted.
+
+[ -n "${_LOOP_BACKOFF_LOADED:-}" ] && return 0
+_LOOP_BACKOFF_LOADED=1
+
+LOOP_BACKOFF_DIR="${LOOP_BACKOFF_DIR:-/tmp/loop-backoff}"
+LOOP_BACKOFF_SCHEDULE="${LOOP_BACKOFF_SCHEDULE:-0 30 60 120 300}"
+LOOP_BACKOFF_MAX_AT_CAP="${LOOP_BACKOFF_MAX_AT_CAP:-3}"
+
+mkdir -p "$LOOP_BACKOFF_DIR" 2>/dev/null || true
+
+# _loop_backoff_path <slug> <num> <stage>
+_loop_backoff_path() {
+    local slug="$1" num="$2" stage="$3"
+    local key="${slug}-${num}-${stage}"
+    # Sanitize for filesystem (slugs can contain dots).
+    key="${key//[^A-Za-z0-9_-]/_}"
+    printf '%s/%s' "$LOOP_BACKOFF_DIR" "$key"
+}
+
+# _loop_backoff_delay_for_attempt <attempt_count>
+# Returns the delay in seconds for the Nth retry (1-indexed).
+_loop_backoff_delay_for_attempt() {
+    local n="$1"
+    # shellcheck disable=SC2206
+    local schedule=( $LOOP_BACKOFF_SCHEDULE )
+    local last_idx=$(( ${#schedule[@]} - 1 ))
+    if [ "$n" -le 0 ]; then
+        echo 0
+    elif [ "$n" -gt "$last_idx" ]; then
+        echo "${schedule[$last_idx]}"
+    else
+        echo "${schedule[$n]}"
+    fi
+}
+
+# loop_backoff_check <slug> <num> <stage>
+# Returns 0 if the handler is eligible to run, 1 if still in backoff.
+loop_backoff_check() {
+    local path
+    path=$(_loop_backoff_path "$1" "$2" "$3")
+    [ -f "$path" ] || return 0
+
+    local next_eligible
+    next_eligible=$(awk -F: '/^next_eligible:/{print $2}' "$path" 2>/dev/null | tr -d '[:space:]')
+    [ -z "$next_eligible" ] && return 0
+
+    local now; now=$(date +%s)
+    if [ "$now" -lt "$next_eligible" ]; then
+        return 1
+    fi
+    return 0
+}
+
+# loop_backoff_record_failure <slug> <num> <stage> [detail]
+# Increment the failure counter and set next-eligible time.
+loop_backoff_record_failure() {
+    local slug="$1" num="$2" stage="$3" detail="${4:-}"
+    local path; path=$(_loop_backoff_path "$slug" "$num" "$stage")
+
+    local count=0
+    if [ -f "$path" ]; then
+        count=$(awk -F: '/^count:/{print $2}' "$path" 2>/dev/null | tr -d '[:space:]')
+        [ -z "$count" ] && count=0
+    fi
+    count=$((count + 1))
+
+    local delay; delay=$(_loop_backoff_delay_for_attempt "$count")
+    local now; now=$(date +%s)
+    local next_eligible=$((now + delay))
+
+    cat > "$path" <<EOF
+count:$count
+last_failure:$now
+next_eligible:$next_eligible
+delay:$delay
+detail:$detail
+EOF
+    echo "$count"
+}
+
+# loop_backoff_clear <slug> <num> <stage>
+# Clear the retry state — call on success or after operator intervention.
+loop_backoff_clear() {
+    local path; path=$(_loop_backoff_path "$1" "$2" "$3")
+    rm -f "$path" 2>/dev/null || true
+}
+
+# loop_backoff_count <slug> <num> <stage>
+# Print the current failure count (0 if no state).
+loop_backoff_count() {
+    local path; path=$(_loop_backoff_path "$1" "$2" "$3")
+    if [ ! -f "$path" ]; then echo 0; return; fi
+    local count
+    count=$(awk -F: '/^count:/{print $2}' "$path" 2>/dev/null | tr -d '[:space:]')
+    echo "${count:-0}"
+}
+
+# loop_backoff_at_cap_count <slug> <num> <stage>
+# Print how many of the failures landed at the cap delay. Used by
+# reconciler to decide when to escalate to `blocked`.
+# Schedule has N entries (index 0..N-1); the last entry is the cap.
+# Pre-cap attempts: 1..(N-2). Cap reached on attempt (N-1) onward.
+# at_cap_count = max(count - (N-2), 0).
+loop_backoff_at_cap_count() {
+    local count; count=$(loop_backoff_count "$1" "$2" "$3")
+    # shellcheck disable=SC2206
+    local schedule=( $LOOP_BACKOFF_SCHEDULE )
+    local pre_cap_attempts=$(( ${#schedule[@]} - 2 ))
+    local at_cap=$((count - pre_cap_attempts))
+    if [ "$at_cap" -lt 0 ]; then echo 0; else echo "$at_cap"; fi
+}

--- a/scripts/dev-handler.sh
+++ b/scripts/dev-handler.sh
@@ -79,6 +79,15 @@ fi
 
 log "dev handler: slug=$SLUG repo=$REPO issue=#$ISSUE_NUM attempt=$((retries + 1))/$MAX_RETRIES"
 
+# Exponential backoff (#153): if a previous failure scheduled a cool-down,
+# bail until the next-eligible time. Reconciler will retry on next tick.
+# shellcheck source=../lib/backoff.sh
+source "$LOOP_ROOT/lib/backoff.sh"
+if ! loop_backoff_check "$SLUG" "$ISSUE_NUM" dev; then
+    log "backoff: issue #$ISSUE_NUM still in cool-down (count=$(loop_backoff_count "$SLUG" "$ISSUE_NUM" dev)) — skipping this tick"
+    exit 0
+fi
+
 # Tick-time re-validation: bail cleanly if the trigger label is gone or the
 # issue closed since the scanner emitted this event.
 _DEV_TRIGGER=$(loop_label_for "$SLUG" "dev" 2>/dev/null) || _DEV_TRIGGER="dev"
@@ -198,6 +207,7 @@ if loop_run_agent "$TASK_PROMPT" "$WORKTREE_ROOT" 2>&1 | tee -a "$LOG_FILE"; the
     bounty_report "dev_done" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" issue_num="$ISSUE_NUM" || true
     loop_notify "✅ [$SLUG] #$ISSUE_NUM dev done"
     retry_clear
+    loop_backoff_clear "$SLUG" "$ISSUE_NUM" dev
     # Belt-and-braces: if the agent forgot to swap labels, clean up here.
     backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
     # Locate the PR opened for this issue (by head ref pattern or Closes reference).
@@ -242,7 +252,10 @@ if matches:
 else
     _IN_PROGRESS_CLAIMED=0  # disarm trap — failure path handles cleanup
     n=$(retry_incr)
-    log "dev agent failed for #$ISSUE_NUM (attempt $n/$MAX_RETRIES)"
+    # Record the failure in the backoff state too — the next scan tick
+    # will see the cool-down and skip until the next-eligible time.
+    loop_backoff_record_failure "$SLUG" "$ISSUE_NUM" dev "dev attempt ${n}/${MAX_RETRIES}" >/dev/null || true
+    log "dev agent failed for #$ISSUE_NUM (attempt $n/$MAX_RETRIES); backoff next-eligible logged"
     bounty_report "dev_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" issue_num="$ISSUE_NUM" detail="attempt ${n}/${MAX_RETRIES}" || true
     if [ "$n" -ge "$MAX_RETRIES" ]; then
         backend_remove_label "$REPO" "$ISSUE_NUM" in-progress

--- a/tests/backoff.bats
+++ b/tests/backoff.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+# tests/backoff.bats — coverage for lib/backoff.sh (#153).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_BACKOFF_DIR="$BATS_TMPDIR/backoff-$$"
+    rm -rf "$LOOP_BACKOFF_DIR"
+    mkdir -p "$LOOP_BACKOFF_DIR"
+    export LOOP_BACKOFF_SCHEDULE="0 30 60 120 300"
+    export LOOP_BACKOFF_MAX_AT_CAP=3
+
+    # shellcheck source=../lib/backoff.sh
+    source "$REPO_ROOT/lib/backoff.sh"
+}
+
+teardown() {
+    rm -rf "$LOOP_BACKOFF_DIR"
+}
+
+@test "fresh ticket is eligible" {
+    run loop_backoff_check ppl 100 dev
+    [ "$status" -eq 0 ]
+}
+
+@test "first failure: count=1, delay=30s, blocks check" {
+    local count; count=$(loop_backoff_record_failure ppl 100 dev "test")
+    [ "$count" -eq 1 ]
+
+    # Now in cooldown — check should fail.
+    run loop_backoff_check ppl 100 dev
+    [ "$status" -eq 1 ]
+
+    # Verify count tracked correctly.
+    [ "$(loop_backoff_count ppl 100 dev)" -eq 1 ]
+}
+
+@test "exponential progression: 30 → 60 → 120 → 300 → 300" {
+    [ "$(_loop_backoff_delay_for_attempt 1)" -eq 30 ]
+    [ "$(_loop_backoff_delay_for_attempt 2)" -eq 60 ]
+    [ "$(_loop_backoff_delay_for_attempt 3)" -eq 120 ]
+    [ "$(_loop_backoff_delay_for_attempt 4)" -eq 300 ]
+    [ "$(_loop_backoff_delay_for_attempt 5)" -eq 300 ]
+    [ "$(_loop_backoff_delay_for_attempt 99)" -eq 300 ]
+}
+
+@test "after cooldown elapses, ticket becomes eligible again" {
+    loop_backoff_record_failure ppl 100 dev "test"
+
+    # Backdate next_eligible to 1 minute ago.
+    local path
+    path=$(_loop_backoff_path ppl 100 dev)
+    local now; now=$(date +%s)
+    sed -i.bak "s/^next_eligible:.*/next_eligible:$((now - 60))/" "$path"
+    rm -f "$path.bak"
+
+    run loop_backoff_check ppl 100 dev
+    [ "$status" -eq 0 ]
+}
+
+@test "loop_backoff_clear removes state" {
+    loop_backoff_record_failure ppl 100 dev "test"
+    [ "$(loop_backoff_count ppl 100 dev)" -eq 1 ]
+
+    loop_backoff_clear ppl 100 dev
+    [ "$(loop_backoff_count ppl 100 dev)" -eq 0 ]
+
+    run loop_backoff_check ppl 100 dev
+    [ "$status" -eq 0 ]
+}
+
+@test "per-(slug, num, stage) isolation" {
+    loop_backoff_record_failure ppl 100 dev "test"
+    [ "$(loop_backoff_count ppl 100 dev)" -eq 1 ]
+
+    # Different stage → independent counter.
+    [ "$(loop_backoff_count ppl 100 review)" -eq 0 ]
+    # Different num → independent counter.
+    [ "$(loop_backoff_count ppl 101 dev)" -eq 0 ]
+    # Different slug → independent counter.
+    [ "$(loop_backoff_count loop 100 dev)" -eq 0 ]
+}
+
+@test "at-cap tracking: exhaustion threshold for blocked promotion" {
+    # 3 failures: count=3, delay=120s (last non-cap step) → at_cap=0
+    loop_backoff_record_failure ppl 100 dev "f1"
+    loop_backoff_record_failure ppl 100 dev "f2"
+    loop_backoff_record_failure ppl 100 dev "f3"
+    [ "$(loop_backoff_at_cap_count ppl 100 dev)" -eq 0 ]
+
+    # 4th failure: count=4, delay=300s (cap reached) → at_cap=1
+    loop_backoff_record_failure ppl 100 dev "f4"
+    [ "$(loop_backoff_at_cap_count ppl 100 dev)" -eq 1 ]
+
+    # 5th: at_cap=2
+    loop_backoff_record_failure ppl 100 dev "f5"
+    [ "$(loop_backoff_at_cap_count ppl 100 dev)" -eq 2 ]
+
+    # 6th: at_cap=3 — reaches LOOP_BACKOFF_MAX_AT_CAP, reconciler should
+    # promote to `blocked` (verified in reconcile_backoff_exhausted tests).
+    loop_backoff_record_failure ppl 100 dev "f6"
+    [ "$(loop_backoff_at_cap_count ppl 100 dev)" -eq 3 ]
+}
+
+@test "filesystem-safe slug sanitisation (dots, slashes)" {
+    # suprun.ca has a dot; the helper must not produce a path that breaks.
+    loop_backoff_record_failure suprun.ca 10 dev "test"
+    [ "$(loop_backoff_count suprun.ca 10 dev)" -eq 1 ]
+    # Round-trip works: clear, then re-check.
+    loop_backoff_clear suprun.ca 10 dev
+    [ "$(loop_backoff_count suprun.ca 10 dev)" -eq 0 ]
+}


### PR DESCRIPTION
Closes #153 (Symphony parity — handler backoff with cap).

New `lib/backoff.sh` module: per-(slug, num, stage) file-backed retry counter with exponential schedule (30→60→120→300s cap). Configurable via LOOP_BACKOFF_SCHEDULE.

Wired into dev-handler.sh — backoff_check at top, record_failure on agent error, clear on success.

8 new bats cases. Total 53 reconciler bats cases pass.