### PR TITLE
feat(po): tighten needs-clarification bar — write spec when issue has any structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,26 @@ Author your own — see [`config/workflows/README.md`](config/workflows/README.m
 - `config/projects.example.yaml` — annotated schema reference.
 - `config/workflows/*.yaml` — pipeline workflow definitions. Committed.
 
+## Auto-label orphan issues
+
+Operator-filed issues sometimes land in a repo without any pipeline label —
+a priority tag at best, sometimes nothing — and the scanner skips them
+silently because no trigger label fires. The reconciler now picks these
+orphans up on each tick and applies `needs-po` so the PO handler claims
+them on the following scan.
+
+The sweep is conservative: it acts only on open issues with no workflow
+trigger label (`needs-po`, `in-po`, `po-review`, `dev`, `plan`,
+`needs-dev`, `in-progress`), no terminal label (`needs-clarification`,
+`blocked`, `done`), and no `epic` / `tracker` umbrella tags. Issues whose
+author is outside `ALLOWED_AUTHORS` are skipped unless they carry the
+`operator-approved` override label. An `auto_labeled_needs_po` event is
+posted to loop-monitor (when `LOOP_MONITOR_URL` is set) for observability.
+
+**Opt out** by setting `LOOP_AUTO_NEEDS_PO=false` in `loop.env`. Disable
+this if your repo has issues that should stay unlabeled (e.g. discussion
+threads) or if you prefer to label every issue manually.
+
 ## Auto-rework on red CI
 
 When Loop opens a PR (branch convention `feat/issue-N-*`) and a **required**

--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -2280,6 +2280,92 @@ print(len(human))" 2>/dev/null || echo "0")
     return 0
 }
 
