### PR TITLE
reconciler: skip orphan-issue auto-label when an open PR closes the issue (closes #312)

### DIFF
--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -2307,12 +2307,22 @@ reconcile_orphan_issues() {
     issues_json=$(gh issue list --repo "$repo" --state open --limit 200 \
         --json number,title,labels,author 2>/dev/null || echo "[]")
 
+    # Pre-fetch open PR bodies once so we can skip issues that already have an
+    # open PR claiming to close them. Without this guard, dev-handler's
+    # post-PR cleanup (removes `needs-dev` from the issue) leaves the issue
+    # with no pipeline label → this function re-labels it `needs-po` → PO
+    # runs again → dev opens another PR → reconcile_duplicate_prs closes the
+    # older one → infinite po → dev → po loop (svv2014/loop#312).
+    local prs_json
+    prs_json=$(backend_list_open_prs_raw "$repo" 2>/dev/null || echo "[]")
+
     local orphans
-    orphans=$(ALLOWED="${ALLOWED_AUTHORS:-}" ISSUES="$issues_json" python3 - <<'PY'
-import json, os
+    orphans=$(ALLOWED="${ALLOWED_AUTHORS:-}" ISSUES="$issues_json" PRS="$prs_json" python3 - <<'PY'
+import json, os, re
 allowed_raw = os.environ.get('ALLOWED', '').strip()
 allowed = {a.strip() for a in allowed_raw.split(',') if a.strip()}
 issues = json.loads(os.environ.get('ISSUES') or '[]')
+prs = json.loads(os.environ.get('PRS') or '[]')
 
 TRIGGERS = {
     'needs-po', 'in-po', 'po-review',
@@ -2321,9 +2331,23 @@ TRIGGERS = {
 TERMINALS = {'needs-clarification', 'blocked', 'done'}
 SKIP_KIND = {'epic', 'tracker'}
 
+# Build the set of issue numbers that have at least one open PR closing them.
+_LINK_RE = re.compile(r'(?:clos(?:e|es|ed)|fix(?:|es|ed)|resolv(?:e|es|ed))\s+#(\d+)', re.I)
+linked = set()
+for pr in prs:
+    for n in _LINK_RE.findall(pr.get('body') or ''):
+        try:
+            linked.add(int(n))
+        except (TypeError, ValueError):
+            pass
+
 for it in issues:
     num = it.get('number')
     if num is None:
+        continue
+    if num in linked:
+        # An open PR already references this issue — pipeline is in flight,
+        # not orphaned. Skip.
         continue
     labels = {
         (l.get('name') if isinstance(l, dict) else l)

--- a/tests/reconciler-orphan-issues.bats
+++ b/tests/reconciler-orphan-issues.bats
@@ -42,9 +42,10 @@ GHEOF
     chmod +x "$BATS_TMPDIR/bin/gh"
     export PATH="$BATS_TMPDIR/bin:$PATH"
 
-    backend_add_label() { echo "add_label $2 $3" >> "$OPS_LOG"; }
-    _loop_emit_event()  { echo "emit_event $1" >> "$OPS_LOG"; }
-    log()               { :; }
+    backend_add_label()         { echo "add_label $2 $3" >> "$OPS_LOG"; }
+    backend_list_open_prs_raw() { printf '%s\n' "${MOCK_PRS_JSON:-[]}"; }
+    _loop_emit_event()          { echo "emit_event $1" >> "$OPS_LOG"; }
+    log()                       { :; }
 }
 
 teardown() {
@@ -161,4 +162,69 @@ teardown() {
     [ "$status" -eq 0 ]
 
     [ ! -f "$OPS_LOG" ] || [ ! -s "$OPS_LOG" ] || ! grep -qE "add_label 77" "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Regression for svv2014/loop#312: issues with an open PR closing them are not
+# orphans — re-labeling them needs-po triggers an infinite po → dev → po loop.
+# ---------------------------------------------------------------------------
+
+@test "reconcile_orphan_issues: issue with open PR closing it is skipped" {
+    export MOCK_ISSUES_JSON='[{
+        "number": 126,
+        "title": "Has an open PR linked to it",
+        "labels": [{"name": "p1-high"}, {"name": "bug"}],
+        "author": {"login": "alice"}
+    }]'
+    export MOCK_PRS_JSON='[{
+        "number": 200,
+        "body": "Closes #126\n\nFixes the leak.",
+        "createdAt": "2026-05-11T10:00:00Z",
+        "title": "[LM-126] fix"
+    }]'
+
+    run reconcile_orphan_issues "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    [ ! -f "$OPS_LOG" ] || [ ! -s "$OPS_LOG" ] || ! grep -qE "add_label 126" "$OPS_LOG"
+}
+
+@test "reconcile_orphan_issues: PR body uses Fixes #N instead of Closes — still skipped" {
+    export MOCK_ISSUES_JSON='[{
+        "number": 50,
+        "title": "Has an open PR via Fixes",
+        "labels": [{"name": "p2-medium"}],
+        "author": {"login": "alice"}
+    }]'
+    export MOCK_PRS_JSON='[{
+        "number": 201,
+        "body": "Fixes #50",
+        "createdAt": "2026-05-11T10:00:00Z",
+        "title": "[fix]"
+    }]'
+
+    run reconcile_orphan_issues "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    [ ! -f "$OPS_LOG" ] || [ ! -s "$OPS_LOG" ] || ! grep -qE "add_label 50" "$OPS_LOG"
+}
+
+@test "reconcile_orphan_issues: issue NOT referenced by any open PR is still labeled" {
+    export MOCK_ISSUES_JSON='[{
+        "number": 99,
+        "title": "No PR for this one",
+        "labels": [{"name": "p1-high"}],
+        "author": {"login": "alice"}
+    }]'
+    export MOCK_PRS_JSON='[{
+        "number": 202,
+        "body": "Closes #1000",
+        "createdAt": "2026-05-11T10:00:00Z",
+        "title": "unrelated PR"
+    }]'
+
+    run reconcile_orphan_issues "$REPO" "$SLUG"
+    [ "$status" -eq 0 ]
+
+    grep -q "add_label 99 needs-po" "$OPS_LOG"
 }


