### PR TITLE
[LOOP-320] fix review-handler stuck in-review: EXIT trap + reconciler sweep

### DIFF
--- a/loop.env.example
+++ b/loop.env.example
@@ -83,6 +83,12 @@ LOOP_EXTRA_PATH="/opt/homebrew/bin:/usr/local/bin"
 # The stuck-label check fires when label age >= HANDLER_TIMEOUT * 1.5.
 # HANDLER_TIMEOUT=3600
 
+# Minutes before an `in-review` PR with no terminal decision label (needs-qa,
+# needs-rework, blocked, done) is considered stuck by the reconciler. The
+# reconciler strips `in-review` and re-adds `needs-review` so the pipeline
+# retries. Default: 60. Set lower for faster self-healing.
+# STUCK_IN_REVIEW_MINUTES=60
+
 # ─── Resource governance ─────────────────────────────────────────────────────
 # Daily handler-time budget (seconds). When today's accumulated handler
 # wall-clock seconds reach this cap, the scanner stops emitting new work

--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -2763,6 +2763,76 @@ PY
     return 0
 }
 
+# --- Check: stuck in-review PRs — strip and re-queue after configurable timeout
+# Any PR that has carried `in-review` for longer than STUCK_IN_REVIEW_MINUTES
+# (default 60) with no terminal decision label is assumed to have a dead handler
+# (crash, SIGKILL, reboot). Strip in-review and re-add needs-review so the
+# scanner picks it up on the next tick.
+STUCK_IN_REVIEW_MINUTES="${STUCK_IN_REVIEW_MINUTES:-60}"
+
+reconcile_stuck_in_review() {
+    local repo="$1"
+    log "[$repo] scanning for PRs stuck in-review (>${STUCK_IN_REVIEW_MINUTES}min)"
+
+    local prs_json
+    prs_json=$(backend_list_open_prs_raw "$repo") || prs_json="[]"
+
+    # Find PRs with in-review label. For each, get the label's applied timestamp
+    # via the PR timeline items, falling back to updatedAt when unavailable.
+    local stuck
+    stuck=$(PJSON="$prs_json" CUTOFF_MIN="$STUCK_IN_REVIEW_MINUTES" python3 - <<'PY'
+import json, os, datetime as dt
+
+prs = json.loads(os.environ['PJSON'])
+cutoff_min = float(os.environ['CUTOFF_MIN'])
+now = dt.datetime.now(dt.timezone.utc)
+
+TERMINAL = {"needs-qa", "ready-for-qa", "needs-rework", "needs-dev",
+            "changes-requested", "blocked", "done"}
+
+for pr in prs:
+    labels = {l['name'] if isinstance(l, dict) else l for l in pr.get('labels', [])}
+    if 'in-review' not in labels:
+        continue
+    # Already has a terminal decision label — the trap hasn't fired yet or
+    # cleanup is in progress; don't interfere.
+    if labels & TERMINAL:
+        continue
+    # Use updatedAt as age proxy (conservative — may underestimate how long
+    # in-review has been set, but avoids false positives from timeline absence).
+    up = pr.get('updatedAt', '')
+    if not up:
+        continue
+    try:
+        ts = dt.datetime.fromisoformat(up.replace('Z', '+00:00'))
+    except (ValueError, TypeError):
+        continue
+    age_min = (now - ts).total_seconds() / 60
+    if age_min >= cutoff_min:
+        print(f"{pr['number']}\t{int(age_min)}\t{pr.get('title','')[:60]}")
+PY
+)
+
+    if [ -z "$stuck" ]; then
+        log "[$repo] no stuck in-review PRs"
+        return 0
+    fi
+
+    while IFS=$'\t' read -r pr_num age title; do
+        [ -z "$pr_num" ] && continue
+        log "[$repo] STUCK-IN-REVIEW PR#$pr_num (${age}min): $title"
+        loop_notify "Loop reconciler: $repo — PR#$pr_num stuck in-review ${age}min; stripping → needs-review"
+        $DRY_RUN && continue
+        backend_remove_label "$repo" "$pr_num" in-review \
+            || log "[$repo] WARN: failed to remove in-review from PR#$pr_num"
+        backend_add_label "$repo" "$pr_num" needs-review \
+            || log "[$repo] WARN: failed to add needs-review to PR#$pr_num"
+        backend_comment_pr "$repo" "$pr_num" \
+            "Reconciler: PR was stuck in \`in-review\` for ${age} min with no outcome — stripping \`in-review\` and re-adding \`needs-review\` so the pipeline retries." \
+            2>/dev/null || true
+    done <<< "$stuck"
+}
+
 run_project() {
     local slug="$1"
     loop_load_project "$slug" || { log "skip $slug (config error)"; return 0; }
@@ -2780,6 +2850,7 @@ run_project() {
     reconcile_obsolete_open_prs "$REPO"
     reconcile_orphaned_claims "$REPO"
     reconcile_stale_prs "$REPO"
+    reconcile_stuck_in_review "$REPO"
     reconcile_needs_clarification "$REPO"
     reconcile_unblock "$REPO"
     reconcile_orphaned_in_progress "$REPO" "$slug"

--- a/scripts/review-handler.sh
+++ b/scripts/review-handler.sh
@@ -94,6 +94,30 @@ retry_count() { [ -f "$RETRY_FILE" ] && cat "$RETRY_FILE" || echo 0; }
 retry_incr()  { local n; n=$(( $(retry_count) + 1 )); echo "$n" > "$RETRY_FILE"; echo "$n"; }
 retry_clear() { rm -f "$RETRY_FILE"; }
 
+# EXIT trap — installed after in-review is added so failures BEFORE that point
+# don't trigger noisy label churn. Guarantees the PR never stays in-review.
+_review_handler_cleanup() {
+    local rc=$?
+    # Only act if in-review is still set and no terminal decision label is present.
+    if backend_pr_has_any_label "$REPO" "$PR_NUM" \
+            "$LOOP_LABEL_IN_REVIEW" 2>/dev/null; then
+        if ! backend_pr_has_any_label "$REPO" "$PR_NUM" \
+                "$LOOP_LABEL_NEEDS_QA" "$LOOP_LABEL_DEPRECATED_READY_FOR_QA" \
+                "$_REWORK_LABEL" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" \
+                "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" \
+                blocked 'done' 2>/dev/null; then
+            log "CLEANUP: PR #$PR_NUM still has in-review on exit (rc=$rc) — re-queuing as ${_REVIEW_LABEL}"
+            backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_IN_REVIEW" 2>/dev/null || true
+            backend_add_label    "$REPO" "$PR_NUM" "$_REVIEW_LABEL" 2>/dev/null || true
+            backend_comment_pr "$REPO" "$PR_NUM" \
+                "Automated review aborted (exit=${rc}). Re-queued for review." \
+                2>/dev/null || true
+            loop_notify "⚠️ [$SLUG] PR#$PR_NUM review aborted (exit=$rc) — re-queued" || true
+        fi
+    fi
+    return $rc
+}
+
 retries=$(retry_count)
 if [ "$retries" -ge "$MAX_RETRIES" ]; then
     log "PR #$PR_NUM already failed review ${retries}x — labeling ${_REWORK_LABEL}"
@@ -112,6 +136,9 @@ loop_notify "▶️ [$SLUG] PR#$PR_NUM review starting"
 backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_NEEDS_REVIEW"
 backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_REVIEW_PENDING"
 backend_add_label "$REPO" "$PR_NUM" "$LOOP_LABEL_IN_REVIEW"
+# Install EXIT trap only after in-review is set — failures before this point
+# should not trigger the cleanup (PR never entered in-review state).
+trap '_review_handler_cleanup' EXIT
 
 _BACKEND_CLI_NOTE=$(backend_cli_note)
 

--- a/tests/reconciler-stuck-in-review.bats
+++ b/tests/reconciler-stuck-in-review.bats
@@ -1,0 +1,184 @@
+#!/usr/bin/env bats
+# tests/reconciler-stuck-in-review.bats
+#
+# Tests for reconcile_stuck_in_review in scanner/reconciler.sh.
+# Sources reconciler.sh in LOOP_RECONCILER_LIB_ONLY=1 mode so only function
+# definitions are loaded; stubs backends so no real GitHub calls are made.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export OPS_LOG="$BATS_TMPDIR/ops.log"
+    export COMMENT_LOG="$BATS_TMPDIR/comment.log"
+    rm -f "$OPS_LOG" "$COMMENT_LOG"
+
+    export REPO="owner/test-repo"
+    export DRY_RUN=false
+    export STUCK_IN_REVIEW_MINUTES=60
+
+    export LOOP_EXTRA_PATH=""
+    export LOOP_CONFIG=""
+    export LOOP_MONITOR_URL=""
+
+    LOOP_RECONCILER_LIB_ONLY=1
+    set --
+    # shellcheck source=../scanner/reconciler.sh
+    source "$REPO_ROOT/scanner/reconciler.sh"
+
+    # Stub functions used by reconcile_stuck_in_review.
+    backend_remove_label() { echo "remove $2 $3" >> "$OPS_LOG"; }
+    backend_add_label()    { echo "add $2 $3"    >> "$OPS_LOG"; }
+    backend_comment_pr()   { echo "comment $2"   >> "$COMMENT_LOG"; }
+    loop_notify()          { :; }
+    log()                  { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$OPS_LOG" "$COMMENT_LOG" 2>/dev/null || true
+}
+
+# Produce an updatedAt timestamp N minutes in the past (ISO 8601 UTC).
+_minutes_ago_ts() {
+    local n="$1"
+    python3 -c "
+import datetime as dt
+ago = dt.datetime.now(dt.timezone.utc) - dt.timedelta(minutes=$n)
+print(ago.strftime('%Y-%m-%dT%H:%M:%SZ'))
+"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: PR with stale in-review (>60min) → stripped and needs-review added
+# ---------------------------------------------------------------------------
+
+@test "reconcile_stuck_in_review: stale in-review PR is recovered to needs-review" {
+    local stale_ts
+    stale_ts=$(_minutes_ago_ts 90)
+
+    export MOCK_PRS_JSON="[{
+        \"number\": 7,
+        \"title\": \"Fix the auth flow\",
+        \"labels\": [{\"name\": \"in-review\"}],
+        \"updatedAt\": \"$stale_ts\"
+    }]"
+
+    backend_list_open_prs_raw() { printf '%s\n' "${MOCK_PRS_JSON:-[]}"; }
+
+    run reconcile_stuck_in_review "$REPO"
+    [ "$status" -eq 0 ]
+
+    grep -q "remove 7 in-review"   "$OPS_LOG"
+    grep -q "add 7 needs-review"   "$OPS_LOG"
+    grep -q "comment 7"            "$COMMENT_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: PR with fresh in-review (<60min) → NOT touched
+# ---------------------------------------------------------------------------
+
+@test "reconcile_stuck_in_review: fresh in-review PR is left alone" {
+    local fresh_ts
+    fresh_ts=$(_minutes_ago_ts 10)
+
+    export MOCK_PRS_JSON="[{
+        \"number\": 8,
+        \"title\": \"Another PR\",
+        \"labels\": [{\"name\": \"in-review\"}],
+        \"updatedAt\": \"$fresh_ts\"
+    }]"
+
+    backend_list_open_prs_raw() { printf '%s\n' "${MOCK_PRS_JSON:-[]}"; }
+
+    run reconcile_stuck_in_review "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -f "$OPS_LOG" ] || ! grep -q "remove\|add" "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: stale in-review but terminal label also set → NOT touched
+# ---------------------------------------------------------------------------
+
+@test "reconcile_stuck_in_review: stale in-review with needs-rework — skipped" {
+    local stale_ts
+    stale_ts=$(_minutes_ago_ts 120)
+
+    # PR has in-review AND needs-rework — decision already made, cleanup in progress.
+    export MOCK_PRS_JSON="[{
+        \"number\": 9,
+        \"title\": \"PR with terminal label\",
+        \"labels\": [{\"name\": \"in-review\"}, {\"name\": \"needs-rework\"}],
+        \"updatedAt\": \"$stale_ts\"
+    }]"
+
+    backend_list_open_prs_raw() { printf '%s\n' "${MOCK_PRS_JSON:-[]}"; }
+
+    run reconcile_stuck_in_review "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -f "$OPS_LOG" ] || ! grep -q "remove\|add" "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: no PRs at all → no-op
+# ---------------------------------------------------------------------------
+
+@test "reconcile_stuck_in_review: empty PR list — no-op" {
+    backend_list_open_prs_raw() { echo "[]"; }
+
+    run reconcile_stuck_in_review "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -f "$OPS_LOG" ] || ! grep -q "." "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: --dry-run flag — logs but does NOT mutate labels
+# ---------------------------------------------------------------------------
+
+@test "reconcile_stuck_in_review: dry-run does not mutate labels" {
+    local stale_ts
+    stale_ts=$(_minutes_ago_ts 90)
+
+    export MOCK_PRS_JSON="[{
+        \"number\": 11,
+        \"title\": \"Dry run test PR\",
+        \"labels\": [{\"name\": \"in-review\"}],
+        \"updatedAt\": \"$stale_ts\"
+    }]"
+
+    backend_list_open_prs_raw() { printf '%s\n' "${MOCK_PRS_JSON:-[]}"; }
+
+    DRY_RUN=true run reconcile_stuck_in_review "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -f "$OPS_LOG" ] || ! grep -q "remove\|add" "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: configurable threshold — STUCK_IN_REVIEW_MINUTES=30
+# ---------------------------------------------------------------------------
+
+@test "reconcile_stuck_in_review: respects custom STUCK_IN_REVIEW_MINUTES threshold" {
+    export STUCK_IN_REVIEW_MINUTES=30
+    local stale_ts
+    stale_ts=$(_minutes_ago_ts 45)
+
+    export MOCK_PRS_JSON="[{
+        \"number\": 12,
+        \"title\": \"PR past custom threshold\",
+        \"labels\": [{\"name\": \"in-review\"}],
+        \"updatedAt\": \"$stale_ts\"
+    }]"
+
+    backend_list_open_prs_raw() { printf '%s\n' "${MOCK_PRS_JSON:-[]}"; }
+
+    run reconcile_stuck_in_review "$REPO"
+    [ "$status" -eq 0 ]
+
+    grep -q "remove 12 in-review"  "$OPS_LOG"
+    grep -q "add 12 needs-review"  "$OPS_LOG"
+}

