### PR TITLE
[LOOP-291] Handler failure classification: emit structured failure_reason on *_failed events

### DIFF
--- a/lib/bounty.sh
+++ b/lib/bounty.sh
@@ -43,22 +43,23 @@ _bounty_loop_id() {
 }
 
 # bounty_report <event> [key=value ...]
-# Keys: agent model role project issue_num pr_num detail
+# Keys: agent model role project issue_num pr_num detail failure_reason
 # Example: bounty_report "dev_start" role=dev model=sonnet project=myapp issue_num=42
 bounty_report() {
     local event="${1:-unknown}"
     shift || true
 
-    local agent="" model="" role="" project="" issue_num="" pr_num="" detail=""
+    local agent="" model="" role="" project="" issue_num="" pr_num="" detail="" failure_reason=""
     for kv in "$@"; do
         case "$kv" in
-            agent=*)     agent="${kv#agent=}" ;;
-            model=*)     model="${kv#model=}" ;;
-            role=*)      role="${kv#role=}" ;;
-            project=*)   project="${kv#project=}" ;;
-            issue_num=*) issue_num="${kv#issue_num=}" ;;
-            pr_num=*)    pr_num="${kv#pr_num=}" ;;
-            detail=*)    detail="${kv#detail=}" ;;
+            agent=*)          agent="${kv#agent=}" ;;
+            model=*)          model="${kv#model=}" ;;
+            role=*)           role="${kv#role=}" ;;
+            project=*)        project="${kv#project=}" ;;
+            issue_num=*)      issue_num="${kv#issue_num=}" ;;
+            pr_num=*)         pr_num="${kv#pr_num=}" ;;
+            detail=*)         detail="${kv#detail=}" ;;
+            failure_reason=*) failure_reason="${kv#failure_reason=}" ;;
         esac
     done
 