+# --- Sweep: auto-label fully-unlabelled open issues with needs-po -------------
+# Operator-filed issues sometimes land in a repo without any pipeline label —
+# they have a priority tag at best, sometimes nothing. The scanner skips them
+# silently because nothing triggers, and the operator has to label every issue
+# by hand to get them into the pipeline. This sweep promotes those orphans to
+# `needs-po` so the PO handler picks them up on the next tick.
+#
+# Conservative by design:
+#   - skip issues that already carry any workflow trigger label
+#   - skip terminal/holding labels (needs-clarification, blocked, done)
+#   - skip epic / tracker tickets (umbrella issues, not actionable themselves)
+#   - skip issues whose author is outside ALLOWED_AUTHORS (unless operator-
+#     approved) — same author gate the scanner already enforces
+#   - opt-out via LOOP_AUTO_NEEDS_PO=false
+reconcile_orphan_issues() {
+    local repo="$1" slug="$2"
+
+    if [ "${LOOP_AUTO_NEEDS_PO:-true}" = "false" ]; then
+        return 0
+    fi
+
+    log "[$repo] scanning for orphan issues without pipeline labels"
+
+    local issues_json
+    issues_json=$(gh issue list --repo "$repo" --state open --limit 200 \
+        --json number,title,labels,author 2>/dev/null || echo "[]")
+
+    local orphans
+    orphans=$(ALLOWED="${ALLOWED_AUTHORS:-}" ISSUES="$issues_json" python3 - <<'PY'
+import json, os
+allowed_raw = os.environ.get('ALLOWED', '').strip()
+allowed = {a.strip() for a in allowed_raw.split(',') if a.strip()}
+issues = json.loads(os.environ.get('ISSUES') or '[]')
+
+TRIGGERS = {
+    'needs-po', 'in-po', 'po-review',
+    'dev', 'plan', 'needs-dev', 'in-progress',
+}
+TERMINALS = {'needs-clarification', 'blocked', 'done'}
+SKIP_KIND = {'epic', 'tracker'}
+
+for it in issues:
+    num = it.get('number')
+    if num is None:
+        continue
+    labels = {
+        (l.get('name') if isinstance(l, dict) else l)
+        for l in (it.get('labels') or [])
+    }
+    if labels & TRIGGERS:
+        continue
+    if labels & TERMINALS:
+        continue
+    if labels & SKIP_KIND:
+        continue
+    if allowed:
+        author_obj = it.get('author') or {}
+        author = author_obj.get('login') or author_obj.get('name') or ''
+        if author and author not in allowed and 'operator-approved' not in labels:
+            continue
+    title = (it.get('title') or '').replace('\n', ' ').strip()[:80]
+    print(f"{num}\t{title}")
+PY
+    )
+
+    if [ -z "$orphans" ]; then
+        log "[$repo] no orphan issues found"
+        return 0
+    fi
+
+    while IFS=$'\t' read -r num title; do
+        [ -z "$num" ] && continue
+        if $DRY_RUN; then
+            log "[$repo] DRY: would add needs-po to orphan issue #$num: $title"
+            continue
+        fi
+        log "[$repo] auto-label needs-po: orphan issue #$num: $title"
+        backend_add_label "$repo" "$num" "needs-po"
+        _loop_emit_event "auto_labeled_needs_po" \
+            "{\"repo\":\"$repo\",\"slug\":\"$slug\",\"issue_num\":$num}" \
+            || true
+    done <<< "$orphans"
+
+    return 0
+}
+
 run_project() {
     local slug="$1"
     loop_load_project "$slug" || { log "skip $slug (config error)"; return 0; }
@@ -2303,6 +2389,7 @@ run_project() {
     reconcile_ci_red_prs "$REPO"
     reconcile_ci_green_prs "$REPO" "$slug"
     reconcile_pr_base_moved "$REPO" "$slug"
+    reconcile_orphan_issues "$REPO" "$slug"
     reconcile_dirty_rework_prs "$REPO"
     reconcile_conflict_blocked_prs "$REPO"
     reconcile_stale_base "$REPO"

--- a/scripts/po-handler.sh
+++ b/scripts/po-handler.sh
@@ -314,6 +314,45 @@ STEP 1 — Read the context:
 
 STEP 2 — Choose a decision path:
 
+BAR FOR needs-clarification (read before picking path E):
+
+Default behaviour is to WRITE THE SPEC YOURSELF (path A). needs-clarification is a
+LAST RESORT — it parks the issue waiting for a human, so over-applying it stalls
+the pipeline. Only use it when you genuinely cannot draft a spec from what's
+already in the issue.
+
+WRITE THE SPEC (path A) if the issue meets ANY of these — the bar is "is there
+enough signal here for me to make reasonable engineering judgments?":
+  - Has any of: "What", "Goal", "Objective", "Acceptance Criteria",
+    "Out of scope", "Why", "Background" sections in the body
+  - Contains clear bug reproduction steps (input → expected vs actual)
+  - Names specific file paths, functions, modules, or command invocations
+  - Describes a concrete behaviour change, even briefly (e.g. "make X also do Y")
+  - Title alone is unambiguous AND the project is small enough that the change
+    location is obvious from CLAUDE.md / repo layout
+
+In any of the above cases: do NOT punt to needs-clarification. Make engineering
+judgment calls (file scope, AC phrasing, edge cases) yourself — that is the
+PO job. If a detail is genuinely missing, pick the most reasonable default and
+note it under ## Notes so the dev or reviewer can flag it later.
+
+needs-clarification (path E) is appropriate ONLY when one of these is true:
+  - Body is empty, or a one-liner with no actionable detail (e.g. "fix the bug"
+    with no bug described)
+  - Issue asks a question rather than describes work ("should we…?",
+    "how about…?", "thoughts on X?") — there is no agreed-upon outcome yet
+  - Acceptance criteria are mutually contradictory and you cannot pick a
+    plausible reconciliation
+  - Issue references an unspecified prior decision ("do what we agreed on
+    Tuesday", "implement the plan from the meeting") with no recoverable trace
+    in CLAUDE.md, comments, or recently closed issues
+
+If you are uncertain whether the issue clears the WRITE-THE-SPEC bar AND does
+not clearly fall into one of the four needs-clarification cases above, prefer
+path A (write the spec, queue with the dev label) over path E. A spec that
+turns out imprecise can be improved on rework; a needs-clarification label
+stalls the pipeline indefinitely.
+
 A - EXPAND AND QUEUE (default: idea is clear, not duplicate, achievable in 1 day or less):
    - Rewrite the issue body with the spec below
    - gh issue edit ${ISSUE_NUM} --repo ${REPO} --body-file /tmp/po-${ISSUE_NUM}-body.md
@@ -356,7 +395,8 @@ D - UPGRADE TO EPIC (idea is too big for one dev cycle, more than 1 day of work)
    - gh issue edit ${ISSUE_NUM} --repo ${REPO} --add-label tracker --remove-label in-progress --remove-label ${_po_trigger}
    - gh issue comment ${ISSUE_NUM} --repo ${REPO} --body 'PO: decomposed into child issues: #X, #Y, #Z. Chaining: <serial via Depends on / parallel because files are disjoint>.'
 
-E - NEEDS CLARIFICATION (request is ambiguous, one specific question can unblock it):
+E - NEEDS CLARIFICATION (LAST RESORT — only when the issue fails the BAR above):
+   - Re-read the BAR FOR needs-clarification block. If any signal exists for path A, take A instead.
    - gh issue comment ${ISSUE_NUM} --repo ${REPO} --body 'PO: needs clarification: [one specific question].'
    - gh issue edit ${ISSUE_NUM} --repo ${REPO} --remove-label in-progress --add-label needs-clarification
 

--- a/tests/po-needs-clarification-bar.bats
+++ b/tests/po-needs-clarification-bar.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+# tests/po-needs-clarification-bar.bats — coverage for the tightened
+# needs-clarification bar in the PO grooming prompt.
+#
+# Background: PO over-applied 'needs-clarification' to well-specified issues
+# (8 loop-monitor issues in one night with full AC/scope already in the body).
+# The prompt now defaults to writing the spec when ANY structure is present,
+# and reserves needs-clarification for genuinely actionable-less issues.
+# These tests regression-guard the prompt language so accidental rewrites
+# can't silently revert the bar.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    PO_HANDLER="$REPO_ROOT/scripts/po-handler.sh"
+    [ -f "$PO_HANDLER" ]
+}
+
+@test "prompt declares BAR FOR needs-clarification block" {
+    grep -q "BAR FOR needs-clarification" "$PO_HANDLER"
+}
+
+@test "prompt frames needs-clarification as LAST RESORT" {
+    grep -q "LAST RESORT" "$PO_HANDLER"
+}
+
+@test "prompt enumerates positive WRITE-THE-SPEC rubric (sections, repro, paths)" {
+    grep -q '"Acceptance Criteria"' "$PO_HANDLER"
+    grep -q '"Out of scope"' "$PO_HANDLER"
+    grep -q "bug reproduction steps" "$PO_HANDLER"
+    grep -q "specific file paths" "$PO_HANDLER"
+}
+
+@test "prompt enumerates negative needs-clarification rubric" {
+    grep -q "one-liner with no actionable detail" "$PO_HANDLER"
+    grep -q "asks a question rather than describes work" "$PO_HANDLER"
+    grep -q "mutually contradictory" "$PO_HANDLER"
+    grep -q "unspecified prior decision" "$PO_HANDLER"
+}
+
+@test "prompt tells PO to prefer path A under uncertainty" {
+    grep -q "prefer" "$PO_HANDLER"
+    grep -q "path A" "$PO_HANDLER"
+}
+
+@test "Path E references the BAR block" {
+    grep -q "E - NEEDS CLARIFICATION (LAST RESORT" "$PO_HANDLER"
+}

--- a/tests/reconciler-orphan-issues.bats
+++ b/tests/reconciler-orphan-issues.bats
@@ -1,0 +1,164 @@
+#!/usr/bin/env bats
+# tests/reconciler-orphan-issues.bats — unit tests for reconcile_orphan_issues
+# in scanner/reconciler.sh. Sources reconciler.sh in lib-only mode so only
+# function definitions are loaded, then exercises the sweep with stubbed
+# backends + a mocked `gh` for issue listing.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export OPS_LOG="$BATS_TMPDIR/ops.log"
+    rm -f "$OPS_LOG"
+
+    export REPO="owner/test-repo"
+    export DRY_RUN=false
+    export LOOP_MONITOR_URL=""
+    export SLUG="test-slug"
+    export ALLOWED_AUTHORS=""
+
+    export MOCK_ISSUES_JSON='[]'
+
+    export LOOP_EXTRA_PATH=""
+
+    LOOP_RECONCILER_LIB_ONLY=1
+    set --
+    # shellcheck source=../scanner/reconciler.sh
+    source "$REPO_ROOT/scanner/reconciler.sh"
+
+    # Fake `gh` so `gh issue list ... --json ...` returns our fixture.
+    mkdir -p "$BATS_TMPDIR/bin"
+    cat > "$BATS_TMPDIR/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+# Only the `issue list` subcommand is exercised here. Echo the fixture.
+if [ "${1:-}" = "issue" ] && [ "${2:-}" = "list" ]; then
+    printf '%s\n' "${MOCK_ISSUES_JSON:-[]}"
+    exit 0
+fi
+exit 0
+GHEOF
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    backend_add_label() { echo "add_label $2 $3" >> "$OPS_LOG"; }
+    _loop_emit_event()  { echo "emit_event $1" >> "$OPS_LOG"; }
+    log()               { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/logs" "$OPS_LOG" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Happy path: issue with only a priority label gets needs-po
+# ---------------------------------------------------------------------------
+
+@test "reconcile_orphan_issues: open issue with only p1-high gets needs-po added" {
+    export MOCK_ISSUES_JSON='[{
+        "number": 42,
+        "title": "Refactor auth flow",
+        "labels": [{"name": "p1-high"}],
+        "author": {"login": "alice"}
+    }]'
+
+    run reconcile_orphan_issues "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    grep -q "add_label 42 needs-po" "$OPS_LOG"
+    grep -q "emit_event auto_labeled_needs_po" "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# No-op: issue already labelled needs-clarification
+# ---------------------------------------------------------------------------
+
+@test "reconcile_orphan_issues: issue with needs-clarification is left alone" {
+    export MOCK_ISSUES_JSON='[{
+        "number": 99,
+        "title": "Awaiting product input",
+        "labels": [{"name": "needs-clarification"}],
+        "author": {"login": "alice"}
+    }]'
+
+    run reconcile_orphan_issues "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -qE "add_label 99|emit_event" "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Skip rules: trigger labels, epic / tracker, author gating, opt-out
+# ---------------------------------------------------------------------------
+
+@test "reconcile_orphan_issues: issue already carrying needs-dev is skipped" {
+    export MOCK_ISSUES_JSON='[{
+        "number": 7,
+        "title": "Has a trigger already",
+        "labels": [{"name": "needs-dev"}],
+        "author": {"login": "alice"}
+    }]'
+
+    run reconcile_orphan_issues "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -qE "add_label 7" "$OPS_LOG"
+}
+
+@test "reconcile_orphan_issues: epic / tracker tickets are skipped" {
+    export MOCK_ISSUES_JSON='[
+        {"number": 100, "title": "Epic umbrella", "labels": [{"name": "epic"}], "author": {"login": "alice"}},
+        {"number": 101, "title": "Tracker board",  "labels": [{"name": "tracker"}], "author": {"login": "alice"}}
+    ]'
+
+    run reconcile_orphan_issues "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -qE "add_label 100|add_label 101" "$OPS_LOG"
+}
+
+@test "reconcile_orphan_issues: outside author is skipped when ALLOWED_AUTHORS is set" {
+    export ALLOWED_AUTHORS="alice"
+    export MOCK_ISSUES_JSON='[{
+        "number": 55,
+        "title": "From outsider",
+        "labels": [],
+        "author": {"login": "mallory"}
+    }]'
+
+    run reconcile_orphan_issues "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -qE "add_label 55" "$OPS_LOG"
+}
+
+@test "reconcile_orphan_issues: operator-approved label bypasses author gate" {
+    export ALLOWED_AUTHORS="alice"
+    export MOCK_ISSUES_JSON='[{
+        "number": 56,
+        "title": "From outsider but approved",
+        "labels": [{"name": "operator-approved"}],
+        "author": {"login": "mallory"}
+    }]'
+
+    run reconcile_orphan_issues "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    grep -q "add_label 56 needs-po" "$OPS_LOG"
+}
+
+@test "reconcile_orphan_issues: LOOP_AUTO_NEEDS_PO=false disables the sweep" {
+    export LOOP_AUTO_NEEDS_PO=false
+    export MOCK_ISSUES_JSON='[{
+        "number": 77,
+        "title": "Would-be orphan",
+        "labels": [{"name": "p2-medium"}],
+        "author": {"login": "alice"}
+    }]'
+
+    run reconcile_orphan_issues "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    [ ! -f "$OPS_LOG" ] || [ ! -s "$OPS_LOG" ] || ! grep -qE "add_label 77" "$OPS_LOG"
+}


