### PR TITLE
feat: PR auto-rework watchdog

### DIFF
--- a/scripts/_watchdog_filter.py
+++ b/scripts/_watchdog_filter.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Filter `gh pr list --json ...` output to PRs that need rework.
+
+Reads JSON array from stdin (output of `gh pr list ... --json
+number,author,labels,mergeable,statusCheckRollup,createdAt,updatedAt`),
+prints `<num>\\t<reason>` lines for PRs that match the auto-rework rules.
+
+Rules — emit a PR if ALL of these hold:
+  - author.login is in --allowed-authors (comma-separated)
+  - none of {needs-rework, blocked, needs-clarification} on the labels
+  - either:
+      mergeable == CONFLICTING and updatedAt older than --conflict-grace seconds, or
+      any statusCheckRollup entry has conclusion == FAILURE and updatedAt older
+        than --ci-grace seconds
+
+`updatedAt` is used as a proxy for "how long has this been in its current bad
+state". It's not perfect — a comment on the PR resets it — but it's the
+cheapest signal that doesn't require additional API calls per PR.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+
+EXCLUDE_LABELS = {"needs-rework", "blocked", "needs-clarification"}
+
+
+def parse_iso(ts: str) -> datetime:
+    if ts.endswith("Z"):
+        ts = ts[:-1] + "+00:00"
+    return datetime.fromisoformat(ts)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--conflict-grace", type=int, required=True)
+    ap.add_argument("--ci-grace", type=int, required=True)
+    ap.add_argument("--allowed-authors", required=True, help="comma-separated")
+    args = ap.parse_args()
+
+    allowed = {a.strip() for a in args.allowed_authors.split(",") if a.strip()}
+    if not allowed:
+        return 0
+
+    try:
+        prs = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    now = datetime.now(timezone.utc)
+
+    for pr in prs:
+        author_login = (pr.get("author") or {}).get("login", "")
+        if author_login not in allowed:
+            continue
+
+        labels = {(l.get("name") or "") for l in pr.get("labels") or []}
+        if labels & EXCLUDE_LABELS:
+            continue
+
+        try:
+            updated_age = (now - parse_iso(pr["updatedAt"])).total_seconds()
+        except (KeyError, ValueError):
+            continue
+
+        reason = None
+
+        # Conflict path
+        if pr.get("mergeable") == "CONFLICTING" and updated_age >= args.conflict_grace:
+            reason = f"conflict for {int(updated_age)}s"
+
+        # CI failure path
+        if reason is None:
+            for chk in pr.get("statusCheckRollup") or []:
+                if chk.get("conclusion") == "FAILURE" and updated_age >= args.ci_grace:
+                    name = chk.get("name") or chk.get("workflowName") or "ci"
+                    reason = f"ci failure ({name}) for {int(updated_age)}s"
+                    break
+
+        if reason:
+            print(f"{pr['number']}\t{reason}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/com.user.loop-pr-watchdog.plist.template
+++ b/scripts/com.user.loop-pr-watchdog.plist.template
@@ -4,9 +4,9 @@
 <!--
   loop-pr-watchdog launchd template.
 
-  Install:
+  Install (LOOP_LOG_DIR must be set, e.g. via your loop.env):
     sed "s|@LOOP_ROOT@|$(cd "$(dirname "$0")/.." && pwd)|g; \
-         s|@LOG_DIR@|${LOOP_LOG_DIR:-/Users/$USER/.openclaw/workspace/logs/loop}|g" \
+         s|@LOG_DIR@|$LOOP_LOG_DIR|g" \
         scripts/com.user.loop-pr-watchdog.plist.template \
         > ~/Library/LaunchAgents/com.user.loop-pr-watchdog.plist
     launchctl load ~/Library/LaunchAgents/com.user.loop-pr-watchdog.plist
@@ -33,8 +33,6 @@
     <string>@LOG_DIR@/loop-pr-watchdog.log</string>
     <key>EnvironmentVariables</key>
     <dict>
-        <key>HOME</key>
-        <string>/Users/CHANGE_ME</string>
         <key>PATH</key>
         <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
     </dict>

--- a/scripts/com.user.loop-pr-watchdog.plist.template
+++ b/scripts/com.user.loop-pr-watchdog.plist.template
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-pr-watchdog launchd template.
+
+  Install:
+    sed "s|@LOOP_ROOT@|$(cd "$(dirname "$0")/.." && pwd)|g; \
+         s|@LOG_DIR@|${LOOP_LOG_DIR:-/Users/$USER/.openclaw/workspace/logs/loop}|g" \
+        scripts/com.user.loop-pr-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-pr-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-pr-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-pr-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-pr-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-pr-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>@LOOP_ROOT@/scripts/pr-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StartInterval</key>
+    <integer>900</integer>
+    <key>StandardOutPath</key>
+    <string>@LOG_DIR@/loop-pr-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>@LOG_DIR@/loop-pr-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/CHANGE_ME</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/pr-watchdog.sh
+++ b/scripts/pr-watchdog.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# pr-watchdog.sh — auto-rework stale loop-authored PRs.
+#
+# Polls every project's open PRs and labels them `needs-rework` if they are:
+#   - authored by an account in ALLOWED_AUTHORS (per-project, from projects.yaml), and
+#   - sitting with a merge conflict for >CONFLICT_GRACE_SECONDS, or
+#   - failing CI for >CI_GRACE_SECONDS,
+#   - and don't already carry needs-rework / blocked / needs-clarification.
+#
+# Designed to run every ~15 min via launchd / cron. The dev-rework handler
+# downstream picks up the label and rebases + fixes.
+#
+# Flags:
+#   --dry-run   list what would be relabeled, don't touch GH
+#   --once      single sweep (default; loop-mode is for future use)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+# shellcheck source=../lib/config.sh
+source "$LOOP_ROOT/lib/config.sh"
+# shellcheck source=../lib/backends/backend.sh
+source "$LOOP_ROOT/lib/backends/backend.sh"
+
+CONFLICT_GRACE_SECONDS="${LOOP_WATCHDOG_CONFLICT_GRACE:-900}"   # 15 min
+CI_GRACE_SECONDS="${LOOP_WATCHDOG_CI_GRACE:-1800}"              # 30 min
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        --once)    : ;;  # default behavior; reserved
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [pr-watchdog] $*"; }
+
+log "tick start (conflict-grace=${CONFLICT_GRACE_SECONDS}s ci-grace=${CI_GRACE_SECONDS}s dry-run=${DRY_RUN})"
+
+# Walk every project. loop_load_project sets REPO and ALLOWED_AUTHORS.
+while IFS= read -r slug; do
+    [ -z "$slug" ] && continue
+    if ! loop_load_project "$slug" 2>/dev/null; then
+        log "skip $slug (load failed)"
+        continue
+    fi
+    if [ -z "${ALLOWED_AUTHORS:-}" ]; then
+        log "skip $slug (ALLOWED_AUTHORS empty — gate disabled)"
+        continue
+    fi
+
+    # One JSON dump per repo, piped to filter.
+    local_payload=$(gh pr list --repo "$REPO" --state open --limit 50 \
+        --json number,author,labels,mergeable,statusCheckRollup,createdAt,updatedAt \
+        2>/dev/null || echo "[]")
+
+    while IFS=$'\t' read -r num reason; do
+        [ -z "$num" ] && continue
+        if $DRY_RUN; then
+            log "DRY $slug #$num would-rework: $reason"
+            continue
+        fi
+        log "rework $slug #$num: $reason"
+        if backend_add_label "$REPO" "$num" needs-rework 2>/dev/null; then
+            loop_notify "🛠 [$slug] PR #$num auto-rework: $reason" || true
+        else
+            log "WARN: failed to add label to $slug #$num"
+        fi
+    done < <(printf '%s' "$local_payload" | python3 "$LOOP_ROOT/scripts/_watchdog_filter.py" \
+            --conflict-grace "$CONFLICT_GRACE_SECONDS" \
+            --ci-grace "$CI_GRACE_SECONDS" \
+            --allowed-authors "$ALLOWED_AUTHORS")
+done < <(loop_list_slugs)
+
+log "tick done"


