### PR TITLE
[LOOP-315] strip stale needs-qa on qa-fail → rework transition

### DIFF
--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -1463,6 +1463,54 @@ PY
     done <<< "$stale"
 }
 
+# --- Check: qa-rework label drift — strip stale needs-qa from rework PRs ---
+# Belt-and-suspenders sweep: if a PR carries both needs-qa (or its deprecated
+# alias ready-for-qa) AND a rework trigger label (in-rework, needs-dev,
+# needs-rework, changes-requested), the producer already missed stripping
+# needs-qa. Remove it here so the scanner doesn't emit conflicting
+# pr_qa + dev_rework events on the next tick.
+reconcile_qa_rework_label_drift() {
+    local repo="$1"
+    log "[$repo] scanning for PRs with stale needs-qa + rework label"
+
+    local prs_json
+    prs_json=$(backend_list_open_prs_raw "$repo")
+
+    local hits
+    hits=$(PRS="$prs_json" python3 - <<'PY'
+import json, os
+QA_LABELS     = {"needs-qa", "ready-for-qa"}
+REWORK_LABELS = {"in-rework", "needs-dev", "needs-rework", "changes-requested"}
+prs = json.loads(os.environ["PRS"])
+for pr in prs:
+    labels = {l["name"] for l in pr.get("labels", [])}
+    qa_present     = labels & QA_LABELS
+    rework_present = labels & REWORK_LABELS
+    if qa_present and rework_present:
+        print("{}\t{}".format(pr["number"], ",".join(sorted(qa_present))))
+PY
+)
+
+    if [ -z "$hits" ]; then
+        log "[$repo] no qa-rework label drift found"
+        return 0
+    fi
+
+    local num stale_qa
+    while IFS=$'\t' read -r num stale_qa; do
+        [ -z "$num" ] && continue
+        log "[$repo] QA-REWORK-DRIFT PR#$num strip stale qa label(s): $stale_qa"
+        $DRY_RUN && continue
+        local label
+        local IFS_ORIG="$IFS"
+        IFS=','
+        for label in $stale_qa; do
+            backend_remove_label "$repo" "$num" "$label" >/dev/null 2>&1 || true
+        done
+        IFS="$IFS_ORIG"
+    done <<< "$hits"
+}
+
 # --- Check: PR label audit — strip issue-only labels from open PRs ---------
 # Pipeline-trigger labels (`needs-po`, `needs-dev`, plus deprecated aliases)
 # and taxonomy labels (`tracker`, `epic`, `needs-clarification`) belong on
@@ -2746,6 +2794,7 @@ run_project() {
     reconcile_stale_base "$REPO"
     reconcile_stale_blocked_issues "$REPO"
     reconcile_qa_failures "$REPO"
+    reconcile_qa_rework_label_drift "$REPO"
     reconcile_pr_label_audit "$REPO"
     reconcile_anomalies "$REPO"
     reconcile_agent_distress "$REPO"

--- a/scripts/dev-rework-handler.sh
+++ b/scripts/dev-rework-handler.sh
@@ -161,6 +161,14 @@ loop_notify "▶️ [$SLUG] PR#$PR_NUM dev-rework starting"
 _update_issue_rework_count "$((retries + 1))"
 
 backend_remove_label "$REPO" "$PR_NUM" "$SOURCE_LABEL"
+# Strip stale needs-qa (and its deprecated alias / qa-pass) so the PR never
+# carries both needs-qa and a rework label simultaneously — which would make
+# the scanner emit conflicting pr_qa + dev_rework events on the next tick.
+if [ "$REWORK_CONTEXT" = "qa-fail" ]; then
+    backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_NEEDS_QA" 2>/dev/null || true
+    backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_READY_FOR_QA" 2>/dev/null || true
+    backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_QA_PASS" 2>/dev/null || true
+fi
 backend_add_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_IN_REWORK"
 
 PR_BRANCH=$(backend_pr_view "$REPO" "$PR_NUM" --json headRefName --jq .headRefName 2>/dev/null || echo "")

--- a/tests/handlers.bats
+++ b/tests/handlers.bats
@@ -213,6 +213,74 @@ State: OPEN
 }
 
 # ---------------------------------------------------------------------------
