### PR TITLE
[LOOP-267] Serial mode + priority-aware scanner picking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ projects.yaml schema, bounty event API, CLI flags, lock dir, log dir).
 
 ### Changed
 - [LOOP-262] resolve rework trigger label per-project in pr-watchdog (#277)
+- [LOOP-267] scanner: new `dev.pipeline_slots` gate (serial mode) +
+  priority-aware pick order (`p0-critical` > `p1-high` > `p2-medium` >
+  `p3-low` > unlabeled, then by number ascending), applied at every stage
 ## [0.4.0] - 2026-05-10
 
 A 12-PR batch focused on making the autonomous pipeline self-correcting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,24 @@ safe. Then `needs-qa` triggers the build/test as normal.
 If you submit a fork PR and CI seems stuck, ping a maintainer to
 review for the `safe-to-test` label.
 
+## Pipeline pacing for contributors
+
+If you're working on scanner or workflow code, two knobs decide which
+tickets get picked each tick:
+
+- **`dev.pipeline_slots`** (in `config/projects.yaml`) — when set, the
+  scanner enforces a per-project cap on in-flight tickets across the whole
+  pipeline. `pipeline_slots: 1` is serial mode (one ticket at a time);
+  larger values cap concurrent work. The gate only suppresses fresh claims
+  at the first issue stage — downstream stages still flow.
+- **Priority-aware ordering** — candidates are sorted by priority label
+  (`p0-critical` → `p1-high` → `p2-medium` → `p3-low` → unlabeled, then by
+  number ascending) before the scanner picks. Applies to every stage.
+
+When adding a workflow stage or changing claim logic in `scanner/scanner.sh`,
+preserve both behaviours: respect `PIPELINE_SLOTS` for first-stage gates and
+keep the `_sort_rows_by_priority` pipe on every backend listing.
+
 ## Versioning
 
 Loop follows [SemVer](https://semver.org). Schema and env-var changes

--- a/README.md
+++ b/README.md
@@ -256,6 +256,50 @@ projects:
       auto_rebase_on_base_move: false   # disable reconciler auto-rebase on base-move
 ```
 
+## Pipeline concurrency & priority
+
+Loop's scanner picks issues to claim every 5 minutes. Two knobs control how
+it picks:
+
+**`dev.pipeline_slots`** (per-project, optional) — cap the number of
+in-flight tickets per project across *all* pipeline stages
+(`needs-po` through `needs-qa` / `qa-pass`). When the project already has
+that many tickets in flight, the scanner refuses to emit fresh claims at
+the first issue stage; downstream stages (review / qa / merge for existing
+work) keep flowing so in-flight tickets drain to completion.
+
+- `pipeline_slots: 1` → **serial mode** (recommended when you want to fully
+  finish one ticket before starting the next; useful for repos where mid-
+  flight rework is expensive or PO/dev failures tend to leave half-done state).
+- `pipeline_slots: N` (N ≥ 2) → cap concurrent tickets at N.
+- Omit to disable the gate (legacy behaviour: `dev.max_concurrent_prs`
+  is the only cap).
+
+```yaml
+projects:
+  - slug: myapp
+    repo: owner/my-app
+    dev:
+      pipeline_slots: 1   # serial: finish one before starting the next
+```
+
+**Priority-aware pick order.** Whenever multiple candidates carry a trigger
+label, the scanner orders them by priority label before claiming:
+
+> `p0-critical` → `p1-high` → `p2-medium` → `p3-low` → unlabeled
+
+Tiebreaker: lower issue/PR number (oldest first). This applies regardless
+of `pipeline_slots`, so multi-slot projects still drain `p1-high` work
+before `p3-low`.
+
+**Serial vs parallel — which to pick?**
+
+| Use serial (`pipeline_slots: 1`) | Use parallel (default / `max_concurrent_prs > 1`) |
+|---|---|
+| Solo project where context-switching is expensive | Big repo with many independent issues |
+| Recent failures left half-done tickets | Mature pipeline with reliable PO/dev/QA |
+| You want one ticket fully merged before the next starts | You want to maximise throughput per scan tick |
+
 ## Supported AI agents
 
 Set `LOOP_AGENT` in `loop.env`:

--- a/config/projects.example.yaml
+++ b/config/projects.example.yaml
@@ -45,6 +45,12 @@ projects:
       # {project_root} is substituted at runtime. If absent, no post-implementation validation runs.
       validation_cmd: |
         cd {project_root} && make build
+      # Optional: cap on in-flight tickets per project across all pipeline
+      # stages (needs-po through qa-pass). `pipeline_slots: 1` is serial mode —
+      # the scanner refuses to emit fresh claims while a ticket is in flight.
+      # Downstream stages (review/qa/merge for existing work) still drain.
+      # Omit to disable the gate. See README → "Pipeline concurrency & priority".
+      # pipeline_slots: 1
 
     qa:
       # Optional: command run by QA handler to validate the PR branch.

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -69,6 +69,10 @@ for p in data.get("projects", []) or []:
         print(f"AUTO_REWORK_ON_CI='{'true' if dev.get('auto_rework_on_ci', True) else 'false'}'")
         print(f"BACKEND='{sh(p.get('backend','github'))}'")
         print(f"MAX_CONCURRENT_PRS='{sh(dev.get('max_concurrent_prs', 1))}'")
+        # PIPELINE_SLOTS: cap on concurrent in-flight tickets per project across
+        # all pipeline stages (needs-po through qa-pass). Empty = no gate.
+        # Configure per-project via `dev.pipeline_slots` in projects.yaml.
+        print(f"PIPELINE_SLOTS='{sh(dev.get('pipeline_slots', ''))}'")
         # WORKTREE_EXTRA_PATHS: paths from the primary checkout to symlink into
         # each fresh worker worktree. Useful for projects with gitignored runtime
         # files (ML training data, downloaded models, large fixtures) that the
@@ -123,7 +127,7 @@ PY
         return 1
     fi
     eval "$out"
-    export NAME REPO ROOT DEFAULT_BRANCH COMMIT_PREFIX DEV_VALIDATION_CMD QA_VALIDATION_CMD QA_BROWSER_URL QA_TIMEOUT_SECONDS HANDLER_TIMEOUT_SECONDS MERGE_STRATEGY AUTO_REBASE AUTO_REWORK_ON_CI BACKEND MAX_CONCURRENT_PRS MAX_CONCURRENT_HANDLERS WORKTREE_EXTRA_PATHS LOOP_AGENT_MODEL ALLOWED_AUTHORS WORKFLOW LOOP_LABEL_OVERRIDES _PROJECT_AGENT _PROJECT_MODEL _PROJECT_FALLBACK
+    export NAME REPO ROOT DEFAULT_BRANCH COMMIT_PREFIX DEV_VALIDATION_CMD QA_VALIDATION_CMD QA_BROWSER_URL QA_TIMEOUT_SECONDS HANDLER_TIMEOUT_SECONDS MERGE_STRATEGY AUTO_REBASE AUTO_REWORK_ON_CI BACKEND MAX_CONCURRENT_PRS PIPELINE_SLOTS MAX_CONCURRENT_HANDLERS WORKTREE_EXTRA_PATHS LOOP_AGENT_MODEL ALLOWED_AUTHORS WORKFLOW LOOP_LABEL_OVERRIDES _PROJECT_AGENT _PROJECT_MODEL _PROJECT_FALLBACK
 }
 
 # loop_list_slugs — print each project slug on its own line

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -248,6 +248,66 @@ author_is_allowed() {
     return 1
 }
 
+# _sort_rows_by_priority — read newline-delimited JSON rows from stdin,
+# write them back to stdout sorted by (priority-label, number ASC).
+# Priority order: p0-critical > p1-high > p2-medium > p3-low > unlabeled.
+# Tiebreaker: lower issue/PR number (proxy for older created_at, since GitHub
+# IDs are monotonic — and `created_at` requires an extra API field).
+_sort_rows_by_priority() {
+    python3 -c '
+import json, sys
+PRIORITY = {"p0-critical": 0, "p1-high": 1, "p2-medium": 2, "p3-low": 3}
+rows = []
+for line in sys.stdin:
+    line = line.rstrip("\n")
+    if not line:
+        continue
+    try:
+        obj = json.loads(line)
+    except Exception:
+        continue
+    labels = obj.get("labels") or []
+    p = min((PRIORITY[l] for l in labels if l in PRIORITY), default=4)
+    rows.append((p, obj.get("number", 0), line))
+rows.sort(key=lambda x: (x[0], x[1]))
+for _, _, line in rows:
+    print(line)
+'
+}
+
+# count_inflight_issues <slug> <repo>
+# Count distinct open issues that carry at least one pipeline label (workflow
+# issue or PR trigger labels, plus handler-set in-flight labels in-progress/blocked).
+# Used by the per-project `pipeline_slots` gate.
+count_inflight_issues() {
+    local slug="$1" repo="$2"
+    local labels
+    labels=$(
+        {
+            loop_polled_labels "$slug" issue 2>/dev/null
+            loop_polled_labels "$slug" pr 2>/dev/null
+            printf 'in-progress\nblocked\n'
+        } | awk 'NF && !seen[$0]++'
+    )
+    local seen_tmp
+    seen_tmp=$(mktemp)
+    local lbl
+    while IFS= read -r lbl; do
+        [ -z "$lbl" ] && continue
+        while IFS= read -r _r; do
+            [ -z "$_r" ] && continue
+            local _n
+            _n=$(printf '%s' "$_r" | python3 -c "import json,sys; print(json.load(sys.stdin).get('number',''))" 2>/dev/null)
+            [ -z "$_n" ] && continue
+            printf '%s\n' "$_n" >> "$seen_tmp"
+        done < <(backend_list_issues_with_label "$repo" "$lbl" 2>/dev/null || true)
+    done <<< "$labels"
+    local n
+    n=$(awk 'NF' "$seen_tmp" | sort -u | wc -l | tr -d ' ')
+    rm -f "$seen_tmp"
+    echo "${n:-0}"
+}
+
 # count_inflight_prs <slug> <repo>
 # Count open PRs that carry at least one pipeline label.
 # Pipeline labels are derived from the project's workflow PR trigger labels
@@ -350,7 +410,7 @@ _scan_issue_stage() {
         # handler ran in the last 30 min and is likely still in flight, so
         # it should consume a concurrency slot too.
         _emitted=$(( _emitted + 1 ))
-    done < <(backend_list_issues_with_label "$repo" "$trigger_label")
+    done < <(backend_list_issues_with_label "$repo" "$trigger_label" | _sort_rows_by_priority)
 }
 
 # _scan_dev_issue_stage — dev_issue with concurrent slot limiting, priority sort, dep gating.
@@ -382,26 +442,10 @@ _scan_dev_issue_stage() {
         fi
     done < <(backend_list_issues_with_label "$repo" "$trigger_label")
 
-    # Sort by (priority-label, issue_number) so high-priority issues fire first.
+    # Sort by (priority-label, number) so high-priority issues fire first.
     local _sorted_tmp
     _sorted_tmp=$(mktemp)
-    _ROWS_FILE="$_rows_tmp" python3 <<'PY' > "$_sorted_tmp"
-import json, sys, os
-PRIORITY = {'p0-critical': 0, 'p1-high': 1, 'p2-medium': 2, 'p3-low': 3}
-rows = []
-with open(os.environ['_ROWS_FILE']) as fh:
-    for line in fh:
-        line = line.rstrip('\n')
-        if not line:
-            continue
-        obj = json.loads(line)
-        labels = obj.get('labels', [])
-        p = min((PRIORITY[l] for l in labels if l in PRIORITY), default=4)
-        rows.append((p, obj['number'], line))
-rows.sort(key=lambda x: (x[0], x[1]))
-for _, _, line in rows:
-    print(line)
-PY
+    _sort_rows_by_priority < "$_rows_tmp" > "$_sorted_tmp"
     mv "$_sorted_tmp" "$_rows_tmp"
 
     local _emitted=0
@@ -483,7 +527,7 @@ _scan_pr_stage() {
               "$rework_context_key" "$rework_context_val")
         emit "$evt" "${event_type}:${slug}:${num}"
         _emitted=$(( _emitted + 1 ))
-    done < <(backend_list_prs_with_label "$repo" "$trigger_label")
+    done < <(backend_list_prs_with_label "$repo" "$trigger_label" | _sort_rows_by_priority)
 }
 
 scan_project() {
@@ -507,12 +551,35 @@ scan_project() {
     wf_name=$(loop_workflow_for_project "$slug")
     log "scan: $slug ($repo) workflow=$wf_name"
 
+    # Serial / N-slot gate: when `dev.pipeline_slots` is set in projects.yaml,
+    # block fresh claims (the workflow's first issue trigger) once the project
+    # has that many tickets in flight already. Downstream stages (review/qa/
+    # merge for already-claimed work) continue normally, so in-flight tickets
+    # keep flowing to completion.
+    local _first_issue_trigger=""
+    _first_issue_trigger=$(loop_polled_labels "$slug" issue 2>/dev/null | awk 'NF{print; exit}')
+    local _slots_gate_active=false
+    if [ -n "${PIPELINE_SLOTS:-}" ] && [ "$PIPELINE_SLOTS" -ge 1 ] 2>/dev/null; then
+        local _if_issues _if_prs _if_total
+        _if_issues=$(count_inflight_issues "$slug" "$repo")
+        _if_prs=$(count_inflight_prs "$slug" "$repo")
+        _if_total=$(( _if_issues + _if_prs ))
+        log "pipeline_slots=${PIPELINE_SLOTS} in-flight=${_if_total} (issues=${_if_issues} prs=${_if_prs})"
+        if [ "$_if_total" -ge "$PIPELINE_SLOTS" ]; then
+            _slots_gate_active=true
+            log "skip first-stage claims for $slug: ${_if_total}/${PIPELINE_SLOTS} tickets in flight"
+        fi
+    fi
+
     # Issue stages — iterated from the project's active workflow.
     while IFS= read -r trigger_label; do
         [ -z "$trigger_label" ] && continue
         local handler event_type
         handler=$(loop_handler_for_label "$slug" "$trigger_label" 2>/dev/null || true)
         [ -z "$handler" ] && continue
+        if $_slots_gate_active && [ "$trigger_label" = "$_first_issue_trigger" ]; then
+            continue
+        fi
         event_type=$(_handler_to_event_type "$handler")
         _scan_issue_stage "$slug" "$repo" "$trigger_label" "$handler" "$event_type"
     done < <(loop_polled_labels "$slug" issue)

--- a/tests/scanner.bats
+++ b/tests/scanner.bats
@@ -450,6 +450,141 @@ YAML
     [ "$count" -eq 1 ]
 }
 
+# ---------------------------------------------------------------------------
+# _sort_rows_by_priority — priority-aware candidate ordering
+# ---------------------------------------------------------------------------
+
+@test "_sort_rows_by_priority: p1 sorts before p2 and p3, unlabeled is last" {
+    local out
+    out=$(printf '%s\n%s\n%s\n%s\n' \
+        '{"number":3,"labels":["p3-low"]}' \
+        '{"number":1,"labels":["p1-high"]}' \
+        '{"number":4,"labels":[]}' \
+        '{"number":2,"labels":["p2-medium"]}' \
+        | _sort_rows_by_priority)
+    local first second third fourth
+    first=$(echo  "$out" | sed -n '1p')
+    second=$(echo "$out" | sed -n '2p')
+    third=$(echo  "$out" | sed -n '3p')
+    fourth=$(echo "$out" | sed -n '4p')
+    [[ "$first"  == *'"number":1'* ]]
+    [[ "$second" == *'"number":2'* ]]
+    [[ "$third"  == *'"number":3'* ]]
+    [[ "$fourth" == *'"number":4'* ]]
+}
+
+@test "_sort_rows_by_priority: p0-critical wins over p1-high; lower number tiebreaks" {
+    local out
+    out=$(printf '%s\n%s\n%s\n' \
+        '{"number":10,"labels":["p1-high"]}' \
+        '{"number":7,"labels":["p1-high"]}' \
+        '{"number":99,"labels":["p0-critical"]}' \
+        | _sort_rows_by_priority)
+    [[ "$(echo "$out" | sed -n '1p')" == *'"number":99'*  ]]
+    [[ "$(echo "$out" | sed -n '2p')" == *'"number":7'*   ]]
+    [[ "$(echo "$out" | sed -n '3p')" == *'"number":10'*  ]]
+}
+
+@test "priority-aware scanner: mixed p1/p2/p3 candidates → dev_issue emits p1 first" {
+    _write_fixture_config
+    export LOOP_CONFIG="$BATS_TMPDIR/fixture.yaml"
+
+    local R1 R2 R3
+    R1='{"number":11,"title":"low","url":"http://gh/11","labels":["needs-dev","p3-low"],"author":"bot"}'
+    R2='{"number":12,"title":"med","url":"http://gh/12","labels":["needs-dev","p2-medium"],"author":"bot"}'
+    R3='{"number":13,"title":"high","url":"http://gh/13","labels":["needs-dev","p1-high"],"author":"bot"}'
+
+    backend_list_issues_with_label() {
+        local _label="$2"
+        if [ "$_label" = "needs-dev" ]; then
+            printf '%s\n%s\n%s\n' "$R1" "$R2" "$R3"
+        fi
+        return 0
+    }
+    backend_list_prs_with_label()  { return 0; }
+    backend_list_open_prs_raw()    { echo "[]"; }
+    backend_issue_has_any_label()  { return 1; }
+    backend_pr_has_any_label()     { return 1; }
+    backend_issue_unmet_deps()     { return 1; }
+    loop_load_backend()            { return 0; }
+    loop_load_project() {
+        REPO="owner/default-repo"
+        MAX_CONCURRENT_PRS=1
+        PIPELINE_SLOTS=""
+        BACKEND=github
+        WORKFLOW=default
+        ALLOWED_AUTHORS=""
+        LOOP_LABEL_OVERRIDES=""
+        return 0
+    }
+
+    local emit_log="$BATS_TMPDIR/emit-prio.log"
+    rm -f "$emit_log"
+    emit() { echo "$1" >> "$emit_log"; return 0; }
+
+    scan_project "proj-default"
+
+    [ -f "$emit_log" ]
+    # MAX_CONCURRENT_PRS=1 means exactly one emit; it must be the p1-high (#13).
+    local lines
+    lines=$(wc -l < "$emit_log" | tr -d ' ')
+    [ "$lines" -eq 1 ]
+    grep -q '"issue_number": 13' "$emit_log"
+}
+
+# ---------------------------------------------------------------------------
+# pipeline_slots — serial-mode gate
+# ---------------------------------------------------------------------------
+
+@test "pipeline_slots=1 + in-flight ticket: scanner emits nothing at first stage" {
+    _write_fixture_config
+    export LOOP_CONFIG="$BATS_TMPDIR/fixture.yaml"
+
+    # Use proj-minimal so the first issue trigger is `needs-dev` and there is
+    # no PO stage to confound the test.
+    local NEW_ISSUE INFLIGHT_ISSUE
+    NEW_ISSUE='{"number":21,"title":"fresh","url":"http://gh/21","labels":["needs-dev"],"author":"bot"}'
+    INFLIGHT_ISSUE='{"number":20,"title":"old","url":"http://gh/20","labels":["in-progress"],"author":"bot"}'
+
+    backend_list_issues_with_label() {
+        local _label="$2"
+        case "$_label" in
+            needs-dev)   printf '%s\n' "$NEW_ISSUE" ;;
+            in-progress) printf '%s\n' "$INFLIGHT_ISSUE" ;;
+        esac
+        return 0
+    }
+    backend_list_prs_with_label()  { return 0; }
+    backend_list_open_prs_raw()    { echo "[]"; }
+    backend_issue_has_any_label()  { return 1; }
+    backend_pr_has_any_label()     { return 1; }
+    backend_issue_unmet_deps()     { return 1; }
+    loop_load_backend()            { return 0; }
+    loop_load_project() {
+        REPO="owner/minimal-repo"
+        MAX_CONCURRENT_PRS=3
+        PIPELINE_SLOTS=1
+        BACKEND=github
+        WORKFLOW=minimal
+        ALLOWED_AUTHORS=""
+        LOOP_LABEL_OVERRIDES=""
+        return 0
+    }
+
+    local emit_log="$BATS_TMPDIR/emit-serial.log"
+    rm -f "$emit_log"
+    emit() { echo "$1" >> "$emit_log"; return 0; }
+
+    scan_project "proj-minimal"
+
+    # Either the emit log was never created or it has zero entries.
+    if [ -f "$emit_log" ]; then
+        local lines
+        lines=$(wc -l < "$emit_log" | tr -d ' ')
+        [ "$lines" -eq 0 ]
+    fi
+}
+
 @test "emit: no dedup key file created when dedup_id is empty" {
     local dispatch_log="$BATS_TMPDIR/dispatch3.log"
     rm -f "$dispatch_log"


### PR DESCRIPTION
Closes #267

## Changes

- **`lib/config.sh`**: Reads `dev.pipeline_slots` per-project; exports as `PIPELINE_SLOTS` (empty when unset → gate disabled).
- **`scanner/scanner.sh`**:
  - New `_sort_rows_by_priority` helper (one Python pass) — sorts JSON rows by priority label (`p0-critical` > `p1-high` > `p2-medium` > `p3-low` > unlabeled) then by lower number as tiebreak. Applied at the end of `_scan_issue_stage`, `_scan_dev_issue_stage`, and `_scan_pr_stage` so every stage emits in priority order regardless of slot count.
  - New `count_inflight_issues` — counts distinct open issues carrying any workflow trigger label OR `in-progress` / `blocked`.
  - `scan_project`: when `PIPELINE_SLOTS` is set and `count_inflight_issues + count_inflight_prs >= PIPELINE_SLOTS`, skip emitting the workflow's **first** issue trigger (the claim stage). Downstream stages for already-claimed work continue normally so in-flight tickets keep flowing to completion.
- **`tests/scanner.bats`**: 4 new tests covering priority ordering (p0 > p1 > p2 > p3 > unlabeled, lower-number tiebreak), mixed-priority dev_issue emit selects p1 first, and `pipeline_slots=1` with an in-flight ticket emits nothing.
- **`README.md`** + **`CONTRIBUTING.md`**: new "Pipeline concurrency & priority" section explaining serial vs parallel modes and when to use each.

## Test Plan

- `bats tests/scanner.bats` → 37/37 pass (4 new + 33 existing).
- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` ✅
- `shellcheck -S warning lib/config.sh scanner/scanner.sh` ✅

## Notes

- `config/projects.yaml` is NOT touched (gitignored, operator-managed).
- The gate only blocks the workflow's *first* issue trigger (e.g. `needs-po` for default workflow, `needs-dev` for minimal). Downstream stages run normally so once a ticket is claimed, it can progress to merge without re-hitting the gate.