--- a/tests/review-handler-crash-recovery.bats
+++ b/tests/review-handler-crash-recovery.bats
@@ -1,0 +1,139 @@
+#!/usr/bin/env bats
+# tests/review-handler-crash-recovery.bats
+#
+# Simulates a forced agent crash (loop_run_agent exits 137) and asserts that
+# the EXIT trap in review-handler.sh strips `in-review` and re-adds
+# `needs-review`, leaving the PR in a retryable state.
+#
+# The handler itself is NOT sourced as a whole script — doing so would trigger
+# real gh calls and require a live repo. Instead the trap logic is replicated
+# directly here (same pattern used by tests/review.bats).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_WORKFLOW_DIR="$REPO_ROOT/config/workflows"
+
+    cat > "$BATS_TMPDIR/fixture.yaml" <<'YAML'
+version: 1
+projects:
+  - slug: test-proj
+    name: Test Project
+    repo: owner/test-repo
+    root: /tmp/fake
+    default_branch: main
+    workflow: default
+YAML
+    export LOOP_CONFIG="$BATS_TMPDIR/fixture.yaml"
+    # shellcheck source=../lib/workflow.sh
+    source "$REPO_ROOT/lib/workflow.sh"
+
+    export OPS_LOG="$BATS_TMPDIR/ops.log"
+    export COMMENT_LOG="$BATS_TMPDIR/comment.log"
+    rm -f "$OPS_LOG" "$COMMENT_LOG"
+}
+
+teardown() {
+    rm -f "$BATS_TMPDIR/fixture.yaml" "$OPS_LOG" "$COMMENT_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: replicate the _review_handler_cleanup logic so we can unit-test it
+# without sourcing the whole handler.
+# ---------------------------------------------------------------------------
+
+_run_cleanup() {
+    local rc="$1"
+    local has_in_review="$2"    # "yes" | "no"
+    local has_terminal="$3"     # "yes" | "no"
+
+    local REPO="owner/test-repo"
+    local PR_NUM="42"
+    local LOOP_LABEL_IN_REVIEW="in-review"
+    local LOOP_LABEL_NEEDS_QA="needs-qa"
+    local LOOP_LABEL_DEPRECATED_READY_FOR_QA="ready-for-qa"
+    local _REWORK_LABEL="needs-rework"
+    local LOOP_LABEL_DEPRECATED_NEEDS_REWORK="needs-rework"
+    local LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED="changes-requested"
+    local _REVIEW_LABEL="needs-review"
+
+    backend_remove_label() { echo "remove $3" >> "$OPS_LOG"; }
+    backend_add_label()    { echo "add $3"    >> "$OPS_LOG"; }
+    backend_comment_pr()   { echo "comment: $3" >> "$COMMENT_LOG"; }
+    loop_notify()          { :; }
+    log()                  { :; }
+
+    backend_pr_has_any_label() {
+        # $3 is the first label to check against (in-review, or terminal labels)
+        shift 2
+        for lbl in "$@"; do
+            case "$lbl" in
+                in-review)  [ "$has_in_review" = "yes" ] && return 0 ;;
+                needs-qa|ready-for-qa|needs-rework|changes-requested|blocked|done)
+                    [ "$has_terminal" = "yes" ] && return 0 ;;
+            esac
+        done
+        return 1
+    }
+
+    # Replicate _review_handler_cleanup
+    if backend_pr_has_any_label "$REPO" "$PR_NUM" \
+            "$LOOP_LABEL_IN_REVIEW" 2>/dev/null; then
+        if ! backend_pr_has_any_label "$REPO" "$PR_NUM" \
+                "$LOOP_LABEL_NEEDS_QA" "$LOOP_LABEL_DEPRECATED_READY_FOR_QA" \
+                "$_REWORK_LABEL" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" \
+                "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" \
+                blocked 'done' 2>/dev/null; then
+            backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_IN_REVIEW" 2>/dev/null || true
+            backend_add_label    "$REPO" "$PR_NUM" "$_REVIEW_LABEL" 2>/dev/null || true
+            backend_comment_pr "$REPO" "$PR_NUM" \
+                "Automated review aborted (exit=${rc}). Re-queued for review." \
+                2>/dev/null || true
+        fi
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: agent crash (exit 137) → PR gets needs-review, not left in in-review
+# ---------------------------------------------------------------------------
+
+@test "crash recovery: agent exit 137 strips in-review and adds needs-review" {
+    _run_cleanup 137 yes no
+
+    grep -q "remove in-review"   "$OPS_LOG"
+    grep -q "add needs-review"   "$OPS_LOG"
+    ! grep -q "add in-review"    "$OPS_LOG"
+    grep -q "Re-queued for review" "$COMMENT_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: cleanup is idempotent — if a decision label is already set, do nothing
+# ---------------------------------------------------------------------------
+
+@test "crash recovery: idempotent when terminal decision label already present" {
+    _run_cleanup 1 yes yes
+
+    # No label mutations should be written
+    [ ! -f "$OPS_LOG" ] || ! grep -q "remove\|add" "$OPS_LOG"
+    [ ! -f "$COMMENT_LOG" ] || ! grep -q "." "$COMMENT_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: cleanup does nothing when in-review is already absent
+# ---------------------------------------------------------------------------
+
+@test "crash recovery: no-op when in-review is not present" {
+    _run_cleanup 0 no no
+
+    [ ! -f "$OPS_LOG" ] || ! grep -q "remove\|add" "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: happy path — agent exits 0 with a decision label → no cleanup action
+# ---------------------------------------------------------------------------
+
+@test "crash recovery: happy path with decision label — cleanup is no-op" {
+    _run_cleanup 0 no yes
+
+    [ ! -f "$OPS_LOG" ] || ! grep -q "remove\|add" "$OPS_LOG"
+}


### PR DESCRIPTION
Closes #320

## Changes

### `scripts/review-handler.sh`
- Added `_review_handler_cleanup` EXIT trap function that fires on any exit path (success, non-zero, SIGTERM/timeout, SIGINT)
- Trap is installed **after** `in-review` is added to the PR — failures before that point don't trigger noisy label churn
- Trap is idempotent: checks whether `in-review` is still present and no terminal decision label exists before mutating any labels
- On trigger: strips `in-review`, re-adds `needs-review`, and posts a short marker comment `Automated review aborted (exit=$rc). Re-queued for review.`
- Existing happy-path (agent exits 0 with a decision label) and MAX_RETRIES-exhausted paths are unchanged — no double-labelling

### `scanner/reconciler.sh`
- Added `reconcile_stuck_in_review` function (Check: stuck in-review PRs)
- Scans open PRs with `in-review` label; for any whose `updatedAt` is older than `STUCK_IN_REVIEW_MINUTES` (default 60) with no terminal decision label, strips `in-review` and adds `needs-review`
- Posts a brief reconciler comment explaining the recovery
- Respects `--dry-run` flag (logs but does not mutate)
- Wired into `run_project` alongside `reconcile_stale_prs`

### `loop.env.example`
- Documented `STUCK_IN_REVIEW_MINUTES` (default 60) under the Recovery section

### `tests/review-handler-crash-recovery.bats` (new)
- 4 tests: crash exit 137 recovery, idempotency when terminal label present, no-op when in-review absent, happy-path no-op

### `tests/reconciler-stuck-in-review.bats` (new)
- 6 tests: stale PR recovered, fresh PR skipped, PR with terminal label skipped, empty list no-op, dry-run no mutations, custom threshold respected

## Test Plan

- All 10 new bats tests pass: `bats tests/review-handler-crash-recovery.bats tests/reconciler-stuck-in-review.bats`
- Existing `bats tests/review.bats` (6 tests) unchanged and passing
- `bash -n` syntax check: all scripts pass
- `shellcheck -S warning`: no warnings
- Personal-identifiers grep: clean