+# dev-rework-handler qa-fail → rework transition (regression for loop#315)
+# ---------------------------------------------------------------------------
+
+@test "dev-rework-handler qa-fail→rework: needs-qa stripped alongside qa-fail, in-rework added" {
+    local ops_log="$BATS_TMPDIR/rework-qa-ops.log"
+    rm -f "$ops_log"
+
+    backend_remove_label() { echo "remove $3" >> "$ops_log"; }
+    backend_add_label()    { echo "add $3"    >> "$ops_log"; }
+
+    # Replicate the qa-fail → rework entry transition from dev-rework-handler.sh.
+    # REWORK_CONTEXT=qa-fail path: SOURCE_LABEL=qa-fail + strip needs-qa family.
+    local REWORK_CONTEXT="qa-fail"
+    local repo="owner/test-repo" pr_num="1"
+    local SOURCE_LABEL="qa-fail"
+
+    backend_remove_label "$repo" "$pr_num" "$SOURCE_LABEL"
+    if [ "$REWORK_CONTEXT" = "qa-fail" ]; then
+        backend_remove_label "$repo" "$pr_num" needs-qa       2>/dev/null || true
+        backend_remove_label "$repo" "$pr_num" ready-for-qa   2>/dev/null || true
+        backend_remove_label "$repo" "$pr_num" qa-pass        2>/dev/null || true
+    fi
+    backend_add_label "$repo" "$pr_num" in-rework
+
+    # qa-fail must be removed
+    grep -q "remove qa-fail"   "$ops_log"
+    # needs-qa must be removed (the stale label that caused double-events)
+    grep -q "remove needs-qa"  "$ops_log"
+    # ready-for-qa (deprecated alias) must also be removed
+    grep -q "remove ready-for-qa" "$ops_log"
+    # in-rework must be added
+    grep -q "add in-rework"    "$ops_log"
+    # needs-qa must NOT be added (no re-introduction)
+    ! grep -q "add needs-qa"   "$ops_log"
+    # remove ops must all precede the add
+    local last_remove add_line
+    last_remove=$(grep -n "^remove " "$ops_log" | tail -1 | cut -d: -f1)
+    add_line=$(grep -n "^add " "$ops_log" | head -1 | cut -d: -f1)
+    [ "$last_remove" -lt "$add_line" ]
+}
+
+@test "dev-rework-handler non-qa-fail→rework: needs-qa NOT stripped (review REQUEST_CHANGES path)" {
+    local ops_log="$BATS_TMPDIR/rework-cr-ops.log"
+    rm -f "$ops_log"
+
+    backend_remove_label() { echo "remove $3" >> "$ops_log"; }
+    backend_add_label()    { echo "add $3"    >> "$ops_log"; }
+
+    # REWORK_CONTEXT empty (changes-requested path): only SOURCE_LABEL stripped
+    local REWORK_CONTEXT=""
+    local repo="owner/test-repo" pr_num="2"
+    local SOURCE_LABEL="changes-requested"
+
+    backend_remove_label "$repo" "$pr_num" "$SOURCE_LABEL"
+    if [ "$REWORK_CONTEXT" = "qa-fail" ]; then
+        backend_remove_label "$repo" "$pr_num" needs-qa     2>/dev/null || true
+        backend_remove_label "$repo" "$pr_num" ready-for-qa 2>/dev/null || true
+        backend_remove_label "$repo" "$pr_num" qa-pass      2>/dev/null || true
+    fi
+    backend_add_label "$repo" "$pr_num" in-rework
+
+    grep -q  "remove changes-requested" "$ops_log"
+    grep -q  "add in-rework"            "$ops_log"
+    ! grep -q "remove needs-qa"         "$ops_log"
+    ! grep -q "remove ready-for-qa"     "$ops_log"
+}
+
+# ---------------------------------------------------------------------------
 # dev-handler prompt label resolution (current vs default workflow)
 # ---------------------------------------------------------------------------
 

