### PR TITLE
[LOOP-291] emit structured failure_reason on *_failed events

### DIFF
--- a/lib/bounty.sh
+++ b/lib/bounty.sh
@@ -49,16 +49,17 @@ bounty_report() {
     local event="${1:-unknown}"
     shift || true
 
-    local agent="" model="" role="" project="" issue_num="" pr_num="" detail=""
+    local agent="" model="" role="" project="" issue_num="" pr_num="" detail="" failure_reason=""
     for kv in "$@"; do
         case "$kv" in
-            agent=*)     agent="${kv#agent=}" ;;
-            model=*)     model="${kv#model=}" ;;
-            role=*)      role="${kv#role=}" ;;
-            project=*)   project="${kv#project=}" ;;
-            issue_num=*) issue_num="${kv#issue_num=}" ;;
-            pr_num=*)    pr_num="${kv#pr_num=}" ;;
-            detail=*)    detail="${kv#detail=}" ;;
+            agent=*)          agent="${kv#agent=}" ;;
+            model=*)          model="${kv#model=}" ;;
+            role=*)           role="${kv#role=}" ;;
+            project=*)        project="${kv#project=}" ;;
+            issue_num=*)      issue_num="${kv#issue_num=}" ;;
+            pr_num=*)         pr_num="${kv#pr_num=}" ;;
+            detail=*)         detail="${kv#detail=}" ;;
+            failure_reason=*) failure_reason="${kv#failure_reason=}" ;;
         esac
     done
 
