### PR TITLE
[LOOP-247] include redacted error context in needs-clarification comment

### DIFF
--- a/lib/redact.sh
+++ b/lib/redact.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# lib/redact.sh — loop_redact_secrets: scrub credentials from text before posting.
+# Sourced by po-handler.sh. Safe to source multiple times.
+# Returns 1 (and prints nothing) when input is empty — callers should fail-closed.
+
+loop_redact_secrets() {
+    local text="$1"
+    [ -z "$text" ] && return 1
+    printf '%s' "$text" \
+      | sed -E 's/(ANTHROPIC_API_KEY|GH_TOKEN|GITHUB_TOKEN|OPENAI_API_KEY)=[^[:space:]'"'"'"]*/\1=[REDACTED]/g' \
+      | sed -E 's/Bearer [A-Za-z0-9._~+/=-]+/Bearer [REDACTED]/g' \
+      | sed -E 's/ghp_[A-Za-z0-9]+/[REDACTED-GH-PAT]/g' \
+      | sed -E 's/sk-[A-Za-z0-9_-]+/[REDACTED-OPENAI]/g' \
+      | sed -E "s|${HOME}|~|g; s|/Users/[^/[:space:]]+|~|g"
+}

--- a/scripts/po-handler.sh
+++ b/scripts/po-handler.sh
@@ -28,6 +28,8 @@ source "$LOOP_ROOT/lib/labels.sh"
 source "$LOOP_ROOT/lib/bounty.sh"
 # shellcheck source=../lib/notify.sh
 source "$LOOP_ROOT/lib/notify.sh"
+# shellcheck source=../lib/redact.sh
+source "$LOOP_ROOT/lib/redact.sh"
 # shellcheck source=../lib/cli-hint.sh
 source "$LOOP_ROOT/lib/cli-hint.sh"
 
@@ -117,13 +119,18 @@ backend_add_label "$REPO" "$ISSUE_NUM" in-progress
 
 # Safety net: restore the workflow PO trigger if killed or set -e fires before explicit cleanup.
 _IN_PROGRESS_CLAIMED=1
+_RUN_LOG=$(mktemp "/tmp/loop-po-run-${SLUG}-${ISSUE_NUM}-XXXX.log")
 _po_label_cleanup() {
     [ "${_IN_PROGRESS_CLAIMED:-0}" = "1" ] || return 0
     log "EXIT trap: clearing orphaned in-progress on #$ISSUE_NUM — restoring to ${_po_trigger}"
     backend_remove_label "$REPO" "$ISSUE_NUM" in-progress 2>/dev/null || true
     backend_add_label "$REPO" "$ISSUE_NUM" "$_po_trigger" 2>/dev/null || true
 }
-trap '_po_label_cleanup' EXIT TERM INT
+_po_exit_cleanup() {
+    _po_label_cleanup
+    rm -f "${_RUN_LOG:-}" 2>/dev/null || true
+}
+trap '_po_exit_cleanup' EXIT TERM INT
 
 ISSUE_BODY=$(backend_issue_view "$REPO" "$ISSUE_NUM" --json body --jq .body 2>/dev/null || echo "")
 
