### PR TITLE
[LOOP-296] loop-recover.sh — operator rollback to last known-good stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,71 @@ Exit codes: `0` = all OK, `2` = any DEGRADED, `1` = any FAIL.
 > files, agent CLI availability, and `gh` auth. `scripts/status.sh` is the
 > runtime variant that checks live pipeline state.
 
+## Recovery
+
+When a ticket ends up in a confused label state (mis-labelled after a partial
+mass-merge, stuck handler left a bad label, etc.) use `scripts/loop-recover.sh`
+to roll it back to a specific pipeline stage without hand-editing labels.
+
+### Usage
+
+```bash
+scripts/loop-recover.sh <issue-or-pr-number> [--slug <slug>] [--to-stage <stage>] [--dry-run]
+```
+
+| Flag | Description |
+|---|---|
+| `<number>` | Issue or PR number to recover |
+| `--slug <slug>` | Project slug from `config/projects.yaml` (required when multiple projects are configured) |
+| `--to-stage <stage>` | Force the ticket to a specific stage: `po`, `dev`, `review`, `qa`, or `merge` |
+| `--dry-run` | Print planned label add/remove and comment without mutating GitHub |
+
+### Auto-detection (without `--to-stage`)
+
+Without `--to-stage`, the script reads the event log at `$LOOP_MONITOR_LOG`
+(defaults to `$LOOP_LOG_DIR/loop-monitor-events.jsonl`), finds the most
+recent `*_done` event for the ticket, and computes the stage to restore:
+
+| Last event | Restored stage | Label applied |
+|---|---|---|
+| `po_done` | `dev` | `needs-dev` |
+| `dev_done` | `review` | `needs-review` |
+| `review_done` | `qa` | `needs-qa` |
+| `qa_done` | `merge` | `qa-pass` |
+
+If no matching event exists, the script exits with a message asking you to
+use `--to-stage` explicitly.
+
+Set `LOOP_MONITOR_LOG` in `loop.env` to the path where your loop-monitor
+instance (or a log shipper) writes its JSONL event stream.
+
+### Examples
+
+```bash
+# Preview what would happen without changing anything:
+scripts/loop-recover.sh 123 --slug myapp --dry-run
+
+# Auto-detect last known-good stage and restore:
+scripts/loop-recover.sh 123 --slug myapp
+
+# Force ticket #456 to the qa stage regardless of event history:
+scripts/loop-recover.sh 456 --slug myapp --to-stage qa
+
+# Single-project setup — slug auto-detected:
+scripts/loop-recover.sh 78 --to-stage dev
+```
+
+### Behaviour
+
+- Removes all pipeline-stage labels from the ticket, then adds the target
+  stage's trigger label.
+- Posts a comment explaining the rollback (target stage, reason,
+  operator-invoked).
+- **Idempotent:** running the same command twice produces the same end state
+  and posts at most one new comment per run (skipped when the last comment
+  already contains the recovery marker).
+- Labels only — no branch state, commits, or PRs are modified.
+
 ## Development
 
 ```bash

--- a/scripts/loop-recover.sh
+++ b/scripts/loop-recover.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+# scripts/loop-recover.sh — operator command to roll a ticket back to its
+# last known-good pipeline stage.
+#
+# Usage:
+#   loop-recover.sh <issue-or-pr-number> [--slug <slug>] [--to-stage <stage>] [--dry-run]
+#
+# Stages: po | dev | review | qa | merge
+#
+# Without --to-stage, reads the event log (LOOP_MONITOR_LOG or
+# $LOOP_LOG_DIR/loop-monitor-events.jsonl), finds the most recent *_done
+# event for this ticket, and maps it to the next pipeline stage.
+#
+# With --to-stage, forces the ticket to the named stage's label set.
+#
+# --dry-run prints planned operations without mutating GitHub.
+#
+# See README.md "Recovery" section for full documentation.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+# shellcheck source=../lib/config.sh
+source "$LOOP_ROOT/lib/config.sh"
+# shellcheck source=../lib/backends/backend.sh
+source "$LOOP_ROOT/lib/backends/backend.sh"
+# shellcheck source=../lib/labels.sh
+source "$LOOP_ROOT/lib/labels.sh"
+# shellcheck source=../lib/stage.sh
+source "$LOOP_ROOT/lib/stage.sh"
+
+TICKET_NUM=""
+SLUG=""
+TO_STAGE=""
+DRY_RUN=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --slug)
+            shift; SLUG="$1"
+            ;;
+        --to-stage)
+            shift; TO_STAGE="$1"
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        -*)
+            printf 'ERROR: unknown flag: %s\n' "$1" >&2; exit 2
+            ;;
+        *)
+            if [ -z "$TICKET_NUM" ]; then
+                TICKET_NUM="$1"
+            else
+                printf 'ERROR: unexpected argument: %s\n' "$1" >&2; exit 2
+            fi
+            ;;
+    esac
+    shift
+done
+
+[ -n "$TICKET_NUM" ] || { printf 'ERROR: ticket number required\n' >&2; exit 2; }
+
+if [ -n "$TO_STAGE" ]; then
+    case "$TO_STAGE" in
+        po|dev|review|qa|merge) ;;
+        *) printf 'ERROR: invalid stage %q. Valid: po dev review qa merge\n' "$TO_STAGE" >&2; exit 2 ;;
+    esac
+fi
+
+log() { printf '[loop-recover] %s\n' "$*" >&2; }
+
+# Resolve slug — use --slug, or auto-detect when only one project is configured.
+if [ -z "$SLUG" ]; then
+    mapfile -t _slugs < <(loop_list_slugs 2>/dev/null || true)
+    if [ "${#_slugs[@]}" -eq 1 ]; then
+        SLUG="${_slugs[0]}"
+        log "auto-detected slug: $SLUG"
+    else
+        printf 'ERROR: --slug is required (found %d projects; cannot auto-detect)\n' \
+            "${#_slugs[@]}" >&2
+        exit 2
+    fi
+fi
+
+loop_load_project "$SLUG" || { printf 'ERROR: unknown slug %q\n' "$SLUG" >&2; exit 2; }
+loop_load_backend
+
+# ---------------------------------------------------------------------------
+# Determine target stage
+# ---------------------------------------------------------------------------
+TARGET_STAGE=""
+REASON=""
+
+if [ -n "$TO_STAGE" ]; then
+    TARGET_STAGE="$TO_STAGE"
+    REASON="operator-forced to stage $TO_STAGE"
+else
+    # Locate the event log (JSONL file written by loop-monitor or a log shipper).
+    MONITOR_LOG="${LOOP_MONITOR_LOG:-${LOOP_LOG_DIR}/loop-monitor-events.jsonl}"
+
+    if [ ! -f "$MONITOR_LOG" ]; then
+        printf 'ERROR: no event log found at %s\n' "$MONITOR_LOG" >&2
+        printf '  Set LOOP_MONITOR_LOG or pass --to-stage <stage> to skip auto-detection.\n' >&2
+        exit 2
+    fi
+
+    # Parse the log: find the most recent *_done event for this ticket number.
+    # Supports two line formats:
+    #   {"type":"dev_done","payload":{"issue_num":42,...}}  (_loop_emit_event format)
+    #   {"event":"dev_done","issue_num":42,...}             (flat bounty format)
+    TARGET_STAGE=$(MONITOR_LOG="$MONITOR_LOG" TICKET_NUM="$TICKET_NUM" python3 - <<'PY'
+import os, sys, json
+
+log_path = os.environ['MONITOR_LOG']
+ticket   = os.environ['TICKET_NUM']
+
+DONE_TO_STAGE = {
+    'po_done':     'dev',
+    'dev_done':    'review',
+    'review_done': 'qa',
+    'qa_done':     'merge',
+}
+
+last_stage = None
+try:
+    with open(log_path) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except Exception:
+                continue
+            # Nested format: {"type":"...","payload":{...}}
+            if 'type' in obj and 'payload' in obj:
+                event_type = obj.get('type', '')
+                payload    = obj.get('payload', {}) or {}
+            else:
+                # Flat format: {"event":"...","issue_num":...}
+                event_type = obj.get('event', obj.get('type', ''))
+                payload    = obj
+            if not event_type.endswith('_done'):
+                continue
+            issue = str(payload.get('issue_num', '') or payload.get('issue', ''))
+            pr    = str(payload.get('pr_num',    '') or payload.get('pr',    ''))
+            if ticket not in (issue, pr):
+                continue
+            stage = DONE_TO_STAGE.get(event_type)
+            if stage:
+                last_stage = stage   # keep iterating to find most recent
+except Exception:
+    pass
+
+if last_stage:
+    print(last_stage)
+    sys.exit(0)
+sys.exit(1)
+PY
+    ) || {
+        printf 'ERROR: no known-good stage found in event log for ticket #%s\n' "$TICKET_NUM" >&2
+        printf '  Pass --to-stage <stage> to force a specific stage.\n' >&2
+        exit 2
+    }
+    REASON="auto-detected from event log (last *_done → $TARGET_STAGE)"
+fi
+
+log "target stage: $TARGET_STAGE ($REASON)"
+
+# Resolve the trigger label for the target stage (honours per-project overrides).
+TARGET_LABEL=$(loop_trigger_label_for_stage "$SLUG" "$TARGET_STAGE") || {
+    printf 'ERROR: could not resolve trigger label for stage %q\n' "$TARGET_STAGE" >&2
+    exit 2
+}
+[ -n "$TARGET_LABEL" ] || {
+    printf 'ERROR: empty trigger label for stage %q\n' "$TARGET_STAGE" >&2
+    exit 2
+}
+log "target label: $TARGET_LABEL"
+
+# ---------------------------------------------------------------------------
+# Read current labels from the ticket
+# ---------------------------------------------------------------------------
+# Try PR first (gh pr view exits non-zero if number is an issue); fall back
+# to issue view. This distinguishes PRs from issues on all backends.
+TICKET_KIND=""
+if backend_pr_view "$REPO" "$TICKET_NUM" --json number >/dev/null 2>&1; then
+    TICKET_KIND="pr"
+elif backend_issue_view "$REPO" "$TICKET_NUM" --json number >/dev/null 2>&1; then
+    TICKET_KIND="issue"
+else
+    printf 'ERROR: ticket #%s not found in %s\n' "$TICKET_NUM" "$REPO" >&2
+    exit 1
+fi
+log "ticket kind: $TICKET_KIND"
+
+CURRENT_LABELS_CSV=""
+if [ "$TICKET_KIND" = "pr" ]; then
+    CURRENT_LABELS_CSV=$(backend_pr_view "$REPO" "$TICKET_NUM" \
+        --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+else
+    CURRENT_LABELS_CSV=$(backend_issue_view "$REPO" "$TICKET_NUM" \
+        --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+fi
+
+# ---------------------------------------------------------------------------
+# Idempotency: check whether target label is already the only pipeline label
+# ---------------------------------------------------------------------------
+ALREADY_DONE=$(CURRENT="$CURRENT_LABELS_CSV" TARGET="$TARGET_LABEL" \
+    STAGE_LABELS="$(loop_pipeline_stage_labels_csv)" python3 - <<'PY'
+import os
+current      = [l for l in os.environ['CURRENT'].split(',') if l]
+target       = os.environ['TARGET']
+stage_labels = set(os.environ['STAGE_LABELS'].split(','))
+pipeline_on  = [l for l in current if l in stage_labels]
+print('yes' if pipeline_on == [target] else 'no')
+PY
+)
+
+# Labels to remove: every pipeline-stage label that is NOT the target.
+LABELS_TO_REMOVE=$(CURRENT="$CURRENT_LABELS_CSV" TARGET="$TARGET_LABEL" \
+    STAGE_LABELS="$(loop_pipeline_stage_labels_csv)" python3 - <<'PY'
+import os
+current      = [l for l in os.environ['CURRENT'].split(',') if l]
+target       = os.environ['TARGET']
+stage_labels = set(os.environ['STAGE_LABELS'].split(','))
+for lbl in current:
+    if lbl in stage_labels and lbl != target:
+        print(lbl)
+PY
+)
+
+# ---------------------------------------------------------------------------
+# Build comment body
+# ---------------------------------------------------------------------------
+COMMENT_BODY="**Loop recovery** — operator rolled ticket #${TICKET_NUM} back to stage \`${TARGET_STAGE}\` (\`${TARGET_LABEL}\`).
+
+**Reason:** ${REASON}
+
+Pipeline labels have been updated: all conflicting stage labels removed; \`${TARGET_LABEL}\` applied. The pipeline will re-claim this ticket on the next scanner tick."
+
+# ---------------------------------------------------------------------------
+# Dry-run output
+# ---------------------------------------------------------------------------
+if $DRY_RUN; then
+    if [ "$ALREADY_DONE" = "yes" ]; then
+        printf '[dry-run] ticket #%s already at stage %s (%s) — no label changes needed\n' \
+            "$TICKET_NUM" "$TARGET_STAGE" "$TARGET_LABEL"
+    else
+        printf '[dry-run] would add label: %s\n' "$TARGET_LABEL"
+        if [ -n "$LABELS_TO_REMOVE" ]; then
+            while IFS= read -r lbl; do
+                printf '[dry-run] would remove label: %s\n' "$lbl"
+            done <<< "$LABELS_TO_REMOVE"
+        fi
+    fi
+    printf '[dry-run] would post comment:\n%s\n' "$COMMENT_BODY"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Apply label changes
+# ---------------------------------------------------------------------------
+if [ "$ALREADY_DONE" != "yes" ]; then
+    if [ -n "$LABELS_TO_REMOVE" ]; then
+        while IFS= read -r lbl; do
+            log "removing label: $lbl"
+            backend_remove_label "$REPO" "$TICKET_NUM" "$lbl" \
+                || log "WARN: failed to remove label $lbl"
+        done <<< "$LABELS_TO_REMOVE"
+    fi
+    log "adding label: $TARGET_LABEL"
+    backend_add_label "$REPO" "$TICKET_NUM" "$TARGET_LABEL" \
+        || log "WARN: failed to add label $TARGET_LABEL"
+else
+    log "ticket #$TICKET_NUM already at $TARGET_STAGE ($TARGET_LABEL) — skipping label changes"
+fi
+
+# ---------------------------------------------------------------------------
+# Post recovery comment (idempotent: skip if last comment already has marker)
+# ---------------------------------------------------------------------------
+RECOVERY_MARKER="**Loop recovery**"
+LAST_COMMENT=""
+if [ "$TICKET_KIND" = "pr" ]; then
+    LAST_COMMENT=$(backend_pr_view "$REPO" "$TICKET_NUM" \
+        --json comments --jq '.comments[-1].body // ""' 2>/dev/null || echo "")
+else
+    LAST_COMMENT=$(backend_issue_view "$REPO" "$TICKET_NUM" \
+        --json comments --jq '.comments[-1].body // ""' 2>/dev/null || echo "")
+fi
+
+if printf '%s' "$LAST_COMMENT" | grep -qF "$RECOVERY_MARKER"; then
+    log "skipping comment — last comment already contains recovery marker (idempotent)"
+else
+    log "posting recovery comment on #$TICKET_NUM ($TICKET_KIND)"
+    if [ "$TICKET_KIND" = "pr" ]; then
+        backend_comment_pr "$REPO" "$TICKET_NUM" "$COMMENT_BODY" \
+            || log "WARN: failed to post comment on PR #$TICKET_NUM"
+    else
+        backend_comment_issue "$REPO" "$TICKET_NUM" "$COMMENT_BODY" \
+            || log "WARN: failed to post comment on issue #$TICKET_NUM"
+    fi
+fi
+
+log "done: ticket #$TICKET_NUM recovered to stage $TARGET_STAGE ($TARGET_LABEL)"

--- a/tests/loop-recover.bats
+++ b/tests/loop-recover.bats
@@ -1,0 +1,371 @@
+#!/usr/bin/env bats
+# tests/loop-recover.bats — unit tests for scripts/loop-recover.sh.
+#
+# Each test:
+#   - provides a fixture event log (LOOP_MONITOR_LOG)
+#   - stubs gh via a mock binary on PATH
+#   - runs loop-recover.sh as a subprocess
+#   - asserts correct label add/remove operations and comment posting
+#
+# No real GitHub calls are made.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_WORKFLOW_DIR="$REPO_ROOT/config/workflows"
+
+    # Isolate logs and config from the operator's real files.
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Suppress loop.env loading (no real env file in tests).
+    export LOOP_CONFIG="$BATS_TMPDIR/fixture.yaml"
+
+    # Minimal project fixture — uses the default workflow so label names are
+    # deterministic: needs-dev, needs-review, needs-qa, qa-pass, needs-po.
+    cat > "$BATS_TMPDIR/fixture.yaml" <<'YAML'
+version: 1
+projects:
+  - slug: test-proj
+    name: Test Project
+    repo: owner/test-repo
+    root: /tmp/fake
+    default_branch: main
+    workflow: default
+YAML
+
+    # Event log (populated per-test).
+    export LOOP_MONITOR_LOG="$BATS_TMPDIR/events.jsonl"
+    rm -f "$LOOP_MONITOR_LOG"
+
+    # gh operations log — written by the mock gh binary.
+    export GH_OPS_LOG="$BATS_TMPDIR/gh-ops.log"
+    rm -f "$GH_OPS_LOG"
+
+    # Put mock gh on PATH before real gh.
+    # LOOP_EXTRA_PATH is prepended to PATH by lib/env.sh, so we must include
+    # the mock bin dir there to ensure our stub wins over the system gh.
+    mkdir -p "$BATS_TMPDIR/bin"
+    export LOOP_EXTRA_PATH="$BATS_TMPDIR/bin"
+    cat > "$BATS_TMPDIR/bin/gh" <<'GHSH'
+#!/usr/bin/env bash
+# Mock gh: log every invocation; return fixture data for view queries.
+printf 'gh %s\n' "$*" >> "$GH_OPS_LOG"
+args="$*"
+case "$args" in
+    *"--json labels"*)
+        # Return current labels CSV via jq-style output.
+        printf '%s\n' "${GH_MOCK_LABELS:-}"
+        ;;
+    *"--json comments"*)
+        # Return last comment body string.
+        printf '%s\n' "${GH_MOCK_LAST_COMMENT:-}"
+        ;;
+    *"pr view"*"--json number"*)
+        # Succeed only when ticket is a PR.
+        exit "${GH_MOCK_IS_PR:-1}"
+        ;;
+    *"issue view"*"--json number"*)
+        # Always succeed (ticket exists as issue).
+        printf '{"number":%s}\n' "${GH_MOCK_TICKET:-42}"
+        ;;
+esac
+exit "${GH_MOCK_EXIT:-0}"
+GHSH
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    # Default: ticket is an issue, no current pipeline labels, no prior comment.
+    export GH_MOCK_IS_PR=1       # non-zero → gh pr view exits 1 (not a PR)
+    export GH_MOCK_LABELS=""     # empty → no current labels
+    export GH_MOCK_LAST_COMMENT=""
+    export GH_MOCK_TICKET=42
+    export GH_MOCK_EXIT=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/fixture.yaml" \
+           "$BATS_TMPDIR/logs" \
+           "$BATS_TMPDIR/bin" \
+           "$BATS_TMPDIR/events.jsonl" \
+           "$BATS_TMPDIR/gh-ops.log" 2>/dev/null || true
+}
+
+# Helper: write a single *_done event to the event log.
+_write_event() {
+    local event_type="$1" issue_num="$2"
+    printf '{"type":"%s","payload":{"project":"test-proj","issue_num":%s}}\n' \
+        "$event_type" "$issue_num" >> "$LOOP_MONITOR_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Stage 1 — po_done → recover to dev (needs-dev)
+# ---------------------------------------------------------------------------
+
+@test "recover: po_done event → adds needs-dev label" {
+    _write_event "po_done" 42
+
+    run "$REPO_ROOT/scripts/loop-recover.sh" 42 --slug test-proj
+    [ "$status" -eq 0 ]
+
+    grep -q "add-label needs-dev" "$GH_OPS_LOG"
+}
+
+@test "recover: po_done event → does not add needs-po (removes old stage)" {
+    export GH_MOCK_LABELS="needs-po"
+    _write_event "po_done" 42
+
+    run "$REPO_ROOT/scripts/loop-recover.sh" 42 --slug test-proj
+    [ "$status" -eq 0 ]
+
+    grep -q "remove-label needs-po" "$GH_OPS_LOG"
+    grep -q "add-label needs-dev" "$GH_OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Stage 2 — dev_done → recover to review (needs-review)
+# ---------------------------------------------------------------------------
+
+@test "recover: dev_done event → adds needs-review label" {
+    _write_event "dev_done" 42
+
+    run "$REPO_ROOT/scripts/loop-recover.sh" 42 --slug test-proj
+    [ "$status" -eq 0 ]
+
+    grep -q "add-label needs-review" "$GH_OPS_LOG"
+}
+
+@test "recover: dev_done event → strips needs-dev when present" {
+    export GH_MOCK_LABELS="needs-dev"
+    _write_event "dev_done" 42
+
+    run "$REPO_ROOT/scripts/loop-recover.sh" 42 --slug test-proj
+    [ "$status" -eq 0 ]
+
+    grep -q "remove-label needs-dev" "$GH_OPS_LOG"
+    grep -q "add-label needs-review" "$GH_OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Stage 3 — review_done → recover to qa (needs-qa)
+# ---------------------------------------------------------------------------
+
+@test "recover: review_done event → adds needs-qa label" {
+    _write_event "review_done" 42
+
+    run "$REPO_ROOT/scripts/loop-recover.sh" 42 --slug test-proj
+    [ "$status" -eq 0 ]
+
+    grep -q "add-label needs-qa" "$GH_OPS_LOG"
+}
+
+@test "recover: review_done event → strips needs-review when present" {
+    export GH_MOCK_LABELS="needs-review"
+    _write_event "review_done" 42
+
+    run "$REPO_ROOT/scripts/loop-recover.sh" 42 --slug test-proj
+    [ "$status" -eq 0 ]
+
+    grep -q "remove-label needs-review" "$GH_OPS_LOG"
+    grep -q "add-label needs-qa" "$GH_OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Stage 4 — qa_done → recover to merge (qa-pass)
+# ---------------------------------------------------------------------------
+
+@test "recover: qa_done event → adds qa-pass label" {
+    _write_event "qa_done" 42
+
+    run "$REPO_ROOT/scripts/loop-recover.sh" 42 --slug test-proj
+    [ "$status" -eq 0 ]
+
+    grep -q "add-label qa-pass" "$GH_OPS_LOG"
+}
+
+@test "recover: qa_done event → strips needs-qa when present" {
+    export GH_MOCK_LABELS="needs-qa"
+    _write_event "qa_done" 42
+
+    run "$REPO_ROOT/scripts/loop-recover.sh" 42 --slug test-proj
+    [ "$status" -eq 0 ]
+
+    grep -q "remove-label needs-qa" "$GH_OPS_LOG"
+    grep -q "add-label qa-pass" "$GH_OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Stage 5 — --to-stage po → adds needs-po
+# ---------------------------------------------------------------------------
+
+@test "recover: --to-stage po → adds needs-po label without reading event log" {
+    # No event log needed when --to-stage is given.
+    export GH_MOCK_LABELS="needs-dev"
+
+    run "$REPO_ROOT/scripts/loop-recover.sh" 42 --slug test-proj --to-stage po
+    [ "$status" -eq 0 ]
+
+    grep -q "add-label needs-po" "$GH_OPS_LOG"
+    grep -q "remove-label needs-dev" "$GH_OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# --to-stage overrides for all stages
+# ---------------------------------------------------------------------------
+
+@test "recover: --to-stage dev → adds needs-dev" {
+    run "$REPO_ROOT/scripts/loop-recover.sh" 42 --slug test-proj --to-stage dev
+    [ "$status" -eq 0 ]
+    grep -q "add-label needs-dev" "$GH_OPS_LOG"
+}
+
+@test "recover: --to-stage review → adds needs-review" {
+    run "$REPO_ROOT/scripts/loop-recover.sh" 42 --slug test-proj --to-stage review
+    [ "$status" -eq 0 ]
+    grep -q "add-label needs-review" "$GH_OPS_LOG"
+}
+
+@test "recover: --to-stage qa → adds needs-qa" {
+    run "$REPO_ROOT/scripts/loop-recover.sh" 42 --slug test-proj --to-stage qa
+    [ "$status" -eq 0 ]
+    grep -q "add-label needs-qa" "$GH_OPS_LOG"
+}
+
+@test "recover: --to-stage merge → adds qa-pass" {
+    run "$REPO_ROOT/scripts/loop-recover.sh" 42 --slug test-proj --to-stage merge
+    [ "$status" -eq 0 ]
+    grep -q "add-label qa-pass" "$GH_OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# --dry-run
+# ---------------------------------------------------------------------------
+
+@test "recover --dry-run: prints planned operations, no gh edit calls" {
+    export GH_MOCK_LABELS="needs-dev"
+    _write_event "dev_done" 42
+
+    run "$REPO_ROOT/scripts/loop-recover.sh" 42 --slug test-proj --dry-run
+    [ "$status" -eq 0 ]
+
+    # Dry-run output must mention what would happen.
+    printf '%s\n' "$output" | grep -q "would add label"
+    printf '%s\n' "$output" | grep -q "would remove label"
+
+    # No real gh edit calls must occur.
+    ! grep -q "issue edit" "$GH_OPS_LOG" || ! grep -q "pr edit" "$GH_OPS_LOG"
+}
+
+@test "recover --dry-run: prints comment body" {
+    _write_event "qa_done" 42
+
+    run "$REPO_ROOT/scripts/loop-recover.sh" 42 --slug test-proj --dry-run
+    [ "$status" -eq 0 ]
+
+    printf '%s\n' "$output" | grep -q "would post comment"
+    printf '%s\n' "$output" | grep -q "Loop recovery"
+}
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+@test "recover: idempotent — already at target stage, no label changes" {
+    # Ticket already carries needs-review (the dev_done target stage).
+    export GH_MOCK_LABELS="needs-review"
+    _write_event "dev_done" 42
+
+    run "$REPO_ROOT/scripts/loop-recover.sh" 42 --slug test-proj
+    [ "$status" -eq 0 ]
+
+    # No add-label or remove-label calls.
+    ! grep -q "add-label" "$GH_OPS_LOG"
+    ! grep -q "remove-label" "$GH_OPS_LOG"
+}
+
+@test "recover: idempotent — second run skips comment when last comment has recovery marker" {
+    export GH_MOCK_LAST_COMMENT="**Loop recovery** — operator rolled ticket #42 back to stage"
+    _write_event "dev_done" 42
+
+    run "$REPO_ROOT/scripts/loop-recover.sh" 42 --slug test-proj
+    [ "$status" -eq 0 ]
+
+    # No issue comment or pr comment call.
+    ! grep -q "issue comment" "$GH_OPS_LOG"
+    ! grep -q "pr comment" "$GH_OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Most-recent-event wins (last *_done in log takes precedence)
+# ---------------------------------------------------------------------------
+
+@test "recover: most recent done event wins when log has multiple events" {
+    # Older event: po_done → dev; newer event: dev_done → review
+    _write_event "po_done" 42
+    _write_event "dev_done" 42
+
+    run "$REPO_ROOT/scripts/loop-recover.sh" 42 --slug test-proj
+    [ "$status" -eq 0 ]
+
+    # Must target review (dev_done), NOT dev (po_done).
+    grep -q "add-label needs-review" "$GH_OPS_LOG"
+    ! grep -q "add-label needs-dev" "$GH_OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+@test "recover: exits non-zero when no event log and no --to-stage" {
+    rm -f "$LOOP_MONITOR_LOG"
+
+    run "$REPO_ROOT/scripts/loop-recover.sh" 42 --slug test-proj
+    [ "$status" -ne 0 ]
+    printf '%s\n' "$output" | grep -qi "event log"
+}
+
+@test "recover: exits non-zero when no matching event for ticket" {
+    # Event is for ticket #99, not #42.
+    _write_event "dev_done" 99
+
+    run "$REPO_ROOT/scripts/loop-recover.sh" 42 --slug test-proj
+    [ "$status" -ne 0 ]
+    printf '%s\n' "$output" | grep -qi "no known-good stage"
+}
+
+@test "recover: exits non-zero for unknown --to-stage value" {
+    run "$REPO_ROOT/scripts/loop-recover.sh" 42 --slug test-proj --to-stage invalid
+    [ "$status" -ne 0 ]
+}
+
+@test "recover: exits non-zero when ticket number is missing" {
+    run "$REPO_ROOT/scripts/loop-recover.sh" --slug test-proj
+    [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Flat event log format (bounty-style)
+# ---------------------------------------------------------------------------
+
+@test "recover: parses flat event format {event:..., issue_num:...}" {
+    printf '{"event":"review_done","project":"test-proj","issue_num":42}\n' \
+        >> "$LOOP_MONITOR_LOG"
+
+    run "$REPO_ROOT/scripts/loop-recover.sh" 42 --slug test-proj
+    [ "$status" -eq 0 ]
+
+    grep -q "add-label needs-qa" "$GH_OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Comment is posted on real run
+# ---------------------------------------------------------------------------
+
+@test "recover: posts comment on issue when not already recovered" {
+    _write_event "dev_done" 42
+
+    run "$REPO_ROOT/scripts/loop-recover.sh" 42 --slug test-proj
+    [ "$status" -eq 0 ]
+
+    grep -q "issue comment" "$GH_OPS_LOG"
+}


### PR DESCRIPTION
Closes #296

## Changes

- **`scripts/loop-recover.sh`** (new, executable): operator command that rolls a ticket back to its last known-good pipeline stage.
  - Reads `*_done` events from a JSONL event log (`$LOOP_MONITOR_LOG`) and maps each to the appropriate next stage (`po_done`→`dev`, `dev_done`→`review`, `review_done`→`qa`, `qa_done`→`merge`)
  - `--to-stage <stage>` overrides auto-detection for any of the five stages (`po`, `dev`, `review`, `qa`, `merge`)
  - `--dry-run` prints planned label add/remove operations and comment body without mutating GitHub
  - `--slug <slug>` selects the project; auto-detects when only one project is configured
  - Derives trigger labels from `loop_trigger_label_for_stage` (lib/stage.sh) and removes conflicting labels via `loop_pipeline_stage_labels_csv` — stays in sync with per-project workflow overrides
  - Posts a recovery comment explaining the rollback; idempotent on both label state and comment (skips comment when last comment already contains the recovery marker)
  - Sources `lib/env.sh`, `lib/config.sh`, `lib/backends/backend.sh`, `lib/labels.sh`, `lib/stage.sh` per project convention

- **`tests/loop-recover.bats`** (new): 24 bats tests covering all 5 pipeline stages (via fixture event logs), `--to-stage` overrides for each stage, `--dry-run`, idempotency (label state + comment), most-recent-event-wins semantics, flat JSONL event format, and error paths. `gh` is stubbed via a mock binary placed on `PATH` via `LOOP_EXTRA_PATH` — no network calls.

- **`README.md`**: new "Recovery" section documenting usage, flags, auto-detection stage→label table, `LOOP_MONITOR_LOG` configuration, and examples.

## Test Plan

- All 24 `bats tests/loop-recover.bats` tests pass locally
- `bash -n` syntax check passes on all scripts
- `shellcheck -S warning` passes on all scripts
- No personal identifiers in committed files