### PR TITLE
[LOOP-300] fix custom agent not cd-ing to cwd in _loop_invoke_agent

### DIFF
--- a/lib/runner.sh
+++ b/lib/runner.sh
@@ -71,7 +71,7 @@ _loop_invoke_agent() {
             local _cmd="${cmd:-$LOOP_AGENT_CMD}"
             local -a _cmd_argv
             read -ra _cmd_argv <<< "$_cmd"
-            "${_cmd_argv[@]}" "$prompt"
+            (cd "$cwd" && "${_cmd_argv[@]}" "$prompt")
             ;;
         *)
             echo "ERROR: Unknown agent='$agent'. Use: claude, codex, gemini, aider, custom" >&2

--- a/tests/runner-fallback.bats
+++ b/tests/runner-fallback.bats
@@ -187,6 +187,32 @@ SH
     [ "$received" = "$injection_prompt" ]
 }
 
+@test "custom agent: invoked inside the cwd passed to loop_run_agent" {
+    local fake_worktree
+    fake_worktree="$(mktemp -d)"
+    local pwd_file="$BATS_TMPDIR/custom_pwd"
+    local custom_script="$BATS_TMPDIR/pwd-recorder.sh"
+    cat > "$custom_script" <<SH
+#!/usr/bin/env bash
+pwd > "$pwd_file"
+exit 0
+SH
+    chmod +x "$custom_script"
+
+    export LOOP_AGENT="custom"
+    export LOOP_AGENT_CMD="$custom_script"
+    unset _PROJECT_FALLBACK
+
+    run loop_run_agent "do something" "$fake_worktree"
+    [ "$status" -eq 0 ]
+
+    local recorded
+    recorded="$(cat "$pwd_file")"
+    [ "$recorded" = "$fake_worktree" ]
+
+    rm -rf "$fake_worktree"
+}
+
 @test "claude branch never passes --cwd flag (regression of LOOP-29 / LOOP-152)" {
     # Stub records full argv so we can assert no --cwd is passed.
     cat > "$STUB_DIR/claude" <<'STUB'


### PR DESCRIPTION
Closes #300

## Changes

- **`lib/runner.sh`**: Wrapped the `custom)` branch invocation in `(cd "$cwd" && ...)`, consistent with the `claude`, `codex`, `gemini`, and `aider` branches. Previously, any operator using `LOOP_AGENT=custom` or a custom fallback entry would have their agent script run in the wrong directory.
- **`tests/runner-fallback.bats`**: Added test `"custom agent: invoked inside the cwd passed to loop_run_agent"` — a stub script records `$PWD` to a temp file; the test asserts the recorded path equals the `cwd` argument passed to `loop_run_agent`.

## Test Plan

- All 10 bats tests in `tests/runner-fallback.bats` pass, including the new cwd assertion test and the existing custom-agent fallback/injection tests.
- `bash -n lib/runner.sh` passes.
- `shellcheck -S warning lib/runner.sh` passes.