### PR TITLE
[LOOP-303] remove dead loop_run_orchestrator function from lib/env.sh

### DIFF
--- a/lib/env.sh
+++ b/lib/env.sh
@@ -35,18 +35,3 @@ export HOME="${HOME:-$(eval echo "~$(whoami)")}"
 
 # Ensure log dir exists
 mkdir -p "$LOOP_LOG_DIR"
-
-# Helper: run orchestrator (or fallback to claude directly)
-loop_run_orchestrator() {
-    local prompt="$1"
-    local cwd="${2:-$(pwd)}"
-
-    if [ -n "$LOOP_ORCHESTRATOR" ] && [ -x "$LOOP_ORCHESTRATOR" ]; then
-        "$LOOP_ORCHESTRATOR" "$prompt" --cwd "$cwd"
-    else
-        # Direct claude invocation (works for anyone with Claude CLI)
-        claude -p --model sonnet --output-format text \
-            --dangerously-skip-permissions \
-            "$prompt"
-    fi
-}


### PR DESCRIPTION
Closes #303

## Changes

Deleted the `loop_run_orchestrator` function (lines 39–52, including the adjacent comment header) from `lib/env.sh`. The function had zero callers in the codebase — confirmed by `grep -rn loop_run_orchestrator -- lib scripts scanner install.sh tests` returning no matches.

The live orchestrator dispatch lives in `lib/runner.sh:loop_run_agent` (~lines 94–110) and handles `--mode quick`, `LOOP_AGENT_MODEL_OVERRIDE`, and the full fallback chain. The dead function in `env.sh` was an inferior duplicate.

**LOOP_ORCHESTRATOR env var:** retained in `lib/env.sh` as an exported default (`export LOOP_ORCHESTRATOR="${LOOP_ORCHESTRATOR:-}"`). It is still read by `lib/runner.sh` and operators may set it externally via `loop.env`. It is not orphaned by this deletion.

## Test Plan

- [x] `grep -rn loop_run_orchestrator -- lib scripts scanner install.sh tests` → no matches
- [x] `bash -n lib/env.sh` → passes
- [x] `shellcheck -S warning lib/env.sh` → passes (no new findings)
- [x] `bash -n` across all `lib/*.sh scripts/*.sh scanner/*.sh install.sh` → all pass