### PR TITLE
[LOOP-317] make qa-handler diff-aware: ignore pre-existing baseline failures

### DIFF
--- a/lib/qa-baseline.sh
+++ b/lib/qa-baseline.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# lib/qa-baseline.sh — diff-aware QA baseline helpers.
+#
+# Functions exposed:
+#   qa_baseline_resolve_sha  <repo> <default_branch>
+#   qa_baseline_cache_path   <slug> <sha>
+#   qa_baseline_run_or_load  <slug> <sha> <root> <default_branch> <validation_cmd>
+#   qa_baseline_diff         <baseline_tap_file> <pr_tap_file>
+#   qa_baseline_parse_failing <tap_file>
+#
+# Escape hatch: callers must check LOOP_QA_DIFF_AWARE != "0" before sourcing any
+# of the above; this file does not enforce it so unit tests can call freely.
+
+LOOP_CACHE_DIR="${LOOP_CACHE_DIR:-${HOME}/.loop/cache}"
+
+# qa_baseline_resolve_sha <repo> <default_branch>
+# Prints the current commit SHA of <default_branch> on the remote.
+# Uses gh API; returns non-zero on failure.
+qa_baseline_resolve_sha() {
+    local repo="$1"
+    local default_branch="${2:-main}"
+    gh api "repos/${repo}/commits/${default_branch}" --jq '.sha' 2>/dev/null
+}
+
+# qa_baseline_cache_path <slug> <sha>
+# Prints the absolute path of the TAP cache file for this slug+sha combination.
+qa_baseline_cache_path() {
+    local slug="$1"
+    local sha="$2"
+    echo "${LOOP_CACHE_DIR}/qa-baseline-${slug}-${sha}.tap"
+}
+
+# qa_baseline_run_or_load <slug> <sha> <root> <default_branch> <validation_cmd>
+# If a cache file for slug+sha already exists, prints its path and returns 0.
+# Otherwise: creates a detached git worktree at <sha> inside <root>'s repo,
+# runs <validation_cmd> there, writes TAP output to the cache file, removes
+# the worktree, and prints the cache path.
+# Returns non-zero (and prints nothing) when the worktree cannot be created.
+qa_baseline_run_or_load() {
+    local slug="$1"
+    local sha="$2"
+    local root="$3"
+    local default_branch="${4:-main}"
+    local validation_cmd="$5"
+
+    mkdir -p "$LOOP_CACHE_DIR"
+    local cache_file
+    cache_file=$(qa_baseline_cache_path "$slug" "$sha")
+
+    if [ -f "$cache_file" ]; then
+        echo "$cache_file"
+        return 0
+    fi
+
+    local tmp_worktree
+    tmp_worktree=$(mktemp -d "/tmp/loop-qa-baseline-XXXXXX")
+
+    # Ensure cleanup even on unexpected exits.
+    local _wt_cleanup_root="$root"
+    local _wt_cleanup_dir="$tmp_worktree"
+    trap 'git -C "$_wt_cleanup_root" worktree remove --force "$_wt_cleanup_dir" 2>/dev/null || rm -rf "$_wt_cleanup_dir"' EXIT
+
+    if ! git -C "$root" worktree add --detach "$tmp_worktree" "$sha" 2>/dev/null; then
+        rm -rf "$tmp_worktree" 2>/dev/null || true
+        trap - EXIT
+        return 1
+    fi
+
+    # Capture TAP output; a non-zero exit from the test runner is normal when
+    # tests fail — we want the output regardless.
+    local tap_output
+    tap_output=$(cd "$tmp_worktree" && eval "$validation_cmd" 2>&1) || true
+
+    printf '%s\n' "$tap_output" > "$cache_file"
+
+    git -C "$root" worktree remove --force "$tmp_worktree" 2>/dev/null || rm -rf "$tmp_worktree"
+    trap - EXIT
+
+    echo "$cache_file"
+}
+
+# qa_baseline_parse_failing <tap_file>
+# Reads a TAP file and prints each failing test name (one per line).
+# Strips trailing TODO/SKIP annotations from the name.
+# Prints nothing and returns 0 for an empty or non-TAP file (treated as no failures).
+qa_baseline_parse_failing() {
+    local tap_file="$1"
+    [ -f "$tap_file" ] || return 0
+
+    python3 - "$tap_file" <<'PY'
+import sys, re
+
+with open(sys.argv[1]) as f:
+    for line in f:
+        line = line.rstrip()
+        # Strip TODO/SKIP annotations before matching
+        line = re.sub(r'\s*#\s*(TODO|SKIP)\b.*$', '', line, flags=re.IGNORECASE)
+        m = re.match(r'^not ok\s+\d+\s*-?\s*(.*)', line)
+        if m:
+            name = m.group(1).strip()
+            if name:
+                print(name)
+PY
+}
+
+# qa_baseline_diff <baseline_tap_file> <pr_tap_file>
+# Pure function (no side effects beyond reading the two files).
+# Prints one classified line per test to stdout:
+#   NEW_FAILURE:<name>    — fails in PR but not in baseline
+#   PRE_EXISTING:<name>   — fails in both
+#   FIXED:<name>          — fails in baseline but passes in PR
+# Exit codes:
+#   0  no new failures found
+#   1  one or more new failures found
+#   2  one or both files are not valid TAP (caller should fall back)
+qa_baseline_diff() {
+    local baseline_tap="$1"
+    local pr_tap="$2"
+
+    python3 - "$baseline_tap" "$pr_tap" <<'PY'
+import sys, re
+
+def parse_tap(path):
+    """Return (failing_set, is_valid_tap) from a TAP file."""
+    try:
+        with open(path) as f:
+            lines = f.readlines()
+    except OSError:
+        return set(), False
+
+    failing = set()
+    found_tap = False
+    for line in lines:
+        line = line.rstrip()
+        line = re.sub(r'\s*#\s*(TODO|SKIP)\b.*$', '', line, flags=re.IGNORECASE)
+        m = re.match(r'^(not ok|ok)\s+\d+\s*-?\s*(.*)', line)
+        if m:
+            found_tap = True
+            status, name = m.group(1), m.group(2).strip()
+            if status == 'not ok' and name:
+                failing.add(name)
+    return failing, found_tap
+
+b_failing, b_valid = parse_tap(sys.argv[1])
+p_failing, p_valid = parse_tap(sys.argv[2])
+
+if not b_valid or not p_valid:
+    sys.exit(2)
+
+new_failures  = p_failing - b_failing
+pre_existing  = p_failing & b_failing
+fixed         = b_failing  - p_failing
+
+for name in sorted(new_failures):
+    print(f'NEW_FAILURE:{name}')
+for name in sorted(pre_existing):
+    print(f'PRE_EXISTING:{name}')
+for name in sorted(fixed):
+    print(f'FIXED:{name}')
+
+sys.exit(1 if new_failures else 0)
+PY
+}