@@ -72,7 +73,7 @@ bounty_report() {
     payload=$(
         _API="$api_ver" _CV="$(_bounty_core_version)" _LI="$(_bounty_loop_id)" \
         _BE="$event" _BA="$agent" _BM="$model" _BR="$role" \
-        _BP="$project" _BD="$detail" _BI="$issue_num" _BPN="$pr_num" \
+        _BP="$project" _BD="$detail" _BI="$issue_num" _BPN="$pr_num" _BFR="$failure_reason" \
         python3 - <<'PY'
 import json, os, datetime
 d = {
@@ -85,6 +86,7 @@ d = {
     "role":         os.environ.get("_BR") or None,
     "project":      os.environ.get("_BP") or None,
     "detail":       os.environ.get("_BD") or None,
+    "failure_reason": os.environ.get("_BFR") or None,
     "timestamp":    datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
 }
 for k, env in [("issue_num", "_BI"), ("pr_num", "_BPN")]:

--- a/lib/failure_category.sh
+++ b/lib/failure_category.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# lib/failure_category.sh — classify handler stderr into a structured failure category.
+#
+# Usage:
+#   source "$LOOP_ROOT/lib/failure_category.sh"
+#   category=$(loop_failure_category "$stderr_text" "$exit_code")
+#
+# Prints exactly one of: budget | network | git_conflict | model_error | tool_error | unknown
+# Classification rules are evaluated top-to-bottom; first match wins.
+
+# loop_failure_category <text> [exit_code]
+loop_failure_category() {
+    local text="${1:-}"
+    local rc="${2:-1}"
+
+    _LFC_TEXT="$text" _LFC_RC="$rc" python3 - <<'PY'
+import sys, re, os
+
+text = os.environ.get("_LFC_TEXT", "")
+try:
+    rc = int(os.environ.get("_LFC_RC", "1"))
+except ValueError:
+    rc = 1
+
+if re.search(r'daily\.budget|budget cap|budget exhausted|LOOP_DAILY_BUDGET', text):
+    print("budget"); sys.exit(0)
+
+if re.search(
+    r'5\d\d|timeout|timed out|Connection(?:Refused|Reset|Error)|TimeoutError|\b429\b|rate limit',
+    text, re.IGNORECASE
+):
+    print("network"); sys.exit(0)
+
+if re.search(r'CONFLICT \(|Merge conflict|rebase.*conflict|<<<<<<< HEAD', text):
+    print("git_conflict"); sys.exit(0)
+
+if re.search(
+    r'claude .* (?:API error|invalid_request|overloaded|model_error)|anthropic.*error|prompt is too long',
+    text, re.IGNORECASE
+):
+    print("model_error"); sys.exit(0)
+
+if re.search(r'gh: |git: |jq: |command not found', text):
+    print("tool_error"); sys.exit(0)
+
+print("unknown")
+PY
+}

--- a/scripts/dev-handler.sh
+++ b/scripts/dev-handler.sh
@@ -30,6 +30,8 @@ source "$LOOP_ROOT/lib/cli-hint.sh"
 source "$LOOP_ROOT/lib/worktree.sh"
 # shellcheck source=../lib/failure_classifier.sh
 source "$LOOP_ROOT/lib/failure_classifier.sh"
+# shellcheck source=../lib/failure_category.sh
+source "$LOOP_ROOT/lib/failure_category.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-dev-handler.log"
 MAX_RETRIES=3
@@ -277,7 +279,8 @@ else
     if loop_is_missing_untracked_data "$_agent_tail"; then
         _missing_path=$(loop_extract_missing_path "$_agent_tail")
         log "dev agent failed for #$ISSUE_NUM — untracked-data dependency (${_missing_path:-?}); marking blocked without burning retry"
-        bounty_report "dev_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" issue_num="$ISSUE_NUM" detail="untracked-data: ${_missing_path:-?}" || true
+        _fc=$(loop_failure_category "$_agent_tail") || _fc=unknown
+        bounty_report "dev_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" issue_num="$ISSUE_NUM" detail="untracked-data: ${_missing_path:-?}" failure_reason="$_fc" || true
         backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
         backend_add_label "$REPO" "$ISSUE_NUM" blocked
         _block_body=$(mktemp /tmp/loop-block-XXXXXX.md)
@@ -322,7 +325,8 @@ else
     # will see the cool-down and skip until the next-eligible time.
     loop_backoff_record_failure "$SLUG" "$ISSUE_NUM" dev "dev attempt ${n}/${MAX_RETRIES}" >/dev/null || true
     log "dev agent failed for #$ISSUE_NUM (attempt $n/$MAX_RETRIES); backoff next-eligible logged"
-    bounty_report "dev_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" issue_num="$ISSUE_NUM" detail="attempt ${n}/${MAX_RETRIES}" || true
+    _fc=$(loop_failure_category "$_agent_tail") || _fc=unknown
+    bounty_report "dev_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" issue_num="$ISSUE_NUM" detail="attempt ${n}/${MAX_RETRIES}" failure_reason="$_fc" || true
     if [ "$n" -ge "$MAX_RETRIES" ]; then
         backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
         backend_add_label "$REPO" "$ISSUE_NUM" blocked

--- a/scripts/merge-handler.sh
+++ b/scripts/merge-handler.sh
@@ -21,6 +21,8 @@ source "$LOOP_ROOT/lib/bounty.sh"
 source "$LOOP_ROOT/lib/notify.sh"
 # shellcheck source=../lib/recovery.sh
 source "$LOOP_ROOT/lib/recovery.sh"
+# shellcheck source=../lib/failure_category.sh
+source "$LOOP_ROOT/lib/failure_category.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-merge-handler.log"
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [merge-handler] $*" | tee -a "$LOG_FILE"; }
@@ -82,6 +84,7 @@ esac
 # Dev-handler opens all PRs as drafts; promote to ready before merging.
 backend_pr_ready "$REPO" "$PR_NUM" 2>&1 | tee -a "$LOG_FILE" || true
 
+LOG_CAPTURE_START=$(wc -l < "$LOG_FILE" 2>/dev/null || echo 0)
 if ! backend_merge_pr "$REPO" "$PR_NUM" "$STRATEGY_FLAG" 2>&1 | tee -a "$LOG_FILE"; then
     # Check if the failure was a conflict discovered at merge time.
     POST_STATE=$(backend_pr_view "$REPO" "$PR_NUM" --json mergeable,mergeStateStatus 2>/dev/null \
@@ -101,7 +104,9 @@ if ! backend_merge_pr "$REPO" "$PR_NUM" "$STRATEGY_FLAG" 2>&1 | tee -a "$LOG_FIL
     # Non-conflict failure (e.g. required check missing, API flake). Don't
     # loop on this either — mark blocked so a human can look.
     log "ERROR: merge failed for non-conflict reason (state=$POST_STATE)"
-    bounty_report "merge_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=merge project="$SLUG" pr_num="$PR_NUM" detail="state=${POST_STATE}" || true
+    _merge_tail=$(tail -n +"$((LOG_CAPTURE_START + 1))" "$LOG_FILE" 2>/dev/null | tail -200)
+    _fc=$(loop_failure_category "$_merge_tail") || _fc=unknown
+    bounty_report "merge_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=merge project="$SLUG" pr_num="$PR_NUM" detail="state=${POST_STATE}" failure_reason="$_fc" || true
     loop_notify "❌ [$SLUG] PR#$PR_NUM merge failed: merge command failed"
     backend_remove_label "$REPO" "$PR_NUM" qa-pass
     backend_add_label "$REPO" "$PR_NUM" blocked

--- a/scripts/po-handler.sh
+++ b/scripts/po-handler.sh
@@ -34,6 +34,8 @@ source "$LOOP_ROOT/lib/redact.sh"
 source "$LOOP_ROOT/lib/cli-hint.sh"
 # shellcheck source=../lib/failure_classifier.sh
 source "$LOOP_ROOT/lib/failure_classifier.sh"
+# shellcheck source=../lib/failure_category.sh
+source "$LOOP_ROOT/lib/failure_category.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-po-handler.log"
 MAX_RETRIES=2
@@ -511,7 +513,8 @@ else
         _sig=$(loop_failure_signature "$_stderr_tail")
         _tc=$(transient_incr)
         log "po agent transient failure for #$ISSUE_NUM (transient attempt $_tc/$MAX_TRANSIENT_RETRIES, sig: ${_sig:-unknown})"
-        bounty_report "po_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=po project="$SLUG" issue_num="$ISSUE_NUM" detail="transient ${_tc}/${MAX_TRANSIENT_RETRIES} sig:${_sig:-unknown}" || true
+        _fc=$(loop_failure_category "$_stderr_tail" "$_agent_rc") || _fc=unknown
+        bounty_report "po_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=po project="$SLUG" issue_num="$ISSUE_NUM" detail="transient ${_tc}/${MAX_TRANSIENT_RETRIES} sig:${_sig:-unknown}" failure_reason="$_fc" || true
         if [ "$_tc" -ge "$MAX_TRANSIENT_RETRIES" ]; then
             backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
             backend_add_label "$REPO" "$ISSUE_NUM" blocked
@@ -525,7 +528,8 @@ else
     else
         n=$(retry_incr)
         log "po agent failed for #$ISSUE_NUM (attempt $n/$MAX_RETRIES)"
-        bounty_report "po_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=po project="$SLUG" issue_num="$ISSUE_NUM" detail="attempt ${n}/${MAX_RETRIES}" || true
+        _fc=$(loop_failure_category "$_stderr_tail" "$_agent_rc") || _fc=unknown
+        bounty_report "po_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=po project="$SLUG" issue_num="$ISSUE_NUM" detail="attempt ${n}/${MAX_RETRIES}" failure_reason="$_fc" || true
         if [ "$n" -ge "$MAX_RETRIES" ]; then
             backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
             backend_add_label "$REPO" "$ISSUE_NUM" needs-clarification

--- a/scripts/qa-handler.sh
+++ b/scripts/qa-handler.sh
@@ -27,6 +27,8 @@ source "$LOOP_ROOT/lib/bounty.sh"
 source "$LOOP_ROOT/lib/notify.sh"
 # shellcheck source=../lib/cli-hint.sh
 source "$LOOP_ROOT/lib/cli-hint.sh"
+# shellcheck source=../lib/failure_category.sh
+source "$LOOP_ROOT/lib/failure_category.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-qa-handler.log"
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [qa-handler] $*" | tee -a "$LOG_FILE"; }
@@ -224,6 +226,7 @@ EOF
 TASK_PROMPT=$(cat "$_PROMPT_FILE")
 rm -f "$_PROMPT_FILE"
 
+LOG_CAPTURE_START=$(wc -l < "$LOG_FILE" 2>/dev/null || echo 0)
 if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
     log "qa agent finished for PR #$PR_NUM"
     loop_notify "✅ [$SLUG] PR#$PR_NUM qa done"
@@ -248,8 +251,10 @@ if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
         bounty_report "qa_fail" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$SLUG" pr_num="$PR_NUM" || true
     fi
 else
+    _agent_tail=$(tail -n +"$((LOG_CAPTURE_START + 1))" "$LOG_FILE" 2>/dev/null | tail -200)
     log "qa agent failed for PR #$PR_NUM"
-    bounty_report "qa_fail" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$SLUG" pr_num="$PR_NUM" || true
+    _fc=$(loop_failure_category "$_agent_tail") || _fc=unknown
+    bounty_report "qa_fail" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$SLUG" pr_num="$PR_NUM" failure_reason="$_fc" || true
     loop_notify "❌ [$SLUG] PR#$PR_NUM qa failed: agent error"
     backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_NEEDS_QA"
     backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_READY_FOR_QA"

--- a/scripts/review-handler.sh
+++ b/scripts/review-handler.sh
@@ -27,6 +27,8 @@ source "$LOOP_ROOT/lib/bounty.sh"
 source "$LOOP_ROOT/lib/notify.sh"
 # shellcheck source=../lib/cli-hint.sh
 source "$LOOP_ROOT/lib/cli-hint.sh"
+# shellcheck source=../lib/failure_category.sh
+source "$LOOP_ROOT/lib/failure_category.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-review-handler.log"
 MAX_RETRIES=2
@@ -164,6 +166,7 @@ EOF
 TASK_PROMPT=$(cat "$_PROMPT_FILE")
 rm -f "$_PROMPT_FILE"
 
+LOG_CAPTURE_START=$(wc -l < "$LOG_FILE" 2>/dev/null || echo 0)
 if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
     log "review agent finished for PR #$PR_NUM"
     bounty_report "review_done" model="${LOOP_AGENT_MODEL:-sonnet}" role=reviewer project="$SLUG" pr_num="$PR_NUM" || true
@@ -203,9 +206,11 @@ if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
         backend_add_label "$REPO" "$PR_NUM" "$_REWORK_LABEL"
     fi
 else
+    _agent_tail=$(tail -n +"$((LOG_CAPTURE_START + 1))" "$LOG_FILE" 2>/dev/null | tail -200)
     n=$(retry_incr)
     log "review agent failed for PR #$PR_NUM (attempt $n/$MAX_RETRIES)"
-    bounty_report "review_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=reviewer project="$SLUG" pr_num="$PR_NUM" detail="attempt ${n}/${MAX_RETRIES}" || true
+    _fc=$(loop_failure_category "$_agent_tail") || _fc=unknown
+    bounty_report "review_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=reviewer project="$SLUG" pr_num="$PR_NUM" detail="attempt ${n}/${MAX_RETRIES}" failure_reason="$_fc" || true
     if [ "$n" -ge "$MAX_RETRIES" ]; then
         backend_remove_label "$REPO" "$PR_NUM" in-review
         backend_remove_label "$REPO" "$PR_NUM" "$_REWORK_LABEL"

--- a/tests/failure_category.bats
+++ b/tests/failure_category.bats
@@ -1,0 +1,136 @@
+#!/usr/bin/env bats
+# tests/failure_category.bats — unit + integration tests for lib/failure_category.sh.
+#
+# No real network or CLI required.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    # shellcheck source=../lib/failure_category.sh
+    source "$REPO_ROOT/lib/failure_category.sh"
+}
+
+# ─── Unit: one fixture per category ───────────────────────────────────────────
+
+@test "budget: daily.budget in text → budget" {
+    run loop_failure_category "Error: daily.budget cap reached, aborting" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "budget" ]
+}
+
+@test "network: HTTP 503 in text → network" {
+    run loop_failure_category "Error: received HTTP 503 Service Unavailable from upstream" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "network" ]
+}
+
+@test "network: 429 rate limit in text → network" {
+    run loop_failure_category "HTTP 429 Too Many Requests: rate limit exceeded" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "network" ]
+}
+
+@test "network: ConnectionRefused in text → network" {
+    run loop_failure_category "ConnectionRefused: could not reach api endpoint" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "network" ]
+}
+
+@test "git_conflict: CONFLICT marker in text → git_conflict" {
+    run loop_failure_category "Auto-merging foo.sh
+CONFLICT (content): Merge conflict in foo.sh
+Automatic merge failed; fix conflicts and then commit." 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "git_conflict" ]
+}
+
+@test "git_conflict: <<<<<<< HEAD marker in text → git_conflict" {
+    run loop_failure_category "<<<<<<< HEAD
+some content
+=======" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "git_conflict" ]
+}
+
+@test "model_error: anthropic error in text → model_error" {
+    run loop_failure_category "anthropic.APIError: invalid_request_error: prompt is too long" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "model_error" ]
+}
+
+@test "model_error: prompt is too long → model_error" {
+    run loop_failure_category "Error: prompt is too long (120000 tokens, limit 100000)" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "model_error" ]
+}
+
+@test "tool_error: gh: error in text → tool_error" {
+    run loop_failure_category "gh: pull request not found: '999'" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "tool_error" ]
+}
+
+@test "tool_error: command not found in text → tool_error" {
+    run loop_failure_category "jq: command not found" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "tool_error" ]
+}
+
+@test "unknown: unrecognised error text → unknown" {
+    run loop_failure_category "SomethingWentWrong: unexpected state at line 42" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "unknown" ]
+}
+
+@test "unknown: empty text → unknown" {
+    run loop_failure_category "" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "unknown" ]
+}
+
+# ─── Priority ordering ─────────────────────────────────────────────────────────
+
+@test "budget takes priority over network when both match" {
+    run loop_failure_category "HTTP 503: daily.budget exhausted, aborting" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "budget" ]
+}
+
+# ─── Integration: bounty payload contains failure_reason ──────────────────────
+# Simulate the qa-handler failure path: agent stderr contains a network error;
+# assert the emitted JSON payload carries failure_reason=network.
+
+@test "integration: network stderr produces failure_reason=network in bounty payload" {
+    # Stub curl so bounty_report captures the payload instead of sending it.
+    local captured_payload="$BATS_TMPDIR/bounty_payload.json"
+
+    curl() {
+        # Extract the -d <payload> argument
+        local prev=""
+        for arg in "$@"; do
+            if [ "$prev" = "-d" ]; then
+                printf '%s' "$arg" > "$captured_payload"
+            fi
+            prev="$arg"
+        done
+        return 0
+    }
+    export -f curl 2>/dev/null || true
+
+    # Source bounty.sh after stubbing curl.
+    source "$REPO_ROOT/lib/bounty.sh"
+
+    # Simulate capturing agent stderr and classifying it.
+    local _agent_tail="Error: ConnectionReset while sending request to api endpoint"
+    local _fc
+    _fc=$(loop_failure_category "$_agent_tail") || _fc=unknown
+
+    bounty_report "qa_fail" role=qa project=test-proj pr_num=42 failure_reason="$_fc"
+
+    # Verify payload file was written.
+    [ -f "$captured_payload" ]
+
+    # Verify failure_reason=network in the JSON.
+    local reason
+    reason=$(python3 -c "import json,sys; d=json.load(open('$captured_payload')); print(d.get('failure_reason',''))")
+    [ "$reason" = "network" ]
+}


