### PR TITLE
feat: detect untracked-data dependencies in dev failures + opt-in worktree extras (closes #264)

### DIFF
--- a/lib/config.sh
+++ b/lib/config.sh
@@ -68,6 +68,14 @@ for p in data.get("projects", []) or []:
         print(f"AUTO_REBASE='{'true' if mg.get('auto_rebase', False) else 'false'}'")
         print(f"BACKEND='{sh(p.get('backend','github'))}'")
         print(f"MAX_CONCURRENT_PRS='{sh(dev.get('max_concurrent_prs', 1))}'")
+        # WORKTREE_EXTRA_PATHS: paths from the primary checkout to symlink into
+        # each fresh worker worktree. Useful for projects with gitignored runtime
+        # files (ML training data, downloaded models, large fixtures) that the
+        # worker needs to read but that aren't tracked by git. Newline-delimited.
+        # Configure per-project via `dev.worktree_extra_paths` in projects.yaml.
+        wtep = dev.get("worktree_extra_paths") or []
+        wtep_lines = [str(p).strip() for p in wtep if str(p).strip()]
+        print(f"WORKTREE_EXTRA_PATHS='{sh(chr(10).join(wtep_lines))}'")
         # MAX_CONCURRENT_HANDLERS: caps emits-per-tick for all non-dev pipeline
         # stages (po, senior-dev, review, qa, merge, dev-rework). Dev has its
         # own slot system (MAX_CONCURRENT_PRS) — that stays separate.
@@ -114,7 +122,7 @@ PY
         return 1
     fi
     eval "$out"
-    export NAME REPO ROOT DEFAULT_BRANCH COMMIT_PREFIX DEV_VALIDATION_CMD QA_VALIDATION_CMD QA_BROWSER_URL QA_TIMEOUT_SECONDS HANDLER_TIMEOUT_SECONDS MERGE_STRATEGY AUTO_REBASE BACKEND MAX_CONCURRENT_PRS MAX_CONCURRENT_HANDLERS LOOP_AGENT_MODEL ALLOWED_AUTHORS WORKFLOW LOOP_LABEL_OVERRIDES _PROJECT_AGENT _PROJECT_MODEL _PROJECT_FALLBACK
+    export NAME REPO ROOT DEFAULT_BRANCH COMMIT_PREFIX DEV_VALIDATION_CMD QA_VALIDATION_CMD QA_BROWSER_URL QA_TIMEOUT_SECONDS HANDLER_TIMEOUT_SECONDS MERGE_STRATEGY AUTO_REBASE BACKEND MAX_CONCURRENT_PRS MAX_CONCURRENT_HANDLERS WORKTREE_EXTRA_PATHS LOOP_AGENT_MODEL ALLOWED_AUTHORS WORKFLOW LOOP_LABEL_OVERRIDES _PROJECT_AGENT _PROJECT_MODEL _PROJECT_FALLBACK
 }
 
 # loop_list_slugs — print each project slug on its own line

--- a/lib/failure_classifier.sh
+++ b/lib/failure_classifier.sh
@@ -34,3 +34,33 @@ loop_failure_signature() {
     local text="$1"
     echo "$text" | grep -oE '(ImportError|ModuleNotFoundError|ConnectionError|TimeoutError|429|5[0-9]{2}|rate limit|timeout)' | head -1
 }
+
+# loop_is_missing_untracked_data <stderr_text>
+# Returns 0 (true) if the failure looks like the worker is asking for files
+# that don't exist in its worktree. Typical pattern: ML/data projects whose
+# preprocessed arrays / model checkpoints / large fixtures are gitignored
+# and therefore absent from the fresh worktree.
+#
+# Heuristic: stderr mentions a missing-file diagnostic AND references a path
+# that looks like runtime data (one of common extensions or directory hints).
+# Conservative — false positives are worse than false negatives here because
+# the consequence is permanently blocking the issue with an explanatory
+# comment, not transparently retrying.
+loop_is_missing_untracked_data() {
+    local text="$1"
+    [ -z "$text" ] && return 1
+    echo "$text" | grep -qE '(FileNotFoundError|No such file or directory|cannot find the file|does not exist)' || return 1
+    echo "$text" | grep -qE '(\.npy|\.npz|\.pt|\.pth|\.ckpt|\.h5|\.hdf5|\.parquet|\.pkl|\.joblib|\.bin|/data/|/models/|/checkpoints/|/fixtures/)' || return 1
+    return 0
+}
+
+# loop_extract_missing_path <stderr_text>
+# Best-effort: pull the offending path out of a "FileNotFoundError" or
+# "No such file or directory" line. Empty string if nothing recognisable.
+loop_extract_missing_path() {
+    local text="$1"
+    {
+        echo "$text" | grep -oE "FileNotFoundError[^']*'[^']+'" | grep -oE "'[^']+'" | tr -d "'" | head -1
+        echo "$text" | grep -oE "No such file or directory[^A-Za-z0-9_/.-]*[A-Za-z0-9_./-]+" | grep -oE "[A-Za-z0-9_./-]+$" | head -1
+    } | grep -v '^$' | head -1
+}

