### PR TITLE
fix: reconciler dup-PR keeps operator-authored over bot/external (closes #354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ projects.yaml schema, bounty event API, CLI flags, lock dir, log dir).
 
 ## [Unreleased]
 
+### Fixed
+- [#354] Reconciler dup-PR keep selection now prefers operator-authored
+  PRs (in `ALLOWED_AUTHORS`) over bot-authored PRs, with oldest-wins as
+  the tiebreaker within the same trust tier. External-contributor PRs
+  (not in `ALLOWED_AUTHORS`, not a bot) are SKIPPED from dedup entirely
+  — the reconciler will never auto-close an external contribution.
+  Previously the highest PR number won unconditionally, which destroyed
+  operator-in-flight work whenever a newer agent-authored duplicate
+  appeared. **p0-critical**.
+
 ### Added
 - External-PR review-only path: PRs carrying the `external-pr` label go
   through review-handler and halt at `external-review-pass` /

--- a/lib/backends/github.sh
+++ b/lib/backends/github.sh
@@ -148,11 +148,15 @@ print(prs[0]['number'] if prs else '')
 
 # backend_list_open_prs_raw <repo>
 # Returns a raw JSON array of open PRs with fields:
-# number, body, createdAt, headRefName, title, labels, updatedAt
+# number, body, createdAt, headRefName, title, labels, updatedAt, author
+# `author` is flattened to the bare login string (gh returns it as a nested
+# object by default; we project the login so downstream callers can use
+# `pr["author"]` as a string).
 backend_list_open_prs_raw() {
     local repo="$1"
     gh pr list --repo "$repo" --state open --limit 100 \
-        --json number,body,createdAt,headRefName,title,labels,updatedAt \
+        --json number,body,createdAt,headRefName,title,labels,updatedAt,author \
+        --jq 'map({number, body, createdAt, headRefName, title, labels, updatedAt, author: (.author.login // "")})' \
         2>/dev/null || echo "[]"
 }
 

--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -108,23 +108,59 @@ reconcile_duplicate_prs() {
     prs_json=$(backend_list_open_prs_raw "$repo")
 
     # Build map: issue_num -> [pr_num,pr_num,...]
-    local map; map=$(PRS="$prs_json" python3 - <<'PY'
+    # Selection rule (operator-preference): when multiple PRs close the same
+    # issue, prefer operator-authored over bot-authored. Within the same
+    # trust tier, the older PR wins so in-flight work is preserved instead
+    # of destroyed. External-contributor PRs (author NOT in ALLOWED_AUTHORS,
+    # not a bot) are EXCLUDED from dedup-close — the reconciler must not
+    # auto-close external contributions; the operator decides.
+    local map; map=$(PRS="$prs_json" ALLOWED="${ALLOWED_AUTHORS:-}" python3 - <<'PY'
 import json, re, os
+
 prs = json.loads(os.environ['PRS'])
+allowed = {a.strip() for a in os.environ.get('ALLOWED', '').replace(',', ' ').split() if a.strip()}
+
+def tier(pr):
+    """Lower tier = higher priority to KEEP. 0=operator, 1=bot, 2=external."""
+    author = pr.get('author', '') or ''
+    if not allowed or author in allowed:
+        # Empty allow-list disables gating — treat all authors as tier 0.
+        return 0
+    if author.endswith('[bot]'):
+        return 1
+    return 2
+
 m = {}
 pat = re.compile(r'(?:clos(?:e|es|ed)|fix(?:|es|ed)|resolv(?:e|es|ed))\s+#(\d+)', re.I)
 for pr in prs:
     seen = set()
     for n in pat.findall(pr.get('body') or ''):
-        if n in seen: continue
+        if n in seen:
+            continue
         seen.add(n)
-        m.setdefault(n, []).append({'pr': pr['number'], 'createdAt': pr['createdAt'], 'title': pr['title']})
+        m.setdefault(n, []).append({
+            'pr': pr['number'],
+            'createdAt': pr.get('createdAt', ''),
+            'title': pr.get('title', ''),
+            'author': pr.get('author', '') or '',
+            'tier': tier(pr),
+        })
+
 for issue, plist in m.items():
-    if len(plist) <= 1: continue
-    plist.sort(key=lambda x: x['pr'], reverse=True)
+    if len(plist) <= 1:
+        continue
+
+    # Skip dedup entirely if any participant is an external contributor.
+    # Operator must triage; the reconciler must not auto-close external PRs.
+    if any(p['tier'] == 2 for p in plist):
+        continue
+
+    # Sort: lower tier first (operator > bot), then older PR first so
+    # in-flight operator work is preserved over newer bot-authored dupes.
+    plist.sort(key=lambda x: (x['tier'], x['pr']))
     keep = plist[0]
     for dup in plist[1:]:
-        print(f"{issue}\t{keep['pr']}\t{dup['pr']}\t{dup['title'][:60]}")
+        print(f"{issue}\t{keep['pr']}\t{dup['pr']}\t{dup['title'][:60]}\t{keep['author']}\t{dup['author']}")
 PY
 )
 
@@ -133,10 +169,10 @@ PY
         return 0
     fi
 
-    while IFS=$'\t' read -r issue keep dup title; do
+    while IFS=$'\t' read -r issue keep dup title keep_author dup_author; do
         [ -z "$issue" ] && continue
-        log "[$repo] DUP issue #$issue: keep PR#$keep, close PR#$dup ($title)"
-        loop_notify "Loop reconciler: $repo — closing duplicate PR#$dup (issue #$issue); keeping PR#$keep"
+        log "[$repo] DUP issue #$issue: keep PR#$keep (author=$keep_author), close PR#$dup (author=$dup_author) — $title"
+        loop_notify "Loop reconciler: $repo — closing duplicate PR#$dup (author $dup_author) for issue #$issue; keeping PR#$keep (author $keep_author)"
         $DRY_RUN && continue
         backend_comment_pr "$repo" "$dup" \
             "Closed by Loop reconciler — duplicate of #$keep (both close issue #$issue)."

--- a/tests/reconciler-dup-prs.bats
+++ b/tests/reconciler-dup-prs.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+# tests/reconciler-dup-prs.bats — covers reconcile_duplicate_prs in
+# scanner/reconciler.sh (issue #354). Verifies operator-preference selection
+# and external-contributor PR skip behavior.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export OPS_LOG="$BATS_TMPDIR/ops.log"
+    rm -f "$OPS_LOG"
+
+    export REPO="owner/test-repo"
+    export DRY_RUN=false
+    export ALLOWED_AUTHORS="svv2014"
+
+    LOOP_RECONCILER_LIB_ONLY=1
+    set --
+    # shellcheck source=../scanner/reconciler.sh
+    source "$REPO_ROOT/scanner/reconciler.sh"
+
+    backend_list_open_prs_raw() { echo "${MOCK_PRS_JSON:-[]}"; }
+    backend_close_pr()          { echo "close_pr $2"        >> "$OPS_LOG"; }
+    backend_comment_pr()        { echo "comment_pr $2"      >> "$OPS_LOG"; }
+    loop_notify()               { echo "notify: $1"         >> "$OPS_LOG"; }
+    log() { :; }
+}
+
+teardown() {
+    rm -rf "$LOOP_LOG_DIR" "$OPS_LOG"
+}
+
+@test "dup PRs: operator-authored kept over bot when both close same issue" {
+    # PR 100 by bot (newer number), PR 50 by operator (older number).
+    # Old logic would keep 100 because it has the higher number.
+    # New logic must keep 50 because operator outranks bot.
+    export MOCK_PRS_JSON='[
+        {"number":50,"body":"closes #1","createdAt":"2026-01-01","title":"op fix","author":"svv2014"},
+        {"number":100,"body":"closes #1","createdAt":"2026-01-02","title":"bot fix","author":"some-bot[bot]"}
+    ]'
+
+    run reconcile_duplicate_prs "$REPO"
+    [ "$status" -eq 0 ]
+
+    grep -q "close_pr 100" "$OPS_LOG"
+    ! grep -q "close_pr 50" "$OPS_LOG"
+}
+
+@test "dup PRs: older operator PR wins over newer operator PR (preserve in-flight)" {
+    export MOCK_PRS_JSON='[
+        {"number":50,"body":"closes #2","createdAt":"2026-01-01","title":"first","author":"svv2014"},
+        {"number":60,"body":"closes #2","createdAt":"2026-01-02","title":"second","author":"svv2014"}
+    ]'
+
+    run reconcile_duplicate_prs "$REPO"
+    [ "$status" -eq 0 ]
+
+    grep -q "close_pr 60" "$OPS_LOG"
+    ! grep -q "close_pr 50" "$OPS_LOG"
+}
+
+@test "dup PRs: external-contributor participant SKIPS dedup entirely" {
+    # When an external PR is among the duplicates, reconciler must not auto-close
+    # anything — operator must triage. Verifies the safety guard for #354.
+    export MOCK_PRS_JSON='[
+        {"number":50,"body":"closes #3","createdAt":"2026-01-01","title":"op fix","author":"svv2014"},
+        {"number":70,"body":"closes #3","createdAt":"2026-01-02","title":"external","author":"random-user"}
+    ]'
+
+    run reconcile_duplicate_prs "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -q "close_pr" "$OPS_LOG"
+}
+
+@test "dup PRs: empty ALLOWED_AUTHORS = gating off, falls back to oldest-wins" {
+    ALLOWED_AUTHORS=""
+    export MOCK_PRS_JSON='[
+        {"number":50,"body":"closes #4","createdAt":"2026-01-01","title":"a","author":"anyone"},
+        {"number":60,"body":"closes #4","createdAt":"2026-01-02","title":"b","author":"anyone-else"}
+    ]'
+
+    run reconcile_duplicate_prs "$REPO"
+    [ "$status" -eq 0 ]
+
+    grep -q "close_pr 60" "$OPS_LOG"
+    ! grep -q "close_pr 50" "$OPS_LOG"
+}
+
+@test "dup PRs: single PR per issue = no-op" {
+    export MOCK_PRS_JSON='[
+        {"number":50,"body":"closes #5","createdAt":"2026-01-01","title":"solo","author":"svv2014"}
+    ]'
+
+    run reconcile_duplicate_prs "$REPO"
+    [ "$status" -eq 0 ]
+
+    [ ! -s "$OPS_LOG" ] || ! grep -q "close_pr" "$OPS_LOG"
+}
+
+@test "dup PRs: notification mentions both authors for transparency" {
+    export MOCK_PRS_JSON='[
+        {"number":50,"body":"closes #6","createdAt":"2026-01-01","title":"op","author":"svv2014"},
+        {"number":100,"body":"closes #6","createdAt":"2026-01-02","title":"bot","author":"some-bot[bot]"}
+    ]'
+
+    run reconcile_duplicate_prs "$REPO"
+    [ "$status" -eq 0 ]
+
+    grep -q "author svv2014" "$OPS_LOG"
+    grep -q "author some-bot" "$OPS_LOG"
+}


