### PR TITLE
[LOOP-tracker-close] reconciler auto-closes trackers when all children done

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,33 @@ posted to loop-monitor (when `LOOP_MONITOR_URL` is set) for observability.
 this if your repo has issues that should stay unlabeled (e.g. discussion
 threads) or if you prefer to label every issue manually.
 
+## Auto-close finished trackers
+
+Tracker / epic issues collect a list of child issue references in the body.
+Once every referenced child is closed, the umbrella issue is effectively
+done, but it rarely gets closed by hand. Each reconciler tick now runs
+`reconcile_tracker_issues`, which parses child references out of each open
+issue labelled `tracker` or `epic`, verifies each child's state via `gh`,
+and closes the tracker (with a comment listing the shipped children) only
+when **all** referenced children are closed.
+
+Parsing is intentionally narrow — false negatives (a child reference we
+don't recognise) are fine; false positives (closing a tracker while open
+work remains) are not. Recognised patterns:
+
+- GitHub task list checkboxes: `- [ ] #123` or `- [x] #123` (the box is
+  treated as a hint only — the child's real state on the server wins, so a
+  manually-ticked `[x]` won't close the tracker if the issue is still open)
+- Plain `#N` inside list items: `- See #45 for context`
+- Keyword references: `Tracks #N`, `Sub-issue #N`, `Child: #N`,
+  `Closes #N`, `Fixes #N`, `Resolves #N` (case-insensitive)
+
+Trackers with no parseable children are skipped — we never close without
+proof. A `tracker_closed` event is posted to loop-monitor (when
+`LOOP_MONITOR_URL` is set) for observability.
+
+**Opt out** by setting `LOOP_AUTO_CLOSE_TRACKERS=false` in `loop.env`.
+
 ## Auto-rework on red CI
 
 When Loop opens a PR (branch convention `feat/issue-N-*`) and a **required**

--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -2537,6 +2537,160 @@ PY
     return 0
 }
 
