### PR TITLE
[LOOP-245] Distinguish transient infra failures from spec failures in PO handler

### DIFF
--- a/docs/failure-handling.md
+++ b/docs/failure-handling.md
@@ -1,0 +1,107 @@
+# Failure Handling in Loop Handlers
+
+## Failure Classes
+
+Loop distinguishes two classes of handler failure:
+
+### Transient (Infra) Failures
+
+Caused by infrastructure problems, not by the issue spec itself. The ticket
+should not be penalised — the problem needs operator attention.
+
+**Recognised signatures:**
+
+| Pattern | Origin |
+|---|---|
+| `ImportError` / `ModuleNotFoundError` | Python dependency missing in orchestrator |
+| `ConnectionError` / `ConnectionRefusedError` | Orchestrator or model API unreachable |
+| `TimeoutError` | Network or model API timeout |
+| HTTP `429` | Model API rate limit |
+| HTTP `5xx` | Model API server error |
+| `rate limit`, `timeout`, `connection refused`, `econnreset`, `service unavailable` | Generic network / auth signals (via `_loop_is_recoverable`) |
+| `401`, `403 auth` | Authentication failure |
+
+Classification is provided by `lib/failure_classifier.sh`:
+
+```bash
+source "$LOOP_ROOT/lib/failure_classifier.sh"
+if loop_is_transient_failure "$stderr_tail" "$exit_code"; then
+    sig=$(loop_failure_signature "$stderr_tail")
+    ...
+fi
+```
+
+### Non-Transient (Spec) Failures
+
+All other failures — bad spec, agent logic error, unexpected output format.
+These are counted against the per-issue retry counter and eventually trigger
+`needs-clarification`.
+
+---
+
+## Counter Files
+
+Two separate counter files exist per issue in the PO handler:
+
+| File | Purpose |
+|---|---|
+| `/tmp/loop-po-retries-<slug>-<issue>` | Non-transient failure count |
+| `/tmp/loop-po-transient-<slug>-<issue>` | Consecutive transient failure count |
+
+The transient counter is reset to zero on any successful run or when the issue
+is escalated to `blocked`. The retry counter is managed independently.
+
+---
+
+## PO Handler Behaviour
+
+### Transient failure path
+
+1. Handler captures runner stderr to a temp file.
+2. On non-zero exit, `loop_is_transient_failure` inspects the last 50 lines.
+3. If transient:
+   - The **retry counter is NOT incremented**.
+   - The transient counter is incremented.
+   - If transient count < `MAX_TRANSIENT_RETRIES` (default 3):
+     - Restores the PO trigger label so the scanner re-emits next tick.
+   - If transient count ≥ `MAX_TRANSIENT_RETRIES`:
+     - Labels the issue `blocked` (not `needs-clarification`).
+     - Calls `loop_notify_human_required` with `"infra: <signature>"`.
+     - Clears the transient counter.
+
+### Non-transient failure path
+
+Unchanged from prior behaviour:
+1. Retry counter incremented.
+2. If count < `MAX_RETRIES` (default 2): restores PO trigger for next attempt.
+3. If count ≥ `MAX_RETRIES`: labels issue `needs-clarification` and notifies.
+
+---
+
+## Operator Escalation Path
+
+When a `blocked` label appears with reason `infra: <signature>`, the operator
+should:
+
+1. Check `~/.loop/logs/loop-po-handler.log` for the full stderr tail.
+2. Fix the underlying infrastructure issue (install missing Python module,
+   rotate API keys, check model API status).
+3. Remove the `blocked` label and re-add the PO trigger label to re-queue.
+
+Example (GitHub):
+
+```bash
+gh issue edit <number> --repo <repo> --remove-label blocked --add-label loop.po_review
+```
+
+---
+
+## Adding Transient Classification to Other Handlers
+
+The same pattern can be applied to `dev-handler.sh`, `qa-handler.sh`, etc. by:
+
+1. Sourcing `lib/failure_classifier.sh` (which requires `lib/runner.sh` sourced first).
+2. Redirecting runner stderr to a temp file.
+3. Calling `loop_is_transient_failure` on the tail and branching accordingly.
+
+See `scripts/po-handler.sh` for the reference implementation.

