### PR TITLE
feat(scanner): cap non-dev pipeline stages at N concurrent handlers/tick

### DIFF
--- a/lib/config.sh
+++ b/lib/config.sh
@@ -68,6 +68,14 @@ for p in data.get("projects", []) or []:
         print(f"AUTO_REBASE='{'true' if mg.get('auto_rebase', False) else 'false'}'")
         print(f"BACKEND='{sh(p.get('backend','github'))}'")
         print(f"MAX_CONCURRENT_PRS='{sh(dev.get('max_concurrent_prs', 1))}'")
+        # MAX_CONCURRENT_HANDLERS: caps emits-per-tick for all non-dev pipeline
+        # stages (po, senior-dev, review, qa, merge, dev-rework). Dev has its
+        # own slot system (MAX_CONCURRENT_PRS) — that stays separate.
+        # Configure per-project via `pipeline.max_concurrent_handlers`,
+        # globally via top-level `max_concurrent_handlers`. Default: 1.
+        global_max_handlers = data.get("max_concurrent_handlers", 1)
+        pipeline = p.get("pipeline") or {}
+        print(f"MAX_CONCURRENT_HANDLERS='{sh(pipeline.get('max_concurrent_handlers', global_max_handlers))}'")
         # model: per-project override → global default_model → hardcoded fallback
         global_model = data.get("default_model") or "claude-sonnet-4-6"
         project_model = p.get("model") or global_model
@@ -106,7 +114,7 @@ PY
         return 1
     fi
     eval "$out"
