### PR TITLE
[LOOP-300] fix custom agent missing cd to cwd in _loop_invoke_agent

### DIFF
--- a/lib/runner.sh
+++ b/lib/runner.sh
@@ -71,7 +71,7 @@ _loop_invoke_agent() {
             local _cmd="${cmd:-$LOOP_AGENT_CMD}"
             local -a _cmd_argv
             read -ra _cmd_argv <<< "$_cmd"
-            "${_cmd_argv[@]}" "$prompt"
+            (cd "$cwd" && "${_cmd_argv[@]}" "$prompt")
             ;;
         *)
             echo "ERROR: Unknown agent='$agent'. Use: claude, codex, gemini, aider, custom" >&2

--- a/tests/runner-fallback.bats
+++ b/tests/runner-fallback.bats
@@ -187,6 +187,33 @@ SH
     [ "$received" = "$injection_prompt" ]
 }
 
+@test "custom agent: runs from the cwd argument, not the caller's directory" {
+    local fake_worktree
+    fake_worktree="$(mktemp -d)"
+    local pwd_file="$BATS_TMPDIR/recorded_pwd"
+
+    local custom_script="$BATS_TMPDIR/cwd-recorder.sh"
+    cat > "$custom_script" <<SH
+#!/usr/bin/env bash
+pwd > "$pwd_file"
+exit 0
+SH
+    chmod +x "$custom_script"
+
+    export LOOP_AGENT="custom"
+    export LOOP_AGENT_CMD="$custom_script"
+    unset _PROJECT_FALLBACK
+
+    run loop_run_agent "do something" "$fake_worktree"
+    [ "$status" -eq 0 ]
+
+    local recorded
+    recorded="$(cat "$pwd_file")"
+    [ "$recorded" = "$fake_worktree" ]
+
+    rm -rf "$fake_worktree"
+}
+
 @test "claude branch never passes --cwd flag (regression of LOOP-29 / LOOP-152)" {
     # Stub records full argv so we can assert no --cwd is passed.
     cat > "$STUB_DIR/claude" <<'STUB'


### PR DESCRIPTION
Closes #300

## Changes

- `lib/runner.sh`: Wrapped the `custom)` branch invocation in `(cd "$cwd" && ...)`, matching the pattern already used by `claude`, `codex`, `gemini`, and `aider` branches. Without this, the custom agent ran from whatever directory the handler process was in, not the project worktree.
- `tests/runner-fallback.bats`: Added test `"custom agent: runs from the cwd argument, not the caller's directory"` — creates a fake worktree with `mktemp -d`, runs `loop_run_agent` with a stub that records `$PWD`, and asserts the recorded path equals the `cwd` argument passed in.

## Test Plan

- All 10 bats tests in `tests/runner-fallback.bats` pass, including the new cwd assertion and the existing custom-agent tests (no regressions).
- `bash -n lib/runner.sh tests/runner-fallback.bats` passes.
- `shellcheck -S warning lib/runner.sh` passes.