### PR TITLE
[LOOP-334] add SQLite jobs schema and lib/jobs.sh primitives

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -69,6 +69,17 @@ bootstrap_check_tools() {
         echo "  [ok]   python3 + pyyaml"
     fi
 
+    if ! command -v sqlite3 >/dev/null 2>&1; then
+        echo "  [fail] 'sqlite3' not found — install it:" >&2
+        echo "           macOS:  brew install sqlite" >&2
+        echo "           Debian/Ubuntu: apt install sqlite3" >&2
+        ok=false
+    else
+        local sqlite_version
+        sqlite_version=$(sqlite3 --version 2>/dev/null | awk '{print $1}')
+        echo "  [ok]   sqlite3 $sqlite_version (need >= 3.35.0 for RETURNING)"
+    fi
+
     local agent_found=false
     local _agent
     for _agent in claude codex gemini aider; do

--- a/lib/jobs.sh
+++ b/lib/jobs.sh
@@ -96,6 +96,7 @@ jobs_claim() {
     db=$(jobs_db_path)
 
     sqlite3 "$db" <<SQL
+.timeout 5000
 BEGIN IMMEDIATE;
 UPDATE jobs
    SET status='in_flight',

--- a/lib/jobs.sh
+++ b/lib/jobs.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# jobs.sh — SQLite-backed job queue primitives for Loop.
+#
+# Provides a single jobs table with a partial unique index that prevents
+# double-enqueue of the same (project, stage, issue_or_pr) while a row is
+# still pending or in_flight.  Once a job reaches completed/failed it can be
+# re-enqueued (e.g. after rework).
+#
+# Design note — jobs_enqueue deduplication policy:
+#   When a (project, stage, issue_or_pr) already has a pending/in_flight row,
+#   jobs_enqueue silently no-ops and prints the existing id.  This is the
+#   idempotent path: the scanner ticks frequently and will re-see the same
+#   issue on every poll; treating the second enqueue as an error would be
+#   noisy and unhelpful.
+#
+# Minimum SQLite version: 3.35.0 (RETURNING clause in jobs_claim).
+# macOS 12+ ships 3.39+; Ubuntu 22.04 ships 3.37+.
+#
+# Usage:
+#   source "$LOOP_ROOT/lib/jobs.sh"
+#   jobs_init_schema
+#   id=$(jobs_enqueue "myproject" "dev" 42)
+#   claimed=$(jobs_claim "myproject" "dev")
+#   jobs_complete "$claimed"
+
+set -euo pipefail
+
+# jobs_db_path — single authority for the DB file location.
+# All other functions call this rather than computing the path themselves.
+jobs_db_path() {
+    echo "${LOOP_JOBS_DB:-${LOOP_LOG_DIR:-$HOME/.loop}/jobs.db}"
+}
+
+# jobs_init_schema — create table + index when absent; idempotent.
+jobs_init_schema() {
+    local db
+    db=$(jobs_db_path)
+    mkdir -p "$(dirname "$db")"
+    sqlite3 "$db" <<'SQL'
+CREATE TABLE IF NOT EXISTS jobs (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    project       TEXT    NOT NULL,
+    stage         TEXT    NOT NULL,
+    issue_or_pr   INTEGER NOT NULL,
+    claimed_by    TEXT,
+    claimed_at    INTEGER,
+    completed_at  INTEGER,
+    status        TEXT    NOT NULL,
+    attempts      INTEGER NOT NULL DEFAULT 0,
+    last_error    TEXT,
+    created_at    INTEGER NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS jobs_active_uniq
+    ON jobs(project, stage, issue_or_pr)
+    WHERE status IN ('pending','in_flight');
+SQL
+}
+
+# jobs_enqueue <project> <stage> <issue_or_pr>
+# Inserts a new pending job and prints its id.
+# If an active (pending/in_flight) row already exists, prints its id and exits 0
+# without inserting a duplicate (idempotent enqueue — see header note).
+jobs_enqueue() {
+    local project="$1"
+    local stage="$2"
+    local issue_or_pr="$3"
+    local db
+    db=$(jobs_db_path)
+
+    local existing
+    existing=$(sqlite3 "$db" \
+        "SELECT id FROM jobs WHERE project='${project}' AND stage='${stage}' AND issue_or_pr=${issue_or_pr} AND status IN ('pending','in_flight') LIMIT 1;")
+    if [ -n "$existing" ]; then
+        echo "$existing"
+        return 0
+    fi
+
+    sqlite3 "$db" <<SQL
+INSERT INTO jobs(project, stage, issue_or_pr, status, created_at)
+VALUES('${project}', '${stage}', ${issue_or_pr}, 'pending', strftime('%s','now'));
+SELECT last_insert_rowid();
+SQL
+}
+
+# jobs_claim <project> <stage> [claimed_by]
+# Atomically claims the lowest-id pending job for (project, stage).
+# Prints the claimed row id, or nothing if no candidate.
+# Uses BEGIN IMMEDIATE so concurrent callers serialize at the SQLite write lock;
+# exactly one obtains the row, the other sees no candidate.
+jobs_claim() {
+    local project="$1"
+    local stage="$2"
+    local claimer="${3:-$$}"
+    local db
+    db=$(jobs_db_path)
+
+    sqlite3 "$db" <<SQL
+BEGIN IMMEDIATE;
+UPDATE jobs
+   SET status='in_flight',
+       claimed_by='${claimer}',
+       claimed_at=strftime('%s','now'),
+       attempts=attempts+1
+ WHERE id = (
+     SELECT id FROM jobs
+      WHERE status='pending'
+        AND project='${project}'
+        AND stage='${stage}'
+      ORDER BY id
+      LIMIT 1
+ )
+ RETURNING id;
+COMMIT;
+SQL
+}
+
+# jobs_complete <id>
+# Marks a job as completed and records the completion timestamp.
+jobs_complete() {
+    local id="$1"
+    local db
+    db=$(jobs_db_path)
+    sqlite3 "$db" "UPDATE jobs SET status='completed', completed_at=strftime('%s','now') WHERE id=${id};"
+}
+
+# jobs_fail <id> <error_message>
+# Marks a job as failed, records the error, and sets completed_at.
+jobs_fail() {
+    local id="$1"
+    local error="${2:-}"
+    local db
+    db=$(jobs_db_path)
+    # Escape single quotes in error message for SQLite
+    local safe_error="${error//\'/\'\'}"
+    sqlite3 "$db" "UPDATE jobs SET status='failed', last_error='${safe_error}', completed_at=strftime('%s','now') WHERE id=${id};"
+}
+
+# jobs_list [project] [stage] [status]
+# Lists jobs, optionally filtered.  Tab-separated output: id|project|stage|issue_or_pr|status|attempts
+jobs_list() {
+    local project="${1:-}"
+    local stage="${2:-}"
+    local filter_status="${3:-}"
+    local db
+    db=$(jobs_db_path)
+
+    local where=""
+    if [ -n "$project" ] || [ -n "$stage" ] || [ -n "$filter_status" ]; then
+        local sep="WHERE"
+        [ -n "$project" ]       && where+=" ${sep} project='${project}'"       && sep="AND"
+        [ -n "$stage" ]         && where+=" ${sep} stage='${stage}'"           && sep="AND"
+        [ -n "$filter_status" ] && where+=" ${sep} status='${filter_status}'"
+    fi
+
+    sqlite3 "$db" "SELECT id, project, stage, issue_or_pr, status, attempts FROM jobs${where} ORDER BY id;"
+}

--- a/tests/jobs-lib.bats
+++ b/tests/jobs-lib.bats
@@ -1,0 +1,198 @@
+#!/usr/bin/env bats
+# tests/jobs-lib.bats — unit tests for lib/jobs.sh
+#
+# Each test gets its own LOOP_JOBS_DB in a temp directory so there is no
+# cross-test contamination.  The tests cover:
+#   (a) init idempotency
+#   (b) enqueue deduplication (pending/in_flight blocks re-enqueue)
+#   (c) claim atomicity — parallel claims → exactly one winner
+#   (d) complete / fail status transitions
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_JOBS_DB="$BATS_TMPDIR/jobs-$$.db"
+    # shellcheck source=../lib/jobs.sh
+    source "$REPO_ROOT/lib/jobs.sh"
+    jobs_init_schema
+}
+
+teardown() {
+    rm -f "$LOOP_JOBS_DB"
+    unset LOOP_JOBS_DB
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (a) Init idempotency
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "jobs_init_schema is idempotent — calling twice produces no error" {
+    # First call already happened in setup; a second call must succeed cleanly.
+    run jobs_init_schema
+    [ "$status" -eq 0 ]
+}
+
+@test "jobs_init_schema creates the jobs table" {
+    local result
+    result=$(sqlite3 "$LOOP_JOBS_DB" \
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='jobs';")
+    [ "$result" = "jobs" ]
+}
+
+@test "jobs_init_schema creates the partial unique index" {
+    local result
+    result=$(sqlite3 "$LOOP_JOBS_DB" \
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='jobs_active_uniq';")
+    [ "$result" = "jobs_active_uniq" ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (b) Enqueue deduplication
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "jobs_enqueue returns an id on first insert" {
+    run jobs_enqueue "proj" "dev" 1
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ ^[0-9]+$ ]]
+}
+
+@test "jobs_enqueue returns the existing id when row is still pending (idempotent)" {
+    local id1 id2
+    id1=$(jobs_enqueue "proj" "dev" 10)
+    id2=$(jobs_enqueue "proj" "dev" 10)
+    [ "$id1" = "$id2" ]
+}
+
+@test "jobs_enqueue returns the existing id when row is in_flight (idempotent)" {
+    local id1
+    id1=$(jobs_enqueue "proj" "dev" 11)
+    # Claim it so it becomes in_flight
+    jobs_claim "proj" "dev" >/dev/null
+
+    local id2
+    id2=$(jobs_enqueue "proj" "dev" 11)
+    [ "$id1" = "$id2" ]
+}
+
+@test "jobs_enqueue allows re-enqueue after completed" {
+    local id1
+    id1=$(jobs_enqueue "proj" "dev" 20)
+    jobs_claim "proj" "dev" >/dev/null
+    jobs_complete "$id1"
+
+    local id2
+    id2=$(jobs_enqueue "proj" "dev" 20)
+    # A new row is inserted — ids differ
+    [ "$id1" != "$id2" ]
+    [[ "$id2" =~ ^[0-9]+$ ]]
+}
+
+@test "jobs_enqueue allows re-enqueue after failed" {
+    local id1
+    id1=$(jobs_enqueue "proj" "dev" 30)
+    jobs_claim "proj" "dev" >/dev/null
+    jobs_fail "$id1" "something broke"
+
+    local id2
+    id2=$(jobs_enqueue "proj" "dev" 30)
+    [ "$id1" != "$id2" ]
+    [[ "$id2" =~ ^[0-9]+$ ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (c) Claim atomicity — two parallel claims → exactly one winner
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "parallel jobs_claim — exactly one caller obtains the id" {
+    jobs_enqueue "proj" "dev" 99 >/dev/null
+
+    local out1="$BATS_TMPDIR/claim1-$$.txt"
+    local out2="$BATS_TMPDIR/claim2-$$.txt"
+
+    # Fire two concurrent claims; the LOOP_JOBS_DB env var is inherited.
+    (jobs_claim "proj" "dev" "worker-1" > "$out1") &
+    local pid1=$!
+    (jobs_claim "proj" "dev" "worker-2" > "$out2") &
+    local pid2=$!
+
+    wait "$pid1"
+    wait "$pid2"
+
+    local c1 c2
+    c1=$(cat "$out1")
+    c2=$(cat "$out2")
+
+    # Exactly one of the two outputs must be non-empty (the winner).
+    local non_empty=0
+    [ -n "$c1" ] && non_empty=$((non_empty + 1))
+    [ -n "$c2" ] && non_empty=$((non_empty + 1))
+
+    rm -f "$out1" "$out2"
+    [ "$non_empty" -eq 1 ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (d) Complete / fail status transitions
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "jobs_complete sets status to completed and records completed_at" {
+    local id
+    id=$(jobs_enqueue "proj" "stage" 50)
+    jobs_claim "proj" "stage" >/dev/null
+    jobs_complete "$id"
+
+    local status_val completed_at
+    status_val=$(sqlite3 "$LOOP_JOBS_DB" "SELECT status FROM jobs WHERE id=${id};")
+    completed_at=$(sqlite3 "$LOOP_JOBS_DB" "SELECT completed_at FROM jobs WHERE id=${id};")
+
+    [ "$status_val" = "completed" ]
+    [[ "$completed_at" =~ ^[0-9]+$ ]]
+}
+
+@test "jobs_fail sets status to failed and records last_error and completed_at" {
+    local id
+    id=$(jobs_enqueue "proj" "stage" 60)
+    jobs_claim "proj" "stage" >/dev/null
+    jobs_fail "$id" "timeout after 30s"
+
+    local status_val last_error completed_at
+    status_val=$(sqlite3 "$LOOP_JOBS_DB" "SELECT status FROM jobs WHERE id=${id};")
+    last_error=$(sqlite3 "$LOOP_JOBS_DB" "SELECT last_error FROM jobs WHERE id=${id};")
+    completed_at=$(sqlite3 "$LOOP_JOBS_DB" "SELECT completed_at FROM jobs WHERE id=${id};")
+
+    [ "$status_val" = "failed" ]
+    [ "$last_error" = "timeout after 30s" ]
+    [[ "$completed_at" =~ ^[0-9]+$ ]]
+}
+
+@test "jobs_list returns all rows when called with no filters" {
+    jobs_enqueue "p1" "dev" 1 >/dev/null
+    jobs_enqueue "p2" "qa"  2 >/dev/null
+
+    run jobs_list
+    [ "$status" -eq 0 ]
+    # Expect two lines
+    [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 2 ]
+}
+
+@test "jobs_list filters by project" {
+    jobs_enqueue "alpha" "dev" 1 >/dev/null
+    jobs_enqueue "beta"  "dev" 2 >/dev/null
+
+    run jobs_list "alpha"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 1 ]
+    [[ "$output" == *"alpha"* ]]
+}
+
+@test "jobs_claim increments attempts counter" {
+    local id
+    id=$(jobs_enqueue "proj" "dev" 70)
+
+    local before after
+    before=$(sqlite3 "$LOOP_JOBS_DB" "SELECT attempts FROM jobs WHERE id=${id};")
+    jobs_claim "proj" "dev" >/dev/null
+    after=$(sqlite3 "$LOOP_JOBS_DB" "SELECT attempts FROM jobs WHERE id=${id};")
+
+    [ "$before" -eq 0 ]
+    [ "$after" -eq 1 ]
+}


### PR DESCRIPTION
Closes #334

## Changes

- **`lib/jobs.sh`** — new file providing the full job queue API:
  - `jobs_db_path` — single source of truth for DB path (`LOOP_JOBS_DB` override, falls back to `${LOOP_LOG_DIR:-$HOME/.loop}/jobs.db`)
  - `jobs_init_schema` — idempotent table + partial unique index creation
  - `jobs_enqueue` — idempotent insert; returns existing id if a pending/in_flight row exists for `(project, stage, issue_or_pr)`
  - `jobs_claim` — `BEGIN IMMEDIATE` transaction; atomically flips the lowest-id pending row to `in_flight`, increments `attempts`, returns the claimed id (empty if no candidate)
  - `jobs_complete` / `jobs_fail` — finalize a job with timestamp and optional error message
  - `jobs_list` — filtered query for introspection

- **`tests/jobs-lib.bats`** — 14 tests covering: init idempotency, enqueue dedup (pending and in_flight cases), re-enqueue after completed/failed, parallel-claim atomicity (`&`/`wait` with two concurrent callers → exactly one winner), complete/fail transitions, `jobs_list` filtering, and `attempts` increment.

- **`install.sh`** — extended `bootstrap_check_tools` to verify `sqlite3` is present; prints actionable install instructions (`brew install sqlite` / `apt install sqlite3`) and exits non-zero when missing.

No handler or scanner integration in this PR (that is child 2/4 of #294).

## Test Plan

- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — all pass
- `shellcheck -S warning` on the same set — all pass
- `bats tests/jobs-lib.bats` — 14/14 pass
- No personal identifiers in committed files