### PR TITLE
[LOOP-291] emit structured failure_reason on *_failed events

### DIFF
--- a/lib/bounty.sh
+++ b/lib/bounty.sh
@@ -49,16 +49,17 @@ bounty_report() {
     local event="${1:-unknown}"
     shift || true
 
-    local agent="" model="" role="" project="" issue_num="" pr_num="" detail=""
+    local agent="" model="" role="" project="" issue_num="" pr_num="" detail="" failure_reason=""
     for kv in "$@"; do
         case "$kv" in
-            agent=*)     agent="${kv#agent=}" ;;
-            model=*)     model="${kv#model=}" ;;
-            role=*)      role="${kv#role=}" ;;
-            project=*)   project="${kv#project=}" ;;
-            issue_num=*) issue_num="${kv#issue_num=}" ;;
-            pr_num=*)    pr_num="${kv#pr_num=}" ;;
-            detail=*)    detail="${kv#detail=}" ;;
+            agent=*)          agent="${kv#agent=}" ;;
+            model=*)          model="${kv#model=}" ;;
+            role=*)           role="${kv#role=}" ;;
+            project=*)        project="${kv#project=}" ;;
+            issue_num=*)      issue_num="${kv#issue_num=}" ;;
+            pr_num=*)         pr_num="${kv#pr_num=}" ;;
+            detail=*)         detail="${kv#detail=}" ;;
+            failure_reason=*) failure_reason="${kv#failure_reason=}" ;;
         esac
     done
 