--- a/scripts/qa-handler.sh
+++ b/scripts/qa-handler.sh
@@ -29,6 +29,8 @@ source "$LOOP_ROOT/lib/notify.sh"
 source "$LOOP_ROOT/lib/cli-hint.sh"
 # shellcheck source=../lib/failure_category.sh
 source "$LOOP_ROOT/lib/failure_category.sh"
+# shellcheck source=../lib/qa-baseline.sh
+source "$LOOP_ROOT/lib/qa-baseline.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-qa-handler.log"
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [qa-handler] $*" | tee -a "$LOG_FILE"; }
@@ -89,6 +91,63 @@ loop_notify "▶️ [$SLUG] PR#$PR_NUM qa starting"
 
 _BACKEND_CLI_NOTE=$(backend_cli_note)
 _VALIDATION_CMD="${QA_VALIDATION_CMD:-}"
+
+# --- Diff-aware baseline (Option B) ---
+# Compute or load a cached TAP baseline from origin/<DEFAULT_BRANCH>.
+# Produces a list of pre-existing failures that should not trigger qa-fail.
+# Skipped when: LOOP_QA_DIFF_AWARE=0, no validation_cmd, or baseline run fails.
+_BASELINE_PRE_EXISTING=""
+_BASELINE_FALLBACK_NOTE=""
+_BASELINE_DIFF_AWARE="${LOOP_QA_DIFF_AWARE:-1}"
+
+if [ "$_BASELINE_DIFF_AWARE" != "0" ] && [ -n "$_VALIDATION_CMD" ]; then
+    log "qa-baseline: resolving baseline SHA for $REPO ($DEFAULT_BRANCH)"
+    _BASELINE_SHA=$(qa_baseline_resolve_sha "$REPO" "$DEFAULT_BRANCH" 2>/dev/null || true)
+
+    if [ -n "$_BASELINE_SHA" ]; then
+        log "qa-baseline: baseline SHA=${_BASELINE_SHA:0:12}"
+        _BASELINE_CACHE=$(qa_baseline_run_or_load \
+            "$SLUG" "$_BASELINE_SHA" "$ROOT" "$DEFAULT_BRANCH" "$_VALIDATION_CMD" 2>/dev/null || true)
+
+        if [ -n "$_BASELINE_CACHE" ] && [ -f "$_BASELINE_CACHE" ]; then
+            _BASELINE_PRE_EXISTING=$(qa_baseline_parse_failing "$_BASELINE_CACHE" 2>/dev/null || true)
+            log "qa-baseline: cache=${_BASELINE_CACHE} pre-existing=$(echo "$_BASELINE_PRE_EXISTING" | grep -c . || echo 0)"
+        else
+            log "qa-baseline: WARN — could not produce baseline; falling back to strict mode"
+            _BASELINE_FALLBACK_NOTE="⚠️ Baseline run failed — falling back to strict pass/fail (all failures count)."
+        fi
+    else
+        log "qa-baseline: WARN — could not resolve baseline SHA; falling back to strict mode"
+        _BASELINE_FALLBACK_NOTE="⚠️ Could not resolve baseline SHA — falling back to strict pass/fail (all failures count)."
+    fi
+fi
+
+# Build Phase 4 instructions (diff-aware vs strict).
+_PHASE4_INSTRUCTIONS=$(
+if [ -z "$_VALIDATION_CMD" ]; then
+    printf '   (no validation_cmd configured for this project — Phase 4 skipped)'
+elif [ -n "$_BASELINE_FALLBACK_NOTE" ]; then
+    printf '%s\n\nRun the validation command:\n   cd %s && %s\n\nIf validation_cmd fails → verdict is qa-fail (cite the failure output).' \
+        "$_BASELINE_FALLBACK_NOTE" "${ROOT}" "$_VALIDATION_CMD"
+elif [ "$_BASELINE_DIFF_AWARE" = "0" ] || { [ -z "$_BASELINE_PRE_EXISTING" ] && [ -z "$_BASELINE_SHA" ]; }; then
+    printf 'Run the validation command:\n   cd %s && %s\n\nIf validation_cmd fails → verdict is qa-fail (cite the failure output).' \
+        "${ROOT}" "$_VALIDATION_CMD"
+else
+    # Build the pre-existing failures list for the prompt.
+    _PE_LIST=$([ -n "$_BASELINE_PRE_EXISTING" ] && printf '%s' "$_BASELINE_PRE_EXISTING" | sed 's/^/  - /' || echo '  (none)')
+    printf 'Run the validation command with TAP output:\n   cd %s && %s\n\nThe following tests were already failing on origin/%s (baseline SHA %s).\nThey are PRE-EXISTING — do NOT count them as failures in your verdict:\n%s\n\nClassify each "not ok" line from the TAP output:\n- Name matches a pre-existing entry → PRE-EXISTING (log, do not fail)\n- Name does NOT match any pre-existing entry → NEW FAILURE → verdict is qa-fail\n- A pre-existing entry now shows "ok" → FIXED in this PR (note it)\n\nIf there are zero new failures → verdict is qa-pass (even if pre-existing failures remain).\nIf there are one or more new failures → verdict is qa-fail.' \
+        "${ROOT}" "$_VALIDATION_CMD" "$DEFAULT_BRANCH" "${_BASELINE_SHA:0:12}" "$_PE_LIST"
+fi
+)
+
+# Build Phase 4 comment section header for the structured QA comment template.
+_PHASE4_COMMENT_TEMPLATE=$(
+if [ -n "$_BASELINE_PRE_EXISTING" ] && [ "$_BASELINE_DIFF_AWARE" != "0" ] && [ -z "$_BASELINE_FALLBACK_NOTE" ]; then
+    printf '**Phase 4: validation_cmd (diff-aware)**\n- New failures: <count> — <names or "none">\n- Pre-existing failures (ignored): <count> — <names or "none">\n- Fixed in this PR: <count> — <names or "none">'
+else
+    printf '**Phase 4: validation_cmd**\n- `<cmd>` → ✓ pass'
+fi
+)
 
 _PROMPT_FILE=$(mktemp /tmp/qa-prompt-XXXXXX.txt)
 cat > "$_PROMPT_FILE" <<EOF