--- a/lib/worktree.sh
+++ b/lib/worktree.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# lib/worktree.sh — helpers for git worktree setup used by dev / dev-rework
+# handlers. Currently exposes one helper:
+#
+#   loop_link_worktree_extras <primary_root> <worktree_root>
+#
+# Symlinks each path declared in $WORKTREE_EXTRA_PATHS (newline-delimited,
+# set by lib/config.sh from `dev.worktree_extra_paths` in projects.yaml)
+# from the primary checkout into the freshly-created worktree at the same
+# relative location.
+#
+# Why: projects with gitignored runtime files (ML training arrays,
+# downloaded models, large fixtures) cannot run inside a vanilla worktree
+# because git only carries tracked files. This makes those paths visible
+# without copying them.
+#
+# Symlink (not copy) — keeps things fast for large directories and the
+# read-only contract is documented; workers must not mutate these paths.
+
+# loop_link_worktree_extras <primary_root> <worktree_root>
+# Walk $WORKTREE_EXTRA_PATHS and symlink each entry from the primary
+# checkout into the worktree. Idempotent: if the link target already exists
+# the entry is skipped.
+loop_link_worktree_extras() {
+    local primary_root="$1" worktree_root="$2"
+
+    [ -z "${WORKTREE_EXTRA_PATHS:-}" ] && return 0
+
+    while IFS= read -r rel; do
+        [ -z "$rel" ] && continue
+        # Normalize: strip leading + trailing slashes so dirname works correctly.
+        rel="${rel#/}"
+        rel="${rel%/}"
+
+        local src="${primary_root%/}/${rel}"
+        local dst="${worktree_root%/}/${rel}"
+
+        if [ ! -e "$src" ]; then
+            echo "  worktree-extras: skip $rel (source not present at $src)" >&2
+            continue
+        fi
+
+        # If something already exists at the worktree path (tracked file with
+        # same name, or a previous run's symlink), skip rather than clobber.
+        if [ -e "$dst" ] || [ -L "$dst" ]; then
+            echo "  worktree-extras: skip $rel (already exists in worktree)" >&2
+            continue
+        fi
+
+        # Make sure the parent directory exists in the worktree.
+        mkdir -p "$(dirname "$dst")"
+
+        if ln -s "$src" "$dst"; then
+            echo "  worktree-extras: linked $rel" >&2
+        else
+            echo "  worktree-extras: WARN failed to link $rel" >&2
+        fi
+    done <<< "$WORKTREE_EXTRA_PATHS"
+}

--- a/scripts/dev-handler.sh
+++ b/scripts/dev-handler.sh
@@ -26,6 +26,10 @@ source "$LOOP_ROOT/lib/bounty.sh"
 source "$LOOP_ROOT/lib/notify.sh"
 # shellcheck source=../lib/cli-hint.sh
 source "$LOOP_ROOT/lib/cli-hint.sh"
+# shellcheck source=../lib/worktree.sh
+source "$LOOP_ROOT/lib/worktree.sh"
+# shellcheck source=../lib/failure_classifier.sh
+source "$LOOP_ROOT/lib/failure_classifier.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-dev-handler.log"
 MAX_RETRIES=3
@@ -132,6 +136,11 @@ if ! git -C "$ROOT" worktree add "$WORKTREE_ROOT" "origin/$DEFAULT_BRANCH" 2>&1 
     exit 1
 fi
 log "worktree ready: $WORKTREE_ROOT (isolated from other handlers)"