@@ -73,19 +74,21 @@ bounty_report() {
         _API="$api_ver" _CV="$(_bounty_core_version)" _LI="$(_bounty_loop_id)" \
         _BE="$event" _BA="$agent" _BM="$model" _BR="$role" \
         _BP="$project" _BD="$detail" _BI="$issue_num" _BPN="$pr_num" \
+        _BFR="$failure_reason" \
         python3 - <<'PY'
 import json, os, datetime
 d = {
-    "api":          os.environ.get("_API") or "1.0",
-    "core_version": os.environ.get("_CV") or "unknown",
-    "loop_id":      os.environ.get("_LI") or "unknown",
-    "event":        os.environ.get("_BE", "unknown"),
-    "agent":        os.environ.get("_BA") or None,
-    "model":        os.environ.get("_BM") or None,
-    "role":         os.environ.get("_BR") or None,
-    "project":      os.environ.get("_BP") or None,
-    "detail":       os.environ.get("_BD") or None,
-    "timestamp":    datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "api":            os.environ.get("_API") or "1.0",
+    "core_version":   os.environ.get("_CV") or "unknown",
+    "loop_id":        os.environ.get("_LI") or "unknown",
+    "event":          os.environ.get("_BE", "unknown"),
+    "agent":          os.environ.get("_BA") or None,
+    "model":          os.environ.get("_BM") or None,
+    "role":           os.environ.get("_BR") or None,
+    "project":        os.environ.get("_BP") or None,
+    "detail":         os.environ.get("_BD") or None,
+    "failure_reason": os.environ.get("_BFR") or None,
+    "timestamp":      datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
 }
 for k, env in [("issue_num", "_BI"), ("pr_num", "_BPN")]:
     v = os.environ.get(env, "")

--- a/lib/failure_category.sh
+++ b/lib/failure_category.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# lib/failure_category.sh — classify handler stderr into structured failure categories.
+#
+# Usage:
+#   source "$LOOP_ROOT/lib/failure_category.sh"
+#   category=$(loop_failure_category "$stderr_text" [exit_code])
+#
+# Returns exactly one of:
+#   budget | network | git_conflict | model_error | tool_error | unknown
+#
+# Rules are evaluated top-to-bottom; first match wins.
+
+# loop_failure_category <stderr_text> [exit_code]
+# Prints a single category token to stdout.
+loop_failure_category() {
+    local text="${1:-}"
+    local rc="${2:-1}"
+
+    # budget — daily budget cap exhausted
+    if printf '%s' "$text" | grep -qE '(daily.budget|budget cap|budget exhausted|LOOP_DAILY_BUDGET)'; then
+        printf 'budget'
+        return
+    fi
+
+    # network — HTTP 5xx, connection errors, timeouts, rate limits
+    if printf '%s' "$text" | grep -qE '(HTTP 5[0-9][0-9]|timeout|timed out|Connection(Refused|Reset|Error)|TimeoutError|429|rate limit)'; then
+        printf 'network'
+        return
+    fi
+
+    # git_conflict — merge or rebase conflict markers
+    if printf '%s' "$text" | grep -qE '(CONFLICT \(|Merge conflict|rebase.*conflict|<<<<<<< HEAD)'; then
+        printf 'git_conflict'
+        return
+    fi
+
+    # model_error — Claude/Anthropic API errors, overloaded, prompt too long
+    if printf '%s' "$text" | grep -qiE '(claude.*(API error|invalid_request|overloaded|model_error)|anthropic.*error|prompt is too long)'; then
+        printf 'model_error'
+        return
+    fi
+
+    # tool_error — gh/git/jq CLI errors, command not found, or any non-zero exit
+    if printf '%s' "$text" | grep -qE '(gh: |git: |jq: |command not found)' \
+        || [ "${rc}" -ne 0 ]; then
+        printf 'tool_error'
+        return
+    fi
+
+    printf 'unknown'
+}

--- a/scripts/dev-handler.sh
+++ b/scripts/dev-handler.sh
@@ -30,6 +30,8 @@ source "$LOOP_ROOT/lib/cli-hint.sh"
 source "$LOOP_ROOT/lib/worktree.sh"
 # shellcheck source=../lib/failure_classifier.sh
 source "$LOOP_ROOT/lib/failure_classifier.sh"
+# shellcheck source=../lib/failure_category.sh
+source "$LOOP_ROOT/lib/failure_category.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-dev-handler.log"
 MAX_RETRIES=3
@@ -277,7 +279,8 @@ else
     if loop_is_missing_untracked_data "$_agent_tail"; then
         _missing_path=$(loop_extract_missing_path "$_agent_tail")
         log "dev agent failed for #$ISSUE_NUM — untracked-data dependency (${_missing_path:-?}); marking blocked without burning retry"
-        bounty_report "dev_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" issue_num="$ISSUE_NUM" detail="untracked-data: ${_missing_path:-?}" || true
+        _failure_reason=$(loop_failure_category "$_agent_tail" 1)
+        bounty_report "dev_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" issue_num="$ISSUE_NUM" detail="untracked-data: ${_missing_path:-?}" failure_reason="$_failure_reason" || true
         backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
         backend_add_label "$REPO" "$ISSUE_NUM" blocked
         _block_body=$(mktemp /tmp/loop-block-XXXXXX.md)
@@ -322,7 +325,8 @@ else
     # will see the cool-down and skip until the next-eligible time.
     loop_backoff_record_failure "$SLUG" "$ISSUE_NUM" dev "dev attempt ${n}/${MAX_RETRIES}" >/dev/null || true
     log "dev agent failed for #$ISSUE_NUM (attempt $n/$MAX_RETRIES); backoff next-eligible logged"
-    bounty_report "dev_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" issue_num="$ISSUE_NUM" detail="attempt ${n}/${MAX_RETRIES}" || true
+    _failure_reason=$(loop_failure_category "$_agent_tail" 1)
+    bounty_report "dev_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" issue_num="$ISSUE_NUM" detail="attempt ${n}/${MAX_RETRIES}" failure_reason="$_failure_reason" || true
     if [ "$n" -ge "$MAX_RETRIES" ]; then
         backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
         backend_add_label "$REPO" "$ISSUE_NUM" blocked

--- a/scripts/merge-handler.sh
+++ b/scripts/merge-handler.sh
@@ -21,6 +21,8 @@ source "$LOOP_ROOT/lib/bounty.sh"
 source "$LOOP_ROOT/lib/notify.sh"
 # shellcheck source=../lib/recovery.sh
 source "$LOOP_ROOT/lib/recovery.sh"
+# shellcheck source=../lib/failure_category.sh
+source "$LOOP_ROOT/lib/failure_category.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-merge-handler.log"
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [merge-handler] $*" | tee -a "$LOG_FILE"; }
@@ -82,6 +84,7 @@ esac
 # Dev-handler opens all PRs as drafts; promote to ready before merging.
 backend_pr_ready "$REPO" "$PR_NUM" 2>&1 | tee -a "$LOG_FILE" || true
 
+_MERGE_LOG_START=$(wc -l < "$LOG_FILE" 2>/dev/null || echo 0)
 if ! backend_merge_pr "$REPO" "$PR_NUM" "$STRATEGY_FLAG" 2>&1 | tee -a "$LOG_FILE"; then
     # Check if the failure was a conflict discovered at merge time.
     POST_STATE=$(backend_pr_view "$REPO" "$PR_NUM" --json mergeable,mergeStateStatus 2>/dev/null \
@@ -101,7 +104,9 @@ if ! backend_merge_pr "$REPO" "$PR_NUM" "$STRATEGY_FLAG" 2>&1 | tee -a "$LOG_FIL
     # Non-conflict failure (e.g. required check missing, API flake). Don't
     # loop on this either — mark blocked so a human can look.
     log "ERROR: merge failed for non-conflict reason (state=$POST_STATE)"
-    bounty_report "merge_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=merge project="$SLUG" pr_num="$PR_NUM" detail="state=${POST_STATE}" || true
+    _merge_tail=$(tail -n +"$((_MERGE_LOG_START + 1))" "$LOG_FILE" 2>/dev/null | tail -200)
+    _failure_reason=$(loop_failure_category "$_merge_tail" 1)
+    bounty_report "merge_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=merge project="$SLUG" pr_num="$PR_NUM" detail="state=${POST_STATE}" failure_reason="$_failure_reason" || true
     loop_notify "❌ [$SLUG] PR#$PR_NUM merge failed: merge command failed"
     backend_remove_label "$REPO" "$PR_NUM" qa-pass
     backend_add_label "$REPO" "$PR_NUM" blocked

--- a/scripts/po-handler.sh
+++ b/scripts/po-handler.sh
@@ -34,6 +34,8 @@ source "$LOOP_ROOT/lib/redact.sh"
 source "$LOOP_ROOT/lib/cli-hint.sh"
 # shellcheck source=../lib/failure_classifier.sh
 source "$LOOP_ROOT/lib/failure_classifier.sh"
+# shellcheck source=../lib/failure_category.sh
+source "$LOOP_ROOT/lib/failure_category.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-po-handler.log"
 MAX_RETRIES=2
@@ -507,11 +509,12 @@ else
     _stderr_tail=$(tail -n 50 "$_RUN_LOG" 2>/dev/null || echo "")
     _IN_PROGRESS_CLAIMED=0  # disarm trap — failure path handles cleanup
 
+    _failure_reason=$(loop_failure_category "$_stderr_tail" "$_agent_rc")
     if loop_is_transient_failure "$_stderr_tail" "$_agent_rc"; then
         _sig=$(loop_failure_signature "$_stderr_tail")
         _tc=$(transient_incr)
         log "po agent transient failure for #$ISSUE_NUM (transient attempt $_tc/$MAX_TRANSIENT_RETRIES, sig: ${_sig:-unknown})"
-        bounty_report "po_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=po project="$SLUG" issue_num="$ISSUE_NUM" detail="transient ${_tc}/${MAX_TRANSIENT_RETRIES} sig:${_sig:-unknown}" || true
+        bounty_report "po_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=po project="$SLUG" issue_num="$ISSUE_NUM" detail="transient ${_tc}/${MAX_TRANSIENT_RETRIES} sig:${_sig:-unknown}" failure_reason="$_failure_reason" || true
         if [ "$_tc" -ge "$MAX_TRANSIENT_RETRIES" ]; then
             backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
             backend_add_label "$REPO" "$ISSUE_NUM" blocked
@@ -525,7 +528,7 @@ else
     else
         n=$(retry_incr)
         log "po agent failed for #$ISSUE_NUM (attempt $n/$MAX_RETRIES)"
-        bounty_report "po_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=po project="$SLUG" issue_num="$ISSUE_NUM" detail="attempt ${n}/${MAX_RETRIES}" || true
+        bounty_report "po_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=po project="$SLUG" issue_num="$ISSUE_NUM" detail="attempt ${n}/${MAX_RETRIES}" failure_reason="$_failure_reason" || true
         if [ "$n" -ge "$MAX_RETRIES" ]; then
             backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
             backend_add_label "$REPO" "$ISSUE_NUM" needs-clarification

--- a/scripts/qa-handler.sh
+++ b/scripts/qa-handler.sh
@@ -27,6 +27,8 @@ source "$LOOP_ROOT/lib/bounty.sh"
 source "$LOOP_ROOT/lib/notify.sh"
 # shellcheck source=../lib/cli-hint.sh
 source "$LOOP_ROOT/lib/cli-hint.sh"
+# shellcheck source=../lib/failure_category.sh
+source "$LOOP_ROOT/lib/failure_category.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-qa-handler.log"
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [qa-handler] $*" | tee -a "$LOG_FILE"; }
@@ -224,6 +226,7 @@ EOF
 TASK_PROMPT=$(cat "$_PROMPT_FILE")
 rm -f "$_PROMPT_FILE"
 
+_QA_LOG_START=$(wc -l < "$LOG_FILE" 2>/dev/null || echo 0)
 if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
     log "qa agent finished for PR #$PR_NUM"
     loop_notify "✅ [$SLUG] PR#$PR_NUM qa done"
@@ -248,8 +251,10 @@ if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
         bounty_report "qa_fail" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$SLUG" pr_num="$PR_NUM" || true
     fi
 else
+    _agent_tail=$(tail -n +"$((_QA_LOG_START + 1))" "$LOG_FILE" 2>/dev/null | tail -200)
     log "qa agent failed for PR #$PR_NUM"
-    bounty_report "qa_fail" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$SLUG" pr_num="$PR_NUM" || true
+    _failure_reason=$(loop_failure_category "$_agent_tail" 1)
+    bounty_report "qa_fail" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$SLUG" pr_num="$PR_NUM" failure_reason="$_failure_reason" || true
     loop_notify "❌ [$SLUG] PR#$PR_NUM qa failed: agent error"
     backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_NEEDS_QA"
     backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_READY_FOR_QA"

--- a/scripts/review-handler.sh
+++ b/scripts/review-handler.sh
@@ -27,6 +27,8 @@ source "$LOOP_ROOT/lib/bounty.sh"
 source "$LOOP_ROOT/lib/notify.sh"
 # shellcheck source=../lib/cli-hint.sh
 source "$LOOP_ROOT/lib/cli-hint.sh"
+# shellcheck source=../lib/failure_category.sh
+source "$LOOP_ROOT/lib/failure_category.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-review-handler.log"
 MAX_RETRIES=2
@@ -164,6 +166,7 @@ EOF
 TASK_PROMPT=$(cat "$_PROMPT_FILE")
 rm -f "$_PROMPT_FILE"
 
+_REVIEW_LOG_START=$(wc -l < "$LOG_FILE" 2>/dev/null || echo 0)
 if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
     log "review agent finished for PR #$PR_NUM"
     bounty_report "review_done" model="${LOOP_AGENT_MODEL:-sonnet}" role=reviewer project="$SLUG" pr_num="$PR_NUM" || true
@@ -203,9 +206,11 @@ if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
         backend_add_label "$REPO" "$PR_NUM" "$_REWORK_LABEL"
     fi
 else
+    _agent_tail=$(tail -n +"$((_REVIEW_LOG_START + 1))" "$LOG_FILE" 2>/dev/null | tail -200)
     n=$(retry_incr)
     log "review agent failed for PR #$PR_NUM (attempt $n/$MAX_RETRIES)"
-    bounty_report "review_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=reviewer project="$SLUG" pr_num="$PR_NUM" detail="attempt ${n}/${MAX_RETRIES}" || true
+    _failure_reason=$(loop_failure_category "$_agent_tail" 1)
+    bounty_report "review_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=reviewer project="$SLUG" pr_num="$PR_NUM" detail="attempt ${n}/${MAX_RETRIES}" failure_reason="$_failure_reason" || true
     if [ "$n" -ge "$MAX_RETRIES" ]; then
         backend_remove_label "$REPO" "$PR_NUM" in-review
         backend_remove_label "$REPO" "$PR_NUM" "$_REWORK_LABEL"

--- a/tests/failure_category.bats
+++ b/tests/failure_category.bats
@@ -1,0 +1,212 @@
+#!/usr/bin/env bats
+# tests/failure_category.bats — unit + integration tests for lib/failure_category.sh.
+#
+# No real network or CLI required.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    # shellcheck source=../lib/failure_category.sh
+    source "$REPO_ROOT/lib/failure_category.sh"
+}
+
+# ── Category: budget ──────────────────────────────────────────────────────────
+
+@test "budget: 'daily.budget' text → budget" {
+    run loop_failure_category "Error: daily.budget limit reached" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "budget" ]
+}
+
+@test "budget: 'budget cap' text → budget" {
+    run loop_failure_category "Operation aborted: budget cap exceeded" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "budget" ]
+}
+
+@test "budget: 'budget exhausted' text → budget" {
+    run loop_failure_category "FATAL budget exhausted for project" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "budget" ]
+}
+
+@test "budget: 'LOOP_DAILY_BUDGET' text → budget" {
+    run loop_failure_category "LOOP_DAILY_BUDGET cap hit, aborting" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "budget" ]
+}
+
+# ── Category: network ─────────────────────────────────────────────────────────
+
+@test "network: HTTP 503 → network" {
+    run loop_failure_category "Request failed: HTTP 503 Service Unavailable" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "network" ]
+}
+
+@test "network: timeout text → network" {
+    run loop_failure_category "Error: operation timeout after 30s" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "network" ]
+}
+
+@test "network: timed out text → network" {
+    run loop_failure_category "Connection timed out" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "network" ]
+}
+
+@test "network: ConnectionRefused → network" {
+    run loop_failure_category "ConnectionRefused: could not reach api.example.com" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "network" ]
+}
+
+@test "network: TimeoutError → network" {
+    run loop_failure_category "TimeoutError: socket timed out" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "network" ]
+}
+
+@test "network: 429 → network" {
+    run loop_failure_category "Error 429: Too Many Requests" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "network" ]
+}
+
+@test "network: rate limit → network" {
+    run loop_failure_category "Blocked due to rate limit policy" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "network" ]
+}
+
+# ── Category: git_conflict ────────────────────────────────────────────────────
+
+@test "git_conflict: CONFLICT ( → git_conflict" {
+    run loop_failure_category "CONFLICT (content): Merge conflict in lib/foo.sh" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "git_conflict" ]
+}
+
+@test "git_conflict: Merge conflict → git_conflict" {
+    run loop_failure_category "Merge conflict detected in scripts/bar.sh" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "git_conflict" ]
+}
+
+@test "git_conflict: rebase.*conflict → git_conflict" {
+    run loop_failure_category "error: rebase aborted due to conflict in file" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "git_conflict" ]
+}
+
+@test "git_conflict: <<<<<<< HEAD → git_conflict" {
+    run loop_failure_category "<<<<<<< HEAD" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "git_conflict" ]
+}
+
+# ── Category: model_error ─────────────────────────────────────────────────────
+
+@test "model_error: claude API error → model_error" {
+    run loop_failure_category "claude exited with API error: invalid response" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "model_error" ]
+}
+
+@test "model_error: claude invalid_request → model_error" {
+    run loop_failure_category "claude returned invalid_request" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "model_error" ]
+}
+
+@test "model_error: claude overloaded → model_error" {
+    run loop_failure_category "claude: overloaded, try again later" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "model_error" ]
+}
+
+@test "model_error: anthropic.*error → model_error" {
+    run loop_failure_category "anthropic API error: bad gateway" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "model_error" ]
+}
+
+@test "model_error: prompt is too long → model_error" {
+    run loop_failure_category "Error: prompt is too long (128000 tokens)" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "model_error" ]
+}
+
+# ── Category: tool_error ──────────────────────────────────────────────────────
+
+@test "tool_error: 'gh: ' prefix → tool_error" {
+    run loop_failure_category "gh: error: pull request not found" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "tool_error" ]
+}
+
+@test "tool_error: 'git: ' prefix → tool_error" {
+    run loop_failure_category "git: fatal: not a git repository" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "tool_error" ]
+}
+
+@test "tool_error: 'jq: ' prefix → tool_error" {
+    run loop_failure_category "jq: error: null has no field" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "tool_error" ]
+}
+
+@test "tool_error: command not found → tool_error" {
+    run loop_failure_category "bash: bats: command not found" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "tool_error" ]
+}
+
+@test "tool_error: non-zero exit with unknown text → tool_error" {
+    run loop_failure_category "some unrecognised error output" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "tool_error" ]
+}
+
+# ── Category: unknown ─────────────────────────────────────────────────────────
+
+@test "unknown: empty text with rc=0 → unknown" {
+    run loop_failure_category "" 0
+    [ "$status" -eq 0 ]
+    [ "$output" = "unknown" ]
+}
+
+@test "unknown: no matching text with rc=0 → unknown" {
+    run loop_failure_category "some benign output with exit 0" 0
+    [ "$status" -eq 0 ]
+    [ "$output" = "unknown" ]
+}
+
+# ── Priority: budget wins over network ────────────────────────────────────────
+
+@test "priority: budget before network — budget keyword wins" {
+    run loop_failure_category "daily.budget cap hit after HTTP 503" 1
+    [ "$status" -eq 0 ]
+    [ "$output" = "budget" ]
+}
+
+# ── Integration: handler failure path emits correct failure_reason ─────────────
+
+@test "integration: network stderr produces failure_reason=network in bounty_report call" {
+    local captured="$BATS_TMPDIR/bounty-capture.txt"
+    rm -f "$captured"
+
+    # Mock bounty_report to record args
+    bounty_report() {
+        printf '%s\n' "$@" > "$captured"
+    }
+    export -f bounty_report 2>/dev/null || true
+
+    local _stderr="Request failed: HTTP 503 Service Unavailable"
+    local _failure_reason
+    _failure_reason=$(loop_failure_category "$_stderr" 1)
+    bounty_report "dev_failed" role=dev project=test failure_reason="$_failure_reason"
+
+    grep -q "^failure_reason=network$" "$captured"
+}


