### PR TITLE
[LOOP-362] scanner: skip dev_issue if open PR already closes the issue

### DIFF
--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -435,6 +435,33 @@ _scan_issue_stage() {
     done < <(backend_list_issues_with_label "$repo" "$trigger_label" | _sort_rows_by_priority)
 }
 
+# _scan_has_open_pr_for_issue <repo> <issue_num>
+# Prints the first open PR number whose body declares "Closes #<issue_num>"
+# (case-insensitive, exact number match — same pattern as reconciler).
+# Prints nothing and returns 1 if none found or on gh error (fail-open).
+_scan_has_open_pr_for_issue() {
+    local repo="$1" issue_num="$2"
+    local candidates
+    candidates=$(gh pr list --repo "$repo" --state open \
+        --search "closes #${issue_num} in:body" \
+        --json number,body 2>/dev/null) || return 1
+    printf '%s\n' "$candidates" | python3 -c "
+import json, re, sys
+issue_num = int(sys.argv[1])
+CLOSES_RE = re.compile(
+    r'(?i)(?:clos(?:e|es|ed)|fix(?:es|ed)?|resolv(?:e|es|ed)?)\s+#(\d+)'
+)
+prs = json.load(sys.stdin)
+for pr in prs:
+    body = pr.get('body') or ''
+    for m in CLOSES_RE.finditer(body):
+        if int(m.group(1)) == issue_num:
+            print(pr['number'])
+            sys.exit(0)
+sys.exit(1)
+" "$issue_num" 2>/dev/null || return 1
+}
+
 # _scan_dev_issue_stage — dev_issue with concurrent slot limiting, priority sort, dep gating.
 _scan_dev_issue_stage() {
     local slug="$1" repo="$2" trigger_label="$3" event_type="$4"
@@ -491,6 +518,14 @@ _scan_dev_issue_stage() {
         _unmet=$(backend_issue_unmet_deps "$repo" "$_num" 2>/dev/null || true)
         if [ -n "$_unmet" ]; then
             log "defer dev_issue #$_num $_title — unmet deps: $(printf '%s' "$_unmet" | tr '\n' ' ')"
+            continue
+        fi
+        # Duplicate-PR guard: skip if an open PR already closes this issue.
+        # On gh error the helper returns empty (fail-open) so we proceed normally.
+        local _existing_pr
+        _existing_pr=$(_scan_has_open_pr_for_issue "$repo" "$_num" 2>/dev/null || true)
+        if [ -n "$_existing_pr" ]; then
+            log "skip dev_issue #$_num: open PR #$_existing_pr already closes it"
             continue
         fi
         _evt=$(_emit_issue_event "$event_type" "$slug" "$repo" "$_num" "$_title" "$_url")


### PR DESCRIPTION
Closes #362

## Changes

Added a duplicate-PR guard to `_scan_dev_issue_stage` in `scanner/scanner.sh` that prevents the scanner from dispatching a new `loop.dev_issue` event when an open PR already closes the same issue.

**New helper `_scan_has_open_pr_for_issue <repo> <issue_num>`:**
- Uses `gh pr list --search "closes #N in:body"` to efficiently narrow candidates
- Verifies exact issue-number match with Python regex (`(?:clos(?:e|es|ed)|fix(?:es|ed)?|resolv(?:e|es|ed)?)\s+#N`) — same pattern as `pr_closes_issues` in the reconciler, avoiding false positives from substring matches (#123 vs #1234)
- Fails open: on any `gh` error, returns empty so the scanner falls through to existing behaviour (reconciler safety net remains the backstop)

**Guard in `_scan_dev_issue_stage`:**
- Runs after the dep-gate check, before `emit`
- Logs `skip dev_issue #N: open PR #M already closes it` at scanner log verbosity
- Does not modify any labels — just skips the dispatch

The reconciler's `reconcile_duplicate_prs` is unchanged and remains the safety net for any edge cases that slip through.

## Test Plan

- [ ] Open an issue with `needs-dev`; create a PR whose body contains `Closes #N`; run scanner with `--dry-run` — verify no `loop.dev_issue` event is emitted for that issue
- [ ] Verify that issues without an existing open PR still get `loop.dev_issue` dispatched normally
- [ ] Verify the rework path (`loop.dev_rework` on a PR with `needs-dev`) is unaffected
- [ ] Run `bash -n` and `shellcheck -S warning` on modified scripts — both pass
- [ ] Confirm `reconcile_duplicate_prs` in reconciler is untouched