+
+# Symlink any project-declared extra paths (gitignored runtime data, models, etc.)
+# from the primary checkout into the worktree. Configurable per-project via
+# `dev.worktree_extra_paths` in projects.yaml. No-op if unset.
+loop_link_worktree_extras "$ROOT" "$WORKTREE_ROOT" 2>&1 | tee -a "$LOG_FILE"
 
 # Resolve workflow-specific labels for this project so the agent prompt + the
 # belt-and-braces apply the right names per the project's active workflow
@@ -251,6 +260,58 @@ if matches:
     cleanup_worktree
 else
     _IN_PROGRESS_CLAIMED=0  # disarm trap — failure path handles cleanup
+
+    # Capture the agent output tail so we can classify the failure.
+    _agent_tail=$(tail -n +"$((LOG_CAPTURE_START + 1))" "$LOG_FILE" 2>/dev/null | tail -200)
+
+    # Fail-fast on untracked-data dependencies — when the worker complains
+    # about a missing file that looks like gitignored runtime data (ML
+    # arrays, model checkpoints, large fixtures), retrying won't help.
+    # Block immediately with an explanation so the operator sees a real
+    # action item instead of three burned attempts.
+    if loop_is_missing_untracked_data "$_agent_tail"; then
+        _missing_path=$(loop_extract_missing_path "$_agent_tail")
+        log "dev agent failed for #$ISSUE_NUM — untracked-data dependency (${_missing_path:-?}); marking blocked without burning retry"
+        bounty_report "dev_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" issue_num="$ISSUE_NUM" detail="untracked-data: ${_missing_path:-?}" || true
+        backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
+        backend_add_label "$REPO" "$ISSUE_NUM" blocked
+        _block_body=$(mktemp /tmp/loop-block-XXXXXX.md)
+        {
+            echo "## Blocked: untracked runtime dependency"
+            echo ""
+            echo "The dev agent runs in an isolated git worktree which only contains **tracked** files."
+            if [ -n "$_missing_path" ]; then
+                echo "It reported a missing file at: \`$_missing_path\`"
+            else
+                echo "It reported a missing file (path could not be auto-extracted; see comment tail below)."
+            fi
+            echo ""
+            echo "Loop's principle is that automated work should not depend on untrackable files."
+            echo "To unblock, choose one:"
+            echo ""
+            echo "1. **Track the file** in git (preferred when it's small and stable)."
+            echo "2. **Configure \`dev.worktree_extra_paths\`** in \`loop\`'s \`projects.yaml\` to symlink"
+            echo "   the gitignored directory into each worker worktree. Use this for large data"
+            echo "   (e.g. \`data/processed/\`, \`models/checkpoints/\`); document the read-only assumption."
+            echo "3. **Run the task manually** outside the autonomous pipeline."
+            echo ""
+            echo "<details><summary>Last agent output</summary>"
+            echo ""
+            echo '```'
+            echo "$_agent_tail" \
+                | sed 's/\(ANTHROPIC_API_KEY=\|GITHUB_TOKEN=\|GH_TOKEN=\|_SECRET=\)[^ ]*/\1REDACTED/g' \
+                | tail -40
+            echo '```'
+            echo "</details>"
+        } > "$_block_body"
+        backend_comment_issue "$REPO" "$ISSUE_NUM" "$(cat "$_block_body")" 2>/dev/null || true
+        rm -f "$_block_body"
+        loop_notify_human_required "$SLUG" "$ISSUE_NUM" blocked "Dev agent: untracked-data dependency"
+        retry_clear
+        cleanup_worktree
+        exit 0
+    fi
+
     n=$(retry_incr)
     # Record the failure in the backoff state too — the next scan tick
     # will see the cool-down and skip until the next-eligible time.

--- a/scripts/dev-rework-handler.sh
+++ b/scripts/dev-rework-handler.sh
@@ -28,6 +28,8 @@ source "$LOOP_ROOT/lib/bounty.sh"
 source "$LOOP_ROOT/lib/notify.sh"
 # shellcheck source=../lib/cli-hint.sh
 source "$LOOP_ROOT/lib/cli-hint.sh"