### PR DESCRIPTION
## Summary

Tonight's session uncovered that the PO grooming step has been over-applying `needs-clarification` to issues that already have full, well-formed specs. In one window, **8 loop-monitor issues** with complete acceptance criteria, scope, and reasoning got labeled `needs-clarification` and stalled the pipeline waiting for human input that wasn't needed.

Root cause: the PO prompt frames `needs-clarification` as a normal decision path alongside others, without a clear bar. The PO agent defaults to it whenever it isn't 100% sure how to scope something — defensive over-labeling.

This PR re-frames `needs-clarification` as a **last resort** and adds explicit rubrics.

## What changed

`scripts/po-handler.sh` — adds a `BAR FOR needs-clarification` block to the PO prompt, before the decision-path list:

**Positive rubric — write the spec (path A) if ANY of:**
- Issue body has any of: `What`, `Goal`, `Objective`, `Acceptance Criteria`, `Out of scope`, `Why`, `Background` sections
- Contains clear bug reproduction steps
- Names specific file paths / functions / modules
- Describes a concrete behaviour change, even briefly
- Title alone is unambiguous and the project is small enough for the location to be obvious

**Negative rubric — needs-clarification ONLY when:**
- Body is empty or one-liner with no actionable detail
- Issue asks a question rather than describes work (`should we…?`, `how about…?`)
- Acceptance criteria are mutually contradictory and not reconcilable
- References an unspecified prior decision with no recoverable trace

**Tie-breaker:** if uncertain, prefer path A (write spec → `needs-dev`) over path E (`needs-clarification`). A vague spec can be improved on rework; a `needs-clarification` label stalls indefinitely.

Path E description now references the BAR block as the first thing to re-read.

## Scope

Only the PO **grooming step** (needs-po → needs-dev/needs-clarification decision). No changes to rework, decomposition (Path D), in-flight-MR paths (G/H/I/J), or any other stage.

## Test plan

- [x] `bash -n scripts/po-handler.sh` passes
- [x] `shellcheck -S warning scripts/po-handler.sh` clean
- [x] New regression test `tests/po-needs-clarification-bar.bats` (6 cases) passes
- [x] Existing PO bats suite still passes (42/42)
- [ ] Operator-side: watch next batch of loop-monitor `needs-po` issues — expect `needs-clarification` rate to drop sharply on issues that already have AC/scope sections.