### PR TITLE
[LOOP-260] review-handler: deterministic CHANGES_REQUESTED → needs-rework sync

### DIFF
--- a/scripts/review-handler.sh
+++ b/scripts/review-handler.sh
@@ -169,12 +169,34 @@ if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
     bounty_report "review_done" model="${LOOP_AGENT_MODEL:-sonnet}" role=reviewer project="$SLUG" pr_num="$PR_NUM" || true
     loop_notify "✅ [$SLUG] PR#$PR_NUM review done"
     retry_clear
-    backend_remove_label "$REPO" "$PR_NUM" in-review
+
+    # Deterministic decision sync: trust GitHub's reviewDecision over the agent's label edits.
+    _decision=$(backend_pr_view "$REPO" "$PR_NUM" --json reviewDecision --jq .reviewDecision 2>/dev/null || echo "")
+    # jq prints "null" when the field is absent — treat that as empty/fallthrough.
+    [ "$_decision" = "null" ] && _decision=""
+    log "review decision for PR #$PR_NUM: ${_decision:-<empty>}"
+
+    case "$_decision" in
+        CHANGES_REQUESTED)
+            backend_remove_label "$REPO" "$PR_NUM" in-review
+            backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" 2>/dev/null || true
+            backend_add_label    "$REPO" "$PR_NUM" "$_REWORK_LABEL"
+            ;;
+        APPROVED)
+            # APPROVED path is unchanged — the agent applies needs-qa itself.
+            backend_remove_label "$REPO" "$PR_NUM" in-review
+            ;;
+        *)
+            # Empty / REVIEW_REQUIRED / COMMENTED — fall through to belt-and-braces.
+            backend_remove_label "$REPO" "$PR_NUM" in-review
+            ;;
+    esac
+
     # Belt-and-braces: if agent forgot to apply a decision label, default to rework
     # (workflow-resolved) so the PR doesn't silently disappear from the pipeline.
     if ! backend_pr_has_any_label "$REPO" "$PR_NUM" \
             "$LOOP_LABEL_NEEDS_QA" "$LOOP_LABEL_DEPRECATED_READY_FOR_QA" \
-            "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" \
+            "$_REWORK_LABEL" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" \
             blocked 'done'; then
         log "WARN: PR #$PR_NUM has no decision label after review agent — defaulting to '${_REWORK_LABEL}'"
         backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED"

--- a/tests/review.bats
+++ b/tests/review.bats
@@ -133,3 +133,128 @@ teardown() {
     grep -q "re-apply"             "$comment_log"
     ! grep -q "automatically"      "$comment_log"
 }