+# --- Sweep: auto-close trackers / epics whose children are all done -------
+# Tracker / epic issues collect a list of child issue references in their
+# body. Once every child is closed, the umbrella issue is effectively done
+# but humans rarely remember to close it. This sweep parses child issue
+# references from the body, verifies each child's state via gh, and closes
+# the tracker only when ALL referenced children are CLOSED.
+#
+# Parsing is intentionally narrow — false negatives (a child reference we
+# don't recognise) are fine; false positives (closing a tracker with still-
+# open work) are not. Recognized patterns (case-insensitive for keywords):
+#   - GitHub task list checkboxes:       "- [ ] #123" / "- [x] #123"
+#   - Plain "#N" inside list items:      "- See #45 for context"
+#   - Keyword references:                "Tracks #N", "Sub-issue #N",
+#                                        "Child: #N", "Closes #N"
+# The checkbox '[x]' is treated as a hint only — the child's real state on
+# the tracker is determined by `gh issue view`.
+#
+# Skipped:
+#   - Trackers with no parseable children (we never close without proof).
+#   - LOOP_AUTO_CLOSE_TRACKERS=false   (opt-out env)
+# DRY_RUN honored.
+reconcile_tracker_issues() {
+    local repo="$1" slug="$2"
+
+    if [ "${LOOP_AUTO_CLOSE_TRACKERS:-true}" = "false" ]; then
+        return 0
+    fi
+
+    log "[$repo] tracker-close sweep"
+
+    local trackers_json
+    trackers_json=$(gh issue list --repo "$repo" --state open --limit 200 \
+        --label tracker --json number,title,body,labels 2>/dev/null || echo "[]")
+    local epics_json
+    epics_json=$(gh issue list --repo "$repo" --state open --limit 200 \
+        --label epic --json number,title,body,labels 2>/dev/null || echo "[]")
+
+    local merged
+    merged=$(TRACKERS="$trackers_json" EPICS="$epics_json" python3 - <<'PY'
+import json, os
+seen = {}
+for raw in (os.environ.get('TRACKERS') or '[]', os.environ.get('EPICS') or '[]'):
+    try:
+        items = json.loads(raw)
+    except Exception:
+        items = []
+    for it in items:
+        num = it.get('number')
+        if num is None or num in seen:
+            continue
+        seen[num] = it
+print(json.dumps(list(seen.values())))
+PY
+    )
+
+    local parsed
+    parsed=$(TRACKERS="$merged" python3 - <<'PY'
+import json, os, re
+trackers = json.loads(os.environ.get('TRACKERS') or '[]')
+
+KEYWORD_RE = re.compile(
+    r'\b(?:tracks|sub-issue|child|closes?|closed|fix(?:es|ed)?|resolves?|resolved)\b[:\s]*#(\d+)',
+    re.IGNORECASE,
+)
+CHECKBOX_RE = re.compile(r'^\s*-\s*\[[ xX]\]\s*#(\d+)')
+LIST_HASH_RE = re.compile(r'^\s*[-*]\s+.*?#(\d+)')
+
+for tr in trackers:
+    num = tr.get('number')
+    body = tr.get('body') or ''
+    title = (tr.get('title') or '').replace('\n', ' ').strip()[:80]
+    children = []
+    seen = set()
+
+    def add(n):
+        try:
+            n = int(n)
+        except (TypeError, ValueError):
+            return
+        if n == num or n in seen:
+            return
+        seen.add(n)
+        children.append(n)
+
+    for line in body.splitlines():
+        m = CHECKBOX_RE.match(line)
+        if m:
+            add(m.group(1))
+            continue
+        m = LIST_HASH_RE.match(line)
+        if m:
+            add(m.group(1))
+        for km in KEYWORD_RE.finditer(line):
+            add(km.group(1))
+
+    if not children:
+        continue
+    print('\t'.join([str(num), title, ','.join(str(c) for c in children)]))
+PY
+    )
+
+    if [ -z "$parsed" ]; then
+        log "[$repo] tracker-close: no trackers with parseable children"
+        return 0
+    fi
+
+    local tnum ttitle tchildren
+    while IFS=$'\t' read -r tnum ttitle tchildren; do
+        [ -z "$tnum" ] && continue
+        [ -z "$tchildren" ] && continue
+
+        local all_closed=true
+        local closed_list=""
+        local IFS_ORIG="$IFS"
+        IFS=','
+        local c
+        for c in $tchildren; do
+            [ -z "$c" ] && continue
+            local cstate
+            cstate=$(gh issue view "$c" --repo "$repo" --json state --jq .state 2>/dev/null || echo "")
+            if [ "$cstate" != "CLOSED" ] && [ "$cstate" != "closed" ]; then
+                all_closed=false
+                break
+            fi
+            closed_list="${closed_list}#${c} "
+        done
+        IFS="$IFS_ORIG"
+
+        if ! $all_closed; then
+            log "[$repo] tracker #$tnum: open child remaining — skip"
+            continue
+        fi
+
+        local comment
+        comment="Loop reconciler: closing tracker — all referenced children are closed: ${closed_list%% }"
+
+        if $DRY_RUN; then
+            log "[$repo] DRY tracker-close #$tnum ($ttitle) children=${tchildren}"
+            continue
+        fi
+
+        log "[$repo] tracker-close #$tnum ($ttitle) children=${tchildren}"
+        backend_comment_issue "$repo" "$tnum" "$comment" \
+            || log "[$repo] failed to comment on tracker #$tnum"
+        backend_close_issue "$repo" "$tnum" \
+            || log "[$repo] failed to close tracker #$tnum"
+        _loop_emit_event "tracker_closed" \
+            "{\"repo\":\"$repo\",\"slug\":\"$slug\",\"issue_num\":$tnum,\"children\":\"$tchildren\"}" \
+            || true
+    done <<< "$parsed"
+
+    return 0
+}
+
 run_project() {
     local slug="$1"
     loop_load_project "$slug" || { log "skip $slug (config error)"; return 0; }
@@ -2561,6 +2715,7 @@ run_project() {
     reconcile_ci_green_prs "$REPO" "$slug"
     reconcile_pr_base_moved "$REPO" "$slug"
     reconcile_orphan_issues "$REPO" "$slug"
+    reconcile_tracker_issues "$REPO" "$slug"
     reconcile_label_consistency "$REPO" "$slug"
     reconcile_dirty_rework_prs "$REPO"
     reconcile_conflict_blocked_prs "$REPO"

--- a/tests/reconciler-tracker-close.bats
+++ b/tests/reconciler-tracker-close.bats
@@ -1,0 +1,176 @@
+#!/usr/bin/env bats
+# tests/reconciler-tracker-close.bats — unit tests for reconcile_tracker_issues
+# in scanner/reconciler.sh. Sources reconciler.sh in lib-only mode, mocks `gh`
+# for the tracker listing + per-child state lookup, and stubs the backend
+# helpers so we can assert on close / comment / emit calls.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export OPS_LOG="$BATS_TMPDIR/ops.log"
+    rm -f "$OPS_LOG"
+
+    export REPO="owner/test-repo"
+    export DRY_RUN=false
+    export LOOP_MONITOR_URL=""
+    export SLUG="test-slug"
+
+    # MOCK_TRACKERS_JSON  → returned for `gh issue list --label tracker`
+    # MOCK_EPICS_JSON     → returned for `gh issue list --label epic`
+    # MOCK_CHILD_STATES   → "num=STATE,num=STATE" lookup table for `gh issue view`
+    export MOCK_TRACKERS_JSON='[]'
+    export MOCK_EPICS_JSON='[]'
+    export MOCK_CHILD_STATES=""
+
+    LOOP_RECONCILER_LIB_ONLY=1
+    set --
+    # shellcheck source=../scanner/reconciler.sh
+    source "$REPO_ROOT/scanner/reconciler.sh"
+
+    mkdir -p "$BATS_TMPDIR/bin"
+    cat > "$BATS_TMPDIR/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+# Stubbed `gh`: supports `issue list --label X` and `issue view N --json state`.
+if [ "${1:-}" = "issue" ] && [ "${2:-}" = "list" ]; then
+    label=""
+    for ((i=3; i<=$#; i++)); do
+        if [ "${!i}" = "--label" ]; then
+            j=$((i+1)); label="${!j}"
+        fi
+    done
+    case "$label" in
+        tracker) printf '%s\n' "${MOCK_TRACKERS_JSON:-[]}" ;;
+        epic)    printf '%s\n' "${MOCK_EPICS_JSON:-[]}"    ;;
+        *)       printf '%s\n' "[]" ;;
+    esac
+    exit 0
+fi
+if [ "${1:-}" = "issue" ] && [ "${2:-}" = "view" ]; then
+    num="$3"
+    # MOCK_CHILD_STATES looks like "1=CLOSED,2=OPEN"
+    IFS=',' read -ra pairs <<< "${MOCK_CHILD_STATES:-}"
+    for p in "${pairs[@]}"; do
+        key="${p%%=*}"; val="${p#*=}"
+        if [ "$key" = "$num" ]; then
+            printf '%s\n' "$val"
+            exit 0
+        fi
+    done
+    printf '%s\n' "OPEN"
+    exit 0
+fi
+exit 0
+GHEOF
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    backend_comment_issue() { echo "comment $2 :: $3" >> "$OPS_LOG"; }
+    backend_close_issue()   { echo "close $2"        >> "$OPS_LOG"; }
+    _loop_emit_event()      { echo "emit_event $1 $2" >> "$OPS_LOG"; }
+    log()                   { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/logs" "$OPS_LOG" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Happy path: tracker with two closed children → close + comment + emit
+# ---------------------------------------------------------------------------
+
+@test "reconcile_tracker_issues: tracker with all children closed gets closed" {
+    export MOCK_TRACKERS_JSON='[{
+        "number": 10,
+        "title": "Q2 cleanup tracker",
+        "labels": [{"name":"tracker"}],
+        "body": "Children:\n- [x] #1\n- [x] #2\n"
+    }]'
+    export MOCK_CHILD_STATES="1=CLOSED,2=CLOSED"
+
+    run reconcile_tracker_issues "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    grep -q "close 10"            "$OPS_LOG"
+    grep -q "comment 10 ::"       "$OPS_LOG"
+    grep -q "emit_event tracker_closed" "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Mixed children: one open → no close
+# ---------------------------------------------------------------------------
+
+@test "reconcile_tracker_issues: tracker with one open child is left alone" {
+    export MOCK_TRACKERS_JSON='[{
+        "number": 20,
+        "title": "Mixed tracker",
+        "labels": [{"name":"tracker"}],
+        "body": "- [x] #5\n- [ ] #6\n"
+    }]'
+    export MOCK_CHILD_STATES="5=CLOSED,6=OPEN"
+
+    run reconcile_tracker_issues "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -qE "close 20|comment 20|tracker_closed" "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# No parseable children → no action
+# ---------------------------------------------------------------------------
+
+@test "reconcile_tracker_issues: tracker without parseable children is skipped" {
+    export MOCK_TRACKERS_JSON='[{
+        "number": 30,
+        "title": "Empty tracker",
+        "labels": [{"name":"tracker"}],
+        "body": "This is just prose with no issue references at all."
+    }]'
+
+    run reconcile_tracker_issues "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -qE "close 30|comment 30|tracker_closed" "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Checkbox '[x]' is a hint only — trust the real state, which is OPEN
+# ---------------------------------------------------------------------------
+
+@test "reconcile_tracker_issues: checkbox '[x]' but real state is OPEN → no close" {
+    export MOCK_TRACKERS_JSON='[{
+        "number": 40,
+        "title": "Stale-checkbox tracker",
+        "labels": [{"name":"tracker"}],
+        "body": "- [x] #9\n"
+    }]'
+    # Operator ticked the box but the issue is actually still open.
+    export MOCK_CHILD_STATES="9=OPEN"
+
+    run reconcile_tracker_issues "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -qE "close 40|comment 40|tracker_closed" "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Opt-out via env
+# ---------------------------------------------------------------------------
+
+@test "reconcile_tracker_issues: LOOP_AUTO_CLOSE_TRACKERS=false disables the sweep" {
+    export LOOP_AUTO_CLOSE_TRACKERS=false
+    export MOCK_TRACKERS_JSON='[{
+        "number": 50,
+        "title": "Would-be closed tracker",
+        "labels": [{"name":"tracker"}],
+        "body": "- [x] #1\n- [x] #2\n"
+    }]'
+    export MOCK_CHILD_STATES="1=CLOSED,2=CLOSED"
+
+    run reconcile_tracker_issues "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    [ ! -f "$OPS_LOG" ] || [ ! -s "$OPS_LOG" ] || ! grep -qE "close 50|comment 50|tracker_closed" "$OPS_LOG"
+}


