### PR TITLE
[LOOP-300] fix custom agent cd to working directory in _loop_invoke_agent

### DIFF
--- a/lib/runner.sh
+++ b/lib/runner.sh
@@ -71,7 +71,7 @@ _loop_invoke_agent() {
             local _cmd="${cmd:-$LOOP_AGENT_CMD}"
             local -a _cmd_argv
             read -ra _cmd_argv <<< "$_cmd"
-            "${_cmd_argv[@]}" "$prompt"
+            (cd "$cwd" && "${_cmd_argv[@]}" "$prompt")
             ;;
         *)
             echo "ERROR: Unknown agent='$agent'. Use: claude, codex, gemini, aider, custom" >&2

--- a/tests/runner-fallback.bats
+++ b/tests/runner-fallback.bats
@@ -187,6 +187,33 @@ SH
     [ "$received" = "$injection_prompt" ]
 }
 
+@test "custom agent: invoked inside the cwd argument (not caller's working directory)" {
+    local fake_worktree
+    fake_worktree="$(mktemp -d)"
+
+    local custom_script="$BATS_TMPDIR/pwd-recorder.sh"
+    local pwd_file="$BATS_TMPDIR/recorded_pwd"
+    cat > "$custom_script" <<SH
+#!/usr/bin/env bash
+printf '%s' "\$PWD" > "$pwd_file"
+exit 0
+SH
+    chmod +x "$custom_script"
+
+    export LOOP_AGENT="custom"
+    export LOOP_AGENT_CMD="$custom_script"
+    unset _PROJECT_FALLBACK
+
+    run loop_run_agent "do something" "$fake_worktree"
+    [ "$status" -eq 0 ]
+
+    local recorded
+    recorded="$(cat "$pwd_file")"
+    [ "$recorded" = "$fake_worktree" ]
+
+    rm -rf "$fake_worktree"
+}
+
 @test "claude branch never passes --cwd flag (regression of LOOP-29 / LOOP-152)" {
     # Stub records full argv so we can assert no --cwd is passed.
     cat > "$STUB_DIR/claude" <<'STUB'


### PR DESCRIPTION
Closes #300

## Changes

**`lib/runner.sh`** — wrapped the `custom)` branch invocation in `(cd "$cwd" && ...)`, consistent with every other agent branch (`claude`, `codex`, `gemini`, `aider`). Without this, a custom agent ran in the caller's working directory instead of the project's isolated git worktree.

**`tests/runner-fallback.bats`** — added test *"custom agent: invoked inside the cwd argument (not caller's working directory)"*: creates a temp worktree via `mktemp -d`, runs a custom stub that writes `\$PWD` to a file, and asserts the recorded directory equals the `cwd` argument passed to `loop_run_agent`.

## Test Plan
- All 10 bats tests in `tests/runner-fallback.bats` pass, including the new cwd test and no regressions in the existing custom-agent tests.
- `bash -n lib/runner.sh` passes.
- `shellcheck -S warning lib/runner.sh` passes.