### PR TITLE
[LOOP-236] Remove stale eval-based loop_notify() from lib/env.sh

### DIFF
--- a/lib/env.sh
+++ b/lib/env.sh
@@ -50,11 +50,3 @@ loop_run_orchestrator() {
             "$prompt"
     fi
 }
-
-# Helper: send notification (no-op if not configured)
-loop_notify() {
-    local msg="$1"
-    if [ -n "$LOOP_NOTIFY" ]; then
-        eval $LOOP_NOTIFY "\"$msg\"" 2>/dev/null || true
-    fi
-}


### PR DESCRIPTION
Closes #236

## Changes

Deleted the `loop_notify()` function body from `lib/env.sh` (lines 54–60). This definition used `eval` to invoke `$LOOP_NOTIFY`, which was the shell-metachar vulnerability fixed by commit `e69a30f` via `lib/notify.sh`. The stale definition was never removed and silently shadowed the safe version — but only when `lib/notify.sh` was sourced after `lib/env.sh` (current handler pattern). Any script sourcing only `env.sh` would have gotten the unsafe `eval` version.

The authoritative safe implementation remains in `lib/notify.sh`. All handlers already source `lib/notify.sh` explicitly (verified with grep — 9 handler/scanner files).

## Test Plan
- `bash -n` passes on all scripts
- `shellcheck -S warning` passes on all scripts
- `tests/notify-quoting.bats` continues to pass (the safe `lib/notify.sh` implementation is unchanged)
- Grep confirms no remaining `loop_notify` definition in `lib/env.sh`