### PR TITLE
[LOOP-304] document reconciler opt-out flags in loop.env.example

### DIFF
--- a/loop.env.example
+++ b/loop.env.example
@@ -115,6 +115,29 @@ LOOP_EXTRA_PATH="/opt/homebrew/bin:/usr/local/bin"
 # LOOP_PROGRESS_INTERVAL_SEC=30
 # LOOP_TRANSCRIPT_DIR=/tmp/orchestrator-transcripts
 
+# ─── Reconciler ──────────────────────────────────────────────────────────────
+# Set any of these to "false" to disable the corresponding reconciler sweep.
+
+# Auto-apply `needs-po` to unlabeled orphan issues (default: true).
+# LOOP_AUTO_NEEDS_PO=true
+
+# Label-state convergence sweep — re-syncs label mismatches each reconciler tick (default: true).
+# LOOP_LABEL_CONVERGE=true
+
+# Auto-close tracker/epic issues when all child issues are closed (default: true).
+# LOOP_AUTO_CLOSE_TRACKERS=true
+
+# Hours before a PR without activity is considered stale (default: 24).
+# LOOP_STALE_PR_HOURS=24
+
+# Hours before a `needs-clarification` issue triggers a reminder (default: 24).
+# LOOP_CLARIFICATION_HOURS=24
+
+# Base-move auto-rebase: set to "false" to skip rebasing PRs when their base
+# branch moves (default: true). Note: this variable intentionally lacks the
+# LOOP_ prefix in reconciler.sh — use the bare name below.
+# AUTO_REBASE_ON_BASE_MOVE=true
+
 # ─── Bounty / loop-monitor ────────────────────────────────────────────────────
 # Stable identifier for this Loop instance sent with every bounty/event payload.
 # Lets loop-monitor distinguish multiple Loop instances reporting to the same endpoint.


### PR DESCRIPTION
Closes #304

## Changes

Added a `# ─── Reconciler ───` section to `loop.env.example` with commented-out entries for all six reconciler opt-out variables:

- `LOOP_AUTO_NEEDS_PO` (default: `true`) — auto-apply \`needs-po\` to unlabeled orphan issues
- `LOOP_LABEL_CONVERGE` (default: `true`) — label-state convergence sweep
- `LOOP_AUTO_CLOSE_TRACKERS` (default: `true`) — auto-close tracker/epic issues when all children close
- `LOOP_STALE_PR_HOURS` (default: `24`) — hours before a PR is considered stale
- `LOOP_CLARIFICATION_HOURS` (default: `24`) — hours before a \`needs-clarification\` issue triggers a reminder
- `AUTO_REBASE_ON_BASE_MOVE` (default: `true`) — documented under its current bare name (path a) with a comment noting it intentionally lacks the \`LOOP_\` prefix; no reconciler changes

All defaults were verified against `scanner/reconciler.sh` (lines 45, 350, 2184, 2350, 2472, 2638) before committing — they match the spec exactly.

No functional code changes; `scanner/reconciler.sh` is untouched.

## Test Plan

- Confirm new section appears in `loop.env.example` with correct defaults and style
- Run `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — passes
- Confirm no personal identifiers introduced