### PR TITLE
feat(rework): thread captured REBASE_CONFLICTS file list into prompt

### DIFF
--- a/scripts/dev-rework-handler.sh
+++ b/scripts/dev-rework-handler.sh
@@ -224,7 +224,14 @@ _FULL_PR_DIAGNOSTICS="Read the PR's full state before deciding what to fix. The 
 
    a. Mergeability:
       gh pr view ${PR_NUM} --repo ${REPO} --json mergeable,mergeStateStatus
-      If mergeable=CONFLICTING or mergeStateStatus=DIRTY: rebase first (see below) before anything else.
+      If mergeable=CONFLICTING or mergeStateStatus=DIRTY: rebase first (see below) before anything else.${REBASE_CONFLICTS:+
+
+      AUTO-REBASE ALREADY ATTEMPTED AND ABORTED — these files conflicted:
+        ${REBASE_CONFLICTS}
+      Re-run \`git rebase origin/${DEFAULT_BRANCH}\` and resolve each file
+      with intent (read both sides, integrate semantically — do not blindly
+      \`--theirs\` or \`--ours\`). Then \`git add\` resolved files,
+      \`git rebase --continue\`, and \`git push --force-with-lease origin ${PR_BRANCH}\`.}
 
    b. CI check status:
       gh pr view ${PR_NUM} --repo ${REPO} --json statusCheckRollup


### PR DESCRIPTION
## Summary

Closes a small but real friction: \`dev-rework-handler\` already captures the exact filenames that conflicted on auto-rebase (\`REBASE_CONFLICTS\`) but didn't pass them to the agent. Agent had to re-discover them via \`git status\` after the abort.

Now the prompt's mergeability section, when an auto-rebase failed, names the conflicting files and reminds the agent to integrate semantically (not blindly \`--theirs\`/\`--ours\`).

## Behavior

- \`REBASE_CONFLICTS\` is unset (clean rebase, or no rebase needed) → no extra prompt content
- \`REBASE_CONFLICTS=\"web/src/App.tsx web/src/lib/types.ts\"\` (auto-rebase aborted) → prompt now says:
  > AUTO-REBASE ALREADY ATTEMPTED AND ABORTED — these files conflicted:
  >   web/src/App.tsx web/src/lib/types.ts
  > Re-run \`git rebase origin/main\` and resolve each file with intent.

Bash \`\${VAR:+...}\` parameter expansion handles the conditional cleanly.

## Test plan

- [x] \`bash -n\` clean
- [x] \`shellcheck -S warning\` clean
- [ ] Live: trigger rework on a conflicting PR, verify prompt names the files

## Why

Live evidence: 7 loop-monitor PRs queued for rework tonight all conflict on the same shared scaffold files. Telling the agent which files to focus on saves a discovery roundtrip per PR × 7 PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)