### PR TITLE
reconciler: keep `needs-dev` on PRs (PR rework trigger in default workflow)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,9 @@ context they need to fix their own failures rather than retry-burn.
   results. GitHub treats PRs as a kind of issue with shared number
   space; without the filter, a PR carrying \`needs-dev\` was emitted as
   a \`loop.dev_issue\` event with a PR-shaped payload (\`pr_number\` not
-  \`issue_number\`), boba-event's interpolator left \`{payload.issue_number}\`
+  \`issue_number\`), the event router's interpolator left \`{payload.issue_number}\`
   as a literal string, and dev-handler bailed on the resulting nonsense.
-  This single fix unblocked loop-monitor's entire pipeline (stalled 17 days).
+  This single fix unblocked the dependent project's entire pipeline (stalled 17 days).
 - **#243** po-handler belt-and-braces guard recognises \`needs-dev\` (was
   only checking the deprecated synonym). Eliminates a silent skip path.
 - **#239** \`_dedup_key\` portability: replace \`md5sum\` with a fallback

--- a/lib/labels.sh
+++ b/lib/labels.sh
@@ -250,9 +250,15 @@ loop_pipeline_tracked_labels_string() {
 # Reconciler strips any of these found on an open PR. Includes deprecated
 # aliases of the trigger labels so a stale `dev`/`po-review`/`plan` on a PR
 # also gets cleaned up.
+#
+# NOTE: `needs-dev` was intentionally REMOVED from this list. In the default
+# workflow (config/workflows/default.yaml) `needs-dev` is also the PR rework
+# trigger emitted by review-handler when changes are requested. Stripping it
+# from open PRs broke the rework flow: PRs ended up with no pipeline label and
+# became invisible to the scanner. Issue/PR overlap of `needs-dev` is by
+# design in the default workflow; treat it as a PR-valid label.
 LOOP_ISSUE_ONLY_LABELS=(
     needs-po
-    needs-dev
     tracker
     epic
     needs-clarification

--- a/tests/reconciler-pr-label-audit.bats
+++ b/tests/reconciler-pr-label-audit.bats
@@ -90,3 +90,18 @@ teardown() {
     [ ! -s "$OPS_LOG" ] || ! grep -q "remove_label" "$OPS_LOG"
     [ ! -s "$OPS_LOG" ] || ! grep -q "comment_pr"   "$OPS_LOG"
 }
+
+# Regression: `needs-dev` is the PR rework trigger in the default workflow.
+# Previously this list included `needs-dev`, so the reconciler stripped it
+# from PRs that had just been routed back for rework by review-handler. The
+# PR was left with zero pipeline labels and stalled invisibly. The fix
+# removed `needs-dev` from LOOP_ISSUE_ONLY_LABELS — assert the audit no
+# longer touches it.
+@test "reconcile_pr_label_audit: PR carrying needs-dev (PR rework trigger) is untouched" {
+    export MOCK_PRS_JSON='[{"number":80,"labels":[{"name":"needs-dev"}]}]'
+
+    run reconcile_pr_label_audit "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -q "remove_label" "$OPS_LOG"
+}


### PR DESCRIPTION
## What

`LOOP_ISSUE_ONLY_LABELS` in `lib/labels.sh` included `needs-dev`, which the reconciler then stripped from every open PR carrying it. But in the **default workflow** `needs-dev` is also the **PR rework trigger** — review-handler sets it when requesting changes. The reconciler was systematically removing the rework label seconds after review-handler set it, leaving PRs with zero pipeline labels and invisible to the scanner.

## Observed live

`svv2014/loop-monitor#166` timeline:
- 05:51 review-handler set `needs-dev` (rework requested)
- 06:07 reconciler removed it with the comment *"removed issue-only label(s): needs-dev. These trigger issue-side handlers and can misfire on PRs."*
- PR stalled with zero pipeline labels.

Same mechanism stranded 5 of 6 open loop-monitor PRs (`#159, #165, #166, #168, #173`) — the reason "nothing moves forward".

## Why this is the same class as #232

`needs-dev` is intentionally overloaded in the default workflow as both the **issue dev trigger** and the **PR rework trigger**. PR #232 fixed the scanner side (`issue_is_claimed` no longer treats issue's own dev trigger as a claim). This patch fixes the reconciler side.

## Fix

Remove `needs-dev` from `LOOP_ISSUE_ONLY_LABELS`. The other entries are correct:
- `needs-po`, `needs-clarification` — issue-only triggers, no PR meaning.
- `tracker`, `epic` — taxonomy markers for issues.
- `po-review`, `dev`, `plan` — deprecated aliases.

## Tests

`tests/reconciler-pr-label-audit.bats` — new regression test:
- PR carrying `needs-dev` is **not** stripped.

Full suite: `bats tests/` → 433 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)