### PR DESCRIPTION
## Summary

Adds \`scripts/pr-watchdog.sh\` + \`_watchdog_filter.py\` — a poll loop that scans every tracked project's open PRs and labels stale loop-authored ones \`needs-rework\` so the dev-rework handler can rebase them automatically.

## Why

Tonight, 8 loop-authored PRs branched off the same commit. The first merge produced merge conflicts on the other 7. Nobody labeled them \`needs-rework\`, so they sat for hours until I manually relabeled them. This is the **single biggest stability gap** observed across two recent operating sessions.

## Detection rule

A PR is auto-relabeled \`needs-rework\` when ALL of:
- author is in the project's \`ALLOWED_AUTHORS\` list (already exported by \`lib/config.sh\`)
- does NOT already carry \`needs-rework\` / \`blocked\` / \`needs-clarification\`
- *either*: \`mergeable=CONFLICTING\` for >\`LOOP_WATCHDOG_CONFLICT_GRACE\` (default 900s / 15 min)
- *or*: any CI check has \`conclusion=FAILURE\` for >\`LOOP_WATCHDOG_CI_GRACE\` (default 1800s / 30 min)

## Files

- **NEW** \`scripts/pr-watchdog.sh\` — driver
- **NEW** \`scripts/_watchdog_filter.py\` — JSON parser + grace-period math
- **NEW** \`scripts/com.user.loop-pr-watchdog.plist.template\` — launchd template (15 min cadence)

## Author safety

\`ALLOWED_AUTHORS\` (already used by scanner — \`scanner/scanner.sh:212-224\`) is required. When empty, watchdog skips that project entirely.

## Local dry-run output

\`\`\`
[pr-watchdog] DRY ppl #443 would-rework: ci failure (qa) for 554030s
[pr-watchdog] DRY pa-scanner #42 would-rework: conflict for 601402s
[pr-watchdog] DRY boba-event #63 would-rework: ci failure (lint) for 24508s
[pr-watchdog] DRY boba-event #58 would-rework: ci failure (lint) for 733370s
\`\`\`

These are stale PRs the watchdog would unstick.

## Test plan

- [x] \`bash -n\` + python ast.parse clean
- [x] dry-run returns sensible candidates
- [ ] Post-merge: install plist, verify one tick relabels a known-stuck PR

## Rollback

Revert PR. \`launchctl unload\` the plist. No persistent state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)