### PR TITLE
[LOOP-268] reconciler: auto-apply needs-rework when loop-opened PR has red CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ see [docs/quick-start.md](docs/quick-start.md).
 6. **Merge handler** squash-merges, closes the linked issue, records a
    bounty event, triggers the judge for a PR scorecard.
 7. **Reconciler** runs every 15 minutes to clean up stuck states,
-   duplicate PRs, dependency unblocks.
+   duplicate PRs, dependency unblocks, and red-CI PRs (see below).
 
 The whole flow is just labels on issues and PRs. You can intervene at
 any stage by manually labeling.
@@ -151,6 +151,31 @@ Author your own — see [`config/workflows/README.md`](config/workflows/README.m
 - `config/projects.yaml` — your project registry. **Not committed.**
 - `config/projects.example.yaml` — annotated schema reference.
 - `config/workflows/*.yaml` — pipeline workflow definitions. Committed.
+
+## Auto-rework on red CI
+
+When Loop opens a PR (branch convention `feat/issue-N-*`) and a **required**
+CI check fails, the reconciler automatically applies `needs-rework` to the PR
+and strips the parent issue's trigger label so the dev agent can fix the
+failures on the next cycle. The reconciler is a no-op when:
+
+- The PR already carries `needs-rework` or `changes-requested`.
+- A human reviewer has approved or requested changes.
+- The failing check is not marked as **required** in the repository settings.
+
+A `pr_ci_failed` event is posted to loop-monitor (if `LOOP_MONITOR_URL` is
+set in `loop.env`) for observability.
+
+**To opt out per project**, add `dev.auto_rework_on_ci: false` to the project
+entry in `config/projects.yaml`:
+
+```yaml
+projects:
+  - slug: myapp
+    repo: owner/my-app
+    dev:
+      auto_rework_on_ci: false   # disable reconciler auto-rework on red CI
+```
 
 ## Supported AI agents
 

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -66,6 +66,7 @@ for p in data.get("projects", []) or []:
         print(f"HANDLER_TIMEOUT_SECONDS='{sh(dev.get('handler_timeout_seconds',''))}'")
         print(f"MERGE_STRATEGY='{sh(mg.get('strategy','squash'))}'")
         print(f"AUTO_REBASE='{'true' if mg.get('auto_rebase', False) else 'false'}'")
+        print(f"AUTO_REWORK_ON_CI='{'true' if dev.get('auto_rework_on_ci', True) else 'false'}'")
         print(f"BACKEND='{sh(p.get('backend','github'))}'")
         print(f"MAX_CONCURRENT_PRS='{sh(dev.get('max_concurrent_prs', 1))}'")
         # WORKTREE_EXTRA_PATHS: paths from the primary checkout to symlink into
@@ -122,7 +123,7 @@ PY
         return 1
     fi
     eval "$out"
-    export NAME REPO ROOT DEFAULT_BRANCH COMMIT_PREFIX DEV_VALIDATION_CMD QA_VALIDATION_CMD QA_BROWSER_URL QA_TIMEOUT_SECONDS HANDLER_TIMEOUT_SECONDS MERGE_STRATEGY AUTO_REBASE BACKEND MAX_CONCURRENT_PRS MAX_CONCURRENT_HANDLERS WORKTREE_EXTRA_PATHS LOOP_AGENT_MODEL ALLOWED_AUTHORS WORKFLOW LOOP_LABEL_OVERRIDES _PROJECT_AGENT _PROJECT_MODEL _PROJECT_FALLBACK
+    export NAME REPO ROOT DEFAULT_BRANCH COMMIT_PREFIX DEV_VALIDATION_CMD QA_VALIDATION_CMD QA_BROWSER_URL QA_TIMEOUT_SECONDS HANDLER_TIMEOUT_SECONDS MERGE_STRATEGY AUTO_REBASE AUTO_REWORK_ON_CI BACKEND MAX_CONCURRENT_PRS MAX_CONCURRENT_HANDLERS WORKTREE_EXTRA_PATHS LOOP_AGENT_MODEL ALLOWED_AUTHORS WORKFLOW LOOP_LABEL_OVERRIDES _PROJECT_AGENT _PROJECT_MODEL _PROJECT_FALLBACK
 }
 
 # loop_list_slugs — print each project slug on its own line

