### PR TITLE
[LOOP-363] Add per-stage scanner emit caps

### DIFF
--- a/loop.env.example
+++ b/loop.env.example
@@ -97,6 +97,16 @@ LOOP_EXTRA_PATH="/opt/homebrew/bin:/usr/local/bin"
 # Unset/empty = disabled (no cap).
 # LOOP_DAILY_HANDLER_BUDGET_SECONDS=14400   # 4 hours/day
 
+# Per-tick scanner emit caps. By default every stage falls back to
+# MAX_CONCURRENT_HANDLERS, then to 1. Event type dots become underscores:
+# event loop.pr_review -> MAX_CONCURRENT_HANDLERS_LOOP_PR_REVIEW.
+# MAX_CONCURRENT_HANDLERS_LOOP_PO_REVIEW=1
+# MAX_CONCURRENT_HANDLERS_LOOP_DEV_ISSUE=1
+# MAX_CONCURRENT_HANDLERS_LOOP_DEV_REWORK=1
+# MAX_CONCURRENT_HANDLERS_LOOP_PR_REVIEW=2
+# MAX_CONCURRENT_HANDLERS_LOOP_PR_QA=2
+# MAX_CONCURRENT_HANDLERS_LOOP_PR_MERGE=3
+
 # PR auto-rework watchdog grace windows. The watchdog (installed via
 # --bootstrap) labels loop-authored PRs `needs-rework` when stuck.
 # CONFLICT_GRACE = how long a mergeable=CONFLICTING state is tolerated

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -77,6 +77,18 @@ _handler_to_event_type() {
     esac
 }
 
+# _stage_cap <event_type>
+# Resolve the per-tick emit cap for a scanner event type. Operators can set
+# MAX_CONCURRENT_HANDLERS_LOOP_PR_REVIEW-style overrides; otherwise we preserve
+# the previous global MAX_CONCURRENT_HANDLERS fallback behavior.
+_stage_cap() {
+    local stage="$1"
+    local stage_upper var
+    stage_upper=$(printf '%s' "$stage" | tr '[:lower:]' '[:upper:]' | tr '.' '_')
+    var="MAX_CONCURRENT_HANDLERS_${stage_upper}"
+    printf '%s' "${!var:-${MAX_CONCURRENT_HANDLERS:-1}}"
+}
+
 # Map event type to handler script (dispatch_direct mode).
 dispatch_direct() {
     local json="$1"
@@ -402,10 +414,11 @@ _scan_issue_stage() {
         return
     fi
 
-    # Simple issue stage (e.g. po-handler, senior-dev-handler).
-    # Cap new emits per tick at MAX_CONCURRENT_HANDLERS so a project with many
-    # ready issues doesn't fan out to N parallel handler runs every tick.
-    local _cap="${MAX_CONCURRENT_HANDLERS:-1}"
+    # Simple issue stage (e.g. po-handler, senior-dev-handler). Cap new emits
+    # per tick per event type so cheap stages can drain faster than expensive
+    # stages without losing the previous global fallback behavior.
+    local _cap
+    _cap=$(_stage_cap "$event_type")
     local _emitted=0
     log "${event_type}: max=${_cap} (per-tick emit cap)"
     while IFS= read -r row; do
@@ -466,10 +479,14 @@ sys.exit(1)
 _scan_dev_issue_stage() {
     local slug="$1" repo="$2" trigger_label="$3" event_type="$4"
 
-    local _inflight _slots
+    local _inflight _slots _stage_limit
     _inflight=$(count_inflight_prs "$slug" "$repo")
     _slots=$(( MAX_CONCURRENT_PRS - _inflight ))
-    log "dev_issue: max=${MAX_CONCURRENT_PRS} in-flight=${_inflight} slots=${_slots}"
+    _stage_limit=$(_stage_cap "$event_type")
+    if [ "$_slots" -gt "$_stage_limit" ]; then
+        _slots="$_stage_limit"
+    fi
+    log "dev_issue: max=${MAX_CONCURRENT_PRS} in-flight=${_inflight} stage-cap=${_stage_limit} slots=${_slots}"
 
     if [ "$_slots" -le 0 ]; then
         log "skip dev_issue for $slug: ${_inflight}/${MAX_CONCURRENT_PRS} pipeline PRs in flight"
@@ -558,8 +575,9 @@ _scan_pr_stage() {
         fi
     fi
 
-    # Cap new emits per tick at MAX_CONCURRENT_HANDLERS, same as _scan_issue_stage.
-    local _cap="${MAX_CONCURRENT_HANDLERS:-1}"
+    # Cap new emits per tick per event type, same as _scan_issue_stage.
+    local _cap
+    _cap=$(_stage_cap "$event_type")
     local _emitted=0
     log "${event_type}: max=${_cap} (per-tick emit cap)"
     while IFS= read -r row; do


### PR DESCRIPTION
Closes #363

## Summary

Adds per-event-type scanner emit caps so cheap stages can drain faster while expensive stages remain serial by default.

## Changes

- Added `_stage_cap <event_type>` to resolve `MAX_CONCURRENT_HANDLERS_<EVENT_TYPE>` with dots converted to underscores.
- Applied the resolver to issue and PR scan stages while preserving the previous `MAX_CONCURRENT_HANDLERS` then `1` fallback.
- Applied the same resolver as a per-tick ceiling on `loop.dev_issue` in addition to the existing `MAX_CONCURRENT_PRS` in-flight PR slots.
- Documented the new commented env vars in `loop.env.example`.

## Test Plan

- `docker run --rm --network none -v "F:\Projects\external-repos\.worktrees\363-svv2014-loop:/workspace:ro" -w /workspace bash:5.2 bash -n scanner/scanner.sh`
- `docker run --rm --network none -v "F:\Projects\external-repos\.worktrees\363-svv2014-loop:/mnt:ro" koalaman/shellcheck:stable -S warning /mnt/scanner/scanner.sh`
- `git diff --check HEAD~1..HEAD`
- `docker run --rm -v "F:\Projects\external-repos\.worktrees\363-svv2014-loop:/workspace:ro" -w /workspace python:3.12-bookworm bash -lc "python -m pip install --quiet pyyaml >/tmp/pip.log && printf 'version: 1\nprojects: []\n' >/tmp/projects.yaml && HOME=/tmp LOOP_CONFIG=/tmp/projects.yaml ./scanner/scanner.sh --dry-run"`