### PR TITLE
feat: external-PR review-only path (review-handler + new canonical labels)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ projects.yaml schema, bounty event API, CLI flags, lock dir, log dir).
 
 ## [Unreleased]
 
+### Added
+- External-PR review-only path: PRs carrying the `external-pr` label go
+  through review-handler and halt at `external-review-pass` /
+  `external-review-fail` (new canonical labels) for operator decision.
+  QA and merge stages do not fire — protects the operator from executing
+  untrusted contributor code via `validation_cmd`. Notifications fire on
+  both terminal states.
 
 ### Changed
 - [LOOP-262] resolve rework trigger label per-project in pr-watchdog (#277)

--- a/lib/labels.sh
+++ b/lib/labels.sh
@@ -48,6 +48,13 @@ LOOP_CANONICAL_LABELS=(
     qa-fail
     blocked
     "done"
+    # External-PR review-only path. PRs carrying `external-pr` (set by the
+    # repo's auto-label GitHub Action) go through review-handler and then
+    # halt at one of these terminal-ish states for operator decision. They
+    # do NOT progress to needs-qa/merge automatically.
+    external-pr
+    external-review-pass
+    external-review-fail
 )
 
 # Convenience scalars — handlers reference these instead of string literals.
@@ -62,6 +69,9 @@ LOOP_LABEL_QA_PASS=qa-pass
 LOOP_LABEL_QA_FAIL=qa-fail
 LOOP_LABEL_BLOCKED=blocked
 LOOP_LABEL_DONE="done"
+LOOP_LABEL_EXTERNAL_PR=external-pr
+LOOP_LABEL_EXTERNAL_REVIEW_PASS=external-review-pass
+LOOP_LABEL_EXTERNAL_REVIEW_FAIL=external-review-fail
 
 # Deprecated label aliases — names still used by older workflows / GitHub
 # repos / PR bodies. Each maps to its canonical replacement. Handlers may

--- a/scripts/review-handler.sh
+++ b/scripts/review-handler.sh
@@ -134,9 +134,15 @@ if [ "$retries" -ge "$MAX_RETRIES" ]; then
     exit 0
 fi
 
-log "review: slug=$SLUG repo=$REPO pr=#$PR_NUM attempt=$((retries + 1))/$MAX_RETRIES"
+# External PR detection — set once, used at decision time below.
+_IS_EXTERNAL_PR=false
+if backend_pr_has_any_label "$REPO" "$PR_NUM" "$LOOP_LABEL_EXTERNAL_PR" 2>/dev/null; then
+    _IS_EXTERNAL_PR=true
+fi
+
+log "review: slug=$SLUG repo=$REPO pr=#$PR_NUM attempt=$((retries + 1))/$MAX_RETRIES external=$_IS_EXTERNAL_PR"
 bounty_report "review_start" model="${LOOP_AGENT_MODEL:-sonnet}" role=reviewer project="$SLUG" pr_num="$PR_NUM" || true
-loop_notify "▶️ [$SLUG] PR#$PR_NUM review starting"
+loop_notify "▶️ [$SLUG] PR#$PR_NUM review starting${_IS_EXTERNAL_PR:+ (external)}"
 
 backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_NEEDS_REVIEW"
 backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_REVIEW_PENDING"
@@ -242,12 +248,34 @@ if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
     case "$_decision" in
         CHANGES_REQUESTED)
             backend_remove_label "$REPO" "$PR_NUM" in-review
-            backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" 2>/dev/null || true
-            backend_add_label    "$REPO" "$PR_NUM" "$_REWORK_LABEL"
+            if [ "$_IS_EXTERNAL_PR" = "true" ]; then
+                # External PR rework path: don't auto-loop. Halt at terminal state and
+                # let the operator decide whether to engage with the contributor.
+                # Also strip any needs-qa/needs-dev/rework labels the agent may have applied.
+                backend_remove_label "$REPO" "$PR_NUM" \
+                    "$LOOP_LABEL_NEEDS_QA" "$LOOP_LABEL_DEPRECATED_READY_FOR_QA" \
+                    "$_REWORK_LABEL" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" \
+                    "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" 2>/dev/null || true
+                backend_add_label "$REPO" "$PR_NUM" "$LOOP_LABEL_EXTERNAL_REVIEW_FAIL"
+                loop_notify "🔴 [$SLUG] external PR#$PR_NUM review: changes requested — needs operator decision"
+            else
+                backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" 2>/dev/null || true
+                backend_add_label    "$REPO" "$PR_NUM" "$_REWORK_LABEL"
+            fi
             ;;
         APPROVED)
-            # APPROVED path is unchanged — the agent applies needs-qa itself.
             backend_remove_label "$REPO" "$PR_NUM" in-review
