### PR TITLE
fix(reconciler): drop pr_body from CI-promote read — newlines split the loop

### DIFF
--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -1921,7 +1921,10 @@ for pr in prs:
         continue
     issue_num = m.group(1)
     lbls = [l['name'] if isinstance(l, dict) else l for l in pr.get('labels', [])]
-    print(f"{pr['number']}\t{head}\t{issue_num}\t{','.join(lbls)}\t{(pr.get('body') or '')[:400]}")
+    # NOTE: do NOT emit PR body — bodies contain newlines which would split the
+    # `while IFS=$'\t' read` loop into one iteration per body line, causing each
+    # markdown line (`### Changes`, `- foo.md`, etc.) to be treated as a PR number.
+    print(f"{pr['number']}\t{head}\t{issue_num}\t{','.join(lbls)}")
 PY
 )
 
@@ -1930,8 +1933,8 @@ PY
         return 0
     fi
 
-    local pr_num head_ref issue_num labels_csv pr_body
-    while IFS=$'\t' read -r pr_num head_ref issue_num labels_csv pr_body; do
+    local pr_num head_ref issue_num labels_csv
+    while IFS=$'\t' read -r pr_num head_ref issue_num labels_csv; do
         [ -z "$pr_num" ] && continue
 
         # PR must have needs-dev to be a promotion candidate.


### PR DESCRIPTION
## Summary

The CI-promote sweep added in #282 emits PR bodies as the 5th tab-separated field, then reads them via `while IFS=$'\t' read -r ... pr_body`. PR bodies contain newlines, so each body line spawns a new loop iteration with the first tab-field treated as a PR number.

Live log evidence (2026-05-10 22:30, pa-scanner):

```
[pa-scanner] CI-promote: PR#53 lacks needs-dev — skip
[pa-scanner] CI-promote: PR### Changes lacks needs-dev — skip
[pa-scanner] CI-promote: PR#- `docs/strategies/ob-pullback-eurusd.md` — ... — skip
[pa-scanner] CI-promote: PR#- `docs/strategy-comparison.md` — ... — skip
```

Markdown headers (`### Changes`) and bullet lines (`- file.md`) from PR descriptions parsed as PR numbers. Each iteration is a no-op (skip) but floods logs and wastes `gh` API calls.

`pr_body` is declared but never used inside the CI-promote function, so removing the field from both the Python emitter and the bash read is zero-logic-change.

## Test plan

- [x] `bash -n scanner/reconciler.sh` passes
- [ ] Next reconciler run shows one log line per loop-opened PR (no spurious `PR### Changes` / `PR#- ...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)