@@ -384,9 +391,36 @@ rm -f "$_PROMPT_FILE"
 
 _post_failure_comment() {
     local target_type="$1" target_num="$2" label_ctx="$3" _attempt="$4" max="$5"
-    # Post only a short marker — never the agent log/prompt, which contains
-    # internal pipeline instructions that must not become public.
-    local body="Automated ${label_ctx} failed ${max} times. Needs human clarification. Operator: see ${LOG_FILE} for the agent transcript."
+    local fallback_body="Automated ${label_ctx} failed ${max} times. Needs human clarification. Operator: see ${LOG_FILE} for the agent transcript."
+    local body="$fallback_body"
+    local run_log="${_RUN_LOG:-}"
+
+    if [ -n "$run_log" ] && [ -f "$run_log" ]; then
+        local tail_text redacted
+        tail_text=$(tail -n 50 "$run_log" 2>/dev/null || true)
+        redacted=$(loop_redact_secrets "$tail_text" 2>/dev/null) || redacted=""
+        if [ -n "$redacted" ]; then
+            local header full_body
+            header="Run: $(date -u +%FT%TZ) | model=${LOOP_PO_MODEL:-claude-opus-4-7} | project=${SLUG} | issue=#${ISSUE_NUM}"
+            full_body="${header}
+\`\`\`text
+${redacted}
+\`\`\`"
+            local max_bytes=60000
+            local body_len="${#full_body}"
+            if [ "$body_len" -gt "$max_bytes" ]; then
+                local excess=$(( body_len - max_bytes ))
+                local redacted_trimmed="${redacted:$excess}"
+                full_body="${header}
+\`\`\`text
+...truncated ${excess} chars...
+${redacted_trimmed}
+\`\`\`"
+            fi
+            body="$full_body"
+        fi
+    fi
+
     if [ "$target_type" = "issue" ]; then
         backend_comment_issue "$REPO" "$target_num" "$body" 2>/dev/null || true
     else
@@ -399,7 +433,7 @@ _post_failure_comment() {
 # `--model <id>`, scoped to this single call. Falls back to whatever the
 # orchestrator config says if the override is unset.
 export LOOP_AGENT_MODEL_OVERRIDE="${LOOP_PO_MODEL:-claude-opus-4-7}"
-if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
+if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE" | tee "$_RUN_LOG" >/dev/null; then
     _IN_PROGRESS_CLAIMED=0  # disarm trap — success path handles cleanup
     log "po agent succeeded for #$ISSUE_NUM"
     bounty_report "po_done" model="${LOOP_PO_MODEL:-claude-opus-4-7}" role=po project="$SLUG" issue_num="$ISSUE_NUM" || true

--- a/tests/po-redact.bats
+++ b/tests/po-redact.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+# tests/po-redact.bats — unit tests for loop_redact_secrets and the
+# comment-truncation logic used by po-handler's _post_failure_comment.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    # shellcheck source=../lib/redact.sh
+    source "$REPO_ROOT/lib/redact.sh"
+    export HOME="${HOME:-/Users/operator}"
+}
+
+# ---------------------------------------------------------------------------
+# loop_redact_secrets — credential patterns
+# ---------------------------------------------------------------------------
+
+@test "redactor: strips ANTHROPIC_API_KEY= value" {
+    local input="ANTHROPIC_API_KEY=sk-ant-api03-abc123xyz output follows"
+    local out
+    out=$(loop_redact_secrets "$input")
+    [[ "$out" == *"ANTHROPIC_API_KEY=[REDACTED]"* ]]
+    [[ "$out" != *"sk-ant-api03-abc123xyz"* ]]
+}
+
+@test "redactor: strips GH_TOKEN= value" {
+    local input="GH_TOKEN=ghs_sometoken rest of line"
+    local out
+    out=$(loop_redact_secrets "$input")
+    [[ "$out" == *"GH_TOKEN=[REDACTED]"* ]]
+    [[ "$out" != *"ghs_sometoken"* ]]
+}
+
+@test "redactor: strips GITHUB_TOKEN= value" {
+    local input="export GITHUB_TOKEN=ghp_abc123def456 extra"
+    local out
+    out=$(loop_redact_secrets "$input")
+    [[ "$out" == *"GITHUB_TOKEN=[REDACTED]"* ]]
+}
+
+@test "redactor: strips OPENAI_API_KEY= value" {
+    local input="OPENAI_API_KEY=sk-openai-secret stuff"
+    local out
+    out=$(loop_redact_secrets "$input")
+    [[ "$out" == *"OPENAI_API_KEY=[REDACTED]"* ]]
+    [[ "$out" != *"sk-openai-secret"* ]]
+}
+
+@test "redactor: strips ghp_ PAT" {
+    local input="token ghp_AbCdEfGhIjKlMnOpQrSt found in output"
+    local out
+    out=$(loop_redact_secrets "$input")
+    [[ "$out" == *"[REDACTED-GH-PAT]"* ]]
+    [[ "$out" != *"ghp_AbCdEfGhIjKlMnOpQrSt"* ]]
+}
+
+@test "redactor: strips Bearer token" {
+    local input="Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+    local out
+    out=$(loop_redact_secrets "$input")
+    [[ "$out" == *"Bearer [REDACTED]"* ]]
+    [[ "$out" != *"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"* ]]
+}
+
+@test "redactor: strips sk- OpenAI key" {
+    local input="key=sk-abc123-def456 used"
+    local out
+    out=$(loop_redact_secrets "$input")
+    [[ "$out" == *"[REDACTED-OPENAI]"* ]]
+    [[ "$out" != *"sk-abc123-def456"* ]]
+}
+
+@test "redactor: passes plain text through unchanged" {
+    local input="No secrets here. Just a normal log line with words and numbers 42."
+    local out
+    out=$(loop_redact_secrets "$input")
+    [ "$out" = "$input" ]
+}
+
+@test "redactor: returns non-zero and prints nothing for empty input" {
+    local out rc=0
+    out=$(loop_redact_secrets "" 2>/dev/null) || rc=$?
+    [ "$rc" -ne 0 ]
+    [ -z "$out" ]
+}
+
+@test "redactor: replaces absolute /Users/ home paths with ~" {
+    local input="Running from /Users/operator/projects/loop"
+    local out
+    out=$(loop_redact_secrets "$input")
+    [[ "$out" == *"~"* ]]
+    [[ "$out" != *"/Users/operator"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Truncation logic (mirrors _post_failure_comment in po-handler.sh)
+# ---------------------------------------------------------------------------
+
+@test "truncation: drops front of text when assembled body exceeds 60000 bytes" {
+    # Build a string longer than 60000 bytes
+    local big_content
+    big_content=$(python3 -c "print('x' * 61000, end='')")
+    local content_len="${#big_content}"
+    [ "$content_len" -ge 61000 ]
+
+    local max_bytes=60000
+    local body_len="$content_len"
+
+    [ "$body_len" -gt "$max_bytes" ]
+
+    local excess=$(( body_len - max_bytes ))
+    local trimmed="${big_content:$excess}"
+    local result="...truncated ${excess} chars...
+${trimmed}"
+
+    # Truncation marker present
+    [[ "$result" == "...truncated "* ]]
+    # Content is shorter than original
+    [ "${#trimmed}" -lt "$content_len" ]
+    # Trimmed length equals expected remainder
+    [ "${#trimmed}" -eq $(( content_len - excess )) ]
+}
+
+@test "truncation: content within 60000 bytes is not truncated" {
+    local small_content
+    small_content=$(python3 -c "print('y' * 1000, end='')")
+
+    local max_bytes=60000
+    local body_len="${#small_content}"
+
+    [ "$body_len" -le "$max_bytes" ]
+
+    # No truncation should happen
+    local result="$small_content"
+    [[ "$result" != *"...truncated"* ]]
+    [ "${#result}" -eq "$body_len" ]
+}


### PR DESCRIPTION
Closes #247

## Changes

**`lib/redact.sh`** (new)
- Adds `loop_redact_secrets` helper that strips credentials (`ANTHROPIC_API_KEY=`, `GH_TOKEN=`, `GITHUB_TOKEN=`, `OPENAI_API_KEY=`, `Bearer <token>`, `ghp_*`, `sk-*`) and replaces absolute home paths with `~`. Returns non-zero on empty input so callers can fail-closed.

**`scripts/po-handler.sh`**
- Sources `lib/redact.sh`
- Creates `_RUN_LOG=$(mktemp ...)` per-invocation temp file before the trap
- Replaces the single `_po_label_cleanup` trap with a combined `_po_exit_cleanup` that calls `_po_label_cleanup` then removes `_RUN_LOG`
- Chains the `loop_run_agent` tee pipeline to also write to `_RUN_LOG`: `| tee -a "$LOG_FILE" | tee "$_RUN_LOG" >/dev/null`
- Enriches `_post_failure_comment` to read `tail -n 50` of `_RUN_LOG`, redact it, and post a fenced `\`\`\`text` block with a `Run: <timestamp> | model=… | project=… | issue=#…` header. Truncates from the front if the assembled body exceeds 60 000 bytes. Falls back to the original short-marker comment if the log is missing or redaction returns empty/non-zero.
- Existing Signal notifications (`loop_notify` + `loop_notify_human_required`) are unchanged.

**`tests/po-redact.bats`** (new)
- 12 tests: redaction of each credential pattern, plain-text passthrough, empty-input fail-closed, home-path replacement, truncation behaviour (exceeds vs fits within 60 000 bytes).

## Test Plan
- `bash -n` clean on all lib/scripts/scanner — verified locally
- `shellcheck -S warning` clean — verified locally
- `bats tests/po-redact.bats` — 12/12 pass
- `bats tests/handlers.bats` — same pass/fail as `main` baseline (3 pre-existing failures unrelated to this change)