### PR TITLE
[LOOP-233] fix shell injection in custom agent via eval

### DIFF
--- a/lib/runner.sh
+++ b/lib/runner.sh
@@ -69,7 +69,9 @@ _loop_invoke_agent() {
                 return 2
             fi
             local _cmd="${cmd:-$LOOP_AGENT_CMD}"
-            eval "$_cmd" "$prompt"
+            local -a _cmd_argv
+            read -ra _cmd_argv <<< "$_cmd"
+            "${_cmd_argv[@]}" "$prompt"
             ;;
         *)
             echo "ERROR: Unknown agent='$agent'. Use: claude, codex, gemini, aider, custom" >&2

--- a/tests/runner-fallback.bats
+++ b/tests/runner-fallback.bats
@@ -156,6 +156,37 @@ SH
     grep -q "custom-local-model" "$ATTEMPTS_LOG"
 }
 
+@test "custom agent: prompt with shell metacharacters is not evaluated (no injection)" {
+    # Prompt contains $(echo INJECTED) — must arrive literally at the custom script.
+    local custom_script="$BATS_TMPDIR/safe-custom.sh"
+    local received_prompt_file="$BATS_TMPDIR/received_prompt"
+    cat > "$custom_script" <<'SH'
+#!/usr/bin/env bash
+# Record the literal first argument; do NOT eval it.
+printf '%s' "$1" > "$BATS_TMPDIR/received_prompt"
+exit 0
+SH
+    chmod +x "$custom_script"
+
+    # Make BATS_TMPDIR available inside the script via env
+    export BATS_TMPDIR
+    export LOOP_AGENT="custom"
+    export LOOP_AGENT_CMD="$custom_script"
+    unset _PROJECT_FALLBACK
+
+    local injection_prompt='hello $(echo INJECTED) world'
+    run loop_run_agent "$injection_prompt" "$BATS_TMPDIR"
+    [ "$status" -eq 0 ]
+
+    # The word INJECTED must NOT appear as standalone output (injection guard)
+    [[ "$output" != *"INJECTED"* ]]
+
+    # The prompt must have arrived verbatim (not evaluated)
+    local received
+    received="$(cat "$received_prompt_file")"
+    [ "$received" = "$injection_prompt" ]
+}
+
 @test "claude branch never passes --cwd flag (regression of LOOP-29 / LOOP-152)" {
     # Stub records full argv so we can assert no --cwd is passed.
     cat > "$STUB_DIR/claude" <<'STUB'


### PR DESCRIPTION
Closes #233

## Changes

- **`lib/runner.sh`**: Replace `eval "$_cmd" "$prompt"` (line 72) with the safe `read -ra` array-split pattern already used in `lib/notify.sh`. The command string is word-split into an array once, then invoked with the prompt as a single, uninterpreted trailing argument — no re-parsing of shell metacharacters.

- **`tests/runner-fallback.bats`**: Add test `"custom agent: prompt with shell metacharacters is not evaluated (no injection)"` — verifies that a prompt containing `$(echo INJECTED)` arrives verbatim at the custom script and does not produce `INJECTED` in output.

## Test Plan

- `bash -n` passes on all `lib/*.sh scripts/*.sh scanner/*.sh install.sh`
- `shellcheck -S warning` passes on same set
- New bats test asserts no injection and literal prompt delivery
- Existing `runner-fallback.bats` tests continue to pass (custom agent stub test unaffected)