### PR TITLE
feat(rework): give agent full PR diagnostics including CI logs

### DIFF
--- a/scripts/dev-rework-handler.sh
+++ b/scripts/dev-rework-handler.sh
@@ -220,26 +220,47 @@ _QA_LABEL=$(loop_label_for "$SLUG" "needs-qa")
 _QA_PASS_LABEL=$(loop_label_for "$SLUG" "qa-pass")
 _QA_FAIL_LABEL=$(loop_label_for "$SLUG" "qa-fail")
 
+_FULL_PR_DIAGNOSTICS="Read the PR's full state before deciding what to fix. The trigger could be ANY of: failing CI, merge conflict, reviewer feedback, QA failure. Always check all four.
+
+   a. Mergeability:
+      gh pr view ${PR_NUM} --repo ${REPO} --json mergeable,mergeStateStatus
+      If mergeable=CONFLICTING or mergeStateStatus=DIRTY: rebase first (see below) before anything else.
+
+   b. CI check status:
+      gh pr view ${PR_NUM} --repo ${REPO} --json statusCheckRollup
+      For EACH check whose conclusion is FAILURE, fetch the actual log:
+        gh run view <run-id> --repo ${REPO} --log-failed | tail -120
+      where <run-id> is the run-id surfaced by statusCheckRollup. The log shows
+      exactly which file/line failed (lint rule, type error, build error,
+      test assertion). DO NOT guess what's wrong — read the log.
+
+   c. Review feedback:
+      gh pr view ${PR_NUM} --repo ${REPO} --json reviews,comments
+      Focus on the most recent review with state=REQUEST_CHANGES, plus its
+      inline comments and general comments. Address every concrete point.
+
+   d. PR comments (e.g. QA failure summaries):
+      Same json fetch above; look for comments containing 'qa-fail', 'QA',
+      lint output, build output, or test failures.
+
+   Now you have the full picture: rebase if needed → fix each CI failure
+   using the actual log output → address review feedback → run validation
+   locally before committing."
+
 if [ "$REWORK_CONTEXT" = "qa-fail" ]; then
     _REWORK_TRIGGER="a QA failure"
-    _STEP2="2. This rework was triggered by a QA FAILURE. Fix the issues reported below.
-   QA failure details:
+    _STEP2="2. ${_FULL_PR_DIAGNOSTICS}
+
+   QA failure details captured at dispatch (use as a starting point; still
+   re-read PR state above):
    ---
    ${QA_FAILURE_DETAILS}
-   ---
-   If no details are shown, run: gh pr view ${PR_NUM} --repo ${REPO} --json comments
-   and look for comments containing QA failure output.
-   Check for merge conflicts too:
-   gh pr view ${PR_NUM} --repo ${REPO} --json mergeable,mergeStateStatus
-   - If mergeable=CONFLICTING or mergeStateStatus=DIRTY: rebase first (see below), then fix QA issues."
+   ---"
     _STEP7="   gh pr comment ${PR_NUM} --repo ${REPO} --body 'Fixed QA failure: <summary of what was fixed>'"
 else
-    _REWORK_TRIGGER="reviewer feedback"
-    _STEP2="2. Check PR state details -- the trigger could be reviewer feedback OR a merge conflict:
-   gh pr view ${PR_NUM} --repo ${REPO} --json body,reviews,comments,mergeable,mergeStateStatus
-   - If mergeable=CONFLICTING or mergeStateStatus=DIRTY: rebase onto origin/${DEFAULT_BRANCH} and resolve conflicts. Use 'git fetch origin && git rebase origin/${DEFAULT_BRANCH}', resolve each conflicted file, 'git add' resolved files, 'git rebase --continue', then 'git push --force-with-lease origin ${PR_BRANCH}'. Skip to step 6.
-   - Otherwise: focus on the most recent review with state REQUEST_CHANGES and its inline comments."
-    _STEP7="   gh pr comment ${PR_NUM} --repo ${REPO} --body 'Addressed review feedback: <summary>'"
+    _REWORK_TRIGGER="reviewer feedback or CI failure"
+    _STEP2="2. ${_FULL_PR_DIAGNOSTICS}"
+    _STEP7="   gh pr comment ${PR_NUM} --repo ${REPO} --body 'Addressed feedback / fixed CI: <summary>'"
 fi
 
 if [ -n "$DEV_VALIDATION_CMD" ]; then


### PR DESCRIPTION
## Summary

Rewrites the dev-rework prompt's diagnostics section so the agent reads **all four** reasons a PR might need rework — including the actual CI failure logs — rather than just \`reviews/comments\`.

## What was missing

The old prompt told the agent to check \`body,reviews,comments,mergeable,mergeStateStatus\`. It did **not** mention \`statusCheckRollup\` or how to fetch the actual log output from failed CI checks. So when lint, typecheck, or build failed, the agent reworked without ever reading the error — often shipping the same code or fixing the wrong thing.

## What's now in the prompt

\`\`\`
Read the PR's full state before deciding what to fix. The trigger could be
ANY of: failing CI, merge conflict, reviewer feedback, QA failure. Always
check all four.

  a. Mergeability:    gh pr view ... --json mergeable,mergeStateStatus
  b. CI status:       gh pr view ... --json statusCheckRollup
                      → for each FAILURE check, gh run view <id> --log-failed
                      → DO NOT guess what's wrong — read the log
  c. Reviews:         REQUEST_CHANGES body + inline comments
  d. Comments:        qa-fail summaries, lint output, etc.
\`\`\`

Both rework contexts (qa-fail and reviewer-feedback) share this diagnostics block. The qa-fail context still gets the captured failure-details snippet as a starting hint.

## Concrete trigger

Loop-monitor's autonomous pipeline produced 7 PRs in one hour after the dispatch fix in #266. All 7 had CI failures the agent had no way to see. Combined with the new \`dev.validation_cmd\` for loop-monitor (so the agent runs lint/typecheck/build locally pre-commit), this closes the loop: errors caught locally on the way in, errors that escape are diagnosed properly on the way back through rework.

## Test plan

- [x] \`bash -n\` clean
- [x] shellcheck clean
- [ ] Live: relabel the 6 stuck loop-monitor PRs \`needs-rework\`, watch the rework-handler log to confirm agents \`gh run view --log-failed\` and address the actual lint output

## Out of scope

- Same upgrade for \`dev-handler\` initial-authoring path (lower leverage; \`validation_cmd\` covers most of it)
- Structured hints from review-handler (could replace the log-diving step entirely)

🤖 Generated with [Claude Code](https://claude.com/claude-code)