### PR TITLE
[LOOP-258] move daily-budget counter from /tmp to persistent location

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -10,8 +10,8 @@ Every piece of mutable state loop creates, in one place:
 |---|---|---|
 | `/tmp/loop-po-retries-<slug>-<num>` | PO retry counter (1–`MAX_RETRIES`). Auto-cleared when an issue's `needs-clarification` label is removed. | Yes — issue gets a fresh attempt next emit. |
 | `/tmp/loop-scanner-dedup/<hash>` | Per-event "emitted within last 30 min" cache. | Yes — scanner re-emits within 30 min. |
-| `/tmp/loop-budget-YYYYMMDD.counter` | Daily handler-time budget tally (seconds spent today). Auto-rotates at midnight. | Yes — drops today's tally to 0. |
-| `/tmp/loop-budget-YYYYMMDD.counter.lock` | Lock file for the budget counter. | Yes (only if no handler is running). |
+| `${LOOP_LOG_DIR}/budget/YYYYMMDD.counter` | Daily handler-time budget tally (seconds spent today). Auto-rotates at midnight. Persists across OS reboots. | Yes — drops today's tally to 0. |
+| `${LOOP_LOG_DIR}/budget/YYYYMMDD.counter.lock` | Lock file for the budget counter. | Yes (only if no handler is running). |
 | `/tmp/loop-scanner.lock` | Single-instance lock for the scanner process. | Only if scanner is confirmed not running. |
 | `${LOOP_LOG_DIR}/loop-scanner.log` | Scanner heartbeat + emit log. | Logrotate-safe (scanner reopens on SIGHUP). |
 | `${LOOP_LOG_DIR}/loop-po-handler.log` | PO transcripts. Append-only. | Logrotate-safe with care. |
@@ -127,5 +127,5 @@ tail -20 ${LOOP_LOG_DIR}/loop-scanner.log
 pgrep -af 'po-handler|dev-handler|qa-handler|review-handler|merge-handler|dev-rework-handler'
 
 # Today's spend (if budget is enabled)