### PR DESCRIPTION
Closes #354 (p0-critical).

## Problem

`reconcile_duplicate_prs` picked the PR to keep by highest PR number unconditionally:

```python
plist.sort(key=lambda x: x['pr'], reverse=True)
keep = plist[0]
```

So a newer agent-authored duplicate would destroy an earlier operator-authored PR. Worse: an external-contributor PR opened later would also win. Filed earlier today after the user noticed it had been quietly closing their hand-crafted work.

## Fix

Trust-tier-first selection:

- Tier 0: author in `ALLOWED_AUTHORS` (operator/maintainer)
- Tier 1: author ends with `[bot]` (known automation)
- Tier 2: anyone else (external contributor)

Within the same tier, oldest PR wins so in-flight work is preserved.

External-contributor PRs (tier 2) are excluded from dedup-close entirely. When any participant in a duplicate set is external, reconciler skips the group — operator decides.

Empty `ALLOWED_AUTHORS` falls back to oldest-wins (gating disabled).

Notifications now include both authors for transparency.

## Test plan

- [x] New `tests/reconciler-dup-prs.bats` — 6 cases, all pass:
  - operator-authored kept over bot
  - older operator PR wins over newer operator PR
  - external-contributor participant skips dedup entirely
  - empty ALLOWED_AUTHORS = gating off, oldest-wins
  - single PR per issue is a no-op
  - notification mentions both authors
- [x] `bash -n` on modified files

## Files changed

- `lib/backends/github.sh` — `backend_list_open_prs_raw` flattens `author.login` → `author` string
- `scanner/reconciler.sh::reconcile_duplicate_prs` — tier-based sort, external skip, notification format
- `tests/reconciler-dup-prs.bats` — new test file
- `CHANGELOG.md` — Fixed entry

## Why this lands first

Operator services (scanner, reconciler, pr-watchdog) are currently paused (operator launchctl unloaded them earlier today) until this lands. Once merged, operator can safely resume autonomous pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)