@@ -73,6 +74,7 @@ bounty_report() {
         _API="$api_ver" _CV="$(_bounty_core_version)" _LI="$(_bounty_loop_id)" \
         _BE="$event" _BA="$agent" _BM="$model" _BR="$role" \
         _BP="$project" _BD="$detail" _BI="$issue_num" _BPN="$pr_num" \
+        _BFR="$failure_reason" \
         python3 - <<'PY'
 import json, os, datetime
 d = {
@@ -85,6 +87,7 @@ d = {
     "role":         os.environ.get("_BR") or None,
     "project":      os.environ.get("_BP") or None,
     "detail":       os.environ.get("_BD") or None,
+    "failure_reason": os.environ.get("_BFR") or None,
     "timestamp":    datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
 }
 for k, env in [("issue_num", "_BI"), ("pr_num", "_BPN")]:

--- a/lib/failure_category.sh
+++ b/lib/failure_category.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# lib/failure_category.sh — classify *_failed events with a structured category.
+#
+# Usage:
+#   source "$LOOP_ROOT/lib/failure_category.sh"
+#   category=$(loop_failure_category "$stderr_text" "$exit_code")
+#
+# Prints exactly one of: budget, network, git_conflict, model_error, tool_error, unknown.
+# Classification rules are evaluated top-to-bottom; first match wins.
+
+# loop_failure_category <stderr_text> [exit_code]
+loop_failure_category() {
+    local text="$1"
+    local rc="${2:-1}"
+    LOOP_FC_TEXT="$text" LOOP_FC_RC="$rc" python3 - <<'PY'
+import os, re, sys
+
+text = os.environ.get('LOOP_FC_TEXT', '')
+rc   = int(os.environ.get('LOOP_FC_RC', '1') or '1')
+
+if re.search(r'daily\.budget|budget cap|budget exhausted|LOOP_DAILY_BUDGET', text):
+    print('budget'); sys.exit(0)
+
+if re.search(r'5\d\d|timeout|timed out|Connection(?:Refused|Reset|Error)|TimeoutError|429|rate limit', text):
+    print('network'); sys.exit(0)
+
+if re.search(r'CONFLICT \(|Merge conflict|rebase.*conflict|<<<<<<< HEAD', text):
+    print('git_conflict'); sys.exit(0)
+
+if re.search(r'claude .*(API error|invalid_request|overloaded|model_error)|anthropic.*error|prompt is too long', text, re.IGNORECASE):
+    print('model_error'); sys.exit(0)
+
+if re.search(r'gh: |git: |jq: |command not found', text) or rc != 0:
+    print('tool_error'); sys.exit(0)
+
+print('unknown')
+PY
+}

--- a/scripts/dev-handler.sh
+++ b/scripts/dev-handler.sh
@@ -30,6 +30,8 @@ source "$LOOP_ROOT/lib/cli-hint.sh"
 source "$LOOP_ROOT/lib/worktree.sh"
 # shellcheck source=../lib/failure_classifier.sh
 source "$LOOP_ROOT/lib/failure_classifier.sh"
+# shellcheck source=../lib/failure_category.sh
+source "$LOOP_ROOT/lib/failure_category.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-dev-handler.log"
 MAX_RETRIES=3
@@ -277,7 +279,8 @@ else
     if loop_is_missing_untracked_data "$_agent_tail"; then
         _missing_path=$(loop_extract_missing_path "$_agent_tail")
         log "dev agent failed for #$ISSUE_NUM — untracked-data dependency (${_missing_path:-?}); marking blocked without burning retry"
-        bounty_report "dev_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" issue_num="$ISSUE_NUM" detail="untracked-data: ${_missing_path:-?}" || true
+        _dev_failure_reason=$(loop_failure_category "$_agent_tail" 1)
+        bounty_report "dev_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" issue_num="$ISSUE_NUM" detail="untracked-data: ${_missing_path:-?}" failure_reason="$_dev_failure_reason" || true
         backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
         backend_add_label "$REPO" "$ISSUE_NUM" blocked
         _block_body=$(mktemp /tmp/loop-block-XXXXXX.md)
@@ -322,7 +325,8 @@ else
     # will see the cool-down and skip until the next-eligible time.
     loop_backoff_record_failure "$SLUG" "$ISSUE_NUM" dev "dev attempt ${n}/${MAX_RETRIES}" >/dev/null || true
     log "dev agent failed for #$ISSUE_NUM (attempt $n/$MAX_RETRIES); backoff next-eligible logged"
-    bounty_report "dev_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" issue_num="$ISSUE_NUM" detail="attempt ${n}/${MAX_RETRIES}" || true
+    _dev_failure_reason=$(loop_failure_category "$_agent_tail" 1)
+    bounty_report "dev_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" issue_num="$ISSUE_NUM" detail="attempt ${n}/${MAX_RETRIES}" failure_reason="$_dev_failure_reason" || true
     if [ "$n" -ge "$MAX_RETRIES" ]; then
         backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
         backend_add_label "$REPO" "$ISSUE_NUM" blocked

--- a/scripts/merge-handler.sh
+++ b/scripts/merge-handler.sh
@@ -21,6 +21,8 @@ source "$LOOP_ROOT/lib/bounty.sh"
 source "$LOOP_ROOT/lib/notify.sh"
 # shellcheck source=../lib/recovery.sh
 source "$LOOP_ROOT/lib/recovery.sh"
+# shellcheck source=../lib/failure_category.sh
+source "$LOOP_ROOT/lib/failure_category.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-merge-handler.log"
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [merge-handler] $*" | tee -a "$LOG_FILE"; }
@@ -101,7 +103,8 @@ if ! backend_merge_pr "$REPO" "$PR_NUM" "$STRATEGY_FLAG" 2>&1 | tee -a "$LOG_FIL
     # Non-conflict failure (e.g. required check missing, API flake). Don't
     # loop on this either — mark blocked so a human can look.
     log "ERROR: merge failed for non-conflict reason (state=$POST_STATE)"
-    bounty_report "merge_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=merge project="$SLUG" pr_num="$PR_NUM" detail="state=${POST_STATE}" || true
+    _merge_failure_reason=$(loop_failure_category "state=${POST_STATE}" 1)
+    bounty_report "merge_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=merge project="$SLUG" pr_num="$PR_NUM" detail="state=${POST_STATE}" failure_reason="$_merge_failure_reason" || true
     loop_notify "❌ [$SLUG] PR#$PR_NUM merge failed: merge command failed"
     backend_remove_label "$REPO" "$PR_NUM" qa-pass
     backend_add_label "$REPO" "$PR_NUM" blocked

--- a/scripts/po-handler.sh
+++ b/scripts/po-handler.sh
@@ -34,6 +34,8 @@ source "$LOOP_ROOT/lib/redact.sh"
 source "$LOOP_ROOT/lib/cli-hint.sh"
 # shellcheck source=../lib/failure_classifier.sh
 source "$LOOP_ROOT/lib/failure_classifier.sh"
+# shellcheck source=../lib/failure_category.sh
+source "$LOOP_ROOT/lib/failure_category.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-po-handler.log"
 MAX_RETRIES=2
@@ -511,7 +513,8 @@ else
         _sig=$(loop_failure_signature "$_stderr_tail")
         _tc=$(transient_incr)
         log "po agent transient failure for #$ISSUE_NUM (transient attempt $_tc/$MAX_TRANSIENT_RETRIES, sig: ${_sig:-unknown})"
-        bounty_report "po_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=po project="$SLUG" issue_num="$ISSUE_NUM" detail="transient ${_tc}/${MAX_TRANSIENT_RETRIES} sig:${_sig:-unknown}" || true
+        _po_failure_reason=$(loop_failure_category "$_stderr_tail" "$_agent_rc")
+        bounty_report "po_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=po project="$SLUG" issue_num="$ISSUE_NUM" detail="transient ${_tc}/${MAX_TRANSIENT_RETRIES} sig:${_sig:-unknown}" failure_reason="$_po_failure_reason" || true
         if [ "$_tc" -ge "$MAX_TRANSIENT_RETRIES" ]; then
             backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
             backend_add_label "$REPO" "$ISSUE_NUM" blocked
@@ -525,7 +528,8 @@ else
     else
         n=$(retry_incr)
         log "po agent failed for #$ISSUE_NUM (attempt $n/$MAX_RETRIES)"
-        bounty_report "po_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=po project="$SLUG" issue_num="$ISSUE_NUM" detail="attempt ${n}/${MAX_RETRIES}" || true
+        _po_failure_reason=$(loop_failure_category "$_stderr_tail" "$_agent_rc")
+        bounty_report "po_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=po project="$SLUG" issue_num="$ISSUE_NUM" detail="attempt ${n}/${MAX_RETRIES}" failure_reason="$_po_failure_reason" || true
         if [ "$n" -ge "$MAX_RETRIES" ]; then
             backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
             backend_add_label "$REPO" "$ISSUE_NUM" needs-clarification

--- a/scripts/qa-handler.sh
+++ b/scripts/qa-handler.sh
@@ -27,6 +27,8 @@ source "$LOOP_ROOT/lib/bounty.sh"
 source "$LOOP_ROOT/lib/notify.sh"
 # shellcheck source=../lib/cli-hint.sh
 source "$LOOP_ROOT/lib/cli-hint.sh"
+# shellcheck source=../lib/failure_category.sh
+source "$LOOP_ROOT/lib/failure_category.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-qa-handler.log"
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [qa-handler] $*" | tee -a "$LOG_FILE"; }
@@ -224,7 +226,9 @@ EOF
 TASK_PROMPT=$(cat "$_PROMPT_FILE")
 rm -f "$_PROMPT_FILE"
 
-if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
+_QA_RUN_LOG=$(mktemp /tmp/loop-qa-run-XXXXXX.log)
+trap 'rm -f "${_QA_RUN_LOG:-}"' EXIT
+if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE" | tee "$_QA_RUN_LOG" >/dev/null; then
     log "qa agent finished for PR #$PR_NUM"
     loop_notify "✅ [$SLUG] PR#$PR_NUM qa done"
     backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_NEEDS_QA"
@@ -249,7 +253,9 @@ if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
     fi
 else
     log "qa agent failed for PR #$PR_NUM"
-    bounty_report "qa_fail" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$SLUG" pr_num="$PR_NUM" || true
+    _qa_stderr_tail=$(tail -n 50 "${_QA_RUN_LOG:-/dev/null}" 2>/dev/null || echo "")
+    _qa_failure_reason=$(loop_failure_category "$_qa_stderr_tail" 1)
+    bounty_report "qa_fail" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$SLUG" pr_num="$PR_NUM" failure_reason="$_qa_failure_reason" || true
     loop_notify "❌ [$SLUG] PR#$PR_NUM qa failed: agent error"
     backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_NEEDS_QA"
     backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_READY_FOR_QA"

--- a/scripts/review-handler.sh
+++ b/scripts/review-handler.sh
@@ -27,6 +27,8 @@ source "$LOOP_ROOT/lib/bounty.sh"
 source "$LOOP_ROOT/lib/notify.sh"
 # shellcheck source=../lib/cli-hint.sh
 source "$LOOP_ROOT/lib/cli-hint.sh"
+# shellcheck source=../lib/failure_category.sh
+source "$LOOP_ROOT/lib/failure_category.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-review-handler.log"
 MAX_RETRIES=2
@@ -164,7 +166,9 @@ EOF
 TASK_PROMPT=$(cat "$_PROMPT_FILE")
 rm -f "$_PROMPT_FILE"
 
-if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
+_REVIEW_RUN_LOG=$(mktemp /tmp/loop-review-run-XXXXXX.log)
+trap 'rm -f "${_REVIEW_RUN_LOG:-}"' EXIT
+if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE" | tee "$_REVIEW_RUN_LOG" >/dev/null; then
     log "review agent finished for PR #$PR_NUM"
     bounty_report "review_done" model="${LOOP_AGENT_MODEL:-sonnet}" role=reviewer project="$SLUG" pr_num="$PR_NUM" || true
     loop_notify "✅ [$SLUG] PR#$PR_NUM review done"
@@ -205,7 +209,9 @@ if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
 else
     n=$(retry_incr)
     log "review agent failed for PR #$PR_NUM (attempt $n/$MAX_RETRIES)"
-    bounty_report "review_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=reviewer project="$SLUG" pr_num="$PR_NUM" detail="attempt ${n}/${MAX_RETRIES}" || true
+    _review_stderr_tail=$(tail -n 50 "${_REVIEW_RUN_LOG:-/dev/null}" 2>/dev/null || echo "")
+    _review_failure_reason=$(loop_failure_category "$_review_stderr_tail" 1)
+    bounty_report "review_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=reviewer project="$SLUG" pr_num="$PR_NUM" detail="attempt ${n}/${MAX_RETRIES}" failure_reason="$_review_failure_reason" || true
     if [ "$n" -ge "$MAX_RETRIES" ]; then
         backend_remove_label "$REPO" "$PR_NUM" in-review
         backend_remove_label "$REPO" "$PR_NUM" "$_REWORK_LABEL"

--- a/tests/failure_category.bats
+++ b/tests/failure_category.bats
@@ -1,0 +1,138 @@
+#!/usr/bin/env bats
+# tests/failure_category.bats — unit tests for lib/failure_category.sh
+# and integration: bounty_report emits failure_reason in *_failed payloads.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    # shellcheck source=../lib/failure_category.sh
+    source "$REPO_ROOT/lib/failure_category.sh"
+}
+
+# ─── loop_failure_category — one fixture per category ────────────────────────
+
+@test "budget: daily.budget text → budget" {
+    run loop_failure_category "Error: daily.budget exceeded for project" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "budget" ]
+}
+
+@test "budget: budget cap text → budget" {
+    run loop_failure_category "Stopping: budget cap reached" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "budget" ]
+}
+
+@test "network: HTTP 503 → network" {
+    run loop_failure_category "Error: received HTTP 503 from upstream" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "network" ]
+}
+
+@test "network: rate limit → network" {
+    run loop_failure_category "Error: rate limit exceeded, please retry later" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "network" ]
+}
+
+@test "network: 429 → network" {
+    run loop_failure_category "HTTP 429 Too Many Requests" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "network" ]
+}
+
+@test "network: timeout → network" {
+    run loop_failure_category "operation timed out after 30 seconds" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "network" ]
+}
+
+@test "git_conflict: CONFLICT marker → git_conflict" {
+    run loop_failure_category "CONFLICT (content): Merge conflict in src/foo.sh" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "git_conflict" ]
+}
+
+@test "git_conflict: <<<<<<< HEAD → git_conflict" {
+    run loop_failure_category "<<<<<<< HEAD" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "git_conflict" ]
+}
+
+@test "model_error: prompt is too long → model_error" {
+    run loop_failure_category "Error: prompt is too long for this model" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "model_error" ]
+}
+
+@test "model_error: anthropic.*error → model_error" {
+    run loop_failure_category "anthropic API error: overloaded_error" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "model_error" ]
+}
+
+@test "tool_error: gh: command → tool_error" {
+    run loop_failure_category "gh: unknown command \"labell\"" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "tool_error" ]
+}
+
+@test "tool_error: command not found → tool_error" {
+    run loop_failure_category "bats: command not found" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "tool_error" ]
+}
+
+@test "tool_error: non-zero exit with no pattern → tool_error" {
+    run loop_failure_category "some unrecognised failure output" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "tool_error" ]
+}
+
+@test "unknown: empty text with exit 0 → unknown" {
+    run loop_failure_category "" 0
+    [ "$status" -eq 0 ]
+    [ "$output" = "unknown" ]
+}
+
+@test "budget wins over network when both match" {
+    run loop_failure_category "budget cap: HTTP 503 upstream" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "budget" ]
+}
+
+@test "network wins over git_conflict when both match" {
+    run loop_failure_category "timeout while fetching: <<<<<<< HEAD appears in diff" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "network" ]
+}
+
+# ─── Integration: bounty_report emits failure_reason field ───────────────────
+
+@test "integration: bounty_report failure_reason=network appears in JSON payload" {
+    # Set up mock curl so we can capture the payload.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-curl.sh" "$BATS_TMPDIR/bin/curl"
+    chmod +x "$BATS_TMPDIR/bin/curl"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    # shellcheck source=../lib/bounty.sh
+    source "$REPO_ROOT/lib/bounty.sh"
+
+    PAYLOAD_FILE="$BATS_TMPDIR/payload.json"
+    export CURL_PAYLOAD_FILE="$PAYLOAD_FILE"
+    export BOUNTY_URL="http://127.0.0.1:18792"
+    export BOUNTY_TIMEOUT="1"
+    export BOUNTY_API_VERSION="1.0"
+
+    # Simulate a network-failure stderr, classify it, emit the event.
+    _stderr="Error: HTTP 503 gateway timeout from upstream API"
+    _reason=$(loop_failure_category "$_stderr" 1)
+    [ "$_reason" = "network" ]
+
+    bounty_report "review_failed" project=myapp pr_num=7 detail="attempt 1/2" failure_reason="$_reason"
+
+    [ -f "$PAYLOAD_FILE" ]
+    run python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('failure_reason','MISSING'))" < "$PAYLOAD_FILE"
+    [ "$status" -eq 0 ]
+    [ "$output" = "network" ]
+}