-cat /tmp/loop-budget-$(date +%Y%m%d).counter 2>/dev/null || echo "budget not yet tallied today"
+cat "${LOOP_LOG_DIR}/budget/$(date +%Y%m%d).counter" 2>/dev/null || echo "budget not yet tallied today"
 ```

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -95,8 +95,8 @@ dispatch_direct() {
     esac
     local effective_timeout="${HANDLER_TIMEOUT_SECONDS:-$HANDLER_TIMEOUT}"
     # Wrap with the budget tally helper so each handler's wall-clock time is
-    # accumulated into /tmp/loop-budget-YYYYMMDD.counter. Wrapper exits with
-    # the handler's exit code so timeout(1) and scanner behavior are unchanged.
+    # accumulated into ${LOOP_LOG_DIR}/budget/YYYYMMDD.counter. Wrapper exits
+    # with the handler's exit code so timeout(1) and scanner behavior are unchanged.
     LOOP_EVENT_JSON="$json" nohup timeout "$effective_timeout" \
         "$LOOP_ROOT/scripts/_handler_with_budget.sh" "$handler" \
         >> "$LOOP_LOG_DIR/loop-scanner.log" 2>&1 &
@@ -105,11 +105,11 @@ dispatch_direct() {
 # _budget_exceeded — returns 0 (true) if today's accumulated handler-seconds
 # meet or exceed LOOP_DAILY_HANDLER_BUDGET_SECONDS. Empty/unset env var =
 # disabled (always returns 1).
+_budget_counter_path() { printf '%s/budget/%s.counter' "${LOOP_LOG_DIR:?LOOP_LOG_DIR must be set}" "$(date +%Y%m%d)"; }
 _budget_exceeded() {
     [ -n "${LOOP_DAILY_HANDLER_BUDGET_SECONDS:-}" ] || return 1
-    local f spent
-    f="/tmp/loop-budget-$(date +%Y%m%d).counter"
-    spent=$(cat "$f" 2>/dev/null || echo 0)
+    local spent
+    spent=$(cat "$(_budget_counter_path)" 2>/dev/null || echo 0)
     [ "$spent" -ge "$LOOP_DAILY_HANDLER_BUDGET_SECONDS" ]
 }
 
@@ -494,7 +494,7 @@ scan_project() {
     # dispatches are paused until the next day rolls over.
     if _budget_exceeded; then
         local spent
-        spent=$(cat "/tmp/loop-budget-$(date +%Y%m%d).counter" 2>/dev/null || echo 0)
+        spent=$(cat "$(_budget_counter_path)" 2>/dev/null || echo 0)
         log "BUDGET: ${spent}s/${LOOP_DAILY_HANDLER_BUDGET_SECONDS}s — skip $slug"
         return
     fi

--- a/scripts/_handler_with_budget.sh
+++ b/scripts/_handler_with_budget.sh
@@ -6,13 +6,14 @@
 #   _handler_with_budget.sh <handler_script> [args...]
 #
 # Records elapsed seconds (regardless of handler exit code) into:
-#   /tmp/loop-budget-YYYYMMDD.counter
+#   ${LOOP_LOG_DIR}/budget/YYYYMMDD.counter
 #
 # Counter file is plain text (one integer). Read by scanner before each
 # scan_project iteration; if >= LOOP_DAILY_HANDLER_BUDGET_SECONDS, scanner
 # skips emitting new work for the rest of the day.
 #
 # A new day rolls over automatically because the filename includes the date.
+# The budget directory is under LOOP_LOG_DIR so it persists across OS reboots.
 
 set -uo pipefail
 
@@ -24,8 +25,13 @@ fi
 HANDLER="$1"
 shift
 
+_budget_dir()     { printf '%s/budget' "${LOOP_LOG_DIR:?LOOP_LOG_DIR must be set}"; }
+_budget_counter_path() { printf '%s/%s.counter' "$(_budget_dir)" "$(date +%Y%m%d)"; }
+_budget_lock_path()    { printf '%s/%s.counter.lock' "$(_budget_dir)" "$(date +%Y%m%d)"; }
+mkdir -p "$(_budget_dir)"
+
 START_TS=$(date +%s)
-COUNTER_FILE="/tmp/loop-budget-$(date +%Y%m%d).counter"
+COUNTER_FILE="$(_budget_counter_path)"
 
 # Run the handler. Don't fail the wrapper just because the handler did —
 # we still need to record its time.
@@ -42,12 +48,12 @@ if command -v flock >/dev/null 2>&1; then
         flock -x 9
         prev=$(cat "$COUNTER_FILE" 2>/dev/null || echo 0)
         echo $(( prev + ELAPSED )) > "$COUNTER_FILE"
-    ) 9>>"$COUNTER_FILE.lock"
+    ) 9>>"$(_budget_lock_path)"
 else
     # Best-effort: a brief lockfile retry. Concurrent handlers may still
     # race here; budget is a soft cap, so undercounting by a few seconds
     # is tolerable.
-    LOCKFILE="$COUNTER_FILE.lock"
+    LOCKFILE="$(_budget_lock_path)"
     for _ in 1 2 3 4 5; do
         if mkdir "$LOCKFILE" 2>/dev/null; then
             prev=$(cat "$COUNTER_FILE" 2>/dev/null || echo 0)


### PR DESCRIPTION
Closes #258

## Changes

- **`scripts/_handler_with_budget.sh`**: Added `_budget_dir`, `_budget_counter_path`, and `_budget_lock_path` helper functions. Counter now writes to `${LOOP_LOG_DIR}/budget/YYYYMMDD.counter` (and lock to `...counter.lock`). Directory created with `mkdir -p` before first write. Updated leading comment.
- **`scanner/scanner.sh`**: Added `_budget_counter_path` helper function mirroring the writer. Updated `_budget_exceeded()` and the `scan_project` spent-seconds banner to read from the new path. Updated inline comment in `dispatch_direct`.
- **`docs/operations.md`**: Updated state-locations table rows for counter and lock file to new paths (with note that counter persists across reboot). Updated troubleshooting `cat` example.

No migration shim — old `/tmp` counters expire naturally on day rollover.

## Test Plan

- `bash -n` syntax check passes on all scripts
- `shellcheck -S warning` passes on all scripts
- Manual: set `LOOP_DAILY_HANDLER_BUDGET_SECONDS`, run a handler, verify `${LOOP_LOG_DIR}/budget/$(date +%Y%m%d).counter` is created and incremented
- Manual: reboot mid-day, verify counter value is retained