### PR TITLE
[LOOP-267-followup] fix scanner serial-mode deadlock — needs-po should not count as in-flight

### DIFF
--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -275,19 +275,24 @@ for _, _, line in rows:
 '
 }
 
-# count_inflight_issues <slug> <repo>
+# count_inflight_issues <slug> <repo> [exclude_label]
 # Count distinct open issues that carry at least one pipeline label (workflow
 # issue or PR trigger labels, plus handler-set in-flight labels in-progress/blocked).
 # Used by the per-project `pipeline_slots` gate.
+#
+# <exclude_label> (optional): a label to OMIT from the pipeline set. The caller
+# passes the first-stage issue trigger here so the queue waiting for that
+# stage isn't counted against the gate — otherwise a backlog of e.g. needs-po
+# tickets self-blocks the very stage that would drain them (#267 follow-up).
 count_inflight_issues() {
-    local slug="$1" repo="$2"
+    local slug="$1" repo="$2" exclude="${3:-}"
     local labels
     labels=$(
         {
             loop_polled_labels "$slug" issue 2>/dev/null
             loop_polled_labels "$slug" pr 2>/dev/null
             printf 'in-progress\nblocked\n'
-        } | awk 'NF && !seen[$0]++'
+        } | awk -v ex="$exclude" 'NF && $0 != ex && !seen[$0]++'
     )
     local seen_tmp
     seen_tmp=$(mktemp)
@@ -561,7 +566,7 @@ scan_project() {
     local _slots_gate_active=false
     if [ -n "${PIPELINE_SLOTS:-}" ] && [ "$PIPELINE_SLOTS" -ge 1 ] 2>/dev/null; then
         local _if_issues _if_prs _if_total
-        _if_issues=$(count_inflight_issues "$slug" "$repo")
+        _if_issues=$(count_inflight_issues "$slug" "$repo" "$_first_issue_trigger")
         _if_prs=$(count_inflight_prs "$slug" "$repo")
         _if_total=$(( _if_issues + _if_prs ))
         log "pipeline_slots=${PIPELINE_SLOTS} in-flight=${_if_total} (issues=${_if_issues} prs=${_if_prs})"

--- a/tests/scanner.bats
+++ b/tests/scanner.bats
@@ -585,6 +585,63 @@ YAML
     fi
 }
 
+# Regression for #267 follow-up: a backlog of issues sitting at the
+# first-stage trigger (e.g. 6 tickets at `needs-po`) used to count against
+# the pipeline_slots gate, deadlocking the very stage that would drain
+# them. Fix: the first-stage trigger is excluded from in-flight counting.
+@test "pipeline_slots=1 + 6 needs-po tickets + 0 inflight: scanner emits ONE po claim (#267)" {
+    _write_fixture_config
+    export LOOP_CONFIG="$BATS_TMPDIR/fixture.yaml"
+
+    # 6 issues all sitting at needs-po (the first-stage trigger for
+    # proj-default). Before the fix these counted as in-flight=6 and the
+    # gate skipped all po claims. After the fix in-flight excludes the
+    # first-stage trigger and the gate lets one through.
+    local I1 I2 I3 I4 I5 I6
+    I1='{"number":1,"title":"a","url":"http://gh/1","labels":["needs-po"],"author":"bot"}'
+    I2='{"number":2,"title":"b","url":"http://gh/2","labels":["needs-po"],"author":"bot"}'
+    I3='{"number":3,"title":"c","url":"http://gh/3","labels":["needs-po"],"author":"bot"}'
+    I4='{"number":4,"title":"d","url":"http://gh/4","labels":["needs-po"],"author":"bot"}'
+    I5='{"number":5,"title":"e","url":"http://gh/5","labels":["needs-po"],"author":"bot"}'
+    I6='{"number":6,"title":"f","url":"http://gh/6","labels":["needs-po"],"author":"bot"}'
+
+    backend_list_issues_with_label() {
+        local _label="$2"
+        if [ "$_label" = "needs-po" ]; then
+            printf '%s\n%s\n%s\n%s\n%s\n%s\n' "$I1" "$I2" "$I3" "$I4" "$I5" "$I6"
+        fi
+        return 0
+    }
+    backend_list_prs_with_label()  { return 0; }
+    backend_list_open_prs_raw()    { echo "[]"; }
+    backend_issue_has_any_label()  { return 1; }
+    backend_pr_has_any_label()     { return 1; }
+    backend_issue_unmet_deps()     { return 1; }
+    loop_load_backend()            { return 0; }
+    loop_load_project() {
+        REPO="owner/default-repo"
+        MAX_CONCURRENT_PRS=3
+        PIPELINE_SLOTS=1
+        BACKEND=github
+        WORKFLOW=default
+        ALLOWED_AUTHORS=""
+        LOOP_LABEL_OVERRIDES=""
+        return 0
+    }
+
+    local emit_log="$BATS_TMPDIR/emit-po-backlog.log"
+    rm -f "$emit_log"
+    emit() { echo "$1" >> "$emit_log"; return 0; }
+
+    scan_project "proj-default"
+
+    [ -f "$emit_log" ]
+    local lines
+    lines=$(wc -l < "$emit_log" | tr -d ' ')
+    [ "$lines" -eq 1 ]
+    grep -q '"type".*"loop\.po_review"' "$emit_log"
+}
+
 @test "emit: no dedup key file created when dedup_id is empty" {
     local dispatch_log="$BATS_TMPDIR/dispatch3.log"
     rm -f "$dispatch_log"


### PR DESCRIPTION
## Summary

PR #285 (issue #267) introduced a `pipeline_slots` gate that counts every issue carrying any workflow trigger label as "in-flight". That set includes the **first-stage trigger itself** (e.g. `needs-po`), so a backlog of 6 `needs-po` tickets reads as `in-flight=6` against `pipeline_slots=1` — and the gate then skips first-stage claims, preventing the very ticket it's meant to gate from ever being claimed.

### Repro (live log)
```
[2026-05-11 01:12:32] scan: loop (svv2014/loop) workflow=default
[2026-05-11 01:12:41] pipeline_slots=1 in-flight=6 (issues=6 prs=0)
[2026-05-11 01:12:41] skip first-stage claims for loop: 6/1 tickets in flight
```
PO never claims, dev never claims, deadlock.

### Fix

`count_inflight_issues` now takes an optional `exclude_label`, and `scan_project` passes the **first-stage issue trigger** (the same label the gate is about to use). The queue waiting on a stage is no longer counted against the gate that drains it.

Downstream / actively-running labels (`in-po`, `in-progress`, `needs-review`, `ready-for-qa`, `qa-pass`, `blocked`, etc.) still count as expected, so `pipeline_slots: 1` keeps its intended "finish one ticket end-to-end before starting the next" semantics.

### Regression test

`tests/scanner.bats`: with `pipeline_slots=1`, 6 `needs-po` tickets, 0 other inflight, the scanner must emit exactly **one** `loop.po_review` claim (previously emitted zero).

## Test plan

- [x] `bash -n scanner/scanner.sh`
- [x] `shellcheck -S warning scanner/scanner.sh`
- [x] `bats tests/scanner.bats` (38/38)
- [x] Full `bats tests/` suite green (497 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)