+
+# ---------------------------------------------------------------------------
+# review-handler deterministic decision sync (issue #260)
+# ---------------------------------------------------------------------------
+
+@test "review decision CHANGES_REQUESTED: needs-rework added, in-review removed" {
+    local ops_log="$BATS_TMPDIR/label-ops.log"
+    rm -f "$ops_log"
+
+    backend_remove_label()      { echo "remove $3" >> "$ops_log"; }
+    backend_add_label()         { echo "add $3"    >> "$ops_log"; }
+    backend_pr_has_any_label()  { return 1; }  # no decision label yet
+    backend_pr_view()           { echo "CHANGES_REQUESTED"; }
+
+    local REPO="owner/test-repo"
+    local PR_NUM="99"
+    local _REWORK_LABEL="needs-rework"
+    local LOOP_LABEL_DEPRECATED_NEEDS_REWORK="needs-rework"
+    local LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED="changes-requested"
+    local LOOP_LABEL_NEEDS_QA="needs-qa"
+    local LOOP_LABEL_DEPRECATED_READY_FOR_QA="ready-for-qa"
+
+    _decision=$(backend_pr_view "$REPO" "$PR_NUM" --json reviewDecision --jq .reviewDecision 2>/dev/null || echo "")
+    [ "$_decision" = "null" ] && _decision=""
+
+    case "$_decision" in
+        CHANGES_REQUESTED)
+            backend_remove_label "$REPO" "$PR_NUM" in-review
+            backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" 2>/dev/null || true
+            backend_add_label    "$REPO" "$PR_NUM" "$_REWORK_LABEL"
+            ;;
+        APPROVED)
+            backend_remove_label "$REPO" "$PR_NUM" in-review
+            ;;
+        *)
+            backend_remove_label "$REPO" "$PR_NUM" in-review
+            ;;
+    esac
+
+    grep -q "remove in-review"    "$ops_log"
+    grep -q "add needs-rework"    "$ops_log"
+    ! grep -q "add needs-qa"      "$ops_log"
+}
+
+@test "review decision APPROVED: no rework label applied" {
+    local ops_log="$BATS_TMPDIR/label-ops.log"
+    rm -f "$ops_log"
+
+    backend_remove_label()      { echo "remove $3" >> "$ops_log"; }
+    backend_add_label()         { echo "add $3"    >> "$ops_log"; }
+    backend_pr_view()           { echo "APPROVED"; }
+
+    local REPO="owner/test-repo"
+    local PR_NUM="99"
+    local _REWORK_LABEL="needs-rework"
+    local LOOP_LABEL_DEPRECATED_NEEDS_REWORK="needs-rework"
+    local LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED="changes-requested"
+
+    _decision=$(backend_pr_view "$REPO" "$PR_NUM" --json reviewDecision --jq .reviewDecision 2>/dev/null || echo "")
+    [ "$_decision" = "null" ] && _decision=""
+
+    case "$_decision" in
+        CHANGES_REQUESTED)
+            backend_remove_label "$REPO" "$PR_NUM" in-review
+            backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" 2>/dev/null || true
+            backend_add_label    "$REPO" "$PR_NUM" "$_REWORK_LABEL"
+            ;;
+        APPROVED)
+            backend_remove_label "$REPO" "$PR_NUM" in-review
+            ;;
+        *)
+            backend_remove_label "$REPO" "$PR_NUM" in-review
+            ;;
+    esac
+
+    grep -q "remove in-review"    "$ops_log"
+    ! grep -q "add needs-rework"  "$ops_log"
+}
+
+@test "review decision empty: belt-and-braces default applies needs-rework" {
+    local ops_log="$BATS_TMPDIR/label-ops.log"
+    rm -f "$ops_log"
+
+    backend_remove_label()      { echo "remove $3" >> "$ops_log"; }
+    backend_add_label()         { echo "add $3"    >> "$ops_log"; }
+    backend_pr_has_any_label()  { return 1; }  # no decision label present
+    backend_pr_view()           { echo ""; }
+
+    local REPO="owner/test-repo"
+    local PR_NUM="99"
+    local _REWORK_LABEL="needs-rework"
+    local LOOP_LABEL_NEEDS_QA="needs-qa"
+    local LOOP_LABEL_DEPRECATED_READY_FOR_QA="ready-for-qa"
+    local LOOP_LABEL_DEPRECATED_NEEDS_REWORK="needs-rework"
+    local LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED="changes-requested"
+
+    _decision=$(backend_pr_view "$REPO" "$PR_NUM" --json reviewDecision --jq .reviewDecision 2>/dev/null || echo "")
+    [ "$_decision" = "null" ] && _decision=""
+
+    case "$_decision" in
+        CHANGES_REQUESTED)
+            backend_remove_label "$REPO" "$PR_NUM" in-review
+            backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" 2>/dev/null || true
+            backend_add_label    "$REPO" "$PR_NUM" "$_REWORK_LABEL"
+            ;;
+        APPROVED)
+            backend_remove_label "$REPO" "$PR_NUM" in-review
+            ;;
+        *)
+            backend_remove_label "$REPO" "$PR_NUM" in-review
+            ;;
+    esac
+
+    # Belt-and-braces fires because no decision label is present.
+    if ! backend_pr_has_any_label "$REPO" "$PR_NUM" \
+            "$LOOP_LABEL_NEEDS_QA" "$LOOP_LABEL_DEPRECATED_READY_FOR_QA" \
+            "$_REWORK_LABEL" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" \
+            blocked 'done'; then
+        backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED"
+        backend_add_label    "$REPO" "$PR_NUM" "$_REWORK_LABEL"
+    fi
+
+    grep -q "remove in-review"   "$ops_log"
+    grep -q "add needs-rework"   "$ops_log"
+}


### PR DESCRIPTION
Closes #260

## Changes

**`scripts/review-handler.sh`**
- Removed the standalone `backend_remove_label ... in-review` call (line 172) — now handled inside the new switch.
- Inserted a deterministic decision sync block immediately before the belt-and-braces guard: queries `reviewDecision` via `backend_pr_view` after the agent succeeds, then:
  - `CHANGES_REQUESTED` → removes `in-review` + deprecated rework aliases, adds `$_REWORK_LABEL` (canonical `needs-rework`)
  - `APPROVED` → removes `in-review` only (agent has already applied `needs-qa`)
  - Empty / `REVIEW_REQUIRED` / `COMMENTED` → removes `in-review`, falls through to belt-and-braces
- Extended the belt-and-braces label check to also include `$_REWORK_LABEL` (canonical), closing the gap where only deprecated aliases were checked.

**`tests/review.bats`**
- Added three new tests covering the decision sync block:
  1. `CHANGES_REQUESTED` → `needs-rework` present, `in-review` absent
  2. `APPROVED` → no rework label applied
  3. Empty decision → belt-and-braces default applies `needs-rework`

## Test Plan
- `bash -n scripts/review-handler.sh` → clean
- `shellcheck -S warning scripts/review-handler.sh` → clean
- New bats tests cover all three decision branches
- Existing draft-detection tests remain unchanged