--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -1723,6 +1723,153 @@ for c in data.get("comments", [])[-10:]:
     return 0
 }
 
+# --- Check: CI red on loop-opened PRs → auto-apply needs-rework ---------------
+# Scans open PRs whose head branch matches the loop branch convention
+# (feat/issue-N-*). For each, queries `gh pr checks` to look for required
+# checks in FAILURE state. If found, and the PR has no human review and no
+# needs-rework label already, applies needs-rework to the PR and strips the
+# parent issue's trigger label (needs-dev / in-dev) so the scanner stops
+# re-claiming it. Emits a pr_ci_failed event to loop-monitor.
+#
+# No-op conditions (checked before any mutation):
+#   - PR already has needs-rework or changes-requested label
+#   - PR has at least one human APPROVED or CHANGES_REQUESTED review
+#   - dev.auto_rework_on_ci is false in projects.yaml for this project
+#
+# Configurable env (all optional):
+#   AUTO_REWORK_ON_CI      — set to "false" to disable per-project (default: true)
+#   LOOP_BRANCH_PREFIX     — branch prefix convention (default: feat/issue-)
+reconcile_ci_red_prs() {
+    local repo="$1"
+    local branch_prefix="${LOOP_BRANCH_PREFIX:-feat/issue-}"
+
+    # Per-project opt-out via dev.auto_rework_on_ci: false in projects.yaml.
+    if [ "${AUTO_REWORK_ON_CI:-true}" = "false" ]; then
+        log "[$repo] CI-rework: disabled via AUTO_REWORK_ON_CI=false — skipping"
+        return 0
+    fi
+
+    log "[$repo] CI-rework: scanning loop-opened PRs for red CI"
+
+    local prs_json
+    prs_json=$(backend_list_open_prs_raw "$repo") || prs_json="[]"
+
+    # Filter to PRs whose head branch matches the loop convention.
+    local loop_prs
+    loop_prs=$(PJSON="$prs_json" PREFIX="$branch_prefix" python3 - <<'PY'
+import json, os, re
+prs = json.loads(os.environ['PJSON'])
+prefix = os.environ['PREFIX']
+pat = re.compile(r'^' + re.escape(prefix) + r'(\d+)-')
+for pr in prs:
+    head = pr.get('headRefName', '')
+    m = pat.match(head)
+    if not m:
+        continue
+    issue_num = m.group(1)
+    lbls = [l['name'] if isinstance(l, dict) else l for l in pr.get('labels', [])]
+    print(f"{pr['number']}\t{head}\t{issue_num}\t{','.join(lbls)}\t{(pr.get('body') or '')[:400]}")
+PY
+)
+
+    if [ -z "$loop_prs" ]; then
+        log "[$repo] CI-rework: no loop-opened PRs found"
+        return 0
+    fi
+
+    local pr_num head_ref issue_num labels_csv pr_body
+    while IFS=$'\t' read -r pr_num head_ref issue_num labels_csv pr_body; do
+        [ -z "$pr_num" ] && continue
+
+        # Skip if PR already has needs-rework or changes-requested (already handled).
+        if echo "$labels_csv" | grep -qE '(needs-rework|changes-requested)'; then
+            log "[$repo] CI-rework: PR#$pr_num already has needs-rework/changes-requested — skip"
+            continue
+        fi
+
+        # Skip if PR has any human review (APPROVED or CHANGES_REQUESTED).
+        local review_state
+        review_state=$(gh pr view "$pr_num" --repo "$repo" \
+            --json reviews --jq '[.reviews[].state] | map(select(. == "APPROVED" or . == "CHANGES_REQUESTED")) | length' \
+            2>/dev/null || echo "0")
+        if [ "${review_state:-0}" -gt 0 ]; then
+            log "[$repo] CI-rework: PR#$pr_num has human review (state=$review_state) — skip"
+            continue
+        fi
+
+        # Query CI checks for this PR.
+        local checks_json
+        checks_json=$(gh pr checks "$pr_num" --repo "$repo" --json name,state,required \
+            2>/dev/null || echo "[]")
+
+        # Detect any required check in FAILURE state.
+        local has_failure
+        has_failure=$(CHECKS="$checks_json" python3 - <<'PY2'
+import json, os
+checks = json.loads(os.environ['CHECKS'])
+for c in checks:
+    # gh pr checks --json uses 'state' field with value 'FAILURE' for failed checks.
+    # 'required' is a bool; treat absent as False.
+    if c.get('required') and c.get('state', '').upper() in ('FAILURE', 'FAILED'):
+        print('yes')
+        break
+PY2
+)
+
+        if [ "$has_failure" != "yes" ]; then
+            log "[$repo] CI-rework: PR#$pr_num — no required check failures"
+            continue
+        fi
+
+        log "[$repo] CI-rework: PR#$pr_num (branch=$head_ref) has required CI failure — applying needs-rework"
+        loop_notify "Loop reconciler: $repo — PR#$pr_num (${head_ref}) has red required CI; applying needs-rework to issue #${issue_num}"
+
+        if $DRY_RUN; then
+            log "[$repo] DRY_RUN: would apply needs-rework to PR#$pr_num and strip trigger label from issue #$issue_num"
+            continue
+        fi
+
+        # Apply needs-rework to the PR.
+        backend_add_label "$repo" "$pr_num" needs-rework \
+            || log "[$repo] WARN: CI-rework: failed to add needs-rework to PR#$pr_num"
+
+        # Strip trigger label(s) from the parent issue so the scanner doesn't re-claim.
+        local trigger_label
+        for trigger_label in needs-dev in-dev dev in-progress; do
+            backend_remove_label "$repo" "$issue_num" "$trigger_label" 2>/dev/null || true
+        done
+
+        # Post a comment on the PR explaining the auto-rework.
+        local failing_checks
+        failing_checks=$(CHECKS="$checks_json" python3 - <<'PY3'
+import json, os
+checks = json.loads(os.environ['CHECKS'])
+names = [c['name'] for c in checks if c.get('required') and c.get('state','').upper() in ('FAILURE','FAILED')]
+print(', '.join(names) if names else 'unknown')
+PY3
+)
+        backend_comment_pr "$repo" "$pr_num" \
+            "Reconciler: required CI check(s) failed (\`${failing_checks}\`). Applying \`needs-rework\` so the dev agent can address the failures. Stripped trigger label from issue #${issue_num}." \
+            2>/dev/null || true
+
+        # Emit pr_ci_failed event to loop-monitor (fire-and-forget; non-fatal if absent).
+        local monitor_url="${LOOP_MONITOR_URL:-}"
+        if [ -n "$monitor_url" ]; then
+            local event_payload
+            event_payload=$(python3 -c "
+import json, sys
+print(json.dumps({'type':'pr_ci_failed','payload':{'repo':'${repo}','pr_number':${pr_num},'issue_number':${issue_num},'branch':'${head_ref}','failing_checks':'${failing_checks}'}}))" 2>/dev/null || echo "")
+            if [ -n "$event_payload" ]; then
+                curl -s -X POST "$monitor_url/events" \
+                    -H 'Content-Type: application/json' \
+                    -d "$event_payload" >/dev/null 2>&1 || true
+            fi
+        fi
+
+        log "[$repo] CI-rework: done — PR#$pr_num → needs-rework, issue #$issue_num trigger stripped"
+    done <<< "$loop_prs"
+}
+
 run_project() {
     local slug="$1"
     loop_load_project "$slug" || { log "skip $slug (config error)"; return 0; }
@@ -1743,6 +1890,7 @@ run_project() {
     reconcile_needs_clarification "$REPO"
     reconcile_unblock "$REPO"
     reconcile_orphaned_in_progress "$REPO" "$slug"
+    reconcile_ci_red_prs "$REPO"
     reconcile_dirty_rework_prs "$REPO"
     reconcile_conflict_blocked_prs "$REPO"
     reconcile_stale_base "$REPO"

--- a/tests/reconciler-ci-rework.bats
+++ b/tests/reconciler-ci-rework.bats
@@ -1,0 +1,280 @@
+#!/usr/bin/env bats
+# tests/reconciler-ci-rework.bats — unit tests for reconcile_ci_red_prs in
+# scanner/reconciler.sh (issue #268). Sources reconciler.sh in lib-only mode
+# so the main run is skipped, then exercises the function with stubbed
+# backends and gh.
+#
+# Covers:
+#   - FAILURE on required check → needs-rework applied, trigger stripped
+#   - SUCCESS (no failures) → no-op
+#   - Already has needs-rework label → no-op
+#   - Human review present → no-op
+#   - AUTO_REWORK_ON_CI=false → no-op
+#   - DRY_RUN → no mutations
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export OPS_LOG="$BATS_TMPDIR/ops.log"
+    rm -f "$OPS_LOG"
+
+    export REPO="owner/test-repo"
+    export DRY_RUN=false
+    export AUTO_REWORK_ON_CI=true
+    export LOOP_BRANCH_PREFIX="feat/issue-"
+    export LOOP_MONITOR_URL=""
+
+    # Source reconciler in lib-only mode so only functions are defined.
+    LOOP_RECONCILER_LIB_ONLY=1
+    set --
+    # shellcheck source=../scanner/reconciler.sh
+    source "$REPO_ROOT/scanner/reconciler.sh"
+
+    # Default: no loop-opened PRs.
+    backend_list_open_prs_raw() { echo "${MOCK_PRS_JSON:-[]}"; }
+    backend_add_label()         { echo "add_label $2 $3"    >> "$OPS_LOG"; }
+    backend_remove_label()      { echo "remove_label $2 $3" >> "$OPS_LOG"; }
+    backend_comment_pr()        { echo "comment_pr $2"      >> "$OPS_LOG"; }
+
+    # gh stub: dispatched for `gh pr view` (reviews) and `gh pr checks`.
+    gh() {
+        # gh pr view <num> --repo <repo> --json reviews --jq ...
+        if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+            echo "${MOCK_REVIEW_COUNT:-0}"
+            return 0
+        fi
+        # gh pr checks <num> --repo <repo> --json name,state,required
+        if [ "$1" = "pr" ] && [ "$2" = "checks" ]; then
+            echo "${MOCK_CHECKS_JSON:-[]}"
+            return 0
+        fi
+        return 0
+    }
+
+    loop_notify() { :; }
+    log()         { :; }
+}
+
+teardown() {
+    rm -rf "$LOOP_LOG_DIR" "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 1: required check FAILURE → apply needs-rework, strip trigger
+# ---------------------------------------------------------------------------
+
+@test "reconcile_ci_red_prs: FAILURE on required check applies needs-rework to PR" {
+    export MOCK_PRS_JSON='[{
+        "number": 133,
+        "headRefName": "feat/issue-42-add-login",
+        "labels": [{"name":"needs-review"}],
+        "body": "Closes #42",
+        "updatedAt": "2026-01-01T00:00:00Z"
+    }]'
+    export MOCK_REVIEW_COUNT=0
+    export MOCK_CHECKS_JSON='[
+        {"name":"lint","state":"FAILURE","required":true},
+        {"name":"build","state":"SUCCESS","required":true}
+    ]'
+
+    run reconcile_ci_red_prs "$REPO"
+    [ "$status" -eq 0 ]
+
+    grep -q "add_label 133 needs-rework" "$OPS_LOG"
+}
+
+@test "reconcile_ci_red_prs: FAILURE strips trigger labels from parent issue" {
+    export MOCK_PRS_JSON='[{
+        "number": 133,
+        "headRefName": "feat/issue-42-add-login",
+        "labels": [{"name":"needs-review"}],
+        "body": "Closes #42",
+        "updatedAt": "2026-01-01T00:00:00Z"
+    }]'
+    export MOCK_REVIEW_COUNT=0
+    export MOCK_CHECKS_JSON='[{"name":"lint","state":"FAILURE","required":true}]'
+
+    run reconcile_ci_red_prs "$REPO"
+    [ "$status" -eq 0 ]
+
+    # At least one trigger label removal on the parent issue (42).
+    grep -qE "remove_label 42 (needs-dev|in-dev|dev|in-progress)" "$OPS_LOG"
+}
+
+@test "reconcile_ci_red_prs: FAILURE posts a comment on the PR" {
+    export MOCK_PRS_JSON='[{
+        "number": 133,
+        "headRefName": "feat/issue-42-add-login",
+        "labels": [],
+        "body": "Closes #42",
+        "updatedAt": "2026-01-01T00:00:00Z"
+    }]'
+    export MOCK_REVIEW_COUNT=0
+    export MOCK_CHECKS_JSON='[{"name":"lint","state":"FAILURE","required":true}]'
+
+    run reconcile_ci_red_prs "$REPO"
+    [ "$status" -eq 0 ]
+
+    grep -q "comment_pr 133" "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 2: all checks SUCCESS → no-op
+# ---------------------------------------------------------------------------
+
+@test "reconcile_ci_red_prs: all checks SUCCESS → no mutations" {
+    export MOCK_PRS_JSON='[{
+        "number": 134,
+        "headRefName": "feat/issue-55-fix-nav",
+        "labels": [],
+        "body": "Closes #55",
+        "updatedAt": "2026-01-01T00:00:00Z"
+    }]'
+    export MOCK_REVIEW_COUNT=0
+    export MOCK_CHECKS_JSON='[
+        {"name":"lint","state":"SUCCESS","required":true},
+        {"name":"build","state":"SUCCESS","required":true}
+    ]'
+
+    run reconcile_ci_red_prs "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -q "add_label" "$OPS_LOG"
+    [ ! -s "$OPS_LOG" ] || ! grep -q "remove_label" "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 3: PR already has needs-rework → no-op
+# ---------------------------------------------------------------------------
+
+@test "reconcile_ci_red_prs: PR already has needs-rework → no-op" {
+    export MOCK_PRS_JSON='[{
+        "number": 200,
+        "headRefName": "feat/issue-99-cache",
+        "labels": [{"name":"needs-rework"}],
+        "body": "Closes #99",
+        "updatedAt": "2026-01-01T00:00:00Z"
+    }]'
+    export MOCK_REVIEW_COUNT=0
+    export MOCK_CHECKS_JSON='[{"name":"lint","state":"FAILURE","required":true}]'
+
+    run reconcile_ci_red_prs "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -q "add_label" "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 4: PR has human review → no-op
+# ---------------------------------------------------------------------------
+
+@test "reconcile_ci_red_prs: human review present → no-op" {
+    export MOCK_PRS_JSON='[{
+        "number": 201,
+        "headRefName": "feat/issue-77-auth",
+        "labels": [],
+        "body": "Closes #77",
+        "updatedAt": "2026-01-01T00:00:00Z"
+    }]'
+    export MOCK_REVIEW_COUNT=1
+    export MOCK_CHECKS_JSON='[{"name":"lint","state":"FAILURE","required":true}]'
+
+    run reconcile_ci_red_prs "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -q "add_label" "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 5: non-required check FAILURE → no-op
+# ---------------------------------------------------------------------------
+
+@test "reconcile_ci_red_prs: only non-required check fails → no mutation" {
+    export MOCK_PRS_JSON='[{
+        "number": 202,
+        "headRefName": "feat/issue-88-perf",
+        "labels": [],
+        "body": "Closes #88",
+        "updatedAt": "2026-01-01T00:00:00Z"
+    }]'
+    export MOCK_REVIEW_COUNT=0
+    export MOCK_CHECKS_JSON='[
+        {"name":"coverage","state":"FAILURE","required":false},
+        {"name":"lint","state":"SUCCESS","required":true}
+    ]'
+
+    run reconcile_ci_red_prs "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -q "add_label" "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 6: AUTO_REWORK_ON_CI=false → skip entirely
+# ---------------------------------------------------------------------------
+
+@test "reconcile_ci_red_prs: AUTO_REWORK_ON_CI=false → no-op" {
+    export AUTO_REWORK_ON_CI=false
+    export MOCK_PRS_JSON='[{
+        "number": 300,
+        "headRefName": "feat/issue-10-login",
+        "labels": [],
+        "body": "Closes #10",
+        "updatedAt": "2026-01-01T00:00:00Z"
+    }]'
+    export MOCK_REVIEW_COUNT=0
+    export MOCK_CHECKS_JSON='[{"name":"lint","state":"FAILURE","required":true}]'
+
+    run reconcile_ci_red_prs "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -q "add_label" "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 7: DRY_RUN → no mutations despite red CI
+# ---------------------------------------------------------------------------
+
+@test "reconcile_ci_red_prs: DRY_RUN performs no mutations" {
+    export DRY_RUN=true
+    export MOCK_PRS_JSON='[{
+        "number": 400,
+        "headRefName": "feat/issue-20-signup",
+        "labels": [],
+        "body": "Closes #20",
+        "updatedAt": "2026-01-01T00:00:00Z"
+    }]'
+    export MOCK_REVIEW_COUNT=0
+    export MOCK_CHECKS_JSON='[{"name":"lint","state":"FAILURE","required":true}]'
+
+    run reconcile_ci_red_prs "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -q "add_label" "$OPS_LOG"
+    [ ! -s "$OPS_LOG" ] || ! grep -q "remove_label" "$OPS_LOG"
+    [ ! -s "$OPS_LOG" ] || ! grep -q "comment_pr" "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 8: PR head does not match loop branch convention → no-op
+# ---------------------------------------------------------------------------
+
+@test "reconcile_ci_red_prs: non-loop branch PR is ignored" {
+    export MOCK_PRS_JSON='[{
+        "number": 500,
+        "headRefName": "hotfix/login-crash",
+        "labels": [],
+        "body": "Closes #30",
+        "updatedAt": "2026-01-01T00:00:00Z"
+    }]'
+    export MOCK_REVIEW_COUNT=0
+    export MOCK_CHECKS_JSON='[{"name":"lint","state":"FAILURE","required":true}]'
+
+    run reconcile_ci_red_prs "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -q "add_label" "$OPS_LOG"
+}