@@ -171,10 +230,7 @@ If no test coverage exists for a touched file, note it and skip.
 
 ## Phase 4 — Final regression guard
 
-Run the validation command:
-$([ -n "$_VALIDATION_CMD" ] && printf '   cd %s && %s' "${ROOT}" "$_VALIDATION_CMD" || printf '   (no validation_cmd configured for this project — Phase 4 skipped)')
-
-If validation_cmd fails → verdict is qa-fail (cite the validation failure output).
+${_PHASE4_INSTRUCTIONS}
 
 ---
 
@@ -199,8 +255,7 @@ After all phases, post a structured comment on the PR using this template:
 - \`lib/foo.sh\` → ran \`tests/foo.bats\` (12 tests, ✓ pass)
 - \`lib/bar.sh\` → no existing test coverage, skipped
 
-**Phase 4: validation_cmd**
-- \`<cmd>\` → ✓ pass
+${_PHASE4_COMMENT_TEMPLATE}
 
 **Verdict:** <qa-pass or qa-fail — reason>
 \`\`\`

--- a/tests/qa-baseline.bats
+++ b/tests/qa-baseline.bats
@@ -1,0 +1,259 @@
+#!/usr/bin/env bats
+# tests/qa-baseline.bats — unit tests for lib/qa-baseline.sh diff routines.
+#
+# Uses static TAP fixtures written inline — no real test runs.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    # shellcheck source=../lib/qa-baseline.sh
+    source "$REPO_ROOT/lib/qa-baseline.sh"
+
+    # Scratch dir for fixture files
+    FIXTURE_DIR="$BATS_TMPDIR/qa-baseline-fixtures-$$"
+    mkdir -p "$FIXTURE_DIR"
+}
+
+teardown() {
+    rm -rf "$FIXTURE_DIR"
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+write_tap() {
+    # write_tap <file> <content>
+    printf '%s\n' "$2" > "$1"
+}
+
+# ---------------------------------------------------------------------------
+# qa_baseline_cache_path
+# ---------------------------------------------------------------------------
+
+@test "cache_path: produces path under LOOP_CACHE_DIR with slug and sha" {
+    export LOOP_CACHE_DIR="$BATS_TMPDIR/cache-$$"
+    result=$(qa_baseline_cache_path "myslug" "abc123")
+    [[ "$result" == "${BATS_TMPDIR}/cache-$$/qa-baseline-myslug-abc123.tap" ]]
+}
+
+@test "cache_path: different slugs produce different paths" {
+    export LOOP_CACHE_DIR="/tmp/c"
+    r1=$(qa_baseline_cache_path "slug-a" "sha1")
+    r2=$(qa_baseline_cache_path "slug-b" "sha1")
+    [ "$r1" != "$r2" ]
+}
+
+@test "cache_path: different shas produce different paths" {
+    export LOOP_CACHE_DIR="/tmp/c"
+    r1=$(qa_baseline_cache_path "slug" "sha1")
+    r2=$(qa_baseline_cache_path "slug" "sha2")
+    [ "$r1" != "$r2" ]
+}
+
+# ---------------------------------------------------------------------------
+# qa_baseline_parse_failing
+# ---------------------------------------------------------------------------
+
+@test "parse_failing: returns failing test names from TAP" {
+    write_tap "$FIXTURE_DIR/t.tap" "TAP version 13
+1..3
+ok 1 - passes fine
+not ok 2 - fails here
+ok 3 - also passes"
+    result=$(qa_baseline_parse_failing "$FIXTURE_DIR/t.tap")
+    [ "$result" = "fails here" ]
+}
+
+@test "parse_failing: returns multiple failing names" {
+    write_tap "$FIXTURE_DIR/t.tap" "TAP version 13
+1..3
+not ok 1 - first failure
+not ok 2 - second failure
+ok 3 - passes"
+    count=$(qa_baseline_parse_failing "$FIXTURE_DIR/t.tap" | wc -l | tr -d ' ')
+    [ "$count" = "2" ]
+}
+
+@test "parse_failing: returns empty for all-passing TAP" {
+    write_tap "$FIXTURE_DIR/t.tap" "TAP version 13
+1..2
+ok 1 - first passes
+ok 2 - second passes"
+    result=$(qa_baseline_parse_failing "$FIXTURE_DIR/t.tap")
+    [ -z "$result" ]
+}
+
+@test "parse_failing: strips TODO annotation from test name" {
+    write_tap "$FIXTURE_DIR/t.tap" "not ok 1 - flaky test # TODO fix later"
+    result=$(qa_baseline_parse_failing "$FIXTURE_DIR/t.tap")
+    [ "$result" = "flaky test" ]
+}
+
+@test "parse_failing: strips SKIP annotation from test name" {
+    write_tap "$FIXTURE_DIR/t.tap" "not ok 1 - skipped test # SKIP not ready"
+    result=$(qa_baseline_parse_failing "$FIXTURE_DIR/t.tap")
+    [ "$result" = "skipped test" ]
+}
+
+@test "parse_failing: returns empty for non-TAP file" {
+    write_tap "$FIXTURE_DIR/t.tap" "this is not tap output at all
+just some random text"
+    result=$(qa_baseline_parse_failing "$FIXTURE_DIR/t.tap")
+    [ -z "$result" ]
+}
+
+@test "parse_failing: returns empty for missing file" {
+    result=$(qa_baseline_parse_failing "$FIXTURE_DIR/nonexistent.tap")
+    [ -z "$result" ]
+}
+
+# ---------------------------------------------------------------------------
+# qa_baseline_diff — core logic
+# ---------------------------------------------------------------------------
+
+@test "diff: identical failure sets → no new failures → exit 0" {
+    write_tap "$FIXTURE_DIR/baseline.tap" "TAP version 13
+1..3
+ok 1 - passes on main
+not ok 2 - flaky on main
+ok 3 - passes on main too"
+    write_tap "$FIXTURE_DIR/pr.tap" "TAP version 13
+1..3
+ok 1 - passes on main
+not ok 2 - flaky on main
+ok 3 - passes on main too"
+
+    run qa_baseline_diff "$FIXTURE_DIR/baseline.tap" "$FIXTURE_DIR/pr.tap"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "PRE_EXISTING:flaky on main"
+    ! echo "$output" | grep -q "NEW_FAILURE:"
+}
+
+@test "diff: PR adds new failure → new failure reported → exit 1" {
+    write_tap "$FIXTURE_DIR/baseline.tap" "TAP version 13
+1..2
+ok 1 - test alpha
+ok 2 - test beta"
+    write_tap "$FIXTURE_DIR/pr.tap" "TAP version 13
+1..2
+ok 1 - test alpha
+not ok 2 - test beta"
+
+    run qa_baseline_diff "$FIXTURE_DIR/baseline.tap" "$FIXTURE_DIR/pr.tap"
+    [ "$status" -eq 1 ]
+    echo "$output" | grep -q "NEW_FAILURE:test beta"
+    ! echo "$output" | grep -q "PRE_EXISTING:"
+}
+
+@test "diff: pre-existing failure not counted as new" {
+    write_tap "$FIXTURE_DIR/baseline.tap" "not ok 1 - old flake"
+    write_tap "$FIXTURE_DIR/pr.tap" "not ok 1 - old flake"
+
+    run qa_baseline_diff "$FIXTURE_DIR/baseline.tap" "$FIXTURE_DIR/pr.tap"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "PRE_EXISTING:old flake"
+    ! echo "$output" | grep -q "NEW_FAILURE:"
+}
+
+@test "diff: test fixed in PR reported as FIXED" {
+    write_tap "$FIXTURE_DIR/baseline.tap" "not ok 1 - old bug"
+    write_tap "$FIXTURE_DIR/pr.tap" "ok 1 - old bug"
+
+    run qa_baseline_diff "$FIXTURE_DIR/baseline.tap" "$FIXTURE_DIR/pr.tap"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "FIXED:old bug"
+    ! echo "$output" | grep -q "NEW_FAILURE:"
+    ! echo "$output" | grep -q "PRE_EXISTING:"
+}
+
+@test "diff: mix of new, pre-existing, and fixed failures" {
+    write_tap "$FIXTURE_DIR/baseline.tap" "TAP version 13
+1..4
+not ok 1 - old flake
+not ok 2 - another old flake
+ok 3 - was passing
+ok 4 - old bug being fixed"
+    write_tap "$FIXTURE_DIR/pr.tap" "TAP version 13
+1..4
+not ok 1 - old flake
+ok 2 - another old flake
+not ok 3 - was passing
+ok 4 - old bug being fixed"
+
+    run qa_baseline_diff "$FIXTURE_DIR/baseline.tap" "$FIXTURE_DIR/pr.tap"
+    [ "$status" -eq 1 ]
+    echo "$output" | grep -q "NEW_FAILURE:was passing"
+    echo "$output" | grep -q "PRE_EXISTING:old flake"
+    echo "$output" | grep -q "FIXED:another old flake"
+}
+
+@test "diff: all passing baseline and PR → no output, exit 0" {
+    write_tap "$FIXTURE_DIR/baseline.tap" "ok 1 - all good
+ok 2 - also good"
+    write_tap "$FIXTURE_DIR/pr.tap" "ok 1 - all good
+ok 2 - also good"
+
+    run qa_baseline_diff "$FIXTURE_DIR/baseline.tap" "$FIXTURE_DIR/pr.tap"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "diff: non-TAP file returns exit 2" {
+    write_tap "$FIXTURE_DIR/baseline.tap" "not tap content"
+    write_tap "$FIXTURE_DIR/pr.tap" "also not tap"
+
+    run qa_baseline_diff "$FIXTURE_DIR/baseline.tap" "$FIXTURE_DIR/pr.tap"
+    [ "$status" -eq 2 ]
+}
+
+@test "diff: valid baseline but non-TAP PR returns exit 2" {
+    write_tap "$FIXTURE_DIR/baseline.tap" "ok 1 - passes"
+    write_tap "$FIXTURE_DIR/pr.tap" "random non-tap output"
+
+    run qa_baseline_diff "$FIXTURE_DIR/baseline.tap" "$FIXTURE_DIR/pr.tap"
+    [ "$status" -eq 2 ]
+}
+
+@test "diff: empty files treated as valid TAP with no tests → exit 0" {
+    write_tap "$FIXTURE_DIR/baseline.tap" ""
+    write_tap "$FIXTURE_DIR/pr.tap" ""
+
+    run qa_baseline_diff "$FIXTURE_DIR/baseline.tap" "$FIXTURE_DIR/pr.tap"
+    # Both empty → no TAP lines → exit 2 (not valid TAP)
+    [ "$status" -eq 2 ]
+}
+
+@test "diff: TODO annotations stripped before comparison" {
+    write_tap "$FIXTURE_DIR/baseline.tap" "not ok 1 - flaky test # TODO fix later"
+    write_tap "$FIXTURE_DIR/pr.tap" "not ok 1 - flaky test # TODO fix later"
+
+    run qa_baseline_diff "$FIXTURE_DIR/baseline.tap" "$FIXTURE_DIR/pr.tap"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "PRE_EXISTING:flaky test"
+}
+
+# ---------------------------------------------------------------------------
+# qa_baseline_diff — qa-pass / qa-fail mapping
+# ---------------------------------------------------------------------------
+
+@test "qa-handler decision: no new failures → qa-pass" {
+    write_tap "$FIXTURE_DIR/baseline.tap" "not ok 1 - pre-existing flake"
+    write_tap "$FIXTURE_DIR/pr.tap" "not ok 1 - pre-existing flake"
+
+    diff_output=$(qa_baseline_diff "$FIXTURE_DIR/baseline.tap" "$FIXTURE_DIR/pr.tap" || true)
+    new_count=$(echo "$diff_output" | grep -c "^NEW_FAILURE:" || true)
+    verdict="qa-pass"
+    [ "$new_count" -gt 0 ] && verdict="qa-fail"
+    [ "$verdict" = "qa-pass" ]
+}
+
+@test "qa-handler decision: new failure present → qa-fail" {
+    write_tap "$FIXTURE_DIR/baseline.tap" "ok 1 - clean baseline"
+    write_tap "$FIXTURE_DIR/pr.tap" "not ok 1 - clean baseline"
+
+    diff_output=$(qa_baseline_diff "$FIXTURE_DIR/baseline.tap" "$FIXTURE_DIR/pr.tap" || true)
+    new_count=$(echo "$diff_output" | grep -c "^NEW_FAILURE:" || true)
+    verdict="qa-pass"
+    [ "$new_count" -gt 0 ] && verdict="qa-fail"
+    [ "$verdict" = "qa-fail" ]
+}


### PR DESCRIPTION
Closes #317

## Changes

### lib/qa-baseline.sh (new)
Pure-function library for diff-aware QA baseline logic:
- `qa_baseline_resolve_sha <repo> <branch>` — resolves current tip SHA via `gh api`
- `qa_baseline_cache_path <slug> <sha>` — returns `~/.loop/cache/qa-baseline-<slug>-<sha>.tap`
- `qa_baseline_run_or_load <slug> <sha> <root> <branch> <validation_cmd>` — checks cache, or creates a detached git worktree at the baseline SHA, runs `validation_cmd`, writes TAP output to cache, removes worktree
- `qa_baseline_parse_failing <tap_file>` — extracts failing test names from TAP (strips TODO/SKIP annotations)
- `qa_baseline_diff <baseline.tap> <pr.tap>` — pure function returning `NEW_FAILURE:`, `PRE_EXISTING:`, and `FIXED:` lines; exits 0 (no new failures), 1 (new failures exist), or 2 (not valid TAP → fallback)

### scripts/qa-handler.sh
- Sources `lib/qa-baseline.sh`
- Before building the agent prompt, resolves the baseline SHA and runs/loads the cached baseline TAP
- Builds `_PHASE4_INSTRUCTIONS` injected into the Phase 4 prompt section:
  - **Diff-aware mode** (default): lists pre-existing failures and instructs the agent to classify each `not ok` line as NEW or PRE_EXISTING, with qa-fail only for new failures
  - **Fallback to strict mode** when: `LOOP_QA_DIFF_AWARE=0`, no `validation_cmd` set, baseline SHA unresolvable, or baseline worktree creation fails (with a warning note in the prompt)
- Updates the Phase 4 QA comment template to include new/pre-existing/fixed counts when in diff-aware mode

### tests/qa-baseline.bats (new)
22 unit tests covering:
- `qa_baseline_cache_path` — slug/sha keying
- `qa_baseline_parse_failing` — TAP parsing, TODO/SKIP stripping, missing file handling
- `qa_baseline_diff` — identical failure sets → exit 0, new failure → exit 1, mixed new/pre-existing/fixed, non-TAP → exit 2
- qa-pass/qa-fail decision mapping based on diff output

## Test Plan
- `bats tests/qa-baseline.bats` → 22/22 pass (run locally)
- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` → clean
- `shellcheck -S warning lib/*.sh scripts/*.sh scanner/*.sh install.sh` → clean
- No personal identifiers
- Escape hatch: set `LOOP_QA_DIFF_AWARE=0` in `loop.env` to revert to strict pass/fail behaviour