### PR TITLE
[LOOP-label-state] reconciler converges conflicting label sets per workflow rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,43 @@ projects:
       auto_rebase_on_base_move: false   # disable reconciler auto-rebase on base-move
 ```
 
+### Label-state convergence
+
+Stage handlers each touch a narrow set of labels, and occasionally leave a
+ticket in a workflow-illegal combination — e.g. a PR with both `qa-pass` AND
+`needs-dev`, or a PR carrying `qa-fail` but no `needs-rework`. These
+combinations confuse the next handler: sometimes the wrong role claims,
+sometimes nothing claims and the ticket stalls.
+
+Every reconciler tick runs `reconcile_label_consistency`, which enforces
+per-stage exclusivity rules so the label state always represents a single
+workflow stage.
+
+**PR rules:**
+
+- `qa-pass` present → strip `needs-dev`, `needs-review`, `needs-rework`,
+  `changes-requested`, `qa-fail`, `in-review`, `in-rework`.
+- `qa-fail` or `changes-requested` present → ensure `needs-rework` is set
+  (add if missing); strip `qa-pass` and `needs-review`.
+- `needs-review` present → never co-exists with `needs-dev`, `needs-rework`,
+  or `changes-requested`. On conflict, the rework signal wins and
+  `needs-review` is removed.
+- `ready-for-qa` present → strip `needs-review`, `needs-dev`.
+
+**Issue rules:**
+
+- `needs-dev` present → strip `needs-po`, `in-po`, `po-review`, `plan`.
+- `needs-po` present → strip `needs-dev`, `in-progress`, `dev`.
+- `blocked` present → terminal state; strip every trigger label
+  (`needs-po`, `needs-dev`, `in-po`, `in-progress`, `dev`, etc).
+
+Each convergence emits a `label_state_converged` event to loop-monitor (if
+`LOOP_MONITOR_URL` is set) with the added/removed labels for observability.
+
+**Opt-out:** set `LOOP_LABEL_CONVERGE=false` in `loop.env` to disable the
+sweep. The check honours `DRY_RUN` (logs intended mutations, makes no API
+calls).
+
 ## Pipeline concurrency & priority
 
 Loop's scanner picks issues to claim every 5 minutes. Two knobs control how

--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -2366,6 +2366,177 @@ PY
     return 0
 }
 
+# --- Sweep: converge conflicting label sets to workflow-legal combinations ---
+# Stage handlers each touch a narrow set of labels and occasionally leave a
+# ticket in a workflow-illegal combination — e.g. a PR with both `qa-pass`
+# AND `needs-dev` (qa passed but the rework signal stayed on), or a PR with
+# `qa-fail` but no `needs-rework` (failed QA, no rework trigger). These
+# combinations confuse the next handler: sometimes the wrong role claims,
+# sometimes nothing claims and the ticket stalls.
+#
+# This sweep enforces per-stage exclusivity rules so the label state always
+# represents a single workflow stage.
+#
+# PR rules:
+#   qa-pass                    → strip needs-dev, needs-review, needs-rework,
+#                                changes-requested, qa-fail, in-review, in-rework
+#   qa-fail | changes-requested → ensure needs-rework; strip qa-pass, needs-review
+#   needs-review               → never co-exists with needs-dev / needs-rework /
+#                                changes-requested (prefer rework, drop needs-review)
+#   ready-for-qa               → strip needs-review, needs-dev
+#
+# Issue rules:
+#   needs-dev → strip needs-po, in-po, po-review, plan
+#   needs-po  → strip needs-dev, in-progress, dev
+#   blocked   → terminal — strip all trigger labels
+#
+# Opt-out:  LOOP_LABEL_CONVERGE=false
+# DRY_RUN honored (logs intended mutations, no API calls).
+reconcile_label_consistency() {
+    local repo="$1" slug="$2"
+
+    if [ "${LOOP_LABEL_CONVERGE:-true}" = "false" ]; then
+        return 0
+    fi
+
+    log "[$repo] label-state convergence sweep"
+
+    local prs_json issues_json
+    prs_json=$(backend_list_open_prs_raw "$repo" 2>/dev/null || echo "[]")
+    issues_json=$(gh issue list --repo "$repo" --state open --limit 200 \
+        --json number,labels 2>/dev/null || echo "[]")
+
+    local plan
+    plan=$(PRS="$prs_json" ISSUES="$issues_json" python3 - <<'PY'
+import json, os
+
+prs = json.loads(os.environ.get('PRS') or '[]')
+issues = json.loads(os.environ.get('ISSUES') or '[]')
+
+PR_TRIGGERS_ON_QA_PASS = [
+    'needs-dev', 'needs-review', 'needs-rework',
+    'changes-requested', 'qa-fail', 'in-review', 'in-rework',
+]
+ISSUE_TRIGGERS_BLOCKED = [
+    'needs-po', 'in-po', 'po-review', 'plan',
+    'needs-dev', 'in-progress', 'dev',
+    'needs-review', 'needs-rework', 'changes-requested',
+    'ready-for-qa', 'in-review', 'in-rework',
+]
+
+def names(item):
+    return {
+        (l.get('name') if isinstance(l, dict) else l)
+        for l in (item.get('labels') or [])
+    }
+
+def emit(kind, num, adds, removes):
+    if not adds and not removes:
+        return
+    # Use '-' as placeholder so bash read doesn't collapse empty tab fields
+    # (bash's read collapses consecutive whitespace-IFS delimiters).
+    print('\t'.join([
+        kind, str(num),
+        ','.join(sorted(adds)) or '-',
+        ','.join(sorted(removes)) or '-',
+    ]))
+
+for pr in prs:
+    num = pr.get('number')
+    if num is None:
+        continue
+    labels = names(pr)
+    adds, removes = set(), set()
+
+    if 'qa-pass' in labels:
+        for l in PR_TRIGGERS_ON_QA_PASS:
+            if l in labels:
+                removes.add(l)
+
+    rework_signal = ('qa-fail' in labels) or ('changes-requested' in labels)
+    if rework_signal:
+        if 'needs-rework' not in labels:
+            adds.add('needs-rework')
+        for l in ('qa-pass', 'needs-review'):
+            if l in labels:
+                removes.add(l)
+
+    # needs-review must not co-exist with dev/rework signals; prefer rework.
+    if 'needs-review' in labels and not rework_signal:
+        if labels & {'needs-dev', 'needs-rework', 'changes-requested'}:
+            removes.add('needs-review')
+
+    if 'ready-for-qa' in labels:
+        for l in ('needs-review', 'needs-dev'):
+            if l in labels:
+                removes.add(l)
+
+    # Don't add and remove the same label in the same pass.
+    removes -= adds
+    emit('pr', num, adds, removes)
+
+for it in issues:
+    num = it.get('number')
+    if num is None:
+        continue
+    labels = names(it)
+    adds, removes = set(), set()
+
+    if 'blocked' in labels:
+        for l in ISSUE_TRIGGERS_BLOCKED:
+            if l in labels:
+                removes.add(l)
+        emit('issue', num, adds, removes)
+        continue
+
+    if 'needs-dev' in labels:
+        for l in ('needs-po', 'in-po', 'po-review', 'plan'):
+            if l in labels:
+                removes.add(l)
+    if 'needs-po' in labels:
+        for l in ('needs-dev', 'in-progress', 'dev'):
+            if l in labels:
+                removes.add(l)
+
+    emit('issue', num, adds, removes)
+PY
+    )
+
+    if [ -z "$plan" ]; then
+        log "[$repo] label-state: no convergence actions needed"
+        return 0
+    fi
+
+    local kind num adds removes
+    while IFS=$'\t' read -r kind num adds removes; do
+        [ -z "$num" ] && continue
+        [ "$adds" = "-" ] && adds=""
+        [ "$removes" = "-" ] && removes=""
+        if $DRY_RUN; then
+            log "[$repo] DRY label-converge $kind#$num adds=[${adds}] removes=[${removes}]"
+            continue
+        fi
+        log "[$repo] label-converge $kind#$num adds=[${adds}] removes=[${removes}]"
+        local label
+        local IFS_ORIG="$IFS"
+        IFS=','
+        for label in $adds; do
+            [ -z "$label" ] && continue
+            backend_add_label "$repo" "$num" "$label" >/dev/null 2>&1 || true
+        done
+        for label in $removes; do
+            [ -z "$label" ] && continue
+            backend_remove_label "$repo" "$num" "$label" >/dev/null 2>&1 || true
+        done
+        IFS="$IFS_ORIG"
+        _loop_emit_event "label_state_converged" \
+            "{\"repo\":\"$repo\",\"slug\":\"$slug\",\"kind\":\"$kind\",\"number\":$num,\"added\":\"$adds\",\"removed\":\"$removes\"}" \
+            || true
+    done <<< "$plan"
+
+    return 0
+}
+
 run_project() {
     local slug="$1"
     loop_load_project "$slug" || { log "skip $slug (config error)"; return 0; }
@@ -2390,6 +2561,7 @@ run_project() {
     reconcile_ci_green_prs "$REPO" "$slug"
     reconcile_pr_base_moved "$REPO" "$slug"
     reconcile_orphan_issues "$REPO" "$slug"
+    reconcile_label_consistency "$REPO" "$slug"
     reconcile_dirty_rework_prs "$REPO"
     reconcile_conflict_blocked_prs "$REPO"
     reconcile_stale_base "$REPO"

--- a/tests/reconciler-label-state.bats
+++ b/tests/reconciler-label-state.bats
@@ -1,0 +1,218 @@
+#!/usr/bin/env bats
+# tests/reconciler-label-state.bats — unit tests for
+# reconcile_label_consistency in scanner/reconciler.sh.
+# Sources reconciler.sh in lib-only mode and exercises the sweep with
+# stubbed backend label ops and a mocked `gh` for issue listing.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export OPS_LOG="$BATS_TMPDIR/ops.log"
+    rm -f "$OPS_LOG"
+
+    export REPO="owner/test-repo"
+    export DRY_RUN=false
+    export LOOP_MONITOR_URL=""
+    export SLUG="test-slug"
+
+    export MOCK_PRS_JSON='[]'
+    export MOCK_ISSUES_JSON='[]'
+
+    LOOP_RECONCILER_LIB_ONLY=1
+    set --
+    # shellcheck source=../scanner/reconciler.sh
+    source "$REPO_ROOT/scanner/reconciler.sh"
+
+    mkdir -p "$BATS_TMPDIR/bin"
+    cat > "$BATS_TMPDIR/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "issue" ] && [ "${2:-}" = "list" ]; then
+    printf '%s\n' "${MOCK_ISSUES_JSON:-[]}"
+    exit 0
+fi
+exit 0
+GHEOF
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    backend_list_open_prs_raw() { printf '%s\n' "${MOCK_PRS_JSON:-[]}"; }
+    backend_add_label()    { echo "add $2 $3" >> "$OPS_LOG"; }
+    backend_remove_label() { echo "remove $2 $3" >> "$OPS_LOG"; }
+    _loop_emit_event()     { echo "emit $1 $2" >> "$OPS_LOG"; }
+    log()                  { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/logs" "$OPS_LOG" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# PR rule: qa-pass strips conflicting rework/review labels
+# ---------------------------------------------------------------------------
+
+@test "PR qa-pass + needs-dev: needs-dev is stripped" {
+    export MOCK_PRS_JSON='[{
+        "number": 11,
+        "labels": [{"name":"qa-pass"},{"name":"needs-dev"}]
+    }]'
+    run reconcile_label_consistency "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+    grep -q "remove 11 needs-dev" "$OPS_LOG"
+    ! grep -q "add 11 " "$OPS_LOG"
+    grep -q "emit label_state_converged" "$OPS_LOG"
+}
+
+@test "PR qa-pass alone: no-op" {
+    export MOCK_PRS_JSON='[{"number":12,"labels":[{"name":"qa-pass"}]}]'
+    run reconcile_label_consistency "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+    [ ! -s "$OPS_LOG" ] || ! grep -qE "^(add|remove) 12 " "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# PR rule: qa-fail / changes-requested ensure needs-rework, strip qa-pass/needs-review
+# ---------------------------------------------------------------------------
+
+@test "PR qa-fail without needs-rework: needs-rework added" {
+    export MOCK_PRS_JSON='[{"number":21,"labels":[{"name":"qa-fail"}]}]'
+    run reconcile_label_consistency "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+    grep -q "add 21 needs-rework" "$OPS_LOG"
+}
+
+@test "PR changes-requested + needs-review: needs-rework added, needs-review removed" {
+    export MOCK_PRS_JSON='[{
+        "number": 22,
+        "labels": [{"name":"changes-requested"},{"name":"needs-review"}]
+    }]'
+    run reconcile_label_consistency "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+    grep -q "add 22 needs-rework" "$OPS_LOG"
+    grep -q "remove 22 needs-review" "$OPS_LOG"
+}
+
+@test "PR qa-fail already has needs-rework: no add" {
+    export MOCK_PRS_JSON='[{
+        "number": 23,
+        "labels": [{"name":"qa-fail"},{"name":"needs-rework"}]
+    }]'
+    run reconcile_label_consistency "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+    ! grep -q "add 23 " "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# PR rule: needs-review conflicts with rework signals → drop needs-review
+# ---------------------------------------------------------------------------
+
+@test "PR needs-review + needs-dev: needs-review stripped" {
+    export MOCK_PRS_JSON='[{
+        "number": 31,
+        "labels": [{"name":"needs-review"},{"name":"needs-dev"}]
+    }]'
+    run reconcile_label_consistency "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+    grep -q "remove 31 needs-review" "$OPS_LOG"
+}
+
+@test "PR needs-review alone: no-op" {
+    export MOCK_PRS_JSON='[{"number":32,"labels":[{"name":"needs-review"}]}]'
+    run reconcile_label_consistency "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+    [ ! -s "$OPS_LOG" ] || ! grep -qE "^(add|remove) 32 " "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# PR rule: ready-for-qa strips needs-review / needs-dev
+# ---------------------------------------------------------------------------
+
+@test "PR ready-for-qa + needs-review + needs-dev: both stripped" {
+    export MOCK_PRS_JSON='[{
+        "number": 41,
+        "labels": [{"name":"ready-for-qa"},{"name":"needs-review"},{"name":"needs-dev"}]
+    }]'
+    run reconcile_label_consistency "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+    grep -q "remove 41 needs-review" "$OPS_LOG"
+    grep -q "remove 41 needs-dev" "$OPS_LOG"
+}
+
+@test "PR ready-for-qa alone: no-op" {
+    export MOCK_PRS_JSON='[{"number":42,"labels":[{"name":"ready-for-qa"}]}]'
+    run reconcile_label_consistency "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+    [ ! -s "$OPS_LOG" ] || ! grep -qE "^(add|remove) 42 " "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Issue rules
+# ---------------------------------------------------------------------------
+
+@test "issue needs-dev + needs-po: needs-po stripped" {
+    export MOCK_ISSUES_JSON='[{
+        "number": 51,
+        "labels": [{"name":"needs-dev"},{"name":"needs-po"}]
+    }]'
+    run reconcile_label_consistency "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+    grep -q "remove 51 needs-po" "$OPS_LOG"
+}
+
+@test "issue needs-po + in-progress: in-progress stripped" {
+    export MOCK_ISSUES_JSON='[{
+        "number": 52,
+        "labels": [{"name":"needs-po"},{"name":"in-progress"}]
+    }]'
+    run reconcile_label_consistency "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+    grep -q "remove 52 in-progress" "$OPS_LOG"
+}
+
+@test "issue blocked: all triggers stripped" {
+    export MOCK_ISSUES_JSON='[{
+        "number": 53,
+        "labels": [{"name":"blocked"},{"name":"needs-po"},{"name":"needs-dev"},{"name":"in-progress"}]
+    }]'
+    run reconcile_label_consistency "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+    grep -q "remove 53 needs-po" "$OPS_LOG"
+    grep -q "remove 53 needs-dev" "$OPS_LOG"
+    grep -q "remove 53 in-progress" "$OPS_LOG"
+    ! grep -q "remove 53 blocked" "$OPS_LOG"
+}
+
+@test "issue needs-dev alone: no-op" {
+    export MOCK_ISSUES_JSON='[{"number":54,"labels":[{"name":"needs-dev"}]}]'
+    run reconcile_label_consistency "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+    [ ! -s "$OPS_LOG" ] || ! grep -qE "^(add|remove) 54 " "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Env switches
+# ---------------------------------------------------------------------------
+
+@test "LOOP_LABEL_CONVERGE=false disables the sweep" {
+    export LOOP_LABEL_CONVERGE=false
+    export MOCK_PRS_JSON='[{
+        "number": 61,
+        "labels": [{"name":"qa-pass"},{"name":"needs-dev"}]
+    }]'
+    run reconcile_label_consistency "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+    [ ! -f "$OPS_LOG" ] || [ ! -s "$OPS_LOG" ]
+}
+
+@test "DRY_RUN logs but does not mutate" {
+    export DRY_RUN=true
+    export MOCK_PRS_JSON='[{
+        "number": 71,
+        "labels": [{"name":"qa-pass"},{"name":"needs-dev"}]
+    }]'
+    run reconcile_label_consistency "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+    [ ! -f "$OPS_LOG" ] || ! grep -qE "^(add|remove|emit) " "$OPS_LOG"
+}


### PR DESCRIPTION
## Problem

PRs and issues occasionally end up with conflicting label combinations that no single stage handler reconciles:

- PR with both `qa-pass` AND `needs-dev` (QA passed but rework label hung on)
- PR with `needs-review` AND `needs-dev` (review requested AND dev queue)
- PR with `qa-fail` but no `needs-rework` (failed QA but no rework signal)
- Issue with `needs-po` AND `needs-dev` simultaneously
- Issue still carrying triggers after being `blocked`

These workflow-illegal combinations confuse the next handler — sometimes the wrong role claims, sometimes nothing claims and the ticket stalls.

## Change

Adds `reconcile_label_consistency` to `scanner/reconciler.sh`, wired into `run_project` immediately after `reconcile_orphan_issues`. It enforces per-stage exclusivity rules and emits `label_state_converged` events.

**PR rules**

- `qa-pass` → strip `needs-dev`, `needs-review`, `needs-rework`, `changes-requested`, `qa-fail`, `in-review`, `in-rework`
- `qa-fail` or `changes-requested` → ensure `needs-rework`; strip `qa-pass`, `needs-review`
- `needs-review` co-existing with `needs-dev` / `needs-rework` / `changes-requested` → rework wins, `needs-review` removed
- `ready-for-qa` → strip `needs-review`, `needs-dev`

**Issue rules**

- `needs-dev` → strip `needs-po`, `in-po`, `po-review`, `plan`
- `needs-po` → strip `needs-dev`, `in-progress`, `dev`
- `blocked` (terminal) → strip all trigger labels

## Knobs

- `LOOP_LABEL_CONVERGE=false` — opt out entirely
- `DRY_RUN` — logs intended mutations, no API calls

## Tests

`tests/reconciler-label-state.bats` — 15 cases covering each rule (positive + no-op) plus the env switches. `bash -n` and `shellcheck -S warning` clean. README updated with the convergence rules.