--- a/lib/failure_classifier.sh
+++ b/lib/failure_classifier.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# lib/failure_classifier.sh — classify handler failures as transient (infra)
+# or non-transient (spec/logic).
+#
+# Transient: Python ImportError/ModuleNotFoundError/ConnectionError/TimeoutError,
+# plus anything _loop_is_recoverable already matches (auth, rate-limit, 5xx,
+# network).  These should NOT burn the per-issue retry counter.
+#
+# Non-transient: everything else (RuntimeError, bad spec, agent logic failure).
+#
+# Usage:
+#   source "$LOOP_ROOT/lib/failure_classifier.sh"
+#   if loop_is_transient_failure "$stderr_text" "$exit_code"; then ...
+#   sig=$(loop_failure_signature "$stderr_text")
+
+# Requires lib/runner.sh to be sourced first (for _loop_is_recoverable).
+
+# loop_is_transient_failure <stderr_text> <exit_code>
+# Returns 0 (true) for transient infra failures, 1 (false) otherwise.
+loop_is_transient_failure() {
+    local text="$1"
+    local rc="${2:-1}"
+    [ "$rc" -eq 0 ] && return 1
+    [ -z "$text" ] && return 1
+    _loop_is_recoverable "$text" && return 0
+    echo "$text" | grep -qE '(ImportError|ModuleNotFoundError|ConnectionError|TimeoutError|ConnectionRefusedError)' && return 0
+    return 1
+}
+
+# loop_failure_signature <stderr_text>
+# Extracts and prints a short signature token from the stderr text (first match).
+# Returns empty string if no known pattern is found.
+loop_failure_signature() {
+    local text="$1"
+    echo "$text" | grep -oE '(ImportError|ModuleNotFoundError|ConnectionError|TimeoutError|429|5[0-9]{2}|rate limit|timeout)' | head -1
+}

--- a/scripts/po-handler.sh
+++ b/scripts/po-handler.sh
@@ -32,9 +32,12 @@ source "$LOOP_ROOT/lib/notify.sh"
 source "$LOOP_ROOT/lib/redact.sh"
 # shellcheck source=../lib/cli-hint.sh
 source "$LOOP_ROOT/lib/cli-hint.sh"
+# shellcheck source=../lib/failure_classifier.sh
+source "$LOOP_ROOT/lib/failure_classifier.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-po-handler.log"
 MAX_RETRIES=2
+MAX_TRANSIENT_RETRIES="${MAX_TRANSIENT_RETRIES:-3}"
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [po-handler] $*" | tee -a "$LOG_FILE"; }
 
@@ -97,6 +100,11 @@ RETRY_FILE="/tmp/loop-po-retries-${SLUG}-${ISSUE_NUM}"
 retry_count() { [ -f "$RETRY_FILE" ] && cat "$RETRY_FILE" || echo 0; }
 retry_incr()  { local n; n=$(( $(retry_count) + 1 )); echo "$n" > "$RETRY_FILE"; echo "$n"; }
 retry_clear() { rm -f "$RETRY_FILE"; }
+
+TRANSIENT_FILE="/tmp/loop-po-transient-${SLUG}-${ISSUE_NUM}"
+transient_count() { [ -f "$TRANSIENT_FILE" ] && cat "$TRANSIENT_FILE" || echo 0; }
+transient_incr()  { local n; n=$(( $(transient_count) + 1 )); echo "$n" > "$TRANSIENT_FILE"; echo "$n"; }
+transient_clear() { rm -f "$TRANSIENT_FILE"; }
 
 retries=$(retry_count)
 if [ "$retries" -ge "$MAX_RETRIES" ] \
@@ -446,6 +454,7 @@ if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE" | tee "$_RUN_
     bounty_report "po_done" model="${LOOP_PO_MODEL:-claude-opus-4-7}" role=po project="$SLUG" issue_num="$ISSUE_NUM" || true
     loop_notify "✅ [$SLUG] #$ISSUE_NUM ${LOOP_LABEL_DEPRECATED_PO_REVIEW} done"
     retry_clear
+    transient_clear
     backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
     # Belt-and-braces: if agent forgot to apply progression label, add 'dev' as safe default.
     if ! backend_issue_has_any_label "$REPO" "$ISSUE_NUM" dev needs-clarification blocked tracker 'done'; then
@@ -453,19 +462,39 @@ if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE" | tee "$_RUN_
         backend_add_label "$REPO" "$ISSUE_NUM" dev
     fi
 else
+    _agent_rc=$?
+    _stderr_tail=$(tail -n 50 "$_RUN_LOG" 2>/dev/null || echo "")
     _IN_PROGRESS_CLAIMED=0  # disarm trap — failure path handles cleanup
