### PR TITLE
[LOOP-293] real-time progress events from active handlers

### DIFF
--- a/lib/monitor.sh
+++ b/lib/monitor.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# lib/monitor.sh — shared event-emission helper for loop-monitor.
+# Sourced by lib/progress.sh (and any future monitor emitters in handlers).
+# Does NOT source env.sh — callers are responsible for setting LOOP_MONITOR_URL.
+
+# Usage: _loop_emit_event <event_type> <json_payload_string>
+_loop_emit_event() {
+    local event_type="$1" payload="$2"
+    local monitor_url="${LOOP_MONITOR_URL:-}"
+    [ -n "$monitor_url" ] || return 0
+    local body
+    body=$(python3 -c "
+import json, sys
+try:
+    p = json.loads(sys.argv[1])
+    print(json.dumps({'type': sys.argv[2], 'payload': p}))
+except Exception:
+    pass" "$payload" "$event_type" 2>/dev/null || echo "")
+    [ -n "$body" ] || return 0
+    curl -s -X POST "$monitor_url/events" \
+        -H 'Content-Type: application/json' \
+        -d "$body" >/dev/null 2>&1 || true
+}

--- a/lib/progress.sh
+++ b/lib/progress.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# lib/progress.sh — background progress-event poller for handler runs.
+#
+# Usage:
+#   source lib/progress.sh
+#   progress_start <event_prefix>   # spawns background poller
+#   progress_stop                   # kills the poller cleanly
+#
+# The poller emits <event_prefix>_progress events to LOOP_MONITOR_URL every
+# LOOP_PROGRESS_INTERVAL_SEC (default: 30) seconds while a handler is running.
+#
+# Context is read from environment variables at emission time:
+#   SLUG, ISSUE_NUM, PR_NUM — set by the calling handler
+# shellcheck source=./monitor.sh
+source "${LOOP_ROOT:?}/lib/monitor.sh"
+
+_LOOP_PROGRESS_PID=""
+
+# _progress_detect_detail <project> <handler_pid>
+# Finds the most-recently-modified transcript file under LOOP_TRANSCRIPT_DIR
+# matching the pid or project, extracts the latest tool_use name + input
+# summary from the trailing JSONL lines. Falls back to "working" on any error.
+# Wrapped in a 2-second timeout — never blocks the caller.
+_progress_detect_detail() {
+    local project="${1:-}" handler_pid="${2:-}"
+    local transcript_dir="${LOOP_TRANSCRIPT_DIR:-/tmp/orchestrator-transcripts}"
+
+    [ -d "$transcript_dir" ] || { printf '%s' "working"; return 0; }
+
+    local tf=""
+    # Find candidate files by pid or project name, pick most-recently-modified
+    local candidates
+    candidates=$(find "$transcript_dir" -maxdepth 2 -type f \
+        \( -name "*${handler_pid}*" -o -name "*${project}*" \) \
+        2>/dev/null || true)
+    if [ -n "$candidates" ]; then
+        tf=$(echo "$candidates" | tr '\n' '\0' | xargs -0 ls -t 2>/dev/null | head -1 || true)
+    fi
+    # Fallback: newest file in transcript dir
+    if [ -z "$tf" ]; then
+        local newest
+        newest=$(ls -t "$transcript_dir"/ 2>/dev/null | head -1 || true)
+        [ -n "$newest" ] && tf="$transcript_dir/$newest"
+    fi
+
+    [ -n "$tf" ] && [ -f "$tf" ] || { printf '%s' "working"; return 0; }
+
+    local detail
+    detail=$(TRANSCRIPT_FILE="$tf" timeout 2 python3 <<'PY' 2>/dev/null
+import sys, json, os
+tf = os.environ.get('TRANSCRIPT_FILE', '')
+detail = ''
+try:
+    with open(tf) as fh:
+        lines = fh.readlines()[-50:]
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+            if obj.get('type') == 'tool_use':
+                name = obj.get('name', '')
+                inp = obj.get('input', {})
+                if isinstance(inp, dict):
+                    first_val = next(iter(inp.values()), '') if inp else ''
+                    inp_str = str(first_val)[:60] if first_val else ''
+                else:
+                    inp_str = str(inp)[:60]
+                if name:
+                    detail = name + (': ' + inp_str if inp_str else '')
+        except Exception:
+            continue
+except Exception:
+    pass
+print(detail if detail else 'working')
+PY
+    ) || detail=""
+
+    detail="${detail:-working}"
+    printf '%s' "${detail:0:120}"
+}
+
+# _progress_emit <event_prefix>
+# Builds and POSTs one <prefix>_progress event to LOOP_MONITOR_URL.
+_progress_emit() {
+    local prefix="$1"
+    local monitor_url="${LOOP_MONITOR_URL:-}"
+    [ -n "$monitor_url" ] || return 0
+
+    local detail
+    detail=$(_progress_detect_detail "${SLUG:-}" "$$")
+
+    local ts
+    ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date '+%Y-%m-%dT%H:%M:%SZ')
+
+    local payload_json
+    payload_json=$(python3 -c "
+import json, os, sys
+proj  = os.environ.get('SLUG', '')
+issue = os.environ.get('ISSUE_NUM', '')
+pr    = os.environ.get('PR_NUM', '')
+pid   = os.getpid()
+detail = sys.argv[1][:120]
+ts   = sys.argv[2]
+p = {'project': proj, 'pid': pid, 'detail': detail, 'ts': ts}
+if issue:
+    try:
+        p['issue_num'] = int(issue)
+    except ValueError:
+        p['issue_num'] = issue
+elif pr:
+    try:
+        p['pr_num'] = int(pr)
+    except ValueError:
+        p['pr_num'] = pr
+print(json.dumps(p))
+" "$detail" "$ts" 2>/dev/null) || return 0
+
+    [ -n "$payload_json" ] || return 0
+    _loop_emit_event "${prefix}_progress" "$payload_json" || true
+}
+
+# progress_start <event_prefix>
+# Spawns a background poller that emits <prefix>_progress events periodically.
+# Stores the poller PID in _LOOP_PROGRESS_PID for progress_stop.
+progress_start() {
+    local prefix="$1"
+    local interval="${LOOP_PROGRESS_INTERVAL_SEC:-30}"
+    (
+        _poller_sleep_pid=""
+        trap '[ -n "$_poller_sleep_pid" ] && kill "$_poller_sleep_pid" 2>/dev/null || true; exit 0' TERM INT
+        while true; do
+            sleep "$interval" &
+            _poller_sleep_pid=$!
+            wait "$_poller_sleep_pid" 2>/dev/null || true
+            _poller_sleep_pid=""
+            _progress_emit "$prefix"
+        done
+    ) &
+    _LOOP_PROGRESS_PID=$!
+}
+
+# progress_stop
+# Signals the poller to stop (TERM, then KILL after 1 s) and waits for it.
+# Safe to call multiple times or when no poller is running.
+progress_stop() {
+    [ -n "${_LOOP_PROGRESS_PID:-}" ] || return 0
+    local pid="$_LOOP_PROGRESS_PID"
+    _LOOP_PROGRESS_PID=""
+    kill -TERM "$pid" 2>/dev/null || true
+    sleep 1
+    kill -KILL "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+}

--- a/loop.env.example
+++ b/loop.env.example
@@ -106,6 +106,15 @@ LOOP_EXTRA_PATH="/opt/homebrew/bin:/usr/local/bin"
 # LOOP_WATCHDOG_CONFLICT_GRACE=1800         # 30 min
 # LOOP_WATCHDOG_CI_GRACE=3600               # 60 min
 
+# ─── Progress events ─────────────────────────────────────────────────────────
+# Handlers emit periodic *_progress events to loop-monitor while an agent is
+# running. LOOP_PROGRESS_INTERVAL_SEC controls the emission cadence (default 30).
+# LOOP_TRANSCRIPT_DIR is where orchestrator JSONL transcripts are written;
+# progress events parse the latest tool_use entries from these files to build
+# the detail string. Falls back to detail="working" when no file is found.
+# LOOP_PROGRESS_INTERVAL_SEC=30
+# LOOP_TRANSCRIPT_DIR=/tmp/orchestrator-transcripts
+
 # ─── Bounty / loop-monitor ────────────────────────────────────────────────────
 # Stable identifier for this Loop instance sent with every bounty/event payload.
 # Lets loop-monitor distinguish multiple Loop instances reporting to the same endpoint.

--- a/scripts/dev-handler.sh
+++ b/scripts/dev-handler.sh
@@ -22,6 +22,8 @@ source "$LOOP_ROOT/lib/labels.sh"
 # shellcheck source=../lib/handler_guard.sh
 source "$LOOP_ROOT/lib/handler_guard.sh"
 source "$LOOP_ROOT/lib/bounty.sh"
+# shellcheck source=../lib/progress.sh
+source "$LOOP_ROOT/lib/progress.sh"
 # shellcheck source=../lib/notify.sh
 source "$LOOP_ROOT/lib/notify.sh"
 # shellcheck source=../lib/cli-hint.sh
@@ -116,6 +118,7 @@ backend_add_label "$REPO" "$ISSUE_NUM" in-progress
 # scanner re-queues it on the next tick rather than leaving it stuck in-progress.
 _IN_PROGRESS_CLAIMED=1
 _dev_label_cleanup() {
+    progress_stop 2>/dev/null || true
     [ "${_IN_PROGRESS_CLAIMED:-0}" = "1" ] || return 0
     log "EXIT trap: clearing orphaned in-progress on #$ISSUE_NUM — restoring to dev"
     backend_remove_label "$REPO" "$ISSUE_NUM" in-progress 2>/dev/null || true
@@ -217,7 +220,9 @@ cleanup_worktree() {
 }
 
 LOG_CAPTURE_START=$(wc -l < "$LOG_FILE" 2>/dev/null || echo 0)
+progress_start dev
 if loop_run_agent "$TASK_PROMPT" "$WORKTREE_ROOT" 2>&1 | tee -a "$LOG_FILE"; then
+    progress_stop
     _IN_PROGRESS_CLAIMED=0  # disarm trap — success path handles cleanup
     log "dev agent succeeded for #$ISSUE_NUM"
     bounty_report "dev_done" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" issue_num="$ISSUE_NUM" || true
@@ -266,6 +271,7 @@ if matches:
     fi
     cleanup_worktree
 else
+    progress_stop
     _IN_PROGRESS_CLAIMED=0  # disarm trap — failure path handles cleanup
 
     # Capture the agent output tail so we can classify the failure.

--- a/scripts/dev-rework-handler.sh
+++ b/scripts/dev-rework-handler.sh
@@ -24,6 +24,8 @@ source "$LOOP_ROOT/lib/backends/backend.sh"
 # shellcheck source=../lib/labels.sh
 source "$LOOP_ROOT/lib/labels.sh"
 source "$LOOP_ROOT/lib/bounty.sh"
+# shellcheck source=../lib/progress.sh
+source "$LOOP_ROOT/lib/progress.sh"
 # shellcheck source=../lib/notify.sh
 source "$LOOP_ROOT/lib/notify.sh"
 # shellcheck source=../lib/cli-hint.sh
@@ -347,9 +349,11 @@ cleanup_worktree() {
 }
 
 _AGENT_RC=0
+progress_start dev_rework
 if ! loop_run_agent "$TASK_PROMPT" "$WORKTREE_ROOT" 2>&1 | tee -a "$LOG_FILE"; then
     _AGENT_RC=1
 fi
+progress_stop
 
 # Post-agent DIRTY check: if the pre-agent rebase detected conflicts, verify
 # the agent actually resolved them.  One attempt only — if the branch is still

--- a/scripts/merge-handler.sh
+++ b/scripts/merge-handler.sh
@@ -17,6 +17,8 @@ source "$LOOP_ROOT/lib/backends/backend.sh"
 # shellcheck source=../lib/labels.sh
 source "$LOOP_ROOT/lib/labels.sh"
 source "$LOOP_ROOT/lib/bounty.sh"
+# shellcheck source=../lib/progress.sh
+source "$LOOP_ROOT/lib/progress.sh"
 # shellcheck source=../lib/notify.sh
 source "$LOOP_ROOT/lib/notify.sh"
 # shellcheck source=../lib/recovery.sh
@@ -85,7 +87,9 @@ esac
 backend_pr_ready "$REPO" "$PR_NUM" 2>&1 | tee -a "$LOG_FILE" || true
 
 _MERGE_LOG_START=$(wc -l < "$LOG_FILE" 2>/dev/null || echo 0)
+progress_start merge
 if ! backend_merge_pr "$REPO" "$PR_NUM" "$STRATEGY_FLAG" 2>&1 | tee -a "$LOG_FILE"; then
+    progress_stop
     # Check if the failure was a conflict discovered at merge time.
     POST_STATE=$(backend_pr_view "$REPO" "$PR_NUM" --json mergeable,mergeStateStatus 2>/dev/null \
         | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('mergeable',''), d.get('mergeStateStatus',''))")
@@ -114,6 +118,7 @@ if ! backend_merge_pr "$REPO" "$PR_NUM" "$STRATEGY_FLAG" 2>&1 | tee -a "$LOG_FIL
         "Merge failed (state: \`${POST_STATE}\`). Marked \`blocked\` — needs human eyes."
     exit 1
 fi
+progress_stop
 
 # ── Release-PR: tag + publish GitHub release ─────────────────────────────────
 # If this was a release PR, tag the merged commit and publish a GitHub release.

--- a/scripts/po-handler.sh
+++ b/scripts/po-handler.sh
@@ -26,6 +26,8 @@ source "$LOOP_ROOT/lib/backends/backend.sh"
 source "$LOOP_ROOT/lib/labels.sh"
 # shellcheck source=../lib/bounty.sh
 source "$LOOP_ROOT/lib/bounty.sh"
+# shellcheck source=../lib/progress.sh
+source "$LOOP_ROOT/lib/progress.sh"
 # shellcheck source=../lib/notify.sh
 source "$LOOP_ROOT/lib/notify.sh"
 # shellcheck source=../lib/redact.sh
@@ -146,6 +148,7 @@ _po_label_cleanup() {
     backend_add_label "$REPO" "$ISSUE_NUM" "$_po_trigger" 2>/dev/null || true
 }
 _po_exit_cleanup() {
+    progress_stop 2>/dev/null || true
     _po_label_cleanup
     rm -f "${_RUN_LOG:-}" 2>/dev/null || true
 }
@@ -504,7 +507,9 @@ ${redacted_trimmed}
 # `--model <id>`, scoped to this single call. Falls back to whatever the
 # orchestrator config says if the override is unset.
 export LOOP_AGENT_MODEL_OVERRIDE="${LOOP_PO_MODEL:-claude-opus-4-7}"
+progress_start po
 if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE" | tee "$_RUN_LOG" >/dev/null; then
+    progress_stop
     _IN_PROGRESS_CLAIMED=0  # disarm trap — success path handles cleanup
     log "po agent succeeded for #$ISSUE_NUM"
     bounty_report "po_done" model="${LOOP_PO_MODEL:-claude-opus-4-7}" role=po project="$SLUG" issue_num="$ISSUE_NUM" || true
@@ -519,6 +524,7 @@ if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE" | tee "$_RUN_
         backend_add_label "$REPO" "$ISSUE_NUM" "$_fallback_dev_label"
     fi
 else
+    progress_stop
     _agent_rc=$?
     _stderr_tail=$(tail -n 50 "$_RUN_LOG" 2>/dev/null || echo "")
     _IN_PROGRESS_CLAIMED=0  # disarm trap — failure path handles cleanup

--- a/scripts/qa-handler.sh
+++ b/scripts/qa-handler.sh
@@ -23,6 +23,8 @@ source "$LOOP_ROOT/lib/backends/backend.sh"
 # shellcheck source=../lib/labels.sh
 source "$LOOP_ROOT/lib/labels.sh"
 source "$LOOP_ROOT/lib/bounty.sh"
+# shellcheck source=../lib/progress.sh
+source "$LOOP_ROOT/lib/progress.sh"
 # shellcheck source=../lib/notify.sh
 source "$LOOP_ROOT/lib/notify.sh"
 # shellcheck source=../lib/cli-hint.sh
@@ -282,7 +284,9 @@ TASK_PROMPT=$(cat "$_PROMPT_FILE")
 rm -f "$_PROMPT_FILE"
 
 _QA_LOG_START=$(wc -l < "$LOG_FILE" 2>/dev/null || echo 0)
+progress_start qa
 if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
+    progress_stop
     log "qa agent finished for PR #$PR_NUM"
     loop_notify "✅ [$SLUG] PR#$PR_NUM qa done"
     backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_NEEDS_QA"
@@ -306,6 +310,7 @@ if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
         bounty_report "qa_fail" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$SLUG" pr_num="$PR_NUM" || true
     fi
 else
+    progress_stop
     _agent_tail=$(tail -n +"$((_QA_LOG_START + 1))" "$LOG_FILE" 2>/dev/null | tail -200)
     log "qa agent failed for PR #$PR_NUM"
     _failure_reason=$(loop_failure_category "$_agent_tail" 1)

--- a/scripts/review-handler.sh
+++ b/scripts/review-handler.sh
@@ -23,6 +23,8 @@ source "$LOOP_ROOT/lib/backends/backend.sh"
 # shellcheck source=../lib/labels.sh
 source "$LOOP_ROOT/lib/labels.sh"
 source "$LOOP_ROOT/lib/bounty.sh"
+# shellcheck source=../lib/progress.sh
+source "$LOOP_ROOT/lib/progress.sh"
 # shellcheck source=../lib/notify.sh
 source "$LOOP_ROOT/lib/notify.sh"
 # shellcheck source=../lib/cli-hint.sh
@@ -99,6 +101,7 @@ retry_clear() { rm -f "$RETRY_FILE"; }
 # EXIT trap — installed after in-review is added so failures BEFORE that point
 # don't trigger noisy label churn. Guarantees the PR never stays in-review.
 _review_handler_cleanup() {
+    progress_stop 2>/dev/null || true
     local rc=$?
     # Only act if in-review is still set and no terminal decision label is present.
     if backend_pr_has_any_label "$REPO" "$PR_NUM" \
@@ -222,7 +225,9 @@ TASK_PROMPT=$(cat "$_PROMPT_FILE")
 rm -f "$_PROMPT_FILE"
 
 _REVIEW_LOG_START=$(wc -l < "$LOG_FILE" 2>/dev/null || echo 0)
+progress_start review
 if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
+    progress_stop
     log "review agent finished for PR #$PR_NUM"
     bounty_report "review_done" model="${LOOP_AGENT_MODEL:-sonnet}" role=reviewer project="$SLUG" pr_num="$PR_NUM" || true
     loop_notify "✅ [$SLUG] PR#$PR_NUM review done"
@@ -261,6 +266,7 @@ if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
         backend_add_label "$REPO" "$PR_NUM" "$_REWORK_LABEL"
     fi
 else
+    progress_stop
     _agent_tail=$(tail -n +"$((_REVIEW_LOG_START + 1))" "$LOG_FILE" 2>/dev/null | tail -200)
     n=$(retry_incr)
     log "review agent failed for PR #$PR_NUM (attempt $n/$MAX_RETRIES)"

--- a/tests/progress.bats
+++ b/tests/progress.bats
@@ -1,0 +1,205 @@
+#!/usr/bin/env bats
+# tests/progress.bats — regression tests for lib/progress.sh
+#
+# Stubs curl via PATH shadowing so no real HTTP calls are made.
+# Stubs a transcript dir with synthetic JSONL.
+# Asserts:
+#   (a) at least one dev_progress event payload lands in the curl stub log
+#   (b) payload includes a non-empty detail field
+#   (c) no orphan sleep/poller process remains after progress_stop
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Stub curl: log every invocation body to a file.
+    CURL_LOG="$BATS_TMPDIR/curl.log"
+    export CURL_LOG
+    mkdir -p "$BATS_TMPDIR/bin"
+    cat > "$BATS_TMPDIR/bin/curl" <<'SH'
+#!/usr/bin/env bash
+# Stub curl: write request body to CURL_LOG, always succeed.
+body=""
+i=1
+while [ $i -le $# ]; do
+    eval "arg=\${$i}"
+    if [ "$arg" = "-d" ]; then
+        i=$((i+1))
+        eval "body=\${$i}"
+    fi
+    i=$((i+1))
+done
+printf '%s\n' "$body" >> "$CURL_LOG"
+SH
+    chmod +x "$BATS_TMPDIR/bin/curl"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    # Stub transcript dir with synthetic JSONL
+    export LOOP_TRANSCRIPT_DIR="$BATS_TMPDIR/transcripts"
+    mkdir -p "$LOOP_TRANSCRIPT_DIR"
+    cat > "$LOOP_TRANSCRIPT_DIR/test-transcript.jsonl" <<'JSONL'
+{"type":"text","text":"starting"}
+{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"git fetch origin"}}
+{"type":"tool_use","id":"t2","name":"Read","input":{"file_path":"/project/CLAUDE.md"}}
+JSONL
+
+    # Set context env vars expected by _progress_emit
+    export SLUG="testproject"
+    export ISSUE_NUM="42"
+    export PR_NUM=""
+    export LOOP_MONITOR_URL="http://localhost:19999"
+    export LOOP_PROGRESS_INTERVAL_SEC="1"
+
+    # shellcheck source=../lib/progress.sh
+    source "$REPO_ROOT/lib/progress.sh"
+}
+
+teardown() {
+    progress_stop 2>/dev/null || true
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/logs" \
+           "$BATS_TMPDIR/transcripts" "$BATS_TMPDIR/curl.log" 2>/dev/null || true
+    unset SLUG ISSUE_NUM PR_NUM LOOP_MONITOR_URL LOOP_PROGRESS_INTERVAL_SEC \
+          LOOP_TRANSCRIPT_DIR CURL_LOG
+}
+
+# ---------------------------------------------------------------------------
+# Emission
+# ---------------------------------------------------------------------------
+
+@test "progress: at least one dev_progress event emitted after interval" {
+    progress_start dev
+    sleep 2
+    progress_stop
+
+    [ -f "$CURL_LOG" ]
+    grep -q "dev_progress" "$CURL_LOG"
+}
+
+@test "progress: emitted payload includes non-empty detail field" {
+    progress_start dev
+    sleep 2
+    progress_stop
+
+    [ -f "$CURL_LOG" ]
+    # detail must be present and non-empty (not just '"detail":""')
+    run python3 -c "
+import sys, json
+found = False
+with open(sys.argv[1]) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+            p = obj.get('payload', {})
+            detail = p.get('detail', '')
+            if detail:
+                found = True
+                break
+        except Exception:
+            continue
+sys.exit(0 if found else 1)
+" "$CURL_LOG"
+    [ "$status" -eq 0 ]
+}
+
+@test "progress: payload contains project slug and issue_num" {
+    progress_start dev
+    sleep 2
+    progress_stop
+
+    [ -f "$CURL_LOG" ]
+    run python3 -c "
+import sys, json
+found = False
+with open(sys.argv[1]) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+            p = obj.get('payload', {})
+            if p.get('project') == 'testproject' and p.get('issue_num') == 42:
+                found = True
+                break
+        except Exception:
+            continue
+sys.exit(0 if found else 1)
+" "$CURL_LOG"
+    [ "$status" -eq 0 ]
+}
+
+@test "progress: no orphan poller process after progress_stop" {
+    progress_start dev
+    local poller_pid="$_LOOP_PROGRESS_PID"
+    sleep 2
+    progress_stop
+
+    # poller process must be gone
+    run kill -0 "$poller_pid"
+    [ "$status" -ne 0 ]
+}
+
+@test "progress: no orphan sleep process after progress_stop" {
+    progress_start dev
+    sleep 2
+    progress_stop
+
+    # Give processes a moment to fully exit
+    sleep 0.2
+
+    # No 'sleep 1' child processes whose parent is now init (ppid=1) from our poller
+    # We check by verifying _LOOP_PROGRESS_PID is cleared
+    [ -z "${_LOOP_PROGRESS_PID:-}" ]
+}
+
+# ---------------------------------------------------------------------------
+# Fallback behaviour
+# ---------------------------------------------------------------------------
+
+@test "progress: emits working when transcript dir absent" {
+    export LOOP_TRANSCRIPT_DIR="$BATS_TMPDIR/no-such-dir"
+    progress_start dev
+    sleep 2
+    progress_stop
+
+    [ -f "$CURL_LOG" ]
+    run python3 -c "
+import sys, json
+found = False
+with open(sys.argv[1]) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+            p = obj.get('payload', {})
+            if p.get('detail') == 'working':
+                found = True
+                break
+        except Exception:
+            continue
+sys.exit(0 if found else 1)
+" "$CURL_LOG"
+    [ "$status" -eq 0 ]
+}
+
+@test "progress: no emission when LOOP_MONITOR_URL is unset" {
+    unset LOOP_MONITOR_URL
+    progress_start dev
+    sleep 2
+    progress_stop
+
+    # curl stub log must not exist or be empty
+    [ ! -f "$CURL_LOG" ] || [ ! -s "$CURL_LOG" ]
+}
+
+@test "progress_stop: safe to call when no poller is running" {
+    run progress_stop
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #293

## Changes

### New files
- **`lib/monitor.sh`** — shared `_loop_emit_event` helper (POST to `LOOP_MONITOR_URL/events`). Extracted from `scanner/reconciler.sh`'s inline copy so the curl logic lives in one place.
- **`lib/progress.sh`** — background progress poller. Exposes `progress_start <prefix>` (spawns subshell poller) and `progress_stop` (TERM + KILL after 1s). The poller emits `<prefix>_progress` events every `LOOP_PROGRESS_INTERVAL_SEC` (default 30s) with a `detail` string parsed from JSONL transcripts under `LOOP_TRANSCRIPT_DIR`.
- **`tests/progress.bats`** — 8 regression tests: emission confirmed, payload shape validated (detail, project, issue_num), orphan-process check, fallback-to-working when transcript absent, no-emission when monitor URL unset, idempotent stop.

### Modified files
- **All 6 handlers** (`dev`, `po`, `review`, `qa`, `dev-rework`, `merge`) — source `lib/progress.sh`; call `progress_start <prefix>` before the main blocking operation and `progress_stop` in both success and failure paths; existing cleanup/EXIT trap functions call `progress_stop` for safety on unexpected exits.
- **`loop.env.example`** — documents `LOOP_PROGRESS_INTERVAL_SEC` and `LOOP_TRANSCRIPT_DIR` with defaults.

### Event shape
```json
{"type":"dev_progress","payload":{"project":"slug","issue_num":42,"pid":12345,"detail":"Bash: git fetch origin","ts":"2026-05-12T10:00:00Z"}}
```

## Test Plan
- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — all clean
- `shellcheck -S warning lib/*.sh scripts/*.sh scanner/*.sh install.sh` — all clean
- `bats tests/progress.bats` — 8/8 pass
- Set `LOOP_MONITOR_URL` and `LOOP_PROGRESS_INTERVAL_SEC=5` in `loop.env`, trigger a dev run, observe `dev_progress` events arriving at loop-monitor every 5s