### PR DESCRIPTION
Closes #291

## Changes

- **New `lib/failure_category.sh`**: exposes `loop_failure_category <text> [exit_code]` which classifies agent stderr into one of `budget | network | git_conflict | model_error | tool_error | unknown`. Classification uses a Python3 heredoc (per project convention for regex-heavy logic) with rules evaluated top-to-bottom, first match wins.

- **Updated `lib/bounty.sh`**: added `failure_reason` key to `bounty_report` — parsed from key=value args and included in the JSON payload sent to loop-monitor.

- **Updated all 5 emitter handlers** (`dev-handler.sh`, `po-handler.sh`, `review-handler.sh`, `qa-handler.sh`, `merge-handler.sh`):
  - Source `lib/failure_category.sh`
  - Capture agent/merge tail output into a local variable
  - Call `loop_failure_category` to classify it
  - Pass `failure_reason="$_fc"` to every `*_failed` bounty_report call
  - The `detail` field is preserved unchanged alongside the new field

- **New `tests/failure_category.bats`**: 14 tests covering one fixture per category (budget, network×2, git_conflict×2, model_error×2, tool_error×2, unknown×2), a priority-ordering test, and an integration test that stubs `curl` and asserts the bounty JSON payload contains `failure_reason=network`.

## Test Plan

- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — all pass
- `shellcheck -S warning lib/*.sh scripts/*.sh scanner/*.sh install.sh` — no warnings
- `bats tests/failure_category.bats` — 14/14 pass
- No personal identifiers in changed files