### PR TITLE
[LOOP-310] add diagnostic context to *_failed and qa_fail bounty events

### DIFF
--- a/lib/bounty.sh
+++ b/lib/bounty.sh
@@ -42,6 +42,21 @@ _bounty_loop_id() {
     printf '%s-%s' "$host" "${root_hash:-00000000}"
 }
 
+# bounty_truncate_detail <text>
+# Normalise <text> for use as a bounty detail value:
+#   newlines → spaces, whitespace collapsed, hard-cut at 200 chars.
+# Returns empty string on empty input.
+# Usage: detail="$(bounty_truncate_detail "$raw") | attempt N/M"
+bounty_truncate_detail() {
+    local raw="${1:-}"
+    [ -z "$raw" ] && return 0
+    printf '%s' "$raw" \
+        | tr '\n\r\t' '   ' \
+        | tr -s ' ' \
+        | sed 's/^ *//;s/ *$//' \
+        | cut -c1-200
+}
+
 # bounty_report <event> [key=value ...]
 # Keys: agent model role project issue_num pr_num detail
 # Example: bounty_report "dev_start" role=dev model=sonnet project=myapp issue_num=42

--- a/scripts/dev-handler.sh
+++ b/scripts/dev-handler.sh
@@ -276,6 +276,7 @@ else
 
     # Capture the agent output tail so we can classify the failure.
     _agent_tail=$(tail -n +"$((LOG_CAPTURE_START + 1))" "$LOG_FILE" 2>/dev/null | tail -200)
+    _dev_diag="$(bounty_truncate_detail "$_agent_tail")"
 
     # Fail-fast on untracked-data dependencies — when the worker complains
     # about a missing file that looks like gitignored runtime data (ML
@@ -286,7 +287,7 @@ else
         _missing_path=$(loop_extract_missing_path "$_agent_tail")
         log "dev agent failed for #$ISSUE_NUM — untracked-data dependency (${_missing_path:-?}); marking blocked without burning retry"
         _failure_reason=$(loop_failure_category "$_agent_tail" 1)
-        bounty_report "dev_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" issue_num="$ISSUE_NUM" detail="untracked-data: ${_missing_path:-?}" failure_reason="$_failure_reason" || true
+        bounty_report "dev_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" issue_num="$ISSUE_NUM" detail="${_dev_diag:+${_dev_diag} | }untracked-data: ${_missing_path:-?}" failure_reason="$_failure_reason" || true
         backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
         backend_add_label "$REPO" "$ISSUE_NUM" blocked
         _block_body=$(mktemp /tmp/loop-block-XXXXXX.md)
@@ -332,7 +333,7 @@ else
     loop_backoff_record_failure "$SLUG" "$ISSUE_NUM" dev "dev attempt ${n}/${MAX_RETRIES}" >/dev/null || true
     log "dev agent failed for #$ISSUE_NUM (attempt $n/$MAX_RETRIES); backoff next-eligible logged"
     _failure_reason=$(loop_failure_category "$_agent_tail" 1)
-    bounty_report "dev_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" issue_num="$ISSUE_NUM" detail="attempt ${n}/${MAX_RETRIES}" failure_reason="$_failure_reason" || true
+    bounty_report "dev_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" issue_num="$ISSUE_NUM" detail="${_dev_diag:+${_dev_diag} | }attempt ${n}/${MAX_RETRIES}" failure_reason="$_failure_reason" || true
     if [ "$n" -ge "$MAX_RETRIES" ]; then
         backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
         backend_add_label "$REPO" "$ISSUE_NUM" blocked

--- a/scripts/dev-rework-handler.sh
+++ b/scripts/dev-rework-handler.sh
@@ -349,11 +349,13 @@ cleanup_worktree() {
 }
 
 _AGENT_RC=0
+_REWORK_LOG_START=$(wc -l < "$LOG_FILE" 2>/dev/null || echo 0)
 progress_start dev_rework
 if ! loop_run_agent "$TASK_PROMPT" "$WORKTREE_ROOT" 2>&1 | tee -a "$LOG_FILE"; then
     _AGENT_RC=1
 fi
 progress_stop
+_rework_tail=$(tail -n +"$((_REWORK_LOG_START + 1))" "$LOG_FILE" 2>/dev/null | tail -200)
 
 # Post-agent DIRTY check: if the pre-agent rebase detected conflicts, verify
 # the agent actually resolved them.  One attempt only — if the branch is still
@@ -396,8 +398,9 @@ if [ "$_POST_DIRTY" = "true" ]; then
         fi
         gh pr comment "$PR_NUM" --repo "$REPO" --body "$_BLOCK_BODY" 2>/dev/null || true
     fi
+    _rework_blocked_diag="$(bounty_truncate_detail "$_rework_tail")"
     bounty_report "rework_blocked" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" \
-        pr_num="$PR_NUM" detail="rebase-conflict files=${_POST_AGENT_CONFLICTS}" || true
+        pr_num="$PR_NUM" detail="${_rework_blocked_diag:+${_rework_blocked_diag} | }rebase-conflict files=${_POST_AGENT_CONFLICTS}" || true
     loop_notify "🚫 [$SLUG] PR#$PR_NUM rework blocked — rebase conflict unresolved"
     cleanup_worktree
     exit 0
@@ -425,7 +428,10 @@ if [ "$_AGENT_RC" -eq 0 ]; then
 else
     n=$(retry_incr)
     log "rework agent failed for PR #$PR_NUM (attempt $n/$MAX_RETRIES)"
-    bounty_report "rework_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" pr_num="$PR_NUM" detail="attempt ${n}/${MAX_RETRIES}" || true
+    # Best-effort: surface unmet AC checkboxes from reviewer feedback in the rework log.
+    _unmet_ac=$(printf '%s' "$_rework_tail" | grep -E '^\s*- \[ \]' | head -3 | tr '\n' ' ' 2>/dev/null || true)
+    _rework_failed_diag="$(bounty_truncate_detail "${_unmet_ac:-$_rework_tail}")"
+    bounty_report "rework_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" pr_num="$PR_NUM" detail="${_rework_failed_diag:+${_rework_failed_diag} | }attempt ${n}/${MAX_RETRIES}" || true
     if [ "$n" -ge "$MAX_RETRIES" ]; then
         backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_IN_REWORK"
         if [ -n "$LINKED_ISSUE" ] && ! _is_senior_escalated; then

--- a/scripts/merge-handler.sh
+++ b/scripts/merge-handler.sh
@@ -127,7 +127,8 @@ if ! backend_merge_pr "$REPO" "$PR_NUM" "$STRATEGY_FLAG" 2>&1 | tee -a "$LOG_FIL
     log "ERROR: merge failed for non-conflict reason (state=$POST_STATE)"
     _merge_tail=$(tail -n +"$((_MERGE_LOG_START + 1))" "$LOG_FILE" 2>/dev/null | tail -200)
     _failure_reason=$(loop_failure_category "$_merge_tail" 1)
-    bounty_report "merge_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=merge project="$SLUG" pr_num="$PR_NUM" detail="state=${POST_STATE}" failure_reason="$_failure_reason" || true
+    _merge_diag="$(bounty_truncate_detail "$_merge_tail")"
+    bounty_report "merge_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=merge project="$SLUG" pr_num="$PR_NUM" detail="${_merge_diag:+${_merge_diag} | }state=${POST_STATE}" failure_reason="$_failure_reason" || true
     loop_notify "❌ [$SLUG] PR#$PR_NUM merge failed: merge command failed"
     backend_remove_label "$REPO" "$PR_NUM" qa-pass
     backend_add_label "$REPO" "$PR_NUM" blocked

--- a/scripts/po-handler.sh
+++ b/scripts/po-handler.sh
@@ -516,11 +516,12 @@ else
     _IN_PROGRESS_CLAIMED=0  # disarm trap — failure path handles cleanup
 
     _failure_reason=$(loop_failure_category "$_stderr_tail" "$_agent_rc")
+    _po_diag="$(bounty_truncate_detail "$_stderr_tail")"
     if loop_is_transient_failure "$_stderr_tail" "$_agent_rc"; then
         _sig=$(loop_failure_signature "$_stderr_tail")
         _tc=$(transient_incr)
         log "po agent transient failure for #$ISSUE_NUM (transient attempt $_tc/$MAX_TRANSIENT_RETRIES, sig: ${_sig:-unknown})"
-        bounty_report "po_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=po project="$SLUG" issue_num="$ISSUE_NUM" detail="transient ${_tc}/${MAX_TRANSIENT_RETRIES} sig:${_sig:-unknown}" failure_reason="$_failure_reason" || true
+        bounty_report "po_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=po project="$SLUG" issue_num="$ISSUE_NUM" detail="${_po_diag:+${_po_diag} | }transient ${_tc}/${MAX_TRANSIENT_RETRIES} sig:${_sig:-unknown}" failure_reason="$_failure_reason" || true
         if [ "$_tc" -ge "$MAX_TRANSIENT_RETRIES" ]; then
             backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
             backend_add_label "$REPO" "$ISSUE_NUM" blocked
@@ -534,7 +535,7 @@ else
     else
         n=$(retry_incr)
         log "po agent failed for #$ISSUE_NUM (attempt $n/$MAX_RETRIES)"
-        bounty_report "po_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=po project="$SLUG" issue_num="$ISSUE_NUM" detail="attempt ${n}/${MAX_RETRIES}" failure_reason="$_failure_reason" || true
+        bounty_report "po_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=po project="$SLUG" issue_num="$ISSUE_NUM" detail="${_po_diag:+${_po_diag} | }attempt ${n}/${MAX_RETRIES}" failure_reason="$_failure_reason" || true
         if [ "$n" -ge "$MAX_RETRIES" ]; then
             backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
             backend_add_label "$REPO" "$ISSUE_NUM" needs-clarification

--- a/scripts/qa-handler.sh
+++ b/scripts/qa-handler.sh
@@ -288,6 +288,8 @@ progress_start qa
 if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
     progress_stop
     log "qa agent finished for PR #$PR_NUM"
+    _qa_agent_tail=$(tail -n +"$((_QA_LOG_START + 1))" "$LOG_FILE" 2>/dev/null | tail -200)
+    _qa_diag="$(bounty_truncate_detail "$_qa_agent_tail")"
     loop_notify "✅ [$SLUG] PR#$PR_NUM qa done"
     backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_NEEDS_QA"
     backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_READY_FOR_QA"
@@ -296,7 +298,7 @@ if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
     if backend_pr_has_any_label "$REPO" "$PR_NUM" qa-pass "$_QA_PASS_LABEL"; then
         bounty_report "qa_pass" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$SLUG" pr_num="$PR_NUM" || true
     else
-        bounty_report "qa_fail" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$SLUG" pr_num="$PR_NUM" || true
+        bounty_report "qa_fail" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$SLUG" pr_num="$PR_NUM" detail="${_qa_diag:+${_qa_diag} | }outcome=qa-fail" || true
     fi
 
     # Belt-and-braces: if agent forgot to apply a decision label, default to qa-failed.
@@ -307,14 +309,15 @@ if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
         backend_comment_pr "$REPO" "$PR_NUM" \
             "QA agent ran but did not apply a decision label. Defaulting to ${_QA_FAIL_LABEL}. Operator: see ${LOG_FILE} for the agent transcript." \
             2>/dev/null || true
-        bounty_report "qa_fail" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$SLUG" pr_num="$PR_NUM" || true
+        bounty_report "qa_fail" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$SLUG" pr_num="$PR_NUM" detail="${_qa_diag:+${_qa_diag} | }outcome=no-decision-label" || true
     fi
 else
     progress_stop
     _agent_tail=$(tail -n +"$((_QA_LOG_START + 1))" "$LOG_FILE" 2>/dev/null | tail -200)
     log "qa agent failed for PR #$PR_NUM"
     _failure_reason=$(loop_failure_category "$_agent_tail" 1)
-    bounty_report "qa_fail" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$SLUG" pr_num="$PR_NUM" failure_reason="$_failure_reason" || true
+    _qa_fail_diag="$(bounty_truncate_detail "$_agent_tail")"
+    bounty_report "qa_fail" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$SLUG" pr_num="$PR_NUM" detail="${_qa_fail_diag:+${_qa_fail_diag} | }agent-error" failure_reason="$_failure_reason" || true
     loop_notify "❌ [$SLUG] PR#$PR_NUM qa failed: agent error"
     backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_NEEDS_QA"
     backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_READY_FOR_QA"

--- a/scripts/review-handler.sh
+++ b/scripts/review-handler.sh
@@ -271,7 +271,10 @@ else
     n=$(retry_incr)
     log "review agent failed for PR #$PR_NUM (attempt $n/$MAX_RETRIES)"
     _failure_reason=$(loop_failure_category "$_agent_tail" 1)
-    bounty_report "review_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=reviewer project="$SLUG" pr_num="$PR_NUM" detail="attempt ${n}/${MAX_RETRIES}" failure_reason="$_failure_reason" || true
+    # Best-effort: surface unmet AC checkboxes from the reviewer log if present.
+    _unmet_ac=$(printf '%s' "$_agent_tail" | grep -E '^\s*- \[ \]' | head -3 | tr '\n' ' ' 2>/dev/null || true)
+    _review_diag="$(bounty_truncate_detail "${_unmet_ac:-$_agent_tail}")"
+    bounty_report "review_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=reviewer project="$SLUG" pr_num="$PR_NUM" detail="${_review_diag:+${_review_diag} | }attempt ${n}/${MAX_RETRIES}" failure_reason="$_failure_reason" || true
     if [ "$n" -ge "$MAX_RETRIES" ]; then
         backend_remove_label "$REPO" "$PR_NUM" in-review
         backend_remove_label "$REPO" "$PR_NUM" "$_REWORK_LABEL"