### PR DESCRIPTION
## Summary

- Adds `reconcile_ci_red_prs` sweep to `scanner/reconciler.sh` that detects loop-opened PRs (`feat/issue-N-*`) with required CI check failures and auto-applies `needs-rework`
- Strips the parent issue's trigger label (`needs-dev` / `in-dev` / etc.) so the scanner stops re-claiming the slot
- Emits a `pr_ci_failed` event to loop-monitor via `LOOP_MONITOR_URL` (no-op if unset)
- Adds `dev.auto_rework_on_ci` config option (default `true`) to opt out per project
- 10 bats fixtures in `tests/reconciler-ci-rework.bats` covering FAILURE, SUCCESS, already-has-rework, human-review, non-required failure, opt-out, DRY_RUN, and non-loop branch cases
- README: new "Auto-rework on red CI" section with opt-out config example

## No-op conditions
- PR already has `needs-rework` or `changes-requested`
- PR has at least one human review (APPROVED or CHANGES_REQUESTED)
- Failing check is not marked **required** in repo settings
- `dev.auto_rework_on_ci: false` in `config/projects.yaml`
- `--dry-run` mode

## Test plan
- [x] `bats tests/reconciler-ci-rework.bats` — 10/10 pass
- [x] Pre-existing test failures confirmed pre-existing on `main` (not introduced by this PR)

Closes #268