### PR TITLE
scanner: don't treat issue's own dev trigger as a 'claimed' label

### DIFF
--- a/lib/workflow.sh
+++ b/lib/workflow.sh
@@ -148,6 +148,7 @@ loop_label_is_trigger() {
         # Encode "empty result" distinctly so we don't re-query forever.
         [ -z "$set" ] && set="__EMPTY__"
         printf -v "$cache_var" '%s' "$set"
+        # shellcheck disable=SC2163  # exporting the var named by $cache_var; intentional indirection.
         export "$cache_var"
     fi
 

--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -597,7 +597,7 @@ reconcile_lost_issues() {
     # etc.) and could be wrong on stale data (GitHub's read-after-write
     # consistency window for gh issue edit → gh issue list is non-zero).
     #
-    # Concrete failure: today on suprun.ca#10 the cycle was alias-rename
+    # Concrete failure: today on example.com#10 the cycle was alias-rename
     # writes po-review → needs-po, lost-issues' next gh-fetch in the same
     # tick missed the update OR labels.sh's pipeline-label set was stale,
     # lost-issues re-applied po-review, alias-rename re-renamed, ...

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -164,14 +164,29 @@ emit() {
 # Returns 0 if the issue has been dispatched or moved past the issue stage.
 # Claimed labels are derived from the project's workflow PR trigger labels
 # plus a fixed set of handler-set operational labels (in-progress, build, blocked).
+#
+# A PR trigger label that is *also* an issue trigger in the same workflow
+# (e.g. `needs-dev` is both the issue dev trigger and the PR rework trigger
+# in the default workflow) must NOT count as a claim — otherwise an issue
+# carrying its own dev trigger is silently filtered out and never dispatched.
 issue_is_claimed() {
     local slug="$1" repo="$2" num="$3"
-    local pr_trigger_labels
-    pr_trigger_labels=$(loop_polled_labels "$slug" pr 2>/dev/null | tr '\n' ' ')
+    local issue_trigger_labels pr_trigger_labels filtered_pr_labels
+    issue_trigger_labels=$(loop_polled_labels "$slug" issue 2>/dev/null | tr '\n' ' ')
+    pr_trigger_labels=$(loop_polled_labels "$slug" pr 2>/dev/null)
+    # Subtract issue triggers from the PR trigger set.
+    filtered_pr_labels=""
+    while IFS= read -r _lbl; do
+        [ -z "$_lbl" ] && continue
+        case " $issue_trigger_labels " in
+            *" $_lbl "*) continue ;;
+        esac
+        filtered_pr_labels="$filtered_pr_labels $_lbl"
+    done <<< "$pr_trigger_labels"
     # shellcheck disable=SC2086
     backend_issue_has_any_label "$repo" "$num" \
         in-progress build blocked 'done' \
-        ${pr_trigger_labels}
+        ${filtered_pr_labels}
 }
 
 # _pr_downstream_labels <slug> <from_label>

--- a/tests/backoff.bats
+++ b/tests/backoff.bats
@@ -102,10 +102,10 @@ teardown() {
 }
 
 @test "filesystem-safe slug sanitisation (dots, slashes)" {
-    # suprun.ca has a dot; the helper must not produce a path that breaks.
-    loop_backoff_record_failure suprun.ca 10 dev "test"
-    [ "$(loop_backoff_count suprun.ca 10 dev)" -eq 1 ]
+    # example.com has a dot; the helper must not produce a path that breaks.
+    loop_backoff_record_failure example.com 10 dev "test"
+    [ "$(loop_backoff_count example.com 10 dev)" -eq 1 ]
     # Round-trip works: clear, then re-check.
-    loop_backoff_clear suprun.ca 10 dev
-    [ "$(loop_backoff_count suprun.ca 10 dev)" -eq 0 ]
+    loop_backoff_clear example.com 10 dev
+    [ "$(loop_backoff_count example.com 10 dev)" -eq 0 ]
 }

--- a/tests/lost-issues-observational.bats
+++ b/tests/lost-issues-observational.bats
@@ -5,7 +5,7 @@
 #   - LOST issues trigger a Signal notification (loop_notify called)
 #   - LOST issues DO NOT mutate state (no backend_add_label, no
 #     backend_comment_issue) — this was the root cause of every label
-#     ping-pong incident on 2026-05-01 (suprun#10 41 comments,
+#     ping-pong incident on 2026-05-01 (proj-x#10 41 comments,
 #     ppl-study#421 80 comments).
 #   - Per-(repo, issue) cool-down suppresses a second Signal within
 #     LOOP_LOST_NOTIFY_HOURS.

--- a/tests/scanner.bats
+++ b/tests/scanner.bats
@@ -198,6 +198,29 @@ teardown() {
     [ "$status" -eq 1 ]
 }
 
+# Regression: the default workflow uses `needs-dev` as the issue dev trigger
+# AND as the PR rework trigger. Before the fix, issue_is_claimed naively
+# treated every PR-trigger label as a claim and silently filtered out any
+# issue that had its own dev trigger — the dev handler never fired, the
+# pipeline stalled after PO. The fix subtracts issue triggers from the
+# PR-trigger set used for the claim check.
+@test "issue_is_claimed: returns 1 when default-workflow issue has only needs-dev (its own dev trigger)" {
+    _write_fixture_config
+    export LOOP_CONFIG="$BATS_TMPDIR/fixture.yaml"
+    export GH_MOCK_OUTPUT="needs-dev"
+    run issue_is_claimed "proj-default" "owner/default-repo" 1
+    [ "$status" -eq 1 ]
+}
+
+# Sanity: a real PR-only stage label still counts as a claim.
+@test "issue_is_claimed: returns 0 when default-workflow issue has needs-review (PR-only stage)" {
+    _write_fixture_config
+    export LOOP_CONFIG="$BATS_TMPDIR/fixture.yaml"
+    export GH_MOCK_OUTPUT="needs-review"
+    run issue_is_claimed "proj-default" "owner/default-repo" 1
+    [ "$status" -eq 0 ]
+}
+
 # ---------------------------------------------------------------------------
 # _pr_downstream_labels
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

\`issue_is_claimed()\` treated every label returned by \`loop_polled_labels(slug, pr)\` as evidence that an issue had moved past the dev stage. In the default workflow, \`needs-dev\` is both the issue dev trigger AND the PR rework trigger — so any issue carrying its own dev trigger was silently filtered out, the dev handler never fired, and the pipeline stalled after PO.

Observed live on \`svv2014/loop-monitor#102\` and previously on #98 — both stuck in \`needs-dev\` for hours with no scanner emit.

## Fix

Subtract issue trigger labels from the PR trigger set before the claim check. PR-only stages (\`needs-review\`, \`needs-qa\`, \`qa-pass\`) still count as claims; the issue's own trigger does not.

\`\`\`bash
issue_trigger_labels=\$(loop_polled_labels \"\$slug\" issue ...)
pr_trigger_labels=\$(loop_polled_labels \"\$slug\" pr ...)
# subtract issue triggers from PR trigger set
\`\`\`

## Tests

\`tests/scanner.bats\`:
- **Regression**: default-workflow issue with only \`needs-dev\` → not claimed.
- **Sanity**: default-workflow issue with \`needs-review\` → still claimed.

\`\`\`
$ bats tests/scanner.bats
... 32 tests, 0 failures
\`\`\`

## Test plan
- Unstuck \`loop-monitor#102\` and \`#98\` should advance to dev on the next scanner tick.
- All bundled workflows (default, minimal, current, docs-only) keep working — only the overlap case behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)