### PR DESCRIPTION
Closes #291

## Changes

**New: `lib/failure_category.sh`**
Exports `loop_failure_category <stderr_text> [exit_code]` — classifies agent failure output into exactly one of `budget`, `network`, `git_conflict`, `model_error`, `tool_error`, or `unknown`. Implemented via inline Python heredoc (per CLAUDE.md convention — no new .py files). Rules are evaluated top-to-bottom; first match wins.

**Updated: `lib/bounty.sh`**
Added `failure_reason` as a recognized key in `bounty_report` and included it in the JSON payload alongside `detail`. Unknown keys continue to be ignored.

**Updated: all five `*_failed` emitter handlers**
- `scripts/dev-handler.sh` — sources helper; classifies `_agent_tail` at both `dev_failed` emission sites (untracked-data path and retry-count path)
- `scripts/po-handler.sh` — classifies `_stderr_tail` at both `po_failed` sites (transient and non-transient)
- `scripts/review-handler.sh` — adds `_REVIEW_RUN_LOG` tmpfile to capture agent output; classifies at `review_failed`
- `scripts/qa-handler.sh` — adds `_QA_RUN_LOG` tmpfile; classifies at the agent-crash `qa_fail` site (not the business-logic qa-fail outcomes)
- `scripts/merge-handler.sh` — classifies the POST_STATE string at `merge_failed`

**New: `tests/failure_category.bats`**
17 tests: 6 per-category fixtures (one each for budget, network, git_conflict, model_error, tool_error, unknown), 6 additional edge-case fixtures (multiple matches, command-not-found, non-zero exit), priority-ordering checks, and one integration test verifying that `bounty_report` emits `failure_reason: "network"` in the JSON payload when wired end-to-end.

## Test Plan
- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — passes
- `shellcheck -S warning lib/*.sh scripts/*.sh scanner/*.sh install.sh` — passes
- `bats tests/failure_category.bats` — 17/17 pass
- `bats tests/bounty.bats tests/failure_classifier.bats` — all pass (no regressions)
- 3 pre-existing failures in `tests/handlers.bats` (unrelated label-resolution tests) also fail on `main` — not introduced by this PR