### PR DESCRIPTION
Fixes #312. Stops the infinite `po → dev → po` loop that has been burning agent compute on ~10 issues for hours.

## Mechanism (verbatim from #312)

1. dev-handler opens PR → strips `needs-dev` from issue.
2. Issue now has only orthogonal labels.
3. `reconcile_orphan_issues` sees no trigger → adds `needs-po`.
4. po-handler re-labels `needs-dev`.
5. dev-handler opens **another** PR (didn't check for existing one).
6. `reconcile_duplicate_prs` closes the older PR.
7. Cycle repeats every ~60 min.

## Fix

`scanner/reconciler.sh::reconcile_orphan_issues` now pre-fetches open PRs and skips any issue referenced via `Closes/Fixes/Resolves #N` in a PR body — an issue with an open PR is in flight, not orphaned.

Single `backend_list_open_prs_raw` call added per repo scan — negligible cost.

## Evidence

Production thrashers caught by this bug (po_start events vs. expected = 1):
- `loop-monitor#126`: 13+ cycles
- `loop#291`: 9+ cycles (now active)
- `boba-orchestrator#27`: 7+ cycles (now active)
- Historical: `ppl#422` (33), `ntc#180-184` (26-27 each), `ppl#417` (26), `pa-scanner#47-50` (20-22 each)

11 affected issues have been temporarily `blocked` while this PR is in flight.

## Tests

`tests/reconciler-orphan-issues.bats`: 3 new regression tests.
- issue with `Closes #N` open PR is skipped
- issue with `Fixes #N` open PR is skipped
- issue with unrelated open PR is still labeled (negative control)

All 10 tests pass.

## Defense-in-depth (not in this PR)

- dev-handler should check for an existing PR before `gh pr create` — separate ticket worth filing.
- When dev-handler strips `needs-dev` from the issue, it could add `in-dev` for positive signal — also separate.

The orphan-issues fix alone breaks the loop deterministically; the two above harden it further but aren't required to stop the bleeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)