### PR TITLE
[LOOP-304] document reconciler opt-out flags in loop.env.example

### DIFF
--- a/loop.env.example
+++ b/loop.env.example
@@ -121,3 +121,29 @@ LOOP_EXTRA_PATH="/opt/homebrew/bin:/usr/local/bin"
 # Defaults to: <hostname>-<first8ofsha256(LOOP_ROOT)>. Set explicitly to pin the id
 # across host renames or when running multiple instances on the same host.
 # LOOP_ID="my-instance-id"
+
+# ─── Reconciler ──────────────────────────────────────────────────────────────
+# Hours before a PR with no activity is considered stale and triggers a
+# notification. Set to 0 to disable stale-PR alerts.
+# LOOP_STALE_PR_HOURS=24
+
+# Hours before a `needs-clarification` issue without an operator reply triggers
+# a reminder notification. Set to 0 to disable.
+# LOOP_CLARIFICATION_HOURS=24
+
+# Auto-apply `needs-po` label to unlabeled orphan issues (issues with no
+# pipeline label). Set to false to manage issue labeling manually.
+# LOOP_AUTO_NEEDS_PO=true
+
+# Label-state convergence sweep: reconciles mismatches between PR state and
+# issue labels on every reconciler tick. Set to false to disable.
+# LOOP_LABEL_CONVERGE=true
+
+# Auto-close tracker/epic issues when all child issues are closed.
+# Set to false to close epics manually.
+# LOOP_AUTO_CLOSE_TRACKERS=true
+
+# Auto-rebase open PRs when their base branch moves. Note: this variable
+# intentionally lacks the LOOP_ prefix (used as AUTO_REBASE_ON_BASE_MOVE
+# in scanner/reconciler.sh). Set to false to disable automatic rebasing.
+# AUTO_REBASE_ON_BASE_MOVE=true


### PR DESCRIPTION
Closes #304

## Changes

Added a `# ─── Reconciler ───` section to `loop.env.example` with commented-out entries for all six reconciler feature flags that were previously undiscoverable without reading reconciler source:

| Variable | Default | What it gates |
|---|---|---|
| `LOOP_STALE_PR_HOURS` | `24` | Hours before a PR is considered stale |
| `LOOP_CLARIFICATION_HOURS` | `24` | Hours before a needs-clarification reminder fires |
| `LOOP_AUTO_NEEDS_PO` | `true` | Auto-apply needs-po to unlabeled orphan issues |
| `LOOP_LABEL_CONVERGE` | `true` | Label-state convergence sweep |
| `LOOP_AUTO_CLOSE_TRACKERS` | `true` | Auto-close tracker/epic issues when all children close |
| `AUTO_REBASE_ON_BASE_MOVE` | `true` | Auto-rebase PRs when base branch moves |

**`AUTO_REBASE_ON_BASE_MOVE` handling:** Took path (a) — pure docs, no code change. The entry is documented under its current bare name with a comment noting the missing `LOOP_` prefix. This matches `reconciler.sh:2184` exactly.

**Defaults verified** by grepping reconciler.sh:
- Line 45: `STALE_PR_HOURS="${LOOP_STALE_PR_HOURS:-24}"` ✓
- Line 350: `CLARIFICATION_REMINDER_HOURS="${LOOP_CLARIFICATION_HOURS:-24}"` ✓ (issue cited line 402 but actual is 350 — used source-of-truth)
- Line 2184: `"${AUTO_REBASE_ON_BASE_MOVE:-true}"` ✓
- Line 2350: `"${LOOP_AUTO_NEEDS_PO:-true}"` ✓
- Line 2472: `"${LOOP_LABEL_CONVERGE:-true}"` ✓
- Line 2638: `"${LOOP_AUTO_CLOSE_TRACKERS:-true}"` ✓

No shell files were modified — docs-only change.

## Test Plan

- `bash -n` passes on all shell files (unchanged)
- `shellcheck -S warning` passes on all shell files (unchanged)
- `loop.env.example` contains a Reconciler section with all six variables
- Each documented default matches the actual default in `scanner/reconciler.sh`