### PR TITLE
[LOOP-302] eliminate N+1 gh API calls in loop_gh_issues_with_label

### DIFF
--- a/lib/github.sh
+++ b/lib/github.sh
@@ -3,20 +3,30 @@
 
 set -euo pipefail
 
-# loop_issue_parent_epic <repo> <number>
-# Parses the issue body for an epic reference (case-insensitive, first match):
+# _loop_parse_parent_epic_body <body>
+# Parses a body string for an epic reference (case-insensitive, first match):
 #   "Epic: #NNN" | "Child of #NNN" | "Parent: #NNN" | "Part of #NNN"
 # Prints the epic issue number, or 9999999 when none is found.
-loop_issue_parent_epic() {
-    local repo="$1" number="$2"
-    local body match
-    body=$(gh issue view "$number" --repo "$repo" --json body --jq '.body' 2>/dev/null) || { echo 9999999; return; }
+# Pure text-in / number-out — no API calls.
+_loop_parse_parent_epic_body() {
+    local body="$1"
+    local match
     [ -z "$body" ] || [ "$body" = "null" ] && { echo 9999999; return; }
     match=$(printf '%s' "$body" \
         | grep -ioE '(epic[[:space:]]*:|child of|parent[[:space:]]*:|part of)[[:space:]]*#([0-9]+)' \
         | head -1 \
         | grep -oE '[0-9]+$') || true
     printf '%s\n' "${match:-9999999}"
+}
+
+# loop_issue_parent_epic <repo> <number>
+# Fetches the issue body and delegates to _loop_parse_parent_epic_body.
+# Kept for external callers; loop_gh_issues_with_label uses the cached body.
+loop_issue_parent_epic() {
+    local repo="$1" number="$2"
+    local body
+    body=$(gh issue view "$number" --repo "$repo" --json body --jq '.body' 2>/dev/null) || { echo 9999999; return; }
+    _loop_parse_parent_epic_body "$body"
 }
 
 # loop_gh_issues_with_label <repo> <label>
@@ -38,14 +48,18 @@ loop_gh_issues_with_label() {
     # stage trigger label gets emitted as an issue event with a PR-shaped
     # payload (pr_number, no issue_number) — breaks downstream interpolation
     # and dispatches dev-handler against a PR. Filter to true issues by URL.
+    #
+    # body is fetched in the same bulk call so that _loop_parse_parent_epic_body
+    # can extract the epic sort key without any per-issue gh API calls.
     gh issue list --repo "$repo" --label "$label" --state open \
-        --json number,title,url,labels,author \
+        --json number,title,url,labels,author,body \
         --jq '
           map(select(.url | contains("/issues/")))
           | map(
               ([.labels[].name]) as $L |
               {
                 number, title, url, labels: $L, author: .author.login,
+                _body: (.body // ""),
                 _p: (
                   if   ($L | index("p0-critical")) then 0
                   elif ($L | index("p1-high"))     then 1
@@ -63,11 +77,12 @@ loop_gh_issues_with_label() {
     fi
 
     while IFS= read -r obj; do
-        local num _p _b epic clean
+        local num _p _b body epic clean
         num=$(printf '%s' "$obj" | jq -r '.number')
         _p=$(printf '%s'  "$obj" | jq -r '._p')
         _b=$(printf '%s'  "$obj" | jq -r '._b')
-        epic=$(loop_issue_parent_epic "$repo" "$num")
+        body=$(printf '%s' "$obj" | jq -r '._body // ""')
+        epic=$(_loop_parse_parent_epic_body "$body")
         clean=$(printf '%s' "$obj" | jq -c '{number, title, url, labels, author}')
         printf '%07d %d %d %07d %s\n' "$epic" "$_p" "$_b" "$num" "$clean" >>"$sort_tmp"
     done <"$raw_tmp"

--- a/tests/github-bulk-body.bats
+++ b/tests/github-bulk-body.bats
@@ -1,0 +1,125 @@
+#!/usr/bin/env bats
+# tests/github-bulk-body.bats
+# Asserts that loop_gh_issues_with_label collapses N+1 API calls into one:
+# body is fetched in the bulk gh issue list call; no per-issue gh issue view.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    # shellcheck source=../lib/github.sh
+    source "$REPO_ROOT/lib/github.sh"
+
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# _loop_parse_parent_epic_body
+# ---------------------------------------------------------------------------
+
+@test "_loop_parse_parent_epic_body: returns 9999999 for empty body" {
+    run _loop_parse_parent_epic_body ""
+    [ "$status" -eq 0 ]
+    [ "$output" = "9999999" ]
+}
+
+@test "_loop_parse_parent_epic_body: returns 9999999 for null body" {
+    run _loop_parse_parent_epic_body "null"
+    [ "$status" -eq 0 ]
+    [ "$output" = "9999999" ]
+}
+
+@test "_loop_parse_parent_epic_body: extracts epic from 'Epic: #42'" {
+    run _loop_parse_parent_epic_body "Epic: #42"
+    [ "$status" -eq 0 ]
+    [ "$output" = "42" ]
+}
+
+@test "_loop_parse_parent_epic_body: extracts epic from 'Child of #100'" {
+    run _loop_parse_parent_epic_body "Child of #100"
+    [ "$status" -eq 0 ]
+    [ "$output" = "100" ]
+}
+
+@test "_loop_parse_parent_epic_body: extracts epic from 'Parent: #7'" {
+    run _loop_parse_parent_epic_body "Parent: #7"
+    [ "$status" -eq 0 ]
+    [ "$output" = "7" ]
+}
+
+@test "_loop_parse_parent_epic_body: extracts epic from 'Part of #55'" {
+    run _loop_parse_parent_epic_body "Part of #55"
+    [ "$status" -eq 0 ]
+    [ "$output" = "55" ]
+}
+
+@test "_loop_parse_parent_epic_body: is case-insensitive" {
+    run _loop_parse_parent_epic_body "EPIC: #99"
+    [ "$status" -eq 0 ]
+    [ "$output" = "99" ]
+}
+
+@test "_loop_parse_parent_epic_body: returns 9999999 when no pattern matches" {
+    run _loop_parse_parent_epic_body "Just a regular issue body with no epic."
+    [ "$status" -eq 0 ]
+    [ "$output" = "9999999" ]
+}
+
+# ---------------------------------------------------------------------------
+# loop_gh_issues_with_label — single gh call assertion
+# ---------------------------------------------------------------------------
+
+@test "loop_gh_issues_with_label makes exactly one gh call for multiple issues" {
+    # Simulate what gh issue list --json ... --jq '...' emits after filtering:
+    # two issues shaped with _body, _p, _b fields.
+    export GH_MOCK_OUTPUT='{"number":1,"title":"Issue One","url":"https://github.com/owner/repo/issues/1","labels":["needs-dev"],"author":"user1","_body":"Epic: #42","_p":4,"_b":1}
+{"number":2,"title":"Issue Two","url":"https://github.com/owner/repo/issues/2","labels":["needs-dev","p1-high"],"author":"user2","_body":"","_p":1,"_b":1}'
+
+    local call_log
+    call_log=$(mktemp)
+    export GH_MOCK_LOG="$call_log"
+
+    run loop_gh_issues_with_label "owner/repo" "needs-dev"
+    [ "$status" -eq 0 ]
+
+    # Each gh invocation starts a new "gh <args>" entry; count only those lines.
+    local call_count
+    call_count=$(grep -c '^gh ' "$call_log" || true)
+    [ "$call_count" -eq 1 ]
+
+    rm -f "$call_log"
+}
+
+@test "loop_gh_issues_with_label emits clean JSON without _body field" {
+    export GH_MOCK_OUTPUT='{"number":3,"title":"Clean Issue","url":"https://github.com/owner/repo/issues/3","labels":["needs-dev"],"author":"user3","_body":"Epic: #10","_p":4,"_b":1}'
+
+    run loop_gh_issues_with_label "owner/repo" "needs-dev"
+    [ "$status" -eq 0 ]
+    # Output must be valid JSON and not expose _body
+    [[ "$output" != *"_body"* ]]
+    [[ "$output" == *'"number":3'* ]]
+}
+
+@test "loop_gh_issues_with_label sorts by epic ascending then priority" {
+    # Issue 10: no epic (9999999), p1-high
+    # Issue 5: epic #2, no priority label
+    # Expected order: issue 5 (epic 2) then issue 10 (epic 9999999)
+    export GH_MOCK_OUTPUT='{"number":10,"title":"No Epic","url":"https://github.com/owner/repo/issues/10","labels":["needs-dev","p1-high"],"author":"u1","_body":"","_p":1,"_b":1}
+{"number":5,"title":"Has Epic","url":"https://github.com/owner/repo/issues/5","labels":["needs-dev"],"author":"u2","_body":"Epic: #2","_p":4,"_b":1}'
+
+    run loop_gh_issues_with_label "owner/repo" "needs-dev"
+    [ "$status" -eq 0 ]
+
+    # Issue 5 (epic #2) should appear before issue 10 (no epic)
+    issue5_pos=$(echo "$output" | grep -n '"number":5' | cut -d: -f1)
+    issue10_pos=$(echo "$output" | grep -n '"number":10' | cut -d: -f1)
+    [ "$issue5_pos" -lt "$issue10_pos" ]
+}


### PR DESCRIPTION
Closes #302

## Changes

### lib/github.sh
- Extracted `_loop_parse_parent_epic_body <body>` — pure text-in / epic-number-out helper containing the existing regex pipeline; no API calls.
- Updated `loop_issue_parent_epic` to delegate to the new helper after fetching the body (external-caller contract preserved).
- `loop_gh_issues_with_label` now includes `body` in the `gh issue list --json` field list and passes it through the jq filter as `_body`. The per-issue `loop_issue_parent_epic` call in the sort loop is replaced by `_loop_parse_parent_epic_body "$body"` against the cached value — collapsing N+1 API calls into exactly one per label per scan tick.

### tests/github-bulk-body.bats (new)
- Unit tests for `_loop_parse_parent_epic_body`: empty body, null, each keyword variant, case-insensitivity, no-match sentinel.
- `loop_gh_issues_with_label` call-count assertion: stubs `gh`, asserts exactly one `gh` invocation regardless of issue count.
- Output-shape test: verifies `_body` is stripped from emitted JSON.
- Sort-order test: verifies epic-ascending ordering (epic #2 before orphan sentinel 9999999).

## Test Plan
- All 28 tests in `tests/github.bats`, `tests/github-issues-exclude-prs.bats`, and `tests/github-bulk-body.bats` pass.
- `bash -n` and `shellcheck -S warning` on all shell files pass cleanly.
- No personal identifiers in committed files.