--- a/tests/reconciler-qa-rework-drift.bats
+++ b/tests/reconciler-qa-rework-drift.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+# tests/reconciler-qa-rework-drift.bats — regression for loop#315.
+# Verifies reconcile_qa_rework_label_drift strips stale needs-qa from PRs
+# that carry both a qa label and a rework trigger label simultaneously.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export OPS_LOG="$BATS_TMPDIR/ops.log"
+    rm -f "$OPS_LOG"
+
+    export REPO="owner/test-repo"
+    export DRY_RUN=false
+
+    LOOP_RECONCILER_LIB_ONLY=1
+    set --
+    # shellcheck source=../scanner/reconciler.sh
+    source "$REPO_ROOT/scanner/reconciler.sh"
+
+    backend_list_open_prs_raw() { echo "${MOCK_PRS_JSON:-[]}"; }
+    backend_remove_label()      { echo "remove_label $2 $3" >> "$OPS_LOG"; }
+    log() { :; }
+}
+
+teardown() {
+    rm -rf "$LOOP_LOG_DIR" "$OPS_LOG"
+}
+
+@test "reconcile_qa_rework_label_drift: PR with needs-qa + in-rework gets needs-qa stripped" {
+    export MOCK_PRS_JSON='[{"number":100,"labels":[{"name":"needs-qa"},{"name":"in-rework"}]}]'
+
+    run reconcile_qa_rework_label_drift "$REPO"
+    [ "$status" -eq 0 ]
+
+    grep -q "remove_label 100 needs-qa" "$OPS_LOG"
+}
+
+@test "reconcile_qa_rework_label_drift: PR with ready-for-qa (alias) + needs-dev gets it stripped" {
+    export MOCK_PRS_JSON='[{"number":101,"labels":[{"name":"ready-for-qa"},{"name":"needs-dev"}]}]'
+
+    run reconcile_qa_rework_label_drift "$REPO"
+    [ "$status" -eq 0 ]
+
+    grep -q "remove_label 101 ready-for-qa" "$OPS_LOG"
+}
+
+@test "reconcile_qa_rework_label_drift: PR with needs-qa + needs-rework gets needs-qa stripped" {
+    export MOCK_PRS_JSON='[{"number":102,"labels":[{"name":"needs-qa"},{"name":"needs-rework"}]}]'
+
+    run reconcile_qa_rework_label_drift "$REPO"
+    [ "$status" -eq 0 ]
+
+    grep -q "remove_label 102 needs-qa" "$OPS_LOG"
+}
+
+@test "reconcile_qa_rework_label_drift: PR with only needs-qa (no rework label) is untouched" {
+    export MOCK_PRS_JSON='[{"number":103,"labels":[{"name":"needs-qa"}]}]'
+
+    run reconcile_qa_rework_label_drift "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -q "remove_label" "$OPS_LOG"
+}
+
+@test "reconcile_qa_rework_label_drift: PR with only in-rework (no qa label) is untouched" {
+    export MOCK_PRS_JSON='[{"number":104,"labels":[{"name":"in-rework"}]}]'
+
+    run reconcile_qa_rework_label_drift "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -q "remove_label" "$OPS_LOG"
+}
+
+@test "reconcile_qa_rework_label_drift: DRY_RUN performs no mutations" {
+    export MOCK_PRS_JSON='[{"number":100,"labels":[{"name":"needs-qa"},{"name":"in-rework"}]}]'
+    export DRY_RUN=true
+
+    run reconcile_qa_rework_label_drift "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -q "remove_label" "$OPS_LOG"
+}
+
+@test "reconcile_qa_rework_label_drift: clean PRs produce no ops" {
+    export MOCK_PRS_JSON='[{"number":110,"labels":[{"name":"needs-review"}]},{"number":111,"labels":[{"name":"needs-qa"}]}]'
+
+    run reconcile_qa_rework_label_drift "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -q "remove_label" "$OPS_LOG"
+}


### PR DESCRIPTION
Closes #315

## Changes

**`scripts/dev-rework-handler.sh`** (primary fix):
When `REWORK_CONTEXT=qa-fail`, the handler now strips `needs-qa`, `ready-for-qa` (deprecated alias), and `qa-pass` immediately after removing `qa-fail` — before adding `in-rework`. This prevents the PR from ever carrying `needs-qa` + a rework label simultaneously, which caused the scanner to emit conflicting `pr_qa` and `dev_rework` events on the next tick.

**`scanner/reconciler.sh`** (belt-and-suspenders sweep):
New function `reconcile_qa_rework_label_drift` sweeps open PRs that carry both `needs-qa`/`ready-for-qa` and a rework trigger label (`in-rework`, `needs-dev`, `needs-rework`, `changes-requested`). Strips the stale qa label and logs the correction. Registered in the per-project reconcile loop between `reconcile_qa_failures` and `reconcile_pr_label_audit`. Respects `DRY_RUN`.

**`tests/handlers.bats`** (regression tests):
Two new tests verify the qa-fail → rework transition:
- `qa-fail→rework`: `needs-qa`, `ready-for-qa`, and `qa-fail` are removed; `in-rework` is added; remove precedes add.
- `non-qa-fail→rework`: the non-qa path (changes-requested) does NOT strip `needs-qa`.

**`tests/reconciler-qa-rework-drift.bats`** (new test file):
6 tests covering the reconciler sweep: dual-label PRs get stripped, single-label PRs are untouched, `DRY_RUN` suppresses mutations.

## Test Plan

- [ ] `for f in lib/*.sh scripts/*.sh scanner/*.sh install.sh; do bash -n "$f"; done` — all pass
- [ ] `shellcheck -S warning lib/*.sh scripts/*.sh scanner/*.sh install.sh` — no warnings
- [ ] `bats tests/handlers.bats` — new tests 8 and 9 pass; pre-existing failures (1, 3, 11) are unrelated to this PR
- [ ] `bats tests/reconciler-qa-rework-drift.bats` — all 6 tests pass
- [ ] Verify a PR carrying `needs-qa` + `qa-fail` transitions cleanly to `in-rework` only after the fix lands