### PR TITLE
fix(scanner): filter PRs out of loop_gh_issues_with_label (root cause of boba-event#64)

### DIFF
--- a/lib/github.sh
+++ b/lib/github.sh
@@ -32,22 +32,29 @@ loop_gh_issues_with_label() {
     raw_tmp=$(mktemp)
     sort_tmp=$(mktemp)
 
+    # IMPORTANT: `gh issue list` returns both issues AND PRs (GitHub's API
+    # treats PRs as a kind of issue with shared number space). Without the
+    # `select(.url | contains("/issues/"))` filter, a PR carrying an issue-
+    # stage trigger label gets emitted as an issue event with a PR-shaped
+    # payload (pr_number, no issue_number) — breaks downstream interpolation
+    # and dispatches dev-handler against a PR. Filter to true issues by URL.
     gh issue list --repo "$repo" --label "$label" --state open \
         --json number,title,url,labels,author \
         --jq '
-          map(
-            ([.labels[].name]) as $L |
-            {
-              number, title, url, labels: $L, author: .author.login,
-              _p: (
-                if   ($L | index("p0-critical")) then 0
-                elif ($L | index("p1-high"))     then 1
-                elif ($L | index("p2-medium"))   then 2
-                elif ($L | index("p3-low"))      then 3
-                else 4 end),
-              _b: (if ($L | index("bug")) then 0 else 1 end)
-            }
-          )[]
+          map(select(.url | contains("/issues/")))
+          | map(
+              ([.labels[].name]) as $L |
+              {
+                number, title, url, labels: $L, author: .author.login,
+                _p: (
+                  if   ($L | index("p0-critical")) then 0
+                  elif ($L | index("p1-high"))     then 1
+                  elif ($L | index("p2-medium"))   then 2
+                  elif ($L | index("p3-low"))      then 3
+                  else 4 end),
+                _b: (if ($L | index("bug")) then 0 else 1 end)
+              }
+            )[]
         ' 2>/dev/null >"$raw_tmp" || true
 
     if [ ! -s "$raw_tmp" ]; then

--- a/tests/github-issues-exclude-prs.bats
+++ b/tests/github-issues-exclude-prs.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# Regression test for the gh-issue-list / pr-shared-number-space bug.
+#
+# `gh issue list` returns BOTH issues and PRs because GitHub's API treats
+# PRs as a kind of issue with shared number space. Without filtering, a PR
+# carrying an issue-stage trigger label (e.g. `needs-dev`) gets emitted by
+# the scanner as a `loop.dev_issue` event with a PR-shaped payload
+# (pr_number, no issue_number) — breaks downstream interpolation and
+# dispatches dev-handler against a PR.
+#
+# loop_gh_issues_with_label must filter on `.url contains "/issues/"`.
+# This test exercises just the jq filter against synthetic input — kept
+# narrow because mocking the full gh+pipeline is brittle.
+
+setup() {
+    INPUT=$(cat <<'JSON'
+[
+  {"number": 100, "title": "real issue", "url": "https://github.com/svv2014/repo/issues/100", "labels": [{"name": "needs-dev"}], "author": {"login": "svv2014"}},
+  {"number": 200, "title": "secret PR",  "url": "https://github.com/svv2014/repo/pull/200",   "labels": [{"name": "needs-dev"}], "author": {"login": "svv2014"}}
+]
+JSON
+)
+}
+
+@test "filter expression keeps issues, drops PRs" {
+    output=$(printf '%s' "$INPUT" | jq '
+      map(select(.url | contains("/issues/"))) | map(.number)
+    ')
+    [[ "$output" == *"100"* ]]
+    [[ "$output" != *"200"* ]]
+}
+
+@test "filter expression survives an empty input" {
+    output=$(printf '[]' | jq '
+      map(select(.url | contains("/issues/")))
+    ')
+    [ "$output" = "[]" ]
+}
+
+@test "filter expression keeps mixed-shape issues with all required fields" {
+    output=$(printf '%s' "$INPUT" | jq '
+      map(select(.url | contains("/issues/")))
+    ')
+    [[ "$output" == *"\"number\": 100"* ]]
+    [[ "$output" == *"\"url\": \"https://github.com/svv2014/repo/issues/100\""* ]]
+}
+
+@test "lib/github.sh contains the contains-check filter" {
+    LOOP_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    grep -q 'select(.url | contains("/issues/"))' "$LOOP_ROOT/lib/github.sh"
+}


### PR DESCRIPTION
## Summary

Fixes the root cause of the literal \`{payload.issue_number}\` bug that's been blocking loop-monitor's autonomous pipeline since the public-repo rename. Filed externally as **boba-event#64**, but the actual cause is in loop's \`gh\` wrapper, not boba-event's interpolator.

## What was happening

GitHub's API treats pull requests as a kind of issue — they share the number space and \`gh issue list --label X\` returns both. When a PR carries an issue-stage trigger label (e.g. \`needs-dev\`, which is both the issue trigger for dev-handler AND the PR trigger for dev-rework-handler in the default workflow), the scanner walks it through the issue-side path and emits:

\`\`\`json
{"type": "loop.dev_issue",
 "payload": {"slug": "loop-monitor", "pr_number": 132, ...}}
\`\`\`

PR-shaped payload under an issue-shaped event type. The router template substitutes \`{payload.issue_number}\` — which doesn't exist — so the literal string flows through to dev-handler:

\`\`\`
LOOP_ISSUE_NUMBER='{payload.issue_number}'
\`\`\`

dev-handler then logs \`issue=#{payload.issue_number}\` and bails. Diagnosed via boba-event's queue.db — confirmed event #24342 had \`pr_number: 132\` instead of \`issue_number\`.

## Fix

Single jq filter in \`loop_gh_issues_with_label\`:

\`\`\`jq
map(select(.url | contains("/issues/")))
\`\`\`

GitHub URLs are stable: \`/issues/N\` for issues, \`/pull/N\` for PRs. Filter excludes PRs reliably without an extra API call. Comment block in the source explains why the filter exists so it doesn't get innocently removed.

PR-side scanning (\`backend_list_prs_with_label\` → \`gh pr list\`) is untouched — \`gh pr list\` already returns only PRs.

## Verification

- [x] \`tests/github-issues-exclude-prs.bats\` — 4 cases pass
- [x] Empirical: ran the new filter against \`gh issue list --label needs-dev\` for loop-monitor; before-fix=1, after-fix=1 currently (no PRs labelled \`needs-dev\` right now), structure verified against history
- [x] \`shellcheck -S warning\` clean

## Impact

Once merged + scanner restart:

- The 13 re-queued loop-monitor tickets (#115–#138) can dispatch correctly
- The Dope UI v0.3 migration unblocks
- boba-event#64 resolves automatically (root cause was here, not there)

## Out of scope

- gitlab.sh / jira-gitlab.sh backends may have similar quirks; separate issue if surfaces
- Migrating other handler scripts that may have the same assumption

🤖 Generated with [Claude Code](https://claude.com/claude-code)