### PR TITLE
[LOOP-262] resolve rework trigger label per-project in pr-watchdog

### DIFF
--- a/scripts/_watchdog_filter.py
+++ b/scripts/_watchdog_filter.py
@@ -24,7 +24,7 @@ import json
 import sys
 from datetime import datetime, timezone
 
-EXCLUDE_LABELS = {"needs-rework", "blocked", "needs-clarification"}
+_DEFAULT_EXCLUDE_LABELS = "needs-rework,blocked,needs-clarification"
 
 
 def parse_iso(ts: str) -> datetime:
@@ -38,7 +38,14 @@ def main() -> int:
     ap.add_argument("--conflict-grace", type=int, required=True)
     ap.add_argument("--ci-grace", type=int, required=True)
     ap.add_argument("--allowed-authors", required=True, help="comma-separated")
+    ap.add_argument(
+        "--exclude-labels",
+        default=_DEFAULT_EXCLUDE_LABELS,
+        help="comma-separated labels that mark a PR as already handled",
+    )
     args = ap.parse_args()
+
+    exclude_labels = {l.strip() for l in args.exclude_labels.split(",") if l.strip()}
 
     allowed = {a.strip() for a in args.allowed_authors.split(",") if a.strip()}
     if not allowed:
@@ -57,7 +64,7 @@ def main() -> int:
             continue
 
         labels = {(l.get("name") or "") for l in pr.get("labels") or []}
-        if labels & EXCLUDE_LABELS:
+        if labels & exclude_labels:
             continue
 
         try:

--- a/scripts/pr-watchdog.sh
+++ b/scripts/pr-watchdog.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 # pr-watchdog.sh — auto-rework stale loop-authored PRs.
 #
-# Polls every project's open PRs and labels them `needs-rework` if they are:
+# Polls every project's open PRs and labels them with the project's rework
+# trigger label (resolved via loop_stage_trigger; falls back to needs-rework) if:
 #   - authored by an account in ALLOWED_AUTHORS (per-project, from projects.yaml), and
 #   - sitting with a merge conflict for >CONFLICT_GRACE_SECONDS, or
 #   - failing CI for >CI_GRACE_SECONDS,
-#   - and don't already carry needs-rework / blocked / needs-clarification.
+#   - and don't already carry the rework trigger / needs-rework / blocked / needs-clarification.
 #
 # Designed to run every ~15 min via launchd / cron. The dev-rework handler
 # downstream picks up the label and rebases + fixes.
@@ -22,6 +23,8 @@ LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$LOOP_ROOT/lib/env.sh"
 # shellcheck source=../lib/config.sh
 source "$LOOP_ROOT/lib/config.sh"
+# shellcheck source=../lib/workflow.sh
+source "$LOOP_ROOT/lib/workflow.sh"
 # shellcheck source=../lib/backends/backend.sh
 source "$LOOP_ROOT/lib/backends/backend.sh"
 
@@ -57,6 +60,9 @@ while IFS= read -r slug; do
         continue
     fi
 
+    rework_label=$(loop_stage_trigger "$slug" "rework" "pr" 2>/dev/null || echo "")
+    [ -z "$rework_label" ] && rework_label="needs-rework"
+
     # One JSON dump per repo, piped to filter.
     local_payload=$(gh pr list --repo "$REPO" --state open --limit 50 \
         --json number,author,labels,mergeable,statusCheckRollup,createdAt,updatedAt \
@@ -65,19 +71,20 @@ while IFS= read -r slug; do
     while IFS=$'\t' read -r num reason; do
         [ -z "$num" ] && continue
         if $DRY_RUN; then
-            log "DRY $slug #$num would-rework: $reason"
+            log "DRY $slug #$num would-rework ($rework_label): $reason"
             continue
         fi
-        log "rework $slug #$num: $reason"
-        if backend_add_label "$REPO" "$num" needs-rework 2>/dev/null; then
-            loop_notify "🛠 [$slug] PR #$num auto-rework: $reason" || true
+        log "rework $slug #$num ($rework_label): $reason"
+        if backend_add_label "$REPO" "$num" "$rework_label" 2>/dev/null; then
+            loop_notify "🛠 [$slug] PR #$num auto-rework ($rework_label): $reason" || true
         else
-            log "WARN: failed to add label to $slug #$num"
+            log "WARN: failed to add label $rework_label to $slug #$num"
         fi
     done < <(printf '%s' "$local_payload" | python3 "$LOOP_ROOT/scripts/_watchdog_filter.py" \
             --conflict-grace "$CONFLICT_GRACE_SECONDS" \
             --ci-grace "$CI_GRACE_SECONDS" \
-            --allowed-authors "$ALLOWED_AUTHORS")
+            --allowed-authors "$ALLOWED_AUTHORS" \
+            --exclude-labels "$rework_label,blocked,needs-clarification,needs-rework")
 done < <(loop_list_slugs)
 
 log "tick done"

