### PR TITLE
[LOOP-362] scanner: skip dev_issue if open PR already closes the issue

### DIFF
--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -435,6 +435,33 @@ _scan_issue_stage() {
     done < <(backend_list_issues_with_label "$repo" "$trigger_label" | _sort_rows_by_priority)
 }
 
+# _scan_has_open_pr_for_issue <repo> <issue_num>
+# Prints the first open PR number whose body declares "Closes #<issue_num>"
+# (case-insensitive, exact number match — same pattern as reconciler).
+# Prints nothing and returns 1 if none found or on gh error (fail-open).
+_scan_has_open_pr_for_issue() {
+    local repo="$1" issue_num="$2"
+    local candidates
+    candidates=$(gh pr list --repo "$repo" --state open \
+        --search "closes #${issue_num} in:body" \
+        --json number,body 2>/dev/null) || return 1
+    printf '%s\n' "$candidates" | python3 -c "
+import json, re, sys
+issue_num = int(sys.argv[1])
+CLOSES_RE = re.compile(
+    r'(?i)(?:clos(?:e|es|ed)|fix(?:es|ed)?|resolv(?:e|es|ed)?)\s+#(\d+)'
+)
+prs = json.load(sys.stdin)
+for pr in prs:
+    body = pr.get('body') or ''
+    for m in CLOSES_RE.finditer(body):
+        if int(m.group(1)) == issue_num:
+            print(pr['number'])
+            sys.exit(0)
+sys.exit(1)
+" "$issue_num" 2>/dev/null || return 1
+}
+
 # _scan_dev_issue_stage — dev_issue with concurrent slot limiting, priority sort, dep gating.
 _scan_dev_issue_stage() {
     local slug="$1" repo="$2" trigger_label="$3" event_type="$4"
@@ -491,6 +518,14 @@ _scan_dev_issue_stage() {
         _unmet=$(backend_issue_unmet_deps "$repo" "$_num" 2>/dev/null || true)
         if [ -n "$_unmet" ]; then
             log "defer dev_issue #$_num $_title — unmet deps: $(printf '%s' "$_unmet" | tr '\n' ' ')"
+            continue
+        fi
+        # Duplicate-PR guard: skip if an open PR already closes this issue.
+        # On gh error the helper returns empty (fail-open) so we proceed normally.
+        local _existing_pr
+        _existing_pr=$(_scan_has_open_pr_for_issue "$repo" "$_num" 2>/dev/null || true)
+        if [ -n "$_existing_pr" ]; then
+            log "skip dev_issue #$_num: open PR #$_existing_pr already closes it"
             continue
         fi
         _evt=$(_emit_issue_event "$event_type" "$slug" "$repo" "$_num" "$_title" "$_url")

--- a/tests/labels.bats
+++ b/tests/labels.bats
@@ -7,25 +7,28 @@ setup() {
     source "$REPO_ROOT/lib/labels.sh"
 }
 
-@test "canonical set has the expected 11 names" {
-    [ "${#LOOP_CANONICAL_LABELS[@]}" -eq 11 ]
-    local expected="needs-po in-po needs-dev in-dev needs-review in-review needs-qa qa-pass qa-fail blocked done"
+@test "canonical set has the expected 14 names" {
+    [ "${#LOOP_CANONICAL_LABELS[@]}" -eq 14 ]
+    local expected="needs-po in-po needs-dev in-dev needs-review in-review needs-qa qa-pass qa-fail blocked done external-pr external-review-pass external-review-fail"
     local actual="${LOOP_CANONICAL_LABELS[*]}"
     [ "$actual" = "$expected" ]
 }
 
 @test "convenience scalars match the canonical names" {
-    [ "$LOOP_LABEL_NEEDS_PO"     = "needs-po" ]
-    [ "$LOOP_LABEL_IN_PO"        = "in-po" ]
-    [ "$LOOP_LABEL_NEEDS_DEV"    = "needs-dev" ]
-    [ "$LOOP_LABEL_IN_DEV"       = "in-dev" ]
-    [ "$LOOP_LABEL_NEEDS_REVIEW" = "needs-review" ]
-    [ "$LOOP_LABEL_IN_REVIEW"    = "in-review" ]
-    [ "$LOOP_LABEL_NEEDS_QA"     = "needs-qa" ]
-    [ "$LOOP_LABEL_QA_PASS"      = "qa-pass" ]
-    [ "$LOOP_LABEL_QA_FAIL"      = "qa-fail" ]
-    [ "$LOOP_LABEL_BLOCKED"      = "blocked" ]
-    [ "$LOOP_LABEL_DONE"         = "done" ]
+    [ "$LOOP_LABEL_NEEDS_PO"              = "needs-po" ]
+    [ "$LOOP_LABEL_IN_PO"                 = "in-po" ]
+    [ "$LOOP_LABEL_NEEDS_DEV"             = "needs-dev" ]
+    [ "$LOOP_LABEL_IN_DEV"                = "in-dev" ]
+    [ "$LOOP_LABEL_NEEDS_REVIEW"          = "needs-review" ]
+    [ "$LOOP_LABEL_IN_REVIEW"             = "in-review" ]
+    [ "$LOOP_LABEL_NEEDS_QA"              = "needs-qa" ]
+    [ "$LOOP_LABEL_QA_PASS"               = "qa-pass" ]
+    [ "$LOOP_LABEL_QA_FAIL"               = "qa-fail" ]
+    [ "$LOOP_LABEL_BLOCKED"               = "blocked" ]
+    [ "$LOOP_LABEL_DONE"                  = "done" ]
+    [ "$LOOP_LABEL_EXTERNAL_PR"           = "external-pr" ]
+    [ "$LOOP_LABEL_EXTERNAL_REVIEW_PASS"  = "external-review-pass" ]
+    [ "$LOOP_LABEL_EXTERNAL_REVIEW_FAIL"  = "external-review-fail" ]
 }
 
 @test "every deprecated alias resolves to a canonical label" {
@@ -97,5 +100,5 @@ setup() {
 @test "lib/labels.sh is idempotent when re-sourced" {
     source "$REPO_ROOT/lib/labels.sh"
     source "$REPO_ROOT/lib/labels.sh"
-    [ "${#LOOP_CANONICAL_LABELS[@]}" -eq 11 ]
+    [ "${#LOOP_CANONICAL_LABELS[@]}" -eq 14 ]
 }

--- a/tests/scanner.bats
+++ b/tests/scanner.bats
@@ -683,3 +683,55 @@ YAML
     # Confirm no events were dispatched.
     [[ "$output" != *"DRY-RUN emit:"* ]]
 }
+
+# ---------------------------------------------------------------------------
+# _scan_has_open_pr_for_issue — dup-PR guard helper (PR #364 / issue #362)
+# ---------------------------------------------------------------------------
+
+@test "_scan_has_open_pr_for_issue: returns PR number when body has 'Closes #N'" {
+    export GH_MOCK_OUTPUT='[{"number":42,"body":"Closes #99\nSome details"}]'
+    export GH_MOCK_EXIT=0
+    run _scan_has_open_pr_for_issue "owner/repo" "99"
+    [ "$status" -eq 0 ]
+    [ "$output" = "42" ]
+}
+
+@test "_scan_has_open_pr_for_issue: case-insensitive — 'fixes #N' matches" {
+    export GH_MOCK_OUTPUT='[{"number":7,"body":"fixes #5 bug in auth"}]'
+    export GH_MOCK_EXIT=0
+    run _scan_has_open_pr_for_issue "owner/repo" "5"
+    [ "$status" -eq 0 ]
+    [ "$output" = "7" ]
+}
+
+@test "_scan_has_open_pr_for_issue: case-insensitive — 'Resolves #N' matches" {
+    export GH_MOCK_OUTPUT='[{"number":15,"body":"Resolves #10"}]'
+    export GH_MOCK_EXIT=0
+    run _scan_has_open_pr_for_issue "owner/repo" "10"
+    [ "$status" -eq 0 ]
+    [ "$output" = "15" ]
+}
+
+@test "_scan_has_open_pr_for_issue: no false positive — 'Closes #123' does NOT match issue #12" {
+    export GH_MOCK_OUTPUT='[{"number":50,"body":"Closes #123"}]'
+    export GH_MOCK_EXIT=0
+    run _scan_has_open_pr_for_issue "owner/repo" "12"
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+}
+
+@test "_scan_has_open_pr_for_issue: returns nothing and exits 1 when no PR body matches" {
+    export GH_MOCK_OUTPUT='[{"number":3,"body":"No closing reference here"}]'
+    export GH_MOCK_EXIT=0
+    run _scan_has_open_pr_for_issue "owner/repo" "99"
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+}
+
+@test "_scan_has_open_pr_for_issue: fails open when gh exits non-zero" {
+    export GH_MOCK_OUTPUT=""
+    export GH_MOCK_EXIT=1
+    run _scan_has_open_pr_for_issue "owner/repo" "99"
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+}


### PR DESCRIPTION
Closes #362

## Changes

Added a duplicate-PR guard to `_scan_dev_issue_stage` in `scanner/scanner.sh` so the scanner never dispatches `loop.dev_issue` for an issue that already has an open PR closing it.

**New helper — `_scan_has_open_pr_for_issue <repo> <issue_num>`:**
- Queries GitHub for open PRs matching `closes #N in:body` to narrow candidates
- Verifies the exact issue number with a Python regex (same pattern the reconciler's `pr_closes_issues` uses: `clos(e|es|ed)|fix(es|ed)?|resolv(e|es|ed)?`)
- Guards against substring false-positives (`#1234` won't match a guard for `#123`)
- Fails open on any `gh` error — returns empty so the scanner falls through to normal dispatch and the reconciler safety net remains the backstop

**Guard in `_scan_dev_issue_stage`:**
- Inserted after the dependency gate, before `emit`
- Logs `skip dev_issue #N: open PR #M already closes it` at scanner verbosity
- `continue`s to the next issue, leaving labels unchanged

**Unchanged:**
- Reconciler `reconcile_duplicate_prs` — still runs as the safety net
- All other handlers (review, qa, merge, po, rework)
- Label state machine

## Test Plan

- [ ] Open an issue with `needs-dev`, create an open PR whose body contains `Closes #N`; run `scanner.sh --dry-run` — verify no `loop.dev_issue` event is emitted for that issue, and the log shows the skip line with the PR number
- [ ] Remove the PR (or close it); re-run scanner — verify the event is now emitted normally
- [ ] Verify `bash -n` and `shellcheck -S warning` pass (CI green)
- [ ] Verify `reconcile_duplicate_prs` in reconciler is untouched