### PR TITLE
[LOOP-300] fix custom agent missing cd to worktree in _loop_invoke_agent

### DIFF
--- a/lib/runner.sh
+++ b/lib/runner.sh
@@ -71,7 +71,7 @@ _loop_invoke_agent() {
             local _cmd="${cmd:-$LOOP_AGENT_CMD}"
             local -a _cmd_argv
             read -ra _cmd_argv <<< "$_cmd"
-            "${_cmd_argv[@]}" "$prompt"
+            (cd "$cwd" && "${_cmd_argv[@]}" "$prompt")
             ;;
         *)
             echo "ERROR: Unknown agent='$agent'. Use: claude, codex, gemini, aider, custom" >&2

--- a/tests/runner-fallback.bats
+++ b/tests/runner-fallback.bats
@@ -187,6 +187,33 @@ SH
     [ "$received" = "$injection_prompt" ]
 }
 
+@test "custom agent: working directory is the cwd argument, not the caller's directory" {
+    local fake_worktree
+    fake_worktree="$(mktemp -d)"
+    local pwd_capture="$BATS_TMPDIR/custom_pwd"
+
+    local custom_script="$BATS_TMPDIR/pwd-recorder.sh"
+    cat > "$custom_script" <<SH
+#!/usr/bin/env bash
+printf '%s' "\$PWD" > "$pwd_capture"
+exit 0
+SH
+    chmod +x "$custom_script"
+
+    export LOOP_AGENT="custom"
+    export LOOP_AGENT_CMD="$custom_script"
+    unset _PROJECT_FALLBACK
+
+    run loop_run_agent "do something" "$fake_worktree"
+    [ "$status" -eq 0 ]
+
+    local recorded_pwd
+    recorded_pwd="$(cat "$pwd_capture")"
+    [ "$recorded_pwd" = "$fake_worktree" ]
+
+    rm -rf "$fake_worktree"
+}
+
 @test "claude branch never passes --cwd flag (regression of LOOP-29 / LOOP-152)" {
     # Stub records full argv so we can assert no --cwd is passed.
     cat > "$STUB_DIR/claude" <<'STUB'


### PR DESCRIPTION
Closes #300

## Changes

- **`lib/runner.sh`**: Wrapped the `custom)` branch of `_loop_invoke_agent` in `(cd "$cwd" && ...)`, consistent with the `claude`, `codex`, `gemini`, and `aider` branches. Previously, custom agents were invoked from whatever directory the handler process happened to be running in, not the project's isolated git worktree.

- **`tests/runner-fallback.bats`**: Added a new test `"custom agent: working directory is the cwd argument, not the caller's directory"` that creates a temp worktree, runs a custom stub script that records `$PWD`, and asserts the recorded directory equals the `cwd` argument passed to `loop_run_agent`.

## Test Plan
- All 10 bats tests pass (`ok 1` through `ok 10`), including the new test (ok 9) and the existing custom-agent tests (ok 7, ok 8)
- `bash -n lib/runner.sh tests/runner-fallback.bats` passes
- `shellcheck -S warning lib/runner.sh` passes
- Full syntax check across all scripts passes