--- a/tests/pr-watchdog.bats
+++ b/tests/pr-watchdog.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+# tests/pr-watchdog.bats — unit tests for pr-watchdog rework label resolution.
+#
+# Verifies that loop_stage_trigger drives $rework_label, with correct fallback.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_WORKFLOW_DIR="$REPO_ROOT/config/workflows"
+    # shellcheck source=../lib/workflow.sh
+    source "$REPO_ROOT/lib/workflow.sh"
+
+    # Minimal project fixture using the default workflow
+    cat > "$BATS_TMPDIR/fixture.yaml" <<'YAML'
+version: 1
+projects:
+  - slug: test-proj
+    name: Test Project
+    repo: owner/test-repo
+    root: /tmp/fake
+    default_branch: main
+    workflow: default
+YAML
+    export LOOP_CONFIG="$BATS_TMPDIR/fixture.yaml"
+}
+
+teardown() {
+    rm -f "$BATS_TMPDIR/fixture.yaml"
+}
+
+# ---------------------------------------------------------------------------
+# rework_label resolution
+# ---------------------------------------------------------------------------
+
+@test "rework_label: default workflow resolves to needs-dev via loop_stage_trigger" {
+    # Run the resolution snippet from pr-watchdog.sh in a subshell
+    result=$(
+        rework_label=$(loop_stage_trigger "test-proj" "rework" "pr" 2>/dev/null || echo "")
+        [ -z "$rework_label" ] && rework_label="needs-rework"
+        echo "$rework_label"
+    )
+    [ "$result" = "needs-dev" ]
+}
+
+@test "rework_label: falls back to needs-rework when loop_stage_trigger returns non-zero" {
+    # Override loop_stage_trigger to simulate a missing workflow
+    loop_stage_trigger() { return 1; }
+    export -f loop_stage_trigger
+
+    result=$(
+        rework_label=$(loop_stage_trigger "no-wf-proj" "rework" "pr" 2>/dev/null || echo "")
+        [ -z "$rework_label" ] && rework_label="needs-rework"
+        echo "$rework_label"
+    )
+    [ "$result" = "needs-rework" ]
+}
+
+@test "rework_label: falls back to needs-rework when loop_stage_trigger outputs empty string" {
+    # Override loop_stage_trigger to echo nothing (empty stdout, exit 0)
+    loop_stage_trigger() { echo ""; return 0; }
+    export -f loop_stage_trigger
+
+    result=$(
+        rework_label=$(loop_stage_trigger "no-wf-proj" "rework" "pr" 2>/dev/null || echo "")
+        [ -z "$rework_label" ] && rework_label="needs-rework"
+        echo "$rework_label"
+    )
+    [ "$result" = "needs-rework" ]
+}


### PR DESCRIPTION
Closes #262

## Changes

- **`scripts/pr-watchdog.sh`**: Sources `lib/workflow.sh` and resolves `rework_label` via `loop_stage_trigger "$slug" "rework" "pr"` immediately after the `ALLOWED_AUTHORS` check. Falls back to `needs-rework` when the call returns empty or non-zero. All log lines, `backend_add_label`, and the filter invocation now use `$rework_label` instead of the hardcoded literal.
- **`scripts/_watchdog_filter.py`**: Added `--exclude-labels` CSV flag (default: `needs-rework,blocked,needs-clarification`, preserving existing behaviour). The watchdog passes `"$rework_label,blocked,needs-clarification,needs-rework"` so PRs carrying either the new trigger or the legacy alias are skipped, preventing double-labeling during alias-rename grace windows.
- **`tests/pr-watchdog.bats`** (new): Three bats tests verifying `$rework_label` resolution — default workflow resolves to `needs-dev`, non-zero exit from `loop_stage_trigger` falls back to `needs-rework`, empty stdout also falls back to `needs-rework`.

## Test Plan

- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — all pass
- `shellcheck -S warning lib/*.sh scripts/*.sh scanner/*.sh install.sh` — clean
- `python3 -m py_compile scripts/_watchdog_filter.py` — passes
- Dry-run on a default-workflow project should show `would-rework (needs-dev): ...` in log output