### PR TITLE
feat(prompt): agent discovers CI commands from project, not from config

### DIFF
--- a/scripts/dev-handler.sh
+++ b/scripts/dev-handler.sh
@@ -176,7 +176,12 @@ Your job:
    If a branch named fix/issue-${ISSUE_NUM}-* or feat/issue-${ISSUE_NUM}-* already exists on origin, delete it first:
    git push origin --delete <existing-branch-name>
 3. Implement the change. Follow CLAUDE.md conventions.
-$( [ -n "$DEV_VALIDATION_CMD" ] && echo "4. Run validation: ${DEV_VALIDATION_CMD//\{project_root\}/$ROOT}" )
+4. Validate locally before committing — match CI exactly. Discover what CI runs by reading the project itself:
+   a. Inspect \`.github/workflows/*.yml\` — list every step (\`run:\` blocks) for jobs triggered on \`pull_request\` or \`push\`.
+   b. Inspect \`package.json\` (\`scripts\`), \`Makefile\` (targets), \`pyproject.toml\` (\`[tool.*]\`), \`pre-commit-config.yaml\` for the actual commands those steps invoke.
+   c. Run those commands locally in this worktree, in dependency order (lint → typecheck → tests → build). Iterate until ALL pass.
+   d. If a command needs deps not in the worktree (e.g. \`node_modules\`, build venv): install them, then run. ${WORKTREE_EXTRA_PATHS:+Some gitignored paths are pre-symlinked from the primary checkout — check before installing.}${DEV_VALIDATION_CMD:+ Operator-provided hint (run this, but do NOT skip the discovery above): ${DEV_VALIDATION_CMD//\{project_root\}/$ROOT}}
+   Commit only after every CI-equivalent check passes locally. Shipping a PR with predictable lint/build failures wastes a full rework cycle.
 5. Before committing, verify there are actual staged changes:
    git diff --cached --quiet && echo 'WARNING: no staged changes' || true
    If there are no changes to commit, comment on the issue explaining why (e.g. already implemented, out of scope) and add label 'needs-clarification' instead of opening an empty PR.

--- a/scripts/dev-rework-handler.sh
+++ b/scripts/dev-rework-handler.sh
@@ -263,11 +263,12 @@ else
     _STEP7="   gh pr comment ${PR_NUM} --repo ${REPO} --body 'Addressed feedback / fixed CI: <summary>'"
 fi
 
-if [ -n "$DEV_VALIDATION_CMD" ]; then
-    _VALIDATION_STEP="4. Run validation: ${DEV_VALIDATION_CMD//\{project_root\}/$ROOT}"
-else
-    _VALIDATION_STEP=""
-fi
+_VALIDATION_STEP="4. Validate locally before committing — match CI exactly. Discover what CI runs by reading the project itself:
+   a. Inspect .github/workflows/*.yml — list every \`run:\` step in jobs triggered on pull_request / push.
+   b. Inspect package.json (scripts), Makefile (targets), pyproject.toml ([tool.*]), .pre-commit-config.yaml for the actual commands.
+   c. Run those commands locally in this worktree, in dependency order (lint → typecheck → tests → build). Iterate until ALL pass.
+   d. If deps are missing (node_modules, build venv): install, then run. Some gitignored paths may be pre-symlinked — check before installing.${DEV_VALIDATION_CMD:+ Operator-provided hint (run this in addition to the discovery above): ${DEV_VALIDATION_CMD//\{project_root\}/$ROOT}}
+   Push only after every CI-equivalent check passes locally."
 _BACKEND_CLI_NOTE=$(backend_cli_note)
 
 _PROMPT_FILE=$(mktemp /tmp/rework-prompt-XXXXXX.txt)


### PR DESCRIPTION
## Summary

Both \`dev-handler\` and \`dev-rework-handler\` prompts now tell the agent to **discover** what to validate by reading the project itself, instead of relying on a static \`DEV_VALIDATION_CMD\` that operators have to keep in sync with CI.

## Why

\`DEV_VALIDATION_CMD\` in \`projects.yaml\` is a config-drift trap. Add a typecheck step in CI → forget to update validation_cmd → agent runs old (partial) validation → CI catches the new step → rework loop. Multiplied across projects this is real maintenance.

The agent has full read access to the worktree. Telling it to inspect \`.github/workflows/\`, \`package.json\`, \`Makefile\`, \`pyproject.toml\`, \`.pre-commit-config.yaml\` and run what's actually there is more robust than parameterizing each project.

## What's in the prompt now

\`\`\`
4. Validate locally before committing — match CI exactly. Discover what
   CI runs by reading the project itself:
   a. Inspect .github/workflows/*.yml — every \`run:\` step in jobs
      triggered on pull_request/push.
   b. Inspect package.json (scripts), Makefile (targets), pyproject.toml
      ([tool.*]), .pre-commit-config.yaml for the actual commands.
   c. Run those commands locally in dependency order (lint → typecheck
      → tests → build). Iterate until ALL pass.
   d. If deps are missing (node_modules, build venv): install. Some
      gitignored paths may be pre-symlinked — check before installing.
\`\`\`

\`DEV_VALIDATION_CMD\` is preserved as a HINT (operators can still pin
fast subsets for feedback), but the agent runs the discovered set
regardless.

## Files

- \`scripts/dev-handler.sh\` — initial-authoring prompt
- \`scripts/dev-rework-handler.sh\` — rework prompt (already reads CI status from #273; now also discovers and runs validation)

## Test plan

- [x] \`bash -n\` clean on both
- [x] \`shellcheck -S warning\` clean
- [ ] Live: a fresh dev dispatch should log the agent inspecting \`.github/workflows/\` and running the discovered commands

## Related

- #266 — PR-filter fix that unblocked dispatch
- #273 — rework prompt now reads CI logs (\`gh run view --log-failed\`)
- This PR — agent discovers what to run rather than being told

🤖 Generated with [Claude Code](https://claude.com/claude-code)