-    n=$(retry_incr)
-    log "po agent failed for #$ISSUE_NUM (attempt $n/$MAX_RETRIES)"
-    bounty_report "po_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=po project="$SLUG" issue_num="$ISSUE_NUM" detail="attempt ${n}/${MAX_RETRIES}" || true
-    if [ "$n" -ge "$MAX_RETRIES" ]; then
-        backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
-        backend_add_label "$REPO" "$ISSUE_NUM" needs-clarification
-        _post_failure_comment issue "$ISSUE_NUM" "PO agent" "$n" "$MAX_RETRIES"
-        loop_notify "❌ [$SLUG] #$ISSUE_NUM ${LOOP_LABEL_DEPRECATED_PO_REVIEW} failed: agent failed after $MAX_RETRIES attempts"
-        loop_notify_human_required "$SLUG" "$ISSUE_NUM" needs-clarification "PO agent failed after $MAX_RETRIES attempts"
+
+    if loop_is_transient_failure "$_stderr_tail" "$_agent_rc"; then
+        _sig=$(loop_failure_signature "$_stderr_tail")
+        _tc=$(transient_incr)
+        log "po agent transient failure for #$ISSUE_NUM (transient attempt $_tc/$MAX_TRANSIENT_RETRIES, sig: ${_sig:-unknown})"
+        bounty_report "po_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=po project="$SLUG" issue_num="$ISSUE_NUM" detail="transient ${_tc}/${MAX_TRANSIENT_RETRIES} sig:${_sig:-unknown}" || true
+        if [ "$_tc" -ge "$MAX_TRANSIENT_RETRIES" ]; then
+            backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
+            backend_add_label "$REPO" "$ISSUE_NUM" blocked
+            loop_notify "🔴 [$SLUG] #$ISSUE_NUM ${LOOP_LABEL_DEPRECATED_PO_REVIEW} blocked: infra failure after $MAX_TRANSIENT_RETRIES transient attempts (${_sig:-unknown})"
+            loop_notify_human_required "$SLUG" "$ISSUE_NUM" blocked "infra: ${_sig:-unknown}"
+            transient_clear
+        else
+            backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
+            backend_add_label "$REPO" "$ISSUE_NUM" "$_po_trigger"
+        fi
     else
-        backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
-        backend_add_label "$REPO" "$ISSUE_NUM" "$_po_trigger"
+        n=$(retry_incr)
+        log "po agent failed for #$ISSUE_NUM (attempt $n/$MAX_RETRIES)"
+        bounty_report "po_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=po project="$SLUG" issue_num="$ISSUE_NUM" detail="attempt ${n}/${MAX_RETRIES}" || true
+        if [ "$n" -ge "$MAX_RETRIES" ]; then
+            backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
+            backend_add_label "$REPO" "$ISSUE_NUM" needs-clarification
+            _post_failure_comment issue "$ISSUE_NUM" "PO agent" "$n" "$MAX_RETRIES"
+            loop_notify "❌ [$SLUG] #$ISSUE_NUM ${LOOP_LABEL_DEPRECATED_PO_REVIEW} failed: agent failed after $MAX_RETRIES attempts"
+            loop_notify_human_required "$SLUG" "$ISSUE_NUM" needs-clarification "PO agent failed after $MAX_RETRIES attempts"
+        else
+            backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
+            backend_add_label "$REPO" "$ISSUE_NUM" "$_po_trigger"
+        fi
     fi
     exit 1
 fi