+# shellcheck source=../lib/worktree.sh
+source "$LOOP_ROOT/lib/worktree.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-dev-rework-handler.log"
 MAX_RETRIES=2
@@ -176,6 +178,10 @@ if ! git -C "$ROOT" worktree add "$WORKTREE_ROOT" "origin/$PR_BRANCH" 2>&1 | tee
     exit 1
 fi
 log "worktree ready: $WORKTREE_ROOT (branch $PR_BRANCH)"
+
+# Symlink any project-declared extra paths (gitignored runtime data, models)
+# from the primary checkout into the worktree.
+loop_link_worktree_extras "$ROOT" "$WORKTREE_ROOT" 2>&1 | tee -a "$LOG_FILE"
 
 # System invariant: rework agent must never run on a stale base. Always rebase
 # the branch onto current origin/<default> so the agent sees up-to-date world.

--- a/tests/failure-classifier-untracked-data.bats
+++ b/tests/failure-classifier-untracked-data.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+# Tests for the untracked-data classifier in lib/failure_classifier.sh.
+
+setup() {
+    LOOP_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    # shellcheck source=../lib/runner.sh
+    source "$LOOP_ROOT/lib/runner.sh"
+    # shellcheck source=../lib/failure_classifier.sh
+    source "$LOOP_ROOT/lib/failure_classifier.sh"
+}
+
+@test "matches FileNotFoundError on .npy data" {
+    text="FileNotFoundError: [Errno 2] No such file or directory: 'data/processed/vanco/X_train.npy'"
+    run loop_is_missing_untracked_data "$text"
+    [ "$status" -eq 0 ]
+}
+
+@test "matches model checkpoint .pt files" {
+    text="No such file or directory: '../models/checkpoints/best.pt'"
+    run loop_is_missing_untracked_data "$text"
+    [ "$status" -eq 0 ]
+}
+
+@test "matches /data/ directory hint without specific extension" {
+    text="No such file or directory: 'project/data/raw_inputs.bin'"
+    run loop_is_missing_untracked_data "$text"
+    [ "$status" -eq 0 ]
+}
+
+@test "does NOT match ModuleNotFoundError (transient infra failure)" {
+    text="ModuleNotFoundError: No module named 'providers.session_manager'"
+    run loop_is_missing_untracked_data "$text"
+    [ "$status" -ne 0 ]
+}
+
+@test "does NOT match plain FileNotFoundError without data signal" {
+    text="FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'"
+    run loop_is_missing_untracked_data "$text"
+    [ "$status" -ne 0 ]
+}
+
+@test "does NOT match unrelated stderr" {
+    text="RuntimeError: agent tried to write to read-only resource"
+    run loop_is_missing_untracked_data "$text"
+    [ "$status" -ne 0 ]
+}
+
+@test "does NOT match empty input" {
+    run loop_is_missing_untracked_data ""
+    [ "$status" -ne 0 ]
+}
+
+@test "extract_missing_path pulls path from FileNotFoundError" {
+    text="FileNotFoundError: [Errno 2] No such file or directory: 'data/x.npy'"
+    run loop_extract_missing_path "$text"
+    [ "$output" = "data/x.npy" ]
+}

