### PR TITLE
[LOOP] loop_label_for now resolves workflow stage triggers (#230)

### DIFF
--- a/lib/workflow.sh
+++ b/lib/workflow.sh
@@ -43,7 +43,16 @@ PY
 }
 
 # loop_label_for <slug> <canonical>
-# Returns the project-specific label name for a canonical workflow label.
+# Returns the actual label name this project uses for a canonical workflow
+# stage. Resolution order:
+#   1. Per-project override in projects.yaml labels: map.
+#   2. The active workflow YAML's trigger label for the stage that <canonical>
+#      belongs to. Closes #230 — post-#188 vocab migration, the canonical
+#      arg passed by handlers may differ from the workflow's actual trigger
+#      (e.g. handlers pass "dev"; default.yaml triggers on "needs-dev").
+#      Without this lookup, dev-handler's guard checked for "dev" and bailed
+#      after reconciler renamed the issue's label to "needs-dev".
+#   3. The <canonical> arg verbatim (legacy fallback).
 loop_label_for() {
     local slug="$1" canonical="$2"
     local config="${LOOP_CONFIG:-${LOOP_ROOT:-.}/config/projects.yaml}"
@@ -51,17 +60,68 @@ loop_label_for() {
         echo "$canonical"
         return 0
     fi
-    SLUG="$slug" CANON="$canonical" CFG="$config" python3 - <<'PY'
+    SLUG="$slug" CANON="$canonical" CFG="$config" \
+    WF_DIR="${_LOOP_WORKFLOW_DIR:-${LOOP_ROOT:-.}/config/workflows}" \
+    python3 - <<'PY'
 import os, sys, yaml
-slug = os.environ['SLUG']
-canon = os.environ['CANON']
-with open(os.environ['CFG']) as f:
+
+slug     = os.environ['SLUG']
+canon    = os.environ['CANON']
+cfg_path = os.environ['CFG']
+wf_dir   = os.environ['WF_DIR']
+
+# Map every canonical name handlers historically pass to the workflow
+# stage ID where it lives. Covers labels.sh canonicals + deprecated aliases.
+CANON_TO_STAGE = {
+    'po-review':         'po',
+    'needs-po':          'po',
+    'dev':               'dev',
+    'needs-dev':         'dev',
+    'plan':              'dev',
+    'in-progress':       'dev',
+    'needs-review':      'review',
+    'review-pending':    'review',
+    'needs-rework':      'rework',
+    'changes-requested': 'rework',
+    'needs-qa':          'qa',
+    'ready-for-qa':      'qa',
+    'qa-pass':           'merge',
+    # qa-fail is a stage-outcome label, not a stage trigger — falls
+    # through to identity below.
+}
+
+with open(cfg_path) as f:
     data = yaml.safe_load(f) or {}
+
+# (1) project override
+project = None
 for p in data.get('projects', []):
     if p.get('slug') == slug:
-        overrides = p.get('labels') or {}
-        print(overrides.get(canon, canon))
-        sys.exit(0)
+        project = p
+        break
+overrides = (project or {}).get('labels') or {}
+if canon in overrides:
+    print(overrides[canon])
+    sys.exit(0)
+
+# (2) workflow stage trigger lookup
+stage_id = CANON_TO_STAGE.get(canon)
+if stage_id and project:
+    wf_name = project.get('workflow', 'default')
+    wf_path = os.path.join(wf_dir, f'{wf_name}.yaml')
+    if os.path.isfile(wf_path):
+        with open(wf_path) as f:
+            wf = yaml.safe_load(f) or {}
+        for key in ('issue_stages', 'pr_stages'):
+            for stage in wf.get(key, []) or []:
+                if stage.get('id') == stage_id:
+                    trig = stage.get('trigger_label')
+                    if trig:
+                        # Per-project override may also remap the trigger.
+                        print(overrides.get(trig, trig))
+                        sys.exit(0)
+
+# (3) verbatim fallback
 print(canon)
 PY
 }

--- a/tests/label-for-workflow-aware.bats
+++ b/tests/label-for-workflow-aware.bats
@@ -1,0 +1,176 @@
+#!/usr/bin/env bats
+# tests/label-for-workflow-aware.bats — coverage for #230.
+#
+# Verifies loop_label_for resolves the active workflow's stage trigger
+# label, not just the verbatim canonical arg. Self-contained: synthesizes
+# a fixture projects.yaml + workflow YAMLs (no dependency on in-tree config).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+
+    # Synthetic workflow dir with two distinct workflows.
+    export LOOP_WORKFLOW_DIR="$BATS_TMPDIR/wf-$$"
+    mkdir -p "$LOOP_WORKFLOW_DIR"
+
+    cat > "$LOOP_WORKFLOW_DIR/canon.yaml" <<'YAML'
+version: 1
+name: canon
+issue_stages:
+  - id: po
+    trigger_label: needs-po
+  - id: dev
+    trigger_label: needs-dev
+pr_stages:
+  - id: review
+    trigger_label: needs-review
+  - id: rework
+    trigger_label: needs-rework
+  - id: qa
+    trigger_label: needs-qa
+  - id: merge
+    trigger_label: qa-pass
+YAML
+
+    cat > "$LOOP_WORKFLOW_DIR/legacy.yaml" <<'YAML'
+version: 1
+name: legacy
+issue_stages:
+  - id: po
+    trigger_label: po-review
+  - id: dev
+    trigger_label: dev
+pr_stages:
+  - id: review
+    trigger_label: review-pending
+  - id: rework
+    trigger_label: changes-requested
+  - id: qa
+    trigger_label: ready-for-qa
+  - id: merge
+    trigger_label: qa-pass
+YAML
+
+    cat > "$BATS_TMPDIR/fixture.yaml" <<'YAML'
+version: 1
+projects:
+  - slug: oncanon
+    name: Canon Workflow Project
+    repo: owner/canon-repo
+    root: /tmp/fake-canon
+    default_branch: main
+    workflow: canon
+  - slug: onlegacy
+    name: Legacy Workflow Project
+    repo: owner/legacy-repo
+    root: /tmp/fake-legacy
+    default_branch: main
+    workflow: legacy
+  - slug: withoverride
+    name: Override Project
+    repo: owner/override-repo
+    root: /tmp/fake-override
+    default_branch: main
+    workflow: canon
+    labels:
+      dev: custom-dev-label
+      qa-pass: custom-merged
+YAML
+    export LOOP_CONFIG="$BATS_TMPDIR/fixture.yaml"
+
+    # shellcheck source=../lib/workflow.sh
+    source "$REPO_ROOT/lib/workflow.sh"
+}
+
+teardown() {
+    rm -rf "$LOOP_WORKFLOW_DIR" "$BATS_TMPDIR/fixture.yaml"
+}
+
+# canon workflow: legacy canonical 'dev' should map to 'needs-dev'
+@test "canon workflow: 'dev' resolves to 'needs-dev' (#230 fix)" {
+    run loop_label_for oncanon dev
+    [ "$status" -eq 0 ]
+    [ "$output" = "needs-dev" ]
+}
+
+@test "canon workflow: 'po-review' resolves to 'needs-po'" {
+    run loop_label_for oncanon po-review
+    [ "$status" -eq 0 ]
+    [ "$output" = "needs-po" ]
+}
+
+@test "canon workflow: 'needs-review' stays 'needs-review' (already canonical)" {
+    run loop_label_for oncanon needs-review
+    [ "$status" -eq 0 ]
+    [ "$output" = "needs-review" ]
+}
+
+@test "canon workflow: 'needs-rework' resolves to 'needs-rework' (canonical→rework stage)" {
+    run loop_label_for oncanon needs-rework
+    [ "$status" -eq 0 ]
+    [ "$output" = "needs-rework" ]
+}
+
+@test "canon workflow: 'qa-pass' stays 'qa-pass' (canonical→merge stage)" {
+    run loop_label_for oncanon qa-pass
+    [ "$status" -eq 0 ]
+    [ "$output" = "qa-pass" ]
+}
+
+# legacy workflow: canonical names should map to legacy triggers
+@test "legacy workflow: 'dev' resolves to 'dev' (legacy trigger preserved)" {
+    run loop_label_for onlegacy dev
+    [ "$status" -eq 0 ]
+    [ "$output" = "dev" ]
+}
+
+@test "legacy workflow: 'needs-dev' resolves to 'dev' (canonical → legacy trigger)" {
+    run loop_label_for onlegacy needs-dev
+    [ "$status" -eq 0 ]
+    [ "$output" = "dev" ]
+}
+
+@test "legacy workflow: 'needs-review' resolves to 'review-pending'" {
+    run loop_label_for onlegacy needs-review
+    [ "$status" -eq 0 ]
+    [ "$output" = "review-pending" ]
+}
+
+@test "legacy workflow: 'needs-rework' resolves to 'changes-requested'" {
+    run loop_label_for onlegacy needs-rework
+    [ "$status" -eq 0 ]
+    [ "$output" = "changes-requested" ]
+}
+
+# project override takes precedence
+@test "project override: literal 'dev' override beats workflow trigger" {
+    run loop_label_for withoverride dev
+    [ "$status" -eq 0 ]
+    [ "$output" = "custom-dev-label" ]
+}
+
+@test "project override: 'qa-pass' override (override beats workflow)" {
+    run loop_label_for withoverride qa-pass
+    [ "$status" -eq 0 ]
+    [ "$output" = "custom-merged" ]
+}
+
+# unknown canonical falls through to identity
+@test "unknown canonical: 'qa-fail' (no stage map) returns verbatim" {
+    run loop_label_for oncanon qa-fail
+    [ "$status" -eq 0 ]
+    [ "$output" = "qa-fail" ]
+}
+
+@test "unknown canonical: 'random-label' returns verbatim" {
+    run loop_label_for oncanon random-label
+    [ "$status" -eq 0 ]
+    [ "$output" = "random-label" ]
+}
+
+# unknown slug returns canonical (no workflow to consult)
+@test "unknown slug: 'dev' returns 'dev' verbatim" {
+    run loop_label_for nonexistent dev
+    [ "$status" -eq 0 ]
+    [ "$output" = "dev" ]
+}


### PR DESCRIPTION
Closes #230.

`loop_label_for` now has three resolution layers (highest precedence first):

1. Project override in `projects.yaml` `labels:` map (existing)
2. **Workflow YAML stage trigger lookup (NEW)** — maps every historical canonical (`po-review`/`needs-po`, `dev`/`needs-dev`/`plan`, `needs-review`/`review-pending`, `needs-rework`/`changes-requested`, `needs-qa`/`ready-for-qa`, `qa-pass`) to its workflow stage id and returns the actual `trigger_label` from the YAML
3. Verbatim canonical fallback

Handlers passing legacy or canonical names get the project's actual workflow trigger automatically. No call-site changes needed in dev/po/review/qa/rework handlers.

## Test
14 new bats cases in `tests/label-for-workflow-aware.bats`. Total 350 bats cases pass.

## Why this fixes the suprun observation
Tonight: PO labelled #10 with literal `dev` → reconciler renamed to `needs-dev` → dev-handler guard checked for `dev` → bailed. With this fix, dev-handler's call `loop_label_for SLUG dev` returns `needs-dev` for default-workflow projects, matches the live label, guard passes.