### PR DESCRIPTION
## Summary

- New `reconcile_tracker_issues` sweep in `scanner/reconciler.sh` that closes tracker / epic issues whose every referenced child is closed.
- Conservative parser: GitHub task list checkboxes (`- [ ] #N` / `- [x] #N`), plain `#N` inside list items, and keyword references (`Tracks #N`, `Sub-issue #N`, `Child: #N`, `Closes/Fixes/Resolves #N`). Trackers with no parseable children are skipped — false positives (closing a tracker with open work) are strictly worse than false negatives. The `[x]` mark is treated only as a hint; the child's real state on the server determines the decision.
- Emits a `tracker_closed` event to loop-monitor for observability. Opt-out: `LOOP_AUTO_CLOSE_TRACKERS=false`.
- Wired into the per-project reconciler loop after `reconcile_orphan_issues`.
- bats coverage in `tests/reconciler-tracker-close.bats`: all-closed children → close, one open child → no-op, no parseable children → no-op, `[x]` checkbox but child actually OPEN → trust child state, opt-out env disables the sweep. README updated with the rules + parse patterns.

## Test plan

- [x] `bash -n` on all scripts
- [x] `shellcheck -S warning scanner/reconciler.sh`
- [x] `bats tests/reconciler-tracker-close.bats` (5/5 passing)
- [x] Existing `tests/reconciler-orphan-issues.bats` + `tests/reconciler-label-state.bats` still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)