+            if [ "$_IS_EXTERNAL_PR" = "true" ]; then
+                # External PR approve path: halt at external-review-pass for operator
+                # merge decision. Do NOT progress to needs-qa — QA would execute the
+                # external contributor's code (validation_cmd) in the operator's shell.
+                # If the agent applied needs-qa, strip it.
+                backend_remove_label "$REPO" "$PR_NUM" \
+                    "$LOOP_LABEL_NEEDS_QA" "$LOOP_LABEL_DEPRECATED_READY_FOR_QA" 2>/dev/null || true
+                backend_add_label "$REPO" "$PR_NUM" "$LOOP_LABEL_EXTERNAL_REVIEW_PASS"
+                loop_notify "🟢 [$SLUG] external PR#$PR_NUM review: approved — ready for operator merge"
+            fi
+            # For internal PRs, APPROVED path is unchanged — the agent applies needs-qa itself.
             ;;
         *)
             # Empty / REVIEW_REQUIRED / COMMENTED — fall through to belt-and-braces.
@@ -257,7 +285,8 @@ if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
 
     # Belt-and-braces: if agent forgot to apply a decision label, default to rework
     # (workflow-resolved) so the PR doesn't silently disappear from the pipeline.
-    if ! backend_pr_has_any_label "$REPO" "$PR_NUM" \
+    # Skip for external PRs — they don't auto-rework. Operator handles it.
+    if [ "$_IS_EXTERNAL_PR" != "true" ] && ! backend_pr_has_any_label "$REPO" "$PR_NUM" \
             "$LOOP_LABEL_NEEDS_QA" "$LOOP_LABEL_DEPRECATED_READY_FOR_QA" \
             "$_REWORK_LABEL" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" \
             blocked 'done'; then


### PR DESCRIPTION
## Summary

Implements the external-PR review flow. PRs from non-operator accounts get auto-labeled `external-pr` + `needs-review` (by a GitHub Action in each repo, see svv2014/loop-monitor#242). This PR makes loop's review-handler treat such PRs differently: run the AI review, post the verdict, then halt at a terminal-ish state. The pipeline does NOT auto-progress to QA/merge for external PRs — that would execute the contributor's code via `validation_cmd`.

## Flow

```
External PR opens
  → GitHub Action labels external-pr + needs-review
  → Scanner picks up needs-review (no author gate on PRs)
  → review-handler runs (text-only, safe — reads diff, comments verdict)
  → On approve: labels external-review-pass, removes any agent-applied needs-qa
  → On reject: labels external-review-fail, removes any agent-applied needs-dev/rework
  → LOOP_NOTIFY fires
  → Operator reads verdict, reads diff, manually merges or closes
```

## Changes

- `lib/labels.sh` — three new canonical labels (`external-pr`, `external-review-pass`, `external-review-fail`) + convenience scalars
- `scripts/review-handler.sh` — branches on `_IS_EXTERNAL_PR` flag (set from label presence). External PRs get terminal labels and notification; internal PRs unchanged.
- `CHANGELOG.md` — Unreleased / Added entry

## Why not author-gate at scanner

Scanner's PR polling path doesn't call `author_is_allowed` today (only issue paths do). So external PRs with `needs-review` are already eligible for dispatch — we just need the review-handler to handle them safely. The branching in this PR is enough.

## Why no QA / merge changes

QA and merge handlers only fire when their trigger labels (`needs-qa`, `qa-pass`) are present. External-PR flow never produces those labels — review-handler stops at `external-review-pass` instead. The strip-the-needs-qa-if-agent-applied safeguard in this PR ensures the agent can't accidentally route an external PR to QA.

## Test plan

- [x] `bash -n` syntax check on modified files
- Manual smoke (with services re-enabled):
  - Open a test PR from a non-operator fork
  - GitHub Action labels external-pr + needs-review
  - Scanner picks it up, review-handler runs
  - Verify final labels are external-pr + external-review-pass (or fail)
  - Verify Signal/Telegram notification fires
  - Verify no qa-handler / merge-handler dispatch

## Dependencies

- svv2014/loop-monitor#242 (and equivalents on each tracked repo) — GitHub Action that auto-labels external PRs. Without that, this PR is dormant.
- svv2014/loop#354 (reconciler operator-preference) — protects operator-authored PRs from being closed by external duplicates.

## Out of scope

- Loop-monitor dashboard surface showing external PRs awaiting merge decision (separate ticket if needed)
- Test fixtures — review-handler has no existing test harness; would be a separate test-infra ticket
- Per-project workflow YAML support for external-review-* labels (current implementation uses canonical names directly; per-project remapping not relevant for these terminal states)

🤖 Generated with [Claude Code](https://claude.com/claude-code)