--- a/tests/worktree-extras.bats
+++ b/tests/worktree-extras.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+# Tests for lib/worktree.sh — symlink-extras-into-worktree helper.
+
+setup() {
+    LOOP_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    # shellcheck source=../lib/worktree.sh
+    source "$LOOP_ROOT/lib/worktree.sh"
+    PRIMARY=$(mktemp -d)
+    WORKTREE=$(mktemp -d)
+}
+
+teardown() {
+    rm -rf "$PRIMARY" "$WORKTREE"
+}
+
+@test "no-op when WORKTREE_EXTRA_PATHS is unset" {
+    unset WORKTREE_EXTRA_PATHS
+    run loop_link_worktree_extras "$PRIMARY" "$WORKTREE"
+    [ "$status" -eq 0 ]
+    [ -z "$(ls "$WORKTREE")" ]
+}
+
+@test "symlinks each entry from primary into worktree" {
+    mkdir -p "$PRIMARY/data/processed" "$PRIMARY/models"
+    touch "$PRIMARY/data/processed/X_train.npy" "$PRIMARY/models/best.pt"
+    WORKTREE_EXTRA_PATHS=$'data/processed/\nmodels/'
+    run loop_link_worktree_extras "$PRIMARY" "$WORKTREE"
+    [ "$status" -eq 0 ]
+    [ -L "$WORKTREE/data/processed" ]
+    [ -L "$WORKTREE/models" ]
+    [ -f "$WORKTREE/data/processed/X_train.npy" ]
+}
+
+@test "skips entries that don't exist in primary" {
+    WORKTREE_EXTRA_PATHS="data/missing/"
+    run loop_link_worktree_extras "$PRIMARY" "$WORKTREE"
+    [ "$status" -eq 0 ]
+    [ ! -e "$WORKTREE/data/missing" ]
+    [[ "$output" == *"skip"* ]]
+}
+
+@test "skips entries that already exist in worktree" {
+    mkdir -p "$PRIMARY/data" "$WORKTREE/data"
+    echo "from-worktree" > "$WORKTREE/data/X.npy"
+    echo "from-primary"  > "$PRIMARY/data/X.npy"
+    WORKTREE_EXTRA_PATHS="data/X.npy"
+    run loop_link_worktree_extras "$PRIMARY" "$WORKTREE"
+    [ "$status" -eq 0 ]
+    # Existing worktree file is preserved (not clobbered)
+    [ "$(cat "$WORKTREE/data/X.npy")" = "from-worktree" ]
+}
+
+@test "creates parent directories before linking" {
+    mkdir -p "$PRIMARY/deep/nested/path"
+    touch "$PRIMARY/deep/nested/path/file.bin"
+    WORKTREE_EXTRA_PATHS="deep/nested/path/file.bin"
+    run loop_link_worktree_extras "$PRIMARY" "$WORKTREE"
+    [ "$status" -eq 0 ]
+    [ -L "$WORKTREE/deep/nested/path/file.bin" ]
+}


### PR DESCRIPTION
## Summary

Closes #264. Surfaces the silent failure mode where the autonomous pipeline burns 3 retry attempts every time on a project whose worker depends on gitignored runtime files (ML data, models, large fixtures).

The principled position: **automated work should not depend on untrackable files**. When that contract is violated, fail fast with a clear, actionable explanation rather than burn retries.

## Two pieces

### 1. Failure classifier — recognise the pattern (\`lib/failure_classifier.sh\`)

- \`loop_is_missing_untracked_data <stderr>\` — true when the worker reported \`FileNotFoundError\` / \"No such file or directory\" **and** the referenced path looks data-like (\`.npy\`/\`.pt\`/\`.ckpt\`/\`.h5\`/\`.parquet\`/\`.pkl\` or \`/data/\` \`/models/\` \`/checkpoints/\` \`/fixtures/\`)
- \`loop_extract_missing_path\` — best-effort path extraction for the operator-facing comment

\`dev-handler\` consults the classifier on failure. Match → label \`blocked\` immediately with an explanatory comment (track the file / configure \`worktree_extra_paths\` / run manually). Retry counter is **not** incremented; backoff is **not** recorded.

### 2. Opt-in escape valve — \`dev.worktree_extra_paths\` (\`lib/worktree.sh\`)

For projects that genuinely need gitignored data:

\`\`\`yaml
- name: vrefm-classifier
  slug: vrefm-classifier
  dev:
    worktree_extra_paths:
      - data/processed/
      - models/checkpoints/
\`\`\`

\`dev-handler\` and \`dev-rework-handler\` symlink each entry from the primary checkout into the worktree post-creation. Symlink (not copy) — fast for large dirs; documented read-only contract. Idempotent: existing files never clobbered.

## Verification

- [x] \`tests/worktree-extras.bats\` — 5 cases pass
- [x] \`tests/failure-classifier-untracked-data.bats\` — 8 cases pass (positive: .npy/.pt/data; negative: ModuleNotFoundError, requirements.txt, plain RuntimeError, empty)
- [x] Existing \`tests/failure_classifier.bats\` still passes
- [x] \`shellcheck -S warning\` clean on all touched files

## Concrete unblock

vrefm-classifier#55 has been stuck on this exact pattern for 17 days. With this change merged + a one-line addition to \`projects.yaml\` for that project, it can either drain (via \`worktree_extra_paths\`) or block-with-explanation cleanly so the operator runs it manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)