### PR TITLE
[LOOP-281] reconciler: auto-rebase loop PRs when base branch moves

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,53 @@ projects:
       auto_promote_on_ci: false   # disable reconciler auto-promote on green CI
 ```
 
+### Auto-rebase on base-move
+
+When Loop opens a PR (branch convention `feat/issue-N-*`) and the base branch
+advances so that the PR's `mergeStateStatus` becomes `DIRTY` or `mergeable`
+becomes `CONFLICTING`, the reconciler automatically attempts a rebase.
+
+**Clean rebase path:** the rebased branch is pushed with
+`--force-with-lease` (never plain `--force` — a concurrent developer push
+causes the push to be rejected rather than clobbered). Labels are NOT changed:
+CI re-runs naturally, and the green-CI sweep (Sweep 1) promotes the PR once
+checks pass.
+
+**Conflict path:** `git rebase --abort` is called. A diagnostic comment is
+posted on the PR listing each conflicted file and the most recent base commit
+that touched it:
+
+```
+Reconciler: auto-rebase onto `origin/<base>` failed with conflicts. Routing to `needs-rework`.
+
+Conflicted files:
+- `lib/runner.sh` — recent base commit: `abc1234 update runner fallback logic`
+- `scanner/reconciler.sh` — recent base commit: `def5678 add ci-red sweep`
+```
+
+`needs-rework` is applied to the PR; trigger labels (`needs-dev`, `in-dev`,
+`dev`, `in-progress`) are stripped from the linked issue so the dev agent
+handles the conflict on the next cycle. A `pr_rebase_conflict` event is
+emitted to loop-monitor (if `LOOP_MONITOR_URL` is set).
+
+**No-op conditions:**
+
+- The PR already carries `needs-rework`, `changes-requested`, or `blocked`.
+- A human reviewer has approved or requested changes on the PR.
+- `mergeStateStatus` is not `DIRTY` and `mergeable` is not `CONFLICTING`.
+
+**To opt out per project**, add `dev.auto_rebase_on_base_move: false` to the
+project entry in `config/projects.yaml` (mirrors the `AUTO_REBASE_ON_BASE_MOVE`
+env var):
+
+```yaml
+projects:
+  - slug: myapp
+    repo: owner/my-app
+    dev:
+      auto_rebase_on_base_move: false   # disable reconciler auto-rebase on base-move
+```
+
 ## Supported AI agents
 
 Set `LOOP_AGENT` in `loop.env`:

--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -2052,6 +2052,234 @@ print(json.dumps({'type':'pr_ci_passed','payload':{'repo':'${repo}','pr_number':
     done <<< "$loop_prs"
 }
 
+# Helper: post a JSON event to loop-monitor (fire-and-forget; non-fatal).
+# Usage: _loop_emit_event <event_type> <json_payload_string>
+_loop_emit_event() {
+    local event_type="$1" payload="$2"
+    local monitor_url="${LOOP_MONITOR_URL:-}"
+    [ -n "$monitor_url" ] || return 0
+    local body
+    body=$(python3 -c "
+import json, sys
+try:
+    p = json.loads(sys.argv[1])
+    print(json.dumps({'type': sys.argv[2], 'payload': p}))
+except Exception:
+    pass" "$payload" "$event_type" 2>/dev/null || echo "")
+    [ -n "$body" ] || return 0
+    curl -s -X POST "$monitor_url/events" \
+        -H 'Content-Type: application/json' \
+        -d "$body" >/dev/null 2>&1 || true
+}
+
+# _reconcile_rebase_one_pr <repo> <pr_num> <base> <head>
+#
+# Performs an isolated git rebase of <head> onto origin/<base> in a temp
+# worktree rooted under LOOP_ROOT. Prints conflicted file list to stdout
+# before returning 3 so the caller can assemble the diagnostic comment.
+#
+# Return codes:
+#   0 — clean rebase and force-with-lease push succeeded
+#   1 — fetch or worktree-add failed (transient; skip, no label mutation)
+#   2 — push --force-with-lease rejected (concurrent update; skip)
+#   3 — rebase conflict; stdout has newline-separated conflicted file paths
+#
+# NOTE: git worktree remove --force can fail when the worktree is still dirty
+# after rebase --abort (git refuses to remove a worktree with untracked files
+# in some versions). The trap falls back to rm -rf; git worktree prune on the
+# next reconciler tick will remove the stale entry from .git/worktrees.
+_reconcile_rebase_one_pr() {
+    local repo="$1" pr_num="$2" base="$3" head="$4"
+    local wt
+    wt=$(mktemp -d "/tmp/loop-rebase-${repo//\//-}-${pr_num}-XXXXXX")
+    # shellcheck disable=SC2064
+    trap "git -C '$LOOP_ROOT' worktree remove --force '$wt' 2>/dev/null || true; rm -rf '$wt'" RETURN
+    git -C "$LOOP_ROOT" fetch --quiet origin "$base" "$head" || return 1
+    git -C "$LOOP_ROOT" worktree add --quiet "$wt" "origin/$head" || return 1
+    if git -C "$wt" rebase --quiet "origin/$base"; then
+        git -C "$wt" push --force-with-lease origin "HEAD:$head" || return 2
+        return 0
+    else
+        local conflicted
+        conflicted=$(git -C "$wt" diff --name-only --diff-filter=U 2>/dev/null || echo "")
+        git -C "$wt" rebase --abort 2>/dev/null || true
+        printf '%s\n' "$conflicted"
+        return 3
+    fi
+}
+
+# --- Sweep: auto-rebase loop PRs when base branch has advanced ----------------
+# Scans open loop-opened PRs (feat/issue-N-*) whose mergeStateStatus is DIRTY
+# or mergeable is CONFLICTING. For each, attempts an isolated git rebase onto
+# origin/<base>. Clean rebases are pushed with --force-with-lease so CI
+# re-runs and Sweep 1 (reconcile_ci_green_prs) can promote them. Conflicting
+# rebases route the PR back to needs-rework with a diagnostic comment listing
+# each conflicted file and the most recent base commit that touched it.
+#
+# No-op conditions (checked before any git operation):
+#   - PR already carries needs-rework, changes-requested, or blocked
+#   - PR has at least one human review (APPROVED or CHANGES_REQUESTED)
+#   - AUTO_REBASE_ON_BASE_MOVE=false
+#
+# This sweep does NOT change labels on a clean rebase — CI re-running and
+# promotion are out-of-band consequences handled by other sweeps.
+#
+# Configurable env (all optional):
+#   AUTO_REBASE_ON_BASE_MOVE — set to "false" to disable per-project (default: true)
+#   LOOP_BRANCH_PREFIX       — branch prefix convention (default: feat/issue-)
+reconcile_pr_base_moved() {
+    local repo="$1" slug="${2:-}"
+    local branch_prefix="${LOOP_BRANCH_PREFIX:-feat/issue-}"
+
+    if [ "${AUTO_REBASE_ON_BASE_MOVE:-true}" = "false" ]; then
+        log "[$repo] base-move: disabled via AUTO_REBASE_ON_BASE_MOVE=false — skipping"
+        return 0
+    fi
+
+    log "[$repo] base-move: scanning loop-opened PRs for base divergence"
+
+    local prs_json
+    prs_json=$(backend_list_open_prs_raw "$repo") || prs_json="[]"
+
+    # Filter to loop-opened PRs; skip those already in terminal rework states.
+    # Emits: pr_num TAB head_ref TAB issue_num TAB labels_csv TAB pr_body(400)
+    local loop_prs
+    loop_prs=$(PJSON="$prs_json" PREFIX="$branch_prefix" python3 - <<'PY'
+import json, os, re
+prs = json.loads(os.environ['PJSON'])
+prefix = os.environ['PREFIX']
+pat = re.compile(r'^' + re.escape(prefix) + r'(\d+)-')
+skip_set = {'needs-rework', 'changes-requested', 'blocked'}
+for pr in prs:
+    head = pr.get('headRefName', '')
+    m = pat.match(head)
+    if not m:
+        continue
+    issue_num = m.group(1)
+    lbls = [l['name'] if isinstance(l, dict) else l for l in pr.get('labels', [])]
+    if skip_set & set(lbls):
+        continue
+    print(f"{pr['number']}\t{head}\t{issue_num}\t{','.join(lbls)}\t{(pr.get('body') or '')[:400]}")
+PY
+)
+
+    if [ -z "$loop_prs" ]; then
+        log "[$repo] base-move: no eligible loop-opened PRs"
+        return 0
+    fi
+
+    local pr_num head_ref issue_num labels_csv pr_body
+    while IFS=$'\t' read -r pr_num head_ref issue_num labels_csv pr_body; do
+        [ -z "$pr_num" ] && continue
+
+        # Query per-PR merge state and reviews in one backend call.
+        local pr_state
+        pr_state=$(backend_pr_view "$repo" "$pr_num" \
+            --json mergeStateStatus,mergeable,baseRefName,latestReviews \
+            2>/dev/null || echo "{}")
+
+        local merge_status mergeable base_ref review_count
+        merge_status=$(printf '%s' "$pr_state" | python3 -c \
+            "import json,sys; d=json.load(sys.stdin); print(d.get('mergeStateStatus',''))" \
+            2>/dev/null || echo "")
+        mergeable=$(printf '%s' "$pr_state" | python3 -c \
+            "import json,sys; d=json.load(sys.stdin); print(d.get('mergeable',''))" \
+            2>/dev/null || echo "")
+        base_ref=$(printf '%s' "$pr_state" | python3 -c \
+            "import json,sys; d=json.load(sys.stdin); print(d.get('baseRefName','main'))" \
+            2>/dev/null || echo "main")
+        review_count=$(printf '%s' "$pr_state" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+reviews = d.get('latestReviews', []) or []
+human = [r for r in reviews if r.get('state') in ('APPROVED', 'CHANGES_REQUESTED')]
+print(len(human))" 2>/dev/null || echo "0")
+
+        # Skip unless base has moved (DIRTY or CONFLICTING merge state).
+        case "${merge_status}:${mergeable}" in
+            DIRTY:*|*:CONFLICTING) : ;;
+            *)
+                log "[$repo] base-move: PR#$pr_num mergeState=$merge_status mergeable=$mergeable — not diverged, skip"
+                continue
+                ;;
+        esac
+
+        # Skip if a human has reviewed — don't auto-modify a reviewed PR.
+        if [ "${review_count:-0}" -gt 0 ]; then
+            log "[$repo] base-move: PR#$pr_num has human review (count=$review_count) — skip"
+            continue
+        fi
+
+        log "[$repo] base-move: PR#$pr_num ($head_ref → origin/$base_ref) is diverged — attempting rebase"
+
+        if $DRY_RUN; then
+            log "[$repo] DRY_RUN: would rebase PR#$pr_num ($head_ref) onto origin/$base_ref"
+            continue
+        fi
+
+        local rebase_out rebase_ret
+        rebase_out=$(_reconcile_rebase_one_pr "$repo" "$pr_num" "$base_ref" "$head_ref") \
+            && rebase_ret=0 || rebase_ret=$?
+
+        case "$rebase_ret" in
+            0)
+                log "[$repo] rebased PR #$pr_num cleanly onto origin/$base_ref"
+                _loop_emit_event "pr_rebased" \
+                    "{\"repo\":\"$repo\",\"pr_num\":$pr_num,\"issue_num\":$issue_num,\"base\":\"$base_ref\",\"head\":\"$head_ref\"}" \
+                    || true
+                ;;
+            3)
+                local conflicted_files="$rebase_out"
+                log "[$repo] base-move: PR#$pr_num rebase conflict — routing to needs-rework"
+
+                # Build diagnostic comment with most recent base commit per file.
+                local comment_lines
+                comment_lines=$(
+                    printf 'Reconciler: auto-rebase onto `origin/%s` failed with conflicts. Routing to `needs-rework`.\n\nConflicted files:\n' "$base_ref"
+                    while IFS= read -r cfile; do
+                        [ -z "$cfile" ] && continue
+                        local recent
+                        recent=$(git -C "$LOOP_ROOT" log --pretty='%h %s' \
+                            "origin/$base_ref" -10 -- "$cfile" 2>/dev/null | head -1 || echo "")
+                        printf -- '- `%s` — recent base commit: `%s`\n' \
+                            "$cfile" "${recent:-(unknown)}"
+                    done <<< "$conflicted_files"
+                )
+                backend_comment_pr "$repo" "$pr_num" "$comment_lines" 2>/dev/null || true
+
+                # Resolve rework trigger label for this project's workflow.
+                local rework_label
+                rework_label=$(loop_stage_trigger "$slug" "rework" "pr" 2>/dev/null \
+                    || echo "needs-rework")
+                [ -n "$rework_label" ] || rework_label="needs-rework"
+
+                backend_add_label "$repo" "$pr_num" "$rework_label" \
+                    || log "[$repo] WARN: base-move: failed to add $rework_label to PR#$pr_num"
+
+                # Strip trigger labels from the parent issue.
+                local trig_label
+                for trig_label in needs-dev in-dev dev in-progress; do
+                    backend_remove_label "$repo" "$issue_num" "$trig_label" 2>/dev/null || true
+                done
+
+                # Emit conflict event.
+                local files_json
+                files_json=$(printf '%s\n' "$conflicted_files" | python3 -c \
+                    "import json,sys; files=[l for l in sys.stdin.read().splitlines() if l]; print(json.dumps(files))" \
+                    2>/dev/null || echo "[]")
+                _loop_emit_event "pr_rebase_conflict" \
+                    "{\"repo\":\"$repo\",\"pr_num\":$pr_num,\"issue_num\":$issue_num,\"conflicted_files\":$files_json}" \
+                    || true
+                ;;
+            1|2)
+                log "[$repo] base-move: PR#$pr_num transient git error (ret=$rebase_ret) — skipping, will retry next tick"
+                ;;
+        esac
+    done <<< "$loop_prs"
+
+    return 0
+}
+
 run_project() {
     local slug="$1"
     loop_load_project "$slug" || { log "skip $slug (config error)"; return 0; }
@@ -2074,6 +2302,7 @@ run_project() {
     reconcile_orphaned_in_progress "$REPO" "$slug"
     reconcile_ci_red_prs "$REPO"
     reconcile_ci_green_prs "$REPO" "$slug"
+    reconcile_pr_base_moved "$REPO" "$slug"
     reconcile_dirty_rework_prs "$REPO"
     reconcile_conflict_blocked_prs "$REPO"
     reconcile_stale_base "$REPO"

--- a/tests/reconciler-base-moved.bats
+++ b/tests/reconciler-base-moved.bats
@@ -1,0 +1,434 @@
+#!/usr/bin/env bats
+# tests/reconciler-base-moved.bats — unit tests for reconcile_pr_base_moved
+# in scanner/reconciler.sh (issue #281). Sources reconciler.sh in lib-only
+# mode so only function definitions are loaded, then exercises the sweep with
+# stubbed backends, git, and loop helpers.
+#
+# Covers:
+#   (a) DIRTY PR, clean rebase → push --force-with-lease called, no labels mutated
+#   (b) DIRTY PR, rebase conflict → needs-rework applied, comment with file names posted
+#   (c) PR already has needs-rework → no-op
+#   (d) AUTO_REBASE_ON_BASE_MOVE=false → no-op
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export OPS_LOG="$BATS_TMPDIR/ops.log"
+    export GIT_LOG="$BATS_TMPDIR/git.log"
+    rm -f "$OPS_LOG" "$GIT_LOG"
+
+    export REPO="owner/test-repo"
+    export DRY_RUN=false
+    export AUTO_REBASE_ON_BASE_MOVE=true
+    export LOOP_BRANCH_PREFIX="feat/issue-"
+    export LOOP_MONITOR_URL=""
+    export SLUG="test-slug"
+
+    # Default mock values (set to non-empty defaults to avoid brace-expansion issues).
+    export MOCK_PRS_JSON='[]'
+    export MOCK_PR_VIEW_JSON='{}'
+    export MOCK_REBASE_EXIT=0
+    export MOCK_PUSH_EXIT=0
+    export MOCK_CONFLICTED_FILES=""
+    export MOCK_GIT_LOG_OUTPUT="abc1234 mock commit subject"
+
+    # Suppress LOOP_EXTRA_PATH so lib/env.sh does not prepend /opt/homebrew/bin
+    # and shadow the fake git binary we place in $BATS_TMPDIR/bin.
+    export LOOP_EXTRA_PATH=""
+
+    # Source reconciler in lib-only mode (before PATH setup so env.sh runs first).
+    LOOP_RECONCILER_LIB_ONLY=1
+    set --
+    # shellcheck source=../scanner/reconciler.sh
+    source "$REPO_ROOT/scanner/reconciler.sh"
+
+    # Fake git binary: intercepts worktree/fetch/rebase/push/diff/log calls.
+    # Must be installed AFTER sourcing (env.sh overwrites PATH) and re-prepended.
+    mkdir -p "$BATS_TMPDIR/bin"
+    cat > "$BATS_TMPDIR/bin/git" <<'GITEOF'
+#!/usr/bin/env bash
+echo "git $*" >> "$GIT_LOG"
+
+# Parse: git [-C <dir>]... <subcmd> [args...]
+args=("$@")
+i=0
+while [ "$i" -lt "${#args[@]}" ] && [ "${args[$i]}" = "-C" ]; do
+    i=$(( i + 2 ))  # skip -C and its argument
+done
+subcmd="${args[$i]:-}"
+rest=("${args[@]:$(( i + 1 ))}")
+action="${rest[0]:-}"
+
+case "$subcmd" in
+    fetch)
+        exit 0
+        ;;
+    worktree)
+        case "$action" in
+            add)
+                # args after "add": [--quiet] <path> <commit>
+                # Find first positional (non-flag) argument = the worktree path.
+                wt_path=""
+                for arg in "${rest[@]:1}"; do
+                    case "$arg" in
+                        --*|-*) continue ;;
+                        *) wt_path="$arg"; break ;;
+                    esac
+                done
+                mkdir -p "$wt_path"
+                exit 0
+                ;;
+            remove)
+                rm -rf "${rest[-1]}" 2>/dev/null || true
+                exit 0
+                ;;
+            *)
+                exit 0
+                ;;
+        esac
+        ;;
+    rebase)
+        if [ "$action" = "--abort" ]; then
+            exit 0
+        fi
+        exit "${MOCK_REBASE_EXIT:-0}"
+        ;;
+    diff)
+        printf '%s\n' "${MOCK_CONFLICTED_FILES:-}"
+        exit 0
+        ;;
+    push)
+        exit "${MOCK_PUSH_EXIT:-0}"
+        ;;
+    log)
+        echo "${MOCK_GIT_LOG_OUTPUT:-abc1234 mock commit subject}"
+        exit 0
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+GITEOF
+    chmod +x "$BATS_TMPDIR/bin/git"
+    # Re-prepend mock bin after env.sh may have modified PATH during source.
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+    export GIT_LOG
+
+    # Stubs: always reference vars without brace-expansion defaults to avoid
+    # the bash issue where ${VAR:-{}} appends a literal } when VAR is set.
+    backend_list_open_prs_raw() { echo "$MOCK_PRS_JSON"; }
+    backend_pr_view()           { echo "$MOCK_PR_VIEW_JSON"; }
+    backend_add_label()         { echo "add_label $2 $3"    >> "$OPS_LOG"; }
+    backend_remove_label()      { echo "remove_label $2 $3" >> "$OPS_LOG"; }
+    backend_comment_pr()        { echo "comment_pr $2: $3"  >> "$OPS_LOG"; }
+
+    loop_stage_trigger()        { echo "needs-rework"; }
+    loop_notify()               { :; }
+    _loop_emit_event()          { echo "emit_event $1" >> "$OPS_LOG"; }
+    log()                       { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/logs" \
+           "$OPS_LOG" "$GIT_LOG" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# (a) DIRTY PR, clean rebase → push called, no labels mutated
+# ---------------------------------------------------------------------------
+
+@test "reconcile_pr_base_moved: DIRTY PR clean rebase calls force-with-lease push" {
+    export MOCK_PRS_JSON='[{
+        "number": 10,
+        "headRefName": "feat/issue-5-add-auth",
+        "labels": [],
+        "body": "Closes #5",
+        "updatedAt": "2026-01-01T00:00:00Z"
+    }]'
+    export MOCK_PR_VIEW_JSON='{
+        "mergeStateStatus": "DIRTY",
+        "mergeable": "MERGEABLE",
+        "baseRefName": "main",
+        "latestReviews": []
+    }'
+    export MOCK_REBASE_EXIT=0
+
+    run reconcile_pr_base_moved "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    grep -q "force-with-lease" "$GIT_LOG"
+}
+
+@test "reconcile_pr_base_moved: DIRTY PR clean rebase does not mutate labels" {
+    export MOCK_PRS_JSON='[{
+        "number": 10,
+        "headRefName": "feat/issue-5-add-auth",
+        "labels": [],
+        "body": "Closes #5",
+        "updatedAt": "2026-01-01T00:00:00Z"
+    }]'
+    export MOCK_PR_VIEW_JSON='{
+        "mergeStateStatus": "DIRTY",
+        "mergeable": "MERGEABLE",
+        "baseRefName": "main",
+        "latestReviews": []
+    }'
+    export MOCK_REBASE_EXIT=0
+
+    run reconcile_pr_base_moved "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -qE "add_label|remove_label" "$OPS_LOG"
+}
+
+@test "reconcile_pr_base_moved: DIRTY PR clean rebase emits pr_rebased event" {
+    export MOCK_PRS_JSON='[{
+        "number": 10,
+        "headRefName": "feat/issue-5-add-auth",
+        "labels": [],
+        "body": "Closes #5",
+        "updatedAt": "2026-01-01T00:00:00Z"
+    }]'
+    export MOCK_PR_VIEW_JSON='{
+        "mergeStateStatus": "DIRTY",
+        "mergeable": "MERGEABLE",
+        "baseRefName": "main",
+        "latestReviews": []
+    }'
+    export MOCK_REBASE_EXIT=0
+
+    run reconcile_pr_base_moved "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    grep -q "emit_event pr_rebased" "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# (b) DIRTY PR, rebase conflict → needs-rework + comment with file names
+# ---------------------------------------------------------------------------
+
+@test "reconcile_pr_base_moved: conflict applies needs-rework to PR" {
+    export MOCK_PRS_JSON='[{
+        "number": 20,
+        "headRefName": "feat/issue-7-cache",
+        "labels": [],
+        "body": "Closes #7",
+        "updatedAt": "2026-01-01T00:00:00Z"
+    }]'
+    export MOCK_PR_VIEW_JSON='{
+        "mergeStateStatus": "DIRTY",
+        "mergeable": "MERGEABLE",
+        "baseRefName": "main",
+        "latestReviews": []
+    }'
+    export MOCK_REBASE_EXIT=1
+    export MOCK_CONFLICTED_FILES=$'lib/cache.sh\nlib/runner.sh'
+
+    run reconcile_pr_base_moved "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    grep -q "add_label 20 needs-rework" "$OPS_LOG"
+}
+
+@test "reconcile_pr_base_moved: conflict posts comment containing both conflicted file names" {
+    export MOCK_PRS_JSON='[{
+        "number": 20,
+        "headRefName": "feat/issue-7-cache",
+        "labels": [],
+        "body": "Closes #7",
+        "updatedAt": "2026-01-01T00:00:00Z"
+    }]'
+    export MOCK_PR_VIEW_JSON='{
+        "mergeStateStatus": "DIRTY",
+        "mergeable": "MERGEABLE",
+        "baseRefName": "main",
+        "latestReviews": []
+    }'
+    export MOCK_REBASE_EXIT=1
+    export MOCK_CONFLICTED_FILES=$'lib/cache.sh\nlib/runner.sh'
+
+    run reconcile_pr_base_moved "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    grep -q "comment_pr 20" "$OPS_LOG"
+    grep -q "lib/cache.sh" "$OPS_LOG"
+    grep -q "lib/runner.sh" "$OPS_LOG"
+}
+
+@test "reconcile_pr_base_moved: conflict strips trigger labels from parent issue" {
+    export MOCK_PRS_JSON='[{
+        "number": 20,
+        "headRefName": "feat/issue-7-cache",
+        "labels": [],
+        "body": "Closes #7",
+        "updatedAt": "2026-01-01T00:00:00Z"
+    }]'
+    export MOCK_PR_VIEW_JSON='{
+        "mergeStateStatus": "DIRTY",
+        "mergeable": "MERGEABLE",
+        "baseRefName": "main",
+        "latestReviews": []
+    }'
+    export MOCK_REBASE_EXIT=1
+    export MOCK_CONFLICTED_FILES="lib/cache.sh"
+
+    run reconcile_pr_base_moved "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    grep -qE "remove_label 7 (needs-dev|in-dev|dev|in-progress)" "$OPS_LOG"
+}
+
+@test "reconcile_pr_base_moved: conflict emits pr_rebase_conflict event" {
+    export MOCK_PRS_JSON='[{
+        "number": 20,
+        "headRefName": "feat/issue-7-cache",
+        "labels": [],
+        "body": "Closes #7",
+        "updatedAt": "2026-01-01T00:00:00Z"
+    }]'
+    export MOCK_PR_VIEW_JSON='{
+        "mergeStateStatus": "DIRTY",
+        "mergeable": "MERGEABLE",
+        "baseRefName": "main",
+        "latestReviews": []
+    }'
+    export MOCK_REBASE_EXIT=1
+    export MOCK_CONFLICTED_FILES="lib/cache.sh"
+
+    run reconcile_pr_base_moved "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    grep -q "emit_event pr_rebase_conflict" "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# (c) PR already has needs-rework → no-op
+# ---------------------------------------------------------------------------
+
+@test "reconcile_pr_base_moved: PR with needs-rework label is skipped" {
+    export MOCK_PRS_JSON='[{
+        "number": 30,
+        "headRefName": "feat/issue-9-nav",
+        "labels": [{"name":"needs-rework"}],
+        "body": "Closes #9",
+        "updatedAt": "2026-01-01T00:00:00Z"
+    }]'
+    export MOCK_PR_VIEW_JSON='{
+        "mergeStateStatus": "DIRTY",
+        "mergeable": "MERGEABLE",
+        "baseRefName": "main",
+        "latestReviews": []
+    }'
+    export MOCK_REBASE_EXIT=0
+
+    run reconcile_pr_base_moved "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    # git should never be invoked for a skipped PR.
+    [ ! -s "$GIT_LOG" ] || ! grep -q "rebase" "$GIT_LOG"
+    [ ! -s "$OPS_LOG" ] || ! grep -qE "add_label|remove_label|comment_pr" "$OPS_LOG"
+}
+
+@test "reconcile_pr_base_moved: PR with changes-requested label is skipped" {
+    export MOCK_PRS_JSON='[{
+        "number": 31,
+        "headRefName": "feat/issue-11-search",
+        "labels": [{"name":"changes-requested"}],
+        "body": "Closes #11",
+        "updatedAt": "2026-01-01T00:00:00Z"
+    }]'
+    export MOCK_PR_VIEW_JSON='{
+        "mergeStateStatus": "DIRTY",
+        "mergeable": "MERGEABLE",
+        "baseRefName": "main",
+        "latestReviews": []
+    }'
+
+    run reconcile_pr_base_moved "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -qE "add_label|remove_label|comment_pr" "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# (d) AUTO_REBASE_ON_BASE_MOVE=false → no-op
+# ---------------------------------------------------------------------------
+
+@test "reconcile_pr_base_moved: AUTO_REBASE_ON_BASE_MOVE=false skips sweep entirely" {
+    export AUTO_REBASE_ON_BASE_MOVE=false
+    export MOCK_PRS_JSON='[{
+        "number": 40,
+        "headRefName": "feat/issue-15-login",
+        "labels": [],
+        "body": "Closes #15",
+        "updatedAt": "2026-01-01T00:00:00Z"
+    }]'
+    export MOCK_PR_VIEW_JSON='{
+        "mergeStateStatus": "DIRTY",
+        "mergeable": "MERGEABLE",
+        "baseRefName": "main",
+        "latestReviews": []
+    }'
+    export MOCK_REBASE_EXIT=0
+
+    run reconcile_pr_base_moved "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$GIT_LOG" ] || ! grep -q "rebase" "$GIT_LOG"
+    [ ! -s "$OPS_LOG" ] || ! grep -qE "add_label|remove_label|comment_pr" "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Extra: CLEAN merge state → no rebase attempted
+# ---------------------------------------------------------------------------
+
+@test "reconcile_pr_base_moved: CLEAN mergeStateStatus → no rebase" {
+    export MOCK_PRS_JSON='[{
+        "number": 50,
+        "headRefName": "feat/issue-20-docs",
+        "labels": [],
+        "body": "Closes #20",
+        "updatedAt": "2026-01-01T00:00:00Z"
+    }]'
+    export MOCK_PR_VIEW_JSON='{
+        "mergeStateStatus": "CLEAN",
+        "mergeable": "MERGEABLE",
+        "baseRefName": "main",
+        "latestReviews": []
+    }'
+
+    run reconcile_pr_base_moved "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$GIT_LOG" ] || ! grep -q "rebase" "$GIT_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Extra: human review present → no-op
+# ---------------------------------------------------------------------------
+
+@test "reconcile_pr_base_moved: PR with human review is skipped" {
+    export MOCK_PRS_JSON='[{
+        "number": 60,
+        "headRefName": "feat/issue-25-api",
+        "labels": [],
+        "body": "Closes #25",
+        "updatedAt": "2026-01-01T00:00:00Z"
+    }]'
+    export MOCK_PR_VIEW_JSON='{
+        "mergeStateStatus": "DIRTY",
+        "mergeable": "MERGEABLE",
+        "baseRefName": "main",
+        "latestReviews": [{"state": "APPROVED"}]
+    }'
+    export MOCK_REBASE_EXIT=0
+
+    run reconcile_pr_base_moved "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$GIT_LOG" ] || ! grep -q "rebase" "$GIT_LOG"
+    [ ! -s "$OPS_LOG" ] || ! grep -qE "add_label|remove_label|comment_pr" "$OPS_LOG"
+}


### PR DESCRIPTION
Closes #281

## Changes

### New: `reconcile_pr_base_moved` sweep in `scanner/reconciler.sh`

Scans open loop-opened PRs (`feat/issue-N-*`) whose `mergeStateStatus` is `DIRTY` or `mergeable` is `CONFLICTING`. For each eligible PR (no human review, no existing `needs-rework`/`changes-requested`/`blocked` labels), attempts an isolated git rebase:

- **Clean rebase:** pushes with `--force-with-lease` (never `--force`). Emits `pr_rebased` event. Does NOT change labels — CI re-runs naturally and Sweep 1 promotes on green.
- **Conflict:** runs `git rebase --abort`, parses conflicted files via `git diff --name-only --diff-filter=U`, posts a diagnostic comment with each file + most recent base commit that touched it, applies `needs-rework` (via `loop_stage_trigger` with fallback), strips trigger labels from the parent issue, emits `pr_rebase_conflict` event.
- **Transient error (return 1/2):** logs and skips — no label mutation.

### New helper: `_reconcile_rebase_one_pr`

Isolated temp worktree via `mktemp -d`, `trap ... RETURN` ensures cleanup (falls back to `rm -rf` + next-tick `git worktree prune` if `worktree remove --force` fails on a dirty worktree).

### New helper: `_loop_emit_event`

Fire-and-forget POST to `LOOP_MONITOR_URL` following the existing pattern in `reconcile_ci_red_prs`.

### Per-project opt-out

`AUTO_REBASE_ON_BASE_MOVE=false` skips the sweep (mirrors `AUTO_REWORK_ON_CI` pattern).

### Wiring

`reconcile_pr_base_moved "$REPO" "$slug"` added to `run_project` immediately after `reconcile_ci_red_prs`.

### Tests: `tests/reconciler-base-moved.bats` (12 tests)

- DIRTY PR + clean rebase → `force-with-lease` push called, no labels mutated, `pr_rebased` emitted
- DIRTY PR + conflict → `needs-rework` applied, comment with both file names, trigger labels stripped, `pr_rebase_conflict` emitted
- PR with `needs-rework` → no-op (skipped before any git call)
- PR with `changes-requested` → no-op
- `AUTO_REBASE_ON_BASE_MOVE=false` → no-op
- `CLEAN` merge state → no rebase
- PR with human review → no-op

### README

New `### Auto-rebase on base-move` subsection documenting the sweep, `--force-with-lease` safety, conflict-comment shape, and opt-out.

## Test Plan

- [ ] All 12 bats tests pass: `bats tests/reconciler-base-moved.bats`
- [ ] `bash -n scanner/reconciler.sh` passes
- [ ] `shellcheck -S warning scanner/reconciler.sh` passes
- [ ] No personal identifiers in committed files
- [ ] Verify `reconcile_pr_base_moved` is called in `run_project` after `reconcile_ci_red_prs`
- [ ] On a real DIRTY loop PR: confirm rebase + force-with-lease push happens in logs