### PR TITLE
[LOOP-workflow-audit] close dead-end states in workflow YAMLs (qa-fail in current; others)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
           done
           shellcheck -S warning "${files[@]}"
 
+      - name: Workflow state-machine lint
+        run: |
+          python3 -c 'import yaml' 2>/dev/null || sudo apt-get install -y python3-yaml
+          ./scripts/lint-workflow.sh
+
       - name: No personal identifiers
         run: |
           if git grep -iE 'vadim|/Users/vadim|boba-event|openclaw|suprun|com\.vadim' -- ':!LICENSE' ':!.github/workflows/qa-build-test.yml' ':!.github/workflows/ci.yml'; then

--- a/config/workflows/README.md
+++ b/config/workflows/README.md
@@ -97,6 +97,29 @@ labels (trigger labels declared in the file or terminal labels below).
 Missing handler scripts produce a warning but do not cause validation
 to fail.
 
+### State-machine lint
+
+`scripts/lint-workflow.sh` runs a structural audit of every workflow's
+state machine and fails CI when it finds either of these gaps:
+
+- **Dead-end label** — a label that a handler can produce (`on_done`,
+  `on_pass`, `on_fail`, `on_blocked`, `on_clarification`,
+  `on_failed_after_max`, or one of `decisions.*`) but no stage triggers
+  on. Tickets reaching that label sit forever because no handler claims
+  them. (Terminals `done`, `blocked`, `needs-clarification` are valid
+  sinks and ignored.)
+- **Orphan trigger** — a `trigger_label` that no handler in the same
+  workflow ever produces, *unless* it is the workflow's entry point
+  (the first issue stage's trigger, e.g. `needs-po` or `needs-dev`).
+
+```bash
+./scripts/lint-workflow.sh                          # audit every file
+./scripts/lint-workflow.sh path/to/workflow.yaml    # audit one file
+```
+
+This check runs in CI on every PR. See the
+[state machine per workflow](#state-machine-per-workflow) section below.
+
 ## Canonical label set
 
 These are the canonical label names used in `default.yaml`. Projects may
@@ -161,6 +184,94 @@ po-review (issue) → dev (issue) → review-pending (PR) → ready-for-qa (PR)
 
 See [docs/migration-from-asdlc.md](../../docs/migration-from-asdlc.md) for a full
 side-by-side mapping and instructions for creating your own `current.yaml`.
+
+## State machine per workflow
+
+Each workflow is a directed graph: trigger labels are states, handler
+output fields (`on_done`, `on_pass`, `on_fail`, `decisions.*`, etc.) are
+transitions. The diagrams below enumerate every state and transition so
+operators can audit coverage at a glance. `scripts/lint-workflow.sh`
+checks each file mechanically against the same model.
+
+Notation: `LABEL --(stage.field)--> LABEL`. Terminal states (`done`,
+`blocked`, `needs-clarification`) are sinks.
+
+### `default`
+
+Entry: `needs-po` (set externally when a new issue is filed).
+
+```
+needs-po       --(po.on_done)-->            needs-dev (issue)
+needs-po       --(po.on_blocked)-->         blocked
+needs-po       --(po.on_clarification)-->   needs-clarification
+needs-dev      --(dev.on_done)-->           needs-review
+needs-dev      --(dev.on_failed_after_max)--> blocked
+needs-review   --(review.approve)-->        needs-qa
+needs-review   --(review.reject)-->         needs-dev      (PR rework)
+needs-dev (PR) --(rework.on_done)-->        needs-review
+needs-dev (PR) --(rework.on_failed_after_max)--> blocked
+needs-qa       --(qa.on_pass)-->            qa-pass
+needs-qa       --(qa.on_fail)-->            qa-fail
+qa-pass        --(merge.on_done)-->         done
+qa-fail        --(qa-rework.on_done)-->     needs-review
+qa-fail        --(qa-rework.on_failed_after_max)--> blocked
+```
+
+Every produced label is either a trigger or a terminal. No dead-ends.
+
+### `current` (operator-local, gitignored)
+
+Entry: `po-review`.
+
+```
+po-review        --(po.on_done)-->            dev
+po-review        --(po.on_blocked)-->         blocked
+po-review        --(po.on_clarification)-->   needs-clarification
+dev              --(dev.on_done)-->           review-pending
+dev              --(dev.on_failed_after_max)--> blocked
+review-pending   --(review.approve)-->        ready-for-qa
+review-pending   --(review.reject)-->         changes-requested
+changes-requested --(rework.on_done)-->       review-pending
+changes-requested --(rework.on_failed_after_max)--> blocked
+ready-for-qa     --(qa.on_pass)-->            qa-pass
+ready-for-qa     --(qa.on_fail)-->            qa-fail
+qa-pass          --(merge.on_done)-->         done
+qa-fail          --(qa-rework.on_done)-->     review-pending
+qa-fail          --(qa-rework.on_failed_after_max)--> blocked
+```
+
+The `qa-rework` stage was added to close the `qa-fail` dead-end found
+during the workflow audit — previously a `qa-fail` label had no handler
+claim and the PR stalled.
+
+### `docs-only`
+
+Entry: `needs-dev`.
+
+```
+needs-dev      --(dev.on_done)-->           needs-review
+needs-dev      --(dev.on_failed_after_max)--> blocked
+needs-review   --(review.approve)-->        qa-pass
+needs-review   --(review.reject)-->         needs-dev    (PR rework)
+needs-dev (PR) --(rework.on_done)-->        needs-review
+needs-dev (PR) --(rework.on_failed_after_max)--> blocked
+qa-pass        --(merge.on_done)-->         done
+```
+
+No QA stage; `qa-pass` is the "approved, ready to merge" signal. No
+dead-ends.
+
+### `minimal`
+
+Entry: `needs-dev`.
+
+```
+needs-dev --(dev.on_done)-->               needs-qa
+needs-dev --(dev.on_failed_after_max)-->   blocked
+needs-qa  --(merge.on_done)-->             done
+```
+
+No review or QA stage. No dead-ends.
 
 ## Per-project overrides
 

--- a/scripts/lint-workflow.sh
+++ b/scripts/lint-workflow.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# lint-workflow.sh — state-machine audit of workflow YAML files.
+#
+# For each workflow file (default: every YAML in config/workflows/):
+#   1. Enumerate every label declared by the workflow (trigger_label values
+#      and every label produced by a handler output — on_done, on_blocked,
+#      on_clarification, on_failed_after_max, on_pass, on_fail, decisions.*).
+#   2. Build the state-machine graph: trigger labels are states, handler
+#      outputs are transitions.
+#   3. Flag DEAD-ENDS: labels that a handler can SET but no stage triggers on.
+#   4. Flag ORPHAN TRIGGERS: trigger_labels that no handler ever produces and
+#      that are not the workflow's entry point (the first issue_stages trigger).
+#
+# Terminal labels (`done`, `blocked`, `needs-clarification`) are valid sinks
+# and never flagged.
+#
+# Usage:
+#   ./scripts/lint-workflow.sh                          # lint every file
+#   ./scripts/lint-workflow.sh path/to/workflow.yaml    # lint one file
+#
+# Exit codes:
+#   0 — no dead-ends, no orphan triggers
+#   1 — at least one issue found
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ $# -eq 0 ]; then
+    set -- "$LOOP_ROOT"/config/workflows/*.yaml
+fi
+
+failed=0
+for path in "$@"; do
+    [ -e "$path" ] || continue
+
+    out=$(WF_PATH="$path" python3 - <<'PY'
+import os, sys
+try:
+    import yaml
+except ImportError:
+    print(f"[error] pyyaml not installed; cannot lint {os.environ['WF_PATH']}", file=sys.stderr)
+    sys.exit(2)
+
+path = os.environ['WF_PATH']
+with open(path) as f:
+    wf = yaml.safe_load(f) or {}
+
+TERMINALS = {'done', 'blocked', 'needs-clarification'}
+PRODUCING_KEYS = (
+    'on_done', 'on_blocked', 'on_clarification',
+    'on_failed_after_max', 'on_pass', 'on_fail',
+)
+
+issue_stages = wf.get('issue_stages') or []
+pr_stages = wf.get('pr_stages') or []
+stages = list(issue_stages) + list(pr_stages)
+
+triggers = set()
+produced = set()
+# {label: [(stage_id, key)]} — for diagnostics
+produced_by = {}
+
+for s in stages:
+    if not isinstance(s, dict):
+        continue
+    t = s.get('trigger_label')
+    if t:
+        triggers.add(t)
+    for key in PRODUCING_KEYS:
+        v = s.get(key)
+        if isinstance(v, str) and v:
+            produced.add(v)
+            produced_by.setdefault(v, []).append((s.get('id', '?'), key))
+    decisions = s.get('decisions') or {}
+    if isinstance(decisions, dict):
+        for dk, dv in decisions.items():
+            if isinstance(dv, str) and dv:
+                produced.add(dv)
+                produced_by.setdefault(dv, []).append(
+                    (s.get('id', '?'), f'decisions.{dk}'))
+
+# Entry point: trigger of the first issue stage (if any), else first PR stage.
+entry = None
+if issue_stages and isinstance(issue_stages[0], dict):
+    entry = issue_stages[0].get('trigger_label')
+elif pr_stages and isinstance(pr_stages[0], dict):
+    entry = pr_stages[0].get('trigger_label')
+
+dead_ends = sorted(
+    label for label in produced
+    if label not in triggers and label not in TERMINALS
+)
+orphan_triggers = sorted(
+    t for t in triggers
+    if t not in produced and t != entry
+)
+
+problems = []
+for label in dead_ends:
+    setters = ', '.join(f'{sid}.{key}' for sid, key in produced_by[label])
+    problems.append(f"dead-end label '{label}' set by [{setters}] but no stage triggers on it")
+for t in orphan_triggers:
+    problems.append(f"orphan trigger '{t}' — no handler in this workflow produces it (and it's not the workflow entry point)")
+
+name = wf.get('name', os.path.basename(path))
+if problems:
+    print(f"[fail] {path} ({name}):")
+    for p in problems:
+        print(f"  - {p}")
+    sys.exit(1)
+else:
+    n_states = len(triggers | produced | TERMINALS)
+    print(f"[ok]   {path} ({name}) — {len(triggers)} triggers, {len(produced)} transitions, {n_states} states; no dead-ends, no orphans")
+    sys.exit(0)
+PY
+    )
+    rc=$?
+    printf '%s\n' "$out"
+    if [ "$rc" -ne 0 ]; then
+        failed=$((failed + 1))
+    fi
+done
+
+if [ "$failed" -gt 0 ]; then
+    echo "lint-workflow: $failed workflow file(s) failed" >&2
+    exit 1
+fi
+exit 0

--- a/tests/lint-workflow.bats
+++ b/tests/lint-workflow.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+# tests/lint-workflow.bats — unit tests for scripts/lint-workflow.sh.
+# Exercises the state-machine audit against synthetic workflow YAMLs.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    LINT="$REPO_ROOT/scripts/lint-workflow.sh"
+    TMP_DIR="$(mktemp -d "$BATS_TMPDIR/lintwf-XXXXXX")"
+}
+
+teardown() {
+    rm -rf "$TMP_DIR" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Bundled workflow files must all pass clean.
+# ---------------------------------------------------------------------------
+
+@test "all bundled workflows pass lint" {
+    run "$LINT"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Dead-end detection: qa-fail set but never triggered (the bug we shipped).
+# ---------------------------------------------------------------------------
+
+@test "detects qa-fail dead-end" {
+    cat > "$TMP_DIR/dead.yaml" <<'EOF'
+version: 1
+name: dead
+issue_stages:
+  - id: dev
+    trigger_label: needs-dev
+    handler: dev-handler
+    on_done: needs-review
+pr_stages:
+  - id: review
+    trigger_label: needs-review
+    handler: review-handler
+    decisions:
+      approve: qa-pass
+      reject: qa-fail
+  - id: merge
+    trigger_label: qa-pass
+    handler: merge-handler
+    on_done: done
+EOF
+    run "$LINT" "$TMP_DIR/dead.yaml"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"dead-end label 'qa-fail'"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Orphan trigger detection: a stage triggered by a label no one sets.
+# ---------------------------------------------------------------------------
+
+@test "detects orphan trigger" {
+    cat > "$TMP_DIR/orphan.yaml" <<'EOF'
+version: 1
+name: orphan
+issue_stages:
+  - id: dev
+    trigger_label: needs-dev
+    handler: dev-handler
+    on_done: needs-review
+pr_stages:
+  - id: review
+    trigger_label: needs-review
+    handler: review-handler
+    decisions:
+      approve: qa-pass
+      reject: needs-dev
+  - id: merge
+    trigger_label: qa-pass
+    handler: merge-handler
+    on_done: done
+  - id: ghost
+    trigger_label: nobody-sets-this
+    handler: noop-handler
+    on_done: done
+EOF
+    run "$LINT" "$TMP_DIR/orphan.yaml"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"orphan trigger 'nobody-sets-this'"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Entry-point trigger (first issue stage) is NOT treated as orphan even
+# though no handler in the workflow produces it.
+# ---------------------------------------------------------------------------
+
+@test "first-stage trigger is treated as entry point, not orphan" {
+    cat > "$TMP_DIR/entry.yaml" <<'EOF'
+version: 1
+name: entry
+issue_stages:
+  - id: dev
+    trigger_label: needs-dev
+    handler: dev-handler
+    on_done: done
+EOF
+    run "$LINT" "$TMP_DIR/entry.yaml"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Terminal labels (done / blocked / needs-clarification) are valid sinks.
+# ---------------------------------------------------------------------------
+
+@test "terminal labels are valid sinks" {
+    cat > "$TMP_DIR/term.yaml" <<'EOF'
+version: 1
+name: term
+issue_stages:
+  - id: po
+    trigger_label: needs-po
+    handler: po-handler
+    on_done: needs-dev
+    on_blocked: blocked
+    on_clarification: needs-clarification
+  - id: dev
+    trigger_label: needs-dev
+    handler: dev-handler
+    on_done: done
+    on_failed_after_max: blocked
+EOF
+    run "$LINT" "$TMP_DIR/term.yaml"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Background

Tonight we discovered the `current` workflow — used by `pa-scanner` — produces a `qa-fail` label that **no stage claims**. PRs labeled `qa-fail` sat forever because no rework handler was triggered on that label. This PR audits every workflow YAML for the same class of bug and adds a CI lint that catches it automatically.

## Audit results

For each workflow I enumerated every label (trigger + handler output) and built the state-machine graph. A **dead-end** is any label a handler can produce that no stage triggers on; an **orphan trigger** is a `trigger_label` no handler in the workflow ever produces (entry points excepted).

| Workflow | Dead-ends | Orphan triggers | Fix |
|---|---|---|---|
| `default.yaml` | none | none | (no change) |
| `current.yaml` | **`qa-fail`** | none | add `qa-rework` stage triggered on `qa-fail`, routing `on_done → review-pending`, mirroring default's qa-rework |
| `docs-only.yaml` | none | none | (no change) |
| `minimal.yaml` | none | none | (no change) |

Only one real gap — the `qa-fail` dead-end in `current`. `current.yaml` is gitignored (operator-local, by design), so the file edit isn't part of this PR; the structural prevention is.

## Changes

- **`scripts/lint-workflow.sh`** — parses every workflow YAML, builds the state graph (trigger labels = states, handler outputs = transitions), and exits non-zero on any dead-end or orphan trigger. Terminals `done` / `blocked` / `needs-clarification` are valid sinks. The first issue stage's trigger is treated as the workflow's entry point and exempt from orphan-trigger detection.
- **`tests/lint-workflow.bats`** — 5 cases: bundled workflows clean, dead-end detection (the qa-fail shape), orphan-trigger detection, entry-point exemption, terminal-sink handling.
- **`config/workflows/README.md`** — new "State machine per workflow" section enumerating every transition in each shipped workflow, plus a "State-machine lint" subsection documenting `lint-workflow.sh`.
- **`.github/workflows/ci.yml`** — new step runs `lint-workflow.sh` on every PR (installs `python3-yaml` only if not present).

## Verification

- `bash -n` + `shellcheck -S warning` clean on all scripts
- `./scripts/validate-workflow.sh` (existing) — all 4 workflows valid
- `./scripts/lint-workflow.sh` (new) — all 4 workflows clean
- `bats tests/lint-workflow.bats` — 5/5 pass

Conservative scope: only added transitions and a lint; no existing transitions removed.