--- a/tests/failure_classifier.bats
+++ b/tests/failure_classifier.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+# tests/failure_classifier.bats — unit tests for lib/failure_classifier.sh.
+#
+# No real network or CLI required. _loop_is_recoverable is stubbed.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    # Stub _loop_is_recoverable (normally comes from lib/runner.sh).
+    # Returns 0 when text matches known recovery signals (401, 429, 5xx, etc.).
+    _loop_is_recoverable() {
+        local text="$1"
+        echo "$text" | grep -qiE \
+            '(\b401\b|403[^0-9]*auth|auth[^0-9]*403|\b429\b|[^0-9]5[0-9]{2}[^0-9]|rate limit|timeout|connection refused|econnreset|service unavailable)'
+    }
+    export -f _loop_is_recoverable 2>/dev/null || true
+
+    # shellcheck source=../lib/failure_classifier.sh
+    source "$REPO_ROOT/lib/failure_classifier.sh"
+}
+
+teardown() {
+    unset -f _loop_is_recoverable 2>/dev/null || true
+}
+
+# ─── loop_is_transient_failure ────────────────────────────────────────────────
+
+@test "ImportError → transient (returns 0)" {
+    run loop_is_transient_failure "Traceback: ImportError: No module named foo" 1
+    [ "$status" -eq 0 ]
+}
+
+@test "ModuleNotFoundError → transient (returns 0)" {
+    run loop_is_transient_failure "ModuleNotFoundError: No module named 'providers.session_manager'" 1
+    [ "$status" -eq 0 ]
+}
+
+@test "ConnectionError → transient (returns 0)" {
+    run loop_is_transient_failure "ConnectionError: failed to connect to api.example.com" 1
+    [ "$status" -eq 0 ]
+}
+
+@test "TimeoutError → transient (returns 0)" {
+    run loop_is_transient_failure "TimeoutError: operation timed out after 30s" 1
+    [ "$status" -eq 0 ]
+}
+
+@test "ConnectionRefusedError → transient (returns 0)" {
+    run loop_is_transient_failure "ConnectionRefusedError: [Errno 111] Connection refused" 1
+    [ "$status" -eq 0 ]
+}
+
+@test "_loop_is_recoverable match (rate limit) → transient (returns 0)" {
+    run loop_is_transient_failure "error: rate limit exceeded, retry later" 1
+    [ "$status" -eq 0 ]
+}
+
+@test "_loop_is_recoverable match (429) → transient (returns 0)" {
+    run loop_is_transient_failure "HTTP 429 Too Many Requests" 1
+    [ "$status" -eq 0 ]
+}
+
+@test "plain RuntimeError: bad spec → non-transient (returns 1)" {
+    run loop_is_transient_failure "RuntimeError: bad spec — missing acceptance criteria" 1
+    [ "$status" -eq 1 ]
+}
+
+@test "exit-code 0 → non-transient regardless of text (sanity check)" {
+    run loop_is_transient_failure "ImportError: something" 0
+    [ "$status" -eq 1 ]
+}
+
+@test "empty stderr → non-transient (returns 1)" {
+    run loop_is_transient_failure "" 1
+    [ "$status" -eq 1 ]
+}
+
+# ─── loop_failure_signature ───────────────────────────────────────────────────
+
+@test "loop_failure_signature extracts ImportError" {
+    run loop_failure_signature "Traceback: ImportError: No module named foo"
+    [ "$status" -eq 0 ]
+    [ "$output" = "ImportError" ]
+}
+
+@test "loop_failure_signature extracts 429" {
+    run loop_failure_signature "HTTP 429 Too Many Requests"
+    [ "$status" -eq 0 ]
+    [ "$output" = "429" ]
+}
+
+@test "loop_failure_signature returns empty for unknown text" {
+    run loop_failure_signature "SyntaxError: unexpected token at line 42"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}


### PR DESCRIPTION
Closes #245

## Changes

**`lib/failure_classifier.sh`** (new)
- `loop_is_transient_failure <text> <exit_code>`: returns 0 for Python import/connection/timeout errors and all `_loop_is_recoverable` patterns (auth, rate-limit, 5xx). Returns 1 for spec failures or exit-code 0.
- `loop_failure_signature <text>`: extracts a short token (e.g. `ImportError`, `429`) for operator messages.
- Wraps `_loop_is_recoverable` from `lib/runner.sh` without modifying it.

**`scripts/po-handler.sh`** (modified)
- Sources `lib/failure_classifier.sh` and adds `MAX_TRANSIENT_RETRIES` (default 3).
- Runner output (stdout+stderr merged via `_RUN_LOG`) is used to detect transient signatures.
- On non-zero runner exit, inspects the last 50 lines of `_RUN_LOG`:
  - **Transient**: increments `/tmp/loop-po-transient-<slug>-<issue>` (separate from retry counter). If below threshold, restores PO trigger for next scan tick. At threshold, labels `blocked`, calls `loop_notify_human_required` with `"infra: <sig>"`, and clears the transient counter.
  - **Non-transient**: existing path — increments retry counter, eventually `needs-clarification`.

**`tests/failure_classifier.bats`** (new)
- 13 tests covering: ImportError, ModuleNotFoundError, ConnectionError, TimeoutError, ConnectionRefusedError, rate-limit, 429 → transient; RuntimeError, exit-0, empty stderr → non-transient; signature extraction for ImportError and 429.

**`docs/failure-handling.md`** (new)
- Documents the two failure classes, recognised signatures, counter files, PO handler flow, operator escalation path, and how to extend the pattern to other handlers.

## Test Plan
- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — all pass
- `shellcheck -S warning lib/failure_classifier.sh scripts/po-handler.sh` — clean
- No personal identifiers in committed files
- `tests/failure_classifier.bats` covers all AC-specified cases