### PR DESCRIPTION
Closes #291

## Changes

- **New `lib/failure_category.sh`**: exports `loop_failure_category <stderr_text> [exit_code]` which prints exactly one of `budget | network | git_conflict | model_error | tool_error | unknown`. Rules match the issue spec verbatim, evaluated top-to-bottom (first match wins).
- **Updated `lib/bounty.sh`**: added `failure_reason=` key-value parameter support; the value is emitted as a `failure_reason` field in the JSON event payload alongside the existing `detail` field.
- **Updated 5 handler scripts** (`dev-handler.sh`, `po-handler.sh`, `review-handler.sh`, `qa-handler.sh`, `merge-handler.sh`): each now sources `lib/failure_category.sh`, captures agent/command output around the failure path (using log-start tracking), calls `loop_failure_category` on the captured text, and passes `failure_reason=` to every `*_failed` `bounty_report` call.
- **New `tests/failure_category.bats`**: 29 tests — fixture per sub-category for all 6 categories, a priority test (budget beats network), and an integration test verifying the network stderr → `failure_reason=network` flow through `bounty_report`.

## Test Plan

- `bash -n` and `shellcheck -S warning` pass on all changed files (verified locally)
- `bats tests/failure_category.bats` — all 29 tests pass
- No pre-existing tests broken (failures in `tests/handlers.bats` tests 14/16/22 are pre-existing, confirmed by stash test)