-    export NAME REPO ROOT DEFAULT_BRANCH COMMIT_PREFIX DEV_VALIDATION_CMD QA_VALIDATION_CMD QA_BROWSER_URL QA_TIMEOUT_SECONDS HANDLER_TIMEOUT_SECONDS MERGE_STRATEGY AUTO_REBASE BACKEND MAX_CONCURRENT_PRS LOOP_AGENT_MODEL ALLOWED_AUTHORS WORKFLOW LOOP_LABEL_OVERRIDES _PROJECT_AGENT _PROJECT_MODEL _PROJECT_FALLBACK
+    export NAME REPO ROOT DEFAULT_BRANCH COMMIT_PREFIX DEV_VALIDATION_CMD QA_VALIDATION_CMD QA_BROWSER_URL QA_TIMEOUT_SECONDS HANDLER_TIMEOUT_SECONDS MERGE_STRATEGY AUTO_REBASE BACKEND MAX_CONCURRENT_PRS MAX_CONCURRENT_HANDLERS LOOP_AGENT_MODEL ALLOWED_AUTHORS WORKFLOW LOOP_LABEL_OVERRIDES _PROJECT_AGENT _PROJECT_MODEL _PROJECT_FALLBACK
 }
 
 # loop_list_slugs — print each project slug on its own line

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -301,8 +301,14 @@ _scan_issue_stage() {
         return
     fi
 
-    # Simple issue stage (e.g. po-handler)
+    # Simple issue stage (e.g. po-handler, senior-dev-handler).
+    # Cap new emits per tick at MAX_CONCURRENT_HANDLERS so a project with many
+    # ready issues doesn't fan out to N parallel handler runs every tick.
+    local _cap="${MAX_CONCURRENT_HANDLERS:-1}"
+    local _emitted=0
+    log "${event_type}: max=${_cap} (per-tick emit cap)"
     while IFS= read -r row; do
+        [ "$_emitted" -ge "$_cap" ] && break
         [ -z "$row" ] && continue
         local num title url author
         num=$(printf '%s' "$row"    | python3 -c "import json,sys; print(json.load(sys.stdin)['number'])")
@@ -321,6 +327,10 @@ _scan_issue_stage() {
         local evt
         evt=$(_emit_issue_event "$event_type" "$slug" "$repo" "$num" "$title" "$url")
         emit "$evt" "${event_type}:${slug}:${num}"
+        # Count attempts, not just fresh emits: a deduped ticket means its
+        # handler ran in the last 30 min and is likely still in flight, so
+        # it should consume a concurrency slot too.
+        _emitted=$(( _emitted + 1 ))
     done < <(backend_list_issues_with_label "$repo" "$trigger_label")
 }
 
@@ -428,7 +438,12 @@ _scan_pr_stage() {
         fi
     fi
 
+    # Cap new emits per tick at MAX_CONCURRENT_HANDLERS, same as _scan_issue_stage.
+    local _cap="${MAX_CONCURRENT_HANDLERS:-1}"
+    local _emitted=0
+    log "${event_type}: max=${_cap} (per-tick emit cap)"
     while IFS= read -r row; do
+        [ "$_emitted" -ge "$_cap" ] && break
         [ -z "$row" ] && continue
         local num title url
         num=$(printf '%s' "$row"   | python3 -c "import json,sys; print(json.load(sys.stdin)['number'])")
@@ -448,6 +463,7 @@ _scan_pr_stage() {
         evt=$(_emit_pr_event "$event_type" "$slug" "$repo" "$num" "$title" "$url" \
               "$rework_context_key" "$rework_context_val")
         emit "$evt" "${event_type}:${slug}:${num}"
+        _emitted=$(( _emitted + 1 ))
     done < <(backend_list_prs_with_label "$repo" "$trigger_label")
 }
 


### PR DESCRIPTION
## Summary

Adds a per-tick emit cap to all non-dev pipeline stages. Default **1**, configurable per-project.

## Why

Today the scanner emits one event per ready ticket every tick. \`dev\` has slot limiting via \`MAX_CONCURRENT_PRS\`, but every other stage was **unbounded**:

- \`po\`, \`senior-dev\` (issue stages)
- \`review\`, \`qa\`, \`merge\`, \`dev-rework\` (PR stages)

A project with, say, 12 \`needs-po\` issues would fan out to 12 parallel PO handler runs every scan tick, all burning tokens simultaneously. With opus-class models in the planner role (svv2014/loop#238), this is a real cost problem.

## What changes

- New env: \`MAX_CONCURRENT_HANDLERS\` (default \`1\`).
- Configure per-project: \`pipeline.max_concurrent_handlers: N\` in \`projects.yaml\`.
- Configure globally: top-level \`max_concurrent_handlers: N\` in \`projects.yaml\`.
- Applied to \`_scan_issue_stage\` (non-dev path) and \`_scan_pr_stage\`.

\`dev\`'s existing \`MAX_CONCURRENT_PRS\` is untouched — different mechanism (counts in-flight PRs, not emits-per-tick).

## Semantics: counts attempts, not fresh emits

If 5 tickets are ready and the cap is 2, the scanner stops after 2 — even if both happen to be deduped. Reason: a deduped ticket means its handler ran in the last 30 min and is likely still in flight, so it should consume a slot. Combined with the 30-min dedup window, this gives roughly "max N concurrent" semantics across overlapping windows.

## Example config

\`\`\`yaml
# global default
max_concurrent_handlers: 1

projects:
  - name: loop-monitor
    slug: loop-monitor
    pipeline:
      max_concurrent_handlers: 2   # bump for this project specifically
    dev:
      max_concurrent_prs: 3        # unrelated, unchanged
\`\`\`

## Test plan

- [x] \`bash -n lib/config.sh\` clean
- [x] \`bash -n scanner/scanner.sh\` clean
- [ ] Existing \`tests/scanner.bats\` still green
- [ ] Manual: project with 5 \`needs-po\` issues, default cap (1) → scan tick emits exactly 1; next tick (after 30 min dedup) emits the next 1
- [ ] Per-project override: bump \`pipeline.max_concurrent_handlers\` to 3 → scan tick emits 3
- [ ] Existing \`dev_issue\` slot logging still appears as before

## Rollback

Revert this PR. Behavior returns to unbounded emit-per-tick. No data migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)