### PR TITLE
feat(scanner): daily handler-time budget with auto-pause

### DIFF
--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -94,7 +94,23 @@ dispatch_direct() {
         *) log "WARN: no handler for event type '$event_type'"; return 1 ;;
     esac
     local effective_timeout="${HANDLER_TIMEOUT_SECONDS:-$HANDLER_TIMEOUT}"
-    LOOP_EVENT_JSON="$json" nohup timeout "$effective_timeout" "$handler" >> "$LOOP_LOG_DIR/loop-scanner.log" 2>&1 &
+    # Wrap with the budget tally helper so each handler's wall-clock time is
+    # accumulated into /tmp/loop-budget-YYYYMMDD.counter. Wrapper exits with
+    # the handler's exit code so timeout(1) and scanner behavior are unchanged.
+    LOOP_EVENT_JSON="$json" nohup timeout "$effective_timeout" \
+        "$LOOP_ROOT/scripts/_handler_with_budget.sh" "$handler" \
+        >> "$LOOP_LOG_DIR/loop-scanner.log" 2>&1 &
+}
+
+# _budget_exceeded — returns 0 (true) if today's accumulated handler-seconds
+# meet or exceed LOOP_DAILY_HANDLER_BUDGET_SECONDS. Empty/unset env var =
+# disabled (always returns 1).
+_budget_exceeded() {
+    [ -n "${LOOP_DAILY_HANDLER_BUDGET_SECONDS:-}" ] || return 1
+    local f="/tmp/loop-budget-$(date +%Y%m%d).counter"
+    local spent
+    spent=$(cat "$f" 2>/dev/null || echo 0)
+    [ "$spent" -ge "$LOOP_DAILY_HANDLER_BUDGET_SECONDS" ]
 }
 
 acquire_lock() {
@@ -469,6 +485,17 @@ _scan_pr_stage() {
 
 scan_project() {
     local slug="$1"
+
+    # Daily handler-time budget — if today's spend has met the cap, skip
+    # emitting new work entirely. In-flight handlers continue; only new
+    # dispatches are paused until the next day rolls over.
+    if _budget_exceeded; then
+        local spent
+        spent=$(cat "/tmp/loop-budget-$(date +%Y%m%d).counter" 2>/dev/null || echo 0)
+        log "BUDGET: ${spent}s/${LOOP_DAILY_HANDLER_BUDGET_SECONDS}s — skip $slug"
+        return
+    fi
+
     loop_load_project "$slug" || { log "skip: slug '$slug' unloadable"; return; }
     loop_load_backend
     local repo="$REPO"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -107,8 +107,8 @@ dispatch_direct() {
 # disabled (always returns 1).
 _budget_exceeded() {
     [ -n "${LOOP_DAILY_HANDLER_BUDGET_SECONDS:-}" ] || return 1
-    local f="/tmp/loop-budget-$(date +%Y%m%d).counter"
-    local spent
+    local f spent
+    f="/tmp/loop-budget-$(date +%Y%m%d).counter"
     spent=$(cat "$f" 2>/dev/null || echo 0)
     [ "$spent" -ge "$LOOP_DAILY_HANDLER_BUDGET_SECONDS" ]
 }

--- a/scripts/_handler_with_budget.sh
+++ b/scripts/_handler_with_budget.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# _handler_with_budget.sh — internal wrapper that runs a handler and records
+# its elapsed wall-clock time toward the daily budget counter.
+#
+# Usage (set by scanner's dispatch_direct):
+#   _handler_with_budget.sh <handler_script> [args...]
+#
+# Records elapsed seconds (regardless of handler exit code) into:
+#   /tmp/loop-budget-YYYYMMDD.counter
+#
+# Counter file is plain text (one integer). Read by scanner before each
+# scan_project iteration; if >= LOOP_DAILY_HANDLER_BUDGET_SECONDS, scanner
+# skips emitting new work for the rest of the day.
+#
+# A new day rolls over automatically because the filename includes the date.
+
+set -uo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "usage: $0 <handler_script> [args...]" >&2
+    exit 2
+fi
+
+HANDLER="$1"
+shift
+
+START_TS=$(date +%s)
+COUNTER_FILE="/tmp/loop-budget-$(date +%Y%m%d).counter"
+
+# Run the handler. Don't fail the wrapper just because the handler did —
+# we still need to record its time.
+"$HANDLER" "$@"
+HANDLER_RC=$?
+
+END_TS=$(date +%s)
+ELAPSED=$(( END_TS - START_TS ))
+
+# Atomic increment — flock keeps concurrent handlers from racing.
+# macOS doesn't ship flock; fall back to a coarser lock-file dance.
+if command -v flock >/dev/null 2>&1; then
+    (
+        flock -x 9
+        prev=$(cat "$COUNTER_FILE" 2>/dev/null || echo 0)
+        echo $(( prev + ELAPSED )) > "$COUNTER_FILE"
+    ) 9>>"$COUNTER_FILE.lock"
+else
+    # Best-effort: a brief lockfile retry. Concurrent handlers may still
+    # race here; budget is a soft cap, so undercounting by a few seconds
+    # is tolerable.
+    LOCKFILE="$COUNTER_FILE.lock"
+    for _ in 1 2 3 4 5; do
+        if mkdir "$LOCKFILE" 2>/dev/null; then
+            prev=$(cat "$COUNTER_FILE" 2>/dev/null || echo 0)
+            echo $(( prev + ELAPSED )) > "$COUNTER_FILE"
+            rmdir "$LOCKFILE"
+            break
+        fi
+        sleep 0.2
+    done
+fi
+
+exit "$HANDLER_RC"


### PR DESCRIPTION
## Summary

Adds an opt-in cap on cumulative handler wall-clock time per day. When today's spend reaches \`LOOP_DAILY_HANDLER_BUDGET_SECONDS\`, the scanner stops emitting new work for the rest of the day. In-flight handlers continue to completion. The counter rolls over automatically at midnight (filename includes the date).

## Why

There is currently no built-in cost or runtime ceiling on loop. Operators have had to throttle by manually changing scanner interval or temporarily relabeling tickets — both ad-hoc. This is a soft cap with a single env var.

## Mechanism

- **\`scripts/_handler_with_budget.sh\`** (new) — wraps every dispatched handler. Measures wall-clock seconds and atomically appends to \`/tmp/loop-budget-YYYYMMDD.counter\`. Exits with the handler's exit code so \`timeout(1)\` and existing scanner behavior are unchanged.
- **\`scanner.sh\` \`dispatch_direct\`** — invokes the wrapper instead of the handler directly.
- **\`scanner.sh\` \`scan_project\`** — consults new \`_budget_exceeded()\` at the top, returns early if today's spend ≥ budget.

## Configuration

Single env var, opt-in:

\`\`\`bash
# loop.env
LOOP_DAILY_HANDLER_BUDGET_SECONDS=14400  # 4 hours/day
\`\`\`

When unset/empty, feature is fully disabled — no behavior change for existing users.

## Soft vs hard cap

Soft. A handler that crashes before the wrapper records its time will not contribute to the counter. Acceptable — this is runaway prevention, not strict accounting.

## Concurrency

The counter file is updated under a lock. Prefers \`flock(1)\` when available; falls back to a mkdir-based retry on macOS (no flock). Brief races may undercount by 1–2 seconds across concurrent handlers — tolerable for the use case.

## Test plan

- [x] \`bash -n\` clean on all touched scripts
- [x] Wrapper accumulates time correctly across multiple invocations (manual test, 1s + 2s sleeps → counter ≈ 3s)
- [x] \`_budget_exceeded()\` unit-tested standalone:
  - env unset → returns false
  - spent < cap → returns false
  - spent ≥ cap → returns true
- [ ] Post-merge: set \`LOOP_DAILY_HANDLER_BUDGET_SECONDS=300\`, run for 1h, verify scanner skips emit after cap and resumes next day

## Rollback

Revert the PR. Counter files at \`/tmp/loop-budget-*.counter\` can be deleted manually if undesired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)