### PR TITLE
[LOOP-237] fix _dedup_key portability: replace md5sum with fallback chain for macOS

### DIFF
--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -132,7 +132,10 @@ DEDUP_DIR="/tmp/loop-scanner-dedup"
 mkdir -p "$DEDUP_DIR"
 
 _dedup_key() {
-    echo "$1" | md5sum | cut -d' ' -f1
+    printf '%s' "$1" | md5sum 2>/dev/null \
+        || printf '%s' "$1" | md5 -q 2>/dev/null \
+        || printf '%s' "$1" | sha256sum | cut -c1-32
+    true
 }
 
 # emit <json> <dedup_id>

--- a/tests/scanner.bats
+++ b/tests/scanner.bats
@@ -436,6 +436,20 @@ YAML
     [ ! -f "$dispatch_log" ]
 }
 
+@test "emit: second identical event within 30-minute window is suppressed" {
+    local dispatch_log="$BATS_TMPDIR/dispatch-dedup.log"
+    rm -f "$dispatch_log"
+    dispatch_direct() { echo "dispatched" >> "$dispatch_log"; return 0; }
+
+    local json='{"type":"loop.dev_issue","payload":{"slug":"test","repo":"owner/repo"}}'
+    emit "$json" "dev_issue:owner/repo:99"
+    emit "$json" "dev_issue:owner/repo:99"
+
+    local count
+    count=$(wc -l < "$dispatch_log" 2>/dev/null | tr -d ' ')
+    [ "$count" -eq 1 ]
+}
+
 @test "emit: no dedup key file created when dedup_id is empty" {
     local dispatch_log="$BATS_TMPDIR/dispatch3.log"
     rm -f "$dispatch_log"


### PR DESCRIPTION
Closes #237

## Changes

- **`scanner/scanner.sh`**: Replaced `echo "$1" | md5sum | cut -d' ' -f1` in `_dedup_key` with a portable fallback chain:
  1. `printf '%s' "$1" | md5sum` (GNU coreutils — Linux)
  2. `printf '%s' "$1" | md5 -q` (macOS built-in)
  3. `printf '%s' "$1" | sha256sum | cut -c1-32` (universal fallback)
  
  Uses `printf '%s'` instead of `echo` to avoid trailing newline affecting the hash. Added `true` to ensure the function exits 0 regardless of which branch ran.

- **`tests/scanner.bats`**: Added test `"emit: second identical event within 30-minute window is suppressed"` that calls `emit` twice with the same dedup_id and asserts `dispatch_direct` is only called once. This test works on both Linux and macOS without platform-specific skips (the `emit` function's `stat` call already handles portability via `stat -f%m 2>/dev/null || stat -c%Y`).

## Test Plan

- `bash -n scanner/scanner.sh` passes ✓
- `shellcheck -S warning scanner/scanner.sh` passes ✓
- Existing `_dedup_key` tests (non-empty output, same input = same hash, different inputs = different hashes) still pass
- New dedup suppression test verifies a second identical event within 30 minutes is not dispatched