### PR TITLE
[LOOP-311] fix merge-handler diagnostic: capture rc, retry on transient failure

### DIFF
--- a/scripts/merge-handler.sh
+++ b/scripts/merge-handler.sh
@@ -104,9 +104,11 @@ if [ -z "$HEAD_OWNER" ] || [ "$HEAD_OWNER" != "$BASE_OWNER" ]; then
 fi
 
 _MERGE_LOG_START=$(wc -l < "$LOG_FILE" 2>/dev/null || echo 0)
+_merge_rc=0
 progress_start merge
-if ! backend_merge_pr "$REPO" "$PR_NUM" "$STRATEGY_FLAG" 2>&1 | tee -a "$LOG_FILE"; then
-    progress_stop
+backend_merge_pr "$REPO" "$PR_NUM" "$STRATEGY_FLAG" 2>&1 | tee -a "$LOG_FILE" || _merge_rc="${PIPESTATUS[0]}"
+progress_stop
+if [ "${_merge_rc}" -ne 0 ]; then
     # Check if the failure was a conflict discovered at merge time.
     POST_STATE=$(backend_pr_view "$REPO" "$PR_NUM" --json mergeable,mergeStateStatus 2>/dev/null \
         | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('mergeable',''), d.get('mergeStateStatus',''))")
@@ -122,21 +124,37 @@ if ! backend_merge_pr "$REPO" "$PR_NUM" "$STRATEGY_FLAG" 2>&1 | tee -a "$LOG_FIL
             ;;
     esac
 
-    # Non-conflict failure (e.g. required check missing, API flake). Don't
-    # loop on this either — mark blocked so a human can look.
-    log "ERROR: merge failed for non-conflict reason (state=$POST_STATE)"
-    _merge_tail=$(tail -n +"$((_MERGE_LOG_START + 1))" "$LOG_FILE" 2>/dev/null | tail -200)
-    _failure_reason=$(loop_failure_category "$_merge_tail" 1)
-    _merge_diag="$(bounty_truncate_detail "$_merge_tail")"
-    bounty_report "merge_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=merge project="$SLUG" pr_num="$PR_NUM" detail="${_merge_diag:+${_merge_diag} | }state=${POST_STATE}" failure_reason="$_failure_reason" || true
-    loop_notify "❌ [$SLUG] PR#$PR_NUM merge failed: merge command failed"
-    backend_remove_label "$REPO" "$PR_NUM" qa-pass
-    backend_add_label "$REPO" "$PR_NUM" blocked
-    backend_comment_pr "$REPO" "$PR_NUM" \
-        "Merge failed (state: \`${POST_STATE}\`). Marked \`blocked\` — needs human eyes."
-    exit 1
+    # Retry once on non-conflict failures where the PR is still in a mergeable
+    # state (e.g. transient gh CLI flake, required-check race).
+    case "$POST_STATE" in
+        *MERGEABLE*CLEAN*|*MERGEABLE*UNSTABLE*)
+            log "merge retry 1/1 (rc=${_merge_rc} state=${POST_STATE})"
+            sleep 3
+            _MERGE_LOG_START=$(wc -l < "$LOG_FILE" 2>/dev/null || echo 0)
+            _merge_rc=0
+            backend_merge_pr "$REPO" "$PR_NUM" "$STRATEGY_FLAG" 2>&1 | tee -a "$LOG_FILE" || _merge_rc="${PIPESTATUS[0]}"
+            if [ "${_merge_rc}" -eq 0 ]; then
+                log "merge retry succeeded for PR #${PR_NUM}"
+            fi
+            ;;
+    esac
+
+    if [ "${_merge_rc}" -ne 0 ]; then
+        # Non-conflict failure — capture actionable detail before marking blocked.
+        log "ERROR: merge failed for non-conflict reason (state=${POST_STATE} rc=${_merge_rc})"
+        _merge_tail=$(tail -n +"$((_MERGE_LOG_START + 1))" "$LOG_FILE" 2>/dev/null | tail -200)
+        _failure_reason=$(loop_failure_category "$_merge_tail" "${_merge_rc}")
+        _merge_diag="$(bounty_truncate_detail "$_merge_tail")"
+        _detail_diag="${_merge_diag:-rc=${_merge_rc}}"
+        bounty_report "merge_failed" model="${LOOP_AGENT_MODEL:-sonnet}" role=merge project="$SLUG" pr_num="$PR_NUM" detail="${_detail_diag} | state=${POST_STATE}" failure_reason="$_failure_reason" || true
+        loop_notify "❌ [$SLUG] PR#$PR_NUM merge failed: merge command failed"
+        backend_remove_label "$REPO" "$PR_NUM" qa-pass
+        backend_add_label "$REPO" "$PR_NUM" blocked
+        backend_comment_pr "$REPO" "$PR_NUM" \
+            "Merge failed (state: \`${POST_STATE}\`). Marked \`blocked\` — needs human eyes."
+        exit 1
+    fi
 fi
-progress_stop
 
 # ── Release-PR: tag + publish GitHub release ─────────────────────────────────
 # If this was a release PR, tag the merged commit and publish a GitHub release.


### PR DESCRIPTION
Closes #311

## Changes

**Root cause:** `scripts/merge-handler.sh` line 131 used `${_merge_diag:+${_merge_diag} | }state=${POST_STATE}` — when `_merge_diag` was empty (no log lines captured), the entire `detail` field collapsed to just `state=MERGEABLE CLEAN`, hiding the real failure reason.

**Fixes:**

1. **Explicit exit code capture** — replaced `if ! backend_merge_pr ... | tee; then` with explicit `_merge_rc="${PIPESTATUS[0]}"` capture so the actual exit code is available for both the `failure_category` classifier and the fallback detail.

2. **Better detail composition** — `_detail_diag="${_merge_diag:-rc=${_merge_rc}}"` ensures the actionable signal (log tail OR exit code) always appears first. Detail now reads `rc=1 | state=MERGEABLE CLEAN` instead of just `state=MERGEABLE CLEAN` when log capture is empty.

3. **Retry once on transient failures** — when `POST_STATE` is `MERGEABLE CLEAN` or `MERGEABLE UNSTABLE` (states GitHub should be able to merge from), the handler retries `backend_merge_pr` once after a 3s sleep. Logged as `merge retry 1/1 (rc=N state=...)`. A successful retry exits 0 with no `merge_failed` event emitted.

4. **Simplified `progress_stop` flow** — moved to be called unconditionally once after the initial merge attempt, removing the duplicate call that existed in the old failure branch.

## Test Plan

- [ ] Verify `bash -n` passes on `scripts/merge-handler.sh` (covered by CI)
- [ ] Verify `shellcheck -S warning` passes on all scripts (covered by CI)
- [ ] Verify no personal identifiers introduced (covered by CI)
- [ ] Synthetic failure: set `LOOP_MERGE_FORCE_FAIL=1` or mock `backend_merge_pr` to fail once — confirm log shows `merge retry 1/1` and `merge retry succeeded` on retry
- [ ] On a clean merge: confirm no `merge_failed` event is emitted in bounty log
- [ ] On a persistent non-conflict failure: confirm `detail` in `merge_failed` bounty event contains `rc=N | state=...` (not just `state=...`)