--- a/tests/bounty-detail.bats
+++ b/tests/bounty-detail.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+# tests/bounty-detail.bats — unit tests for bounty_truncate_detail helper.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    # shellcheck source=../lib/bounty.sh
+    source "$REPO_ROOT/lib/bounty.sh"
+}
+
+# ---------------------------------------------------------------------------
+# (a) multi-line input >200 chars: collapse newlines, truncate to ≤200
+# ---------------------------------------------------------------------------
+
+@test "bounty_truncate_detail: multi-line >200 chars has no newlines and length ≤200" {
+    local input=""
+    for i in $(seq 1 20); do
+        input="${input}diagnostic output line ${i} with agent error context here"$'\n'
+    done
+
+    run bounty_truncate_detail "$input"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+    [ "${#output}" -le 200 ]
+    # no embedded newlines
+    local stripped
+    stripped="$(printf '%s' "$output" | tr -d '\n')"
+    [ "$output" = "$stripped" ]
+}
+
+# ---------------------------------------------------------------------------
+# (b) empty input returns empty string
+# ---------------------------------------------------------------------------
+
+@test "bounty_truncate_detail: empty input returns empty output" {
+    run bounty_truncate_detail ""
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# (c) input already ≤200 chars passes through (trimmed, no newlines added)
+# ---------------------------------------------------------------------------
+
+@test "bounty_truncate_detail: short input ≤200 chars is returned intact" {
+    local input="agent exited with code 1 on step 3"
+    run bounty_truncate_detail "$input"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+    [ "${#output}" -le 200 ]
+    # no newlines
+    local stripped
+    stripped="$(printf '%s' "$output" | tr -d '\n')"
+    [ "$output" = "$stripped" ]
+}
+
+# ---------------------------------------------------------------------------
+# Appending " | attempt 1/2" keeps total ≤230 chars
+# ---------------------------------------------------------------------------
+
+@test "bounty_truncate_detail: result + ' | attempt 1/2' suffix is ≤230 chars" {
+    # Build a string well over 200 chars to force truncation.
+    local long_input=""
+    for i in $(seq 1 10); do
+        long_input="${long_input}error in pipeline stage ${i} caused by missing fixture data "
+    done
+
+    local diag
+    diag="$(bounty_truncate_detail "$long_input")"
+    local full_detail="${diag:+${diag} | }attempt 1/2"
+    [ "${#full_detail}" -le 230 ]
+}
+
+# ---------------------------------------------------------------------------
+# Whitespace is collapsed (multiple spaces/tabs become one space)
+# ---------------------------------------------------------------------------
+
+@test "bounty_truncate_detail: multiple spaces are collapsed to one" {
+    local input="foo   bar    baz"
+    run bounty_truncate_detail "$input"
+    [ "$status" -eq 0 ]
+    [ "$output" = "foo bar baz" ]
+}


### PR DESCRIPTION
Closes #310

## Changes

- **`lib/bounty.sh`**: Added `bounty_truncate_detail()` helper that normalises agent log output for use in bounty event `detail` fields — collapses newlines to spaces, trims whitespace, hard-cuts at 200 chars.
- **`scripts/po-handler.sh`**: Both `po_failed` emit sites (transient + retry) now prepend truncated `_RUN_LOG` tail before existing context (`transient N/M ...` or `attempt N/M`).
- **`scripts/dev-handler.sh`**: Both `dev_failed` emit sites (untracked-data + retry) prepend truncated agent log tail before existing context.
- **`scripts/dev-rework-handler.sh`**: Captures `_REWORK_LOG_START` before agent run; `rework_blocked` prepends log tail, `rework_failed` attempts AC-checkbox extraction (`grep -E '^\s*- \[ \]'`) from the log tail as the diagnostic, falling back to raw log tail.
- **`scripts/review-handler.sh`**: `review_failed` attempts AC-checkbox extraction from agent log, falls back to log tail, prepends to `attempt N/M`.
- **`scripts/qa-handler.sh`**: All three `qa_fail` emit sites now carry detail — agent tail + `outcome=qa-fail` / `outcome=no-decision-label` / `agent-error`.
- **`scripts/merge-handler.sh`**: `merge_failed` prepends truncated merge log tail while preserving the existing `state=${POST_STATE}` context.
- **`tests/bounty-detail.bats`**: New bats test suite for `bounty_truncate_detail` covering multi-line >200 chars, empty input, short input, and suffix cap (≤230 chars total).

All `bounty_report` calls remain best-effort (`|| true`). Wire format unchanged — only the `detail` field value is enriched.

## Test Plan

- `bash -n` syntax check passes on all modified scripts
- `shellcheck -S warning` passes on all modified scripts
- `bats tests/bounty-detail.bats` — 5/5 tests pass
- `bats tests/bounty.bats` — 17/17 existing tests pass