### PR TITLE
[LOOP-363] scanner: per-stage emit cap via MAX_CONCURRENT_HANDLERS_<STAGE>

### DIFF
--- a/loop.env.example
+++ b/loop.env.example
@@ -125,6 +125,27 @@ LOOP_EXTRA_PATH="/opt/homebrew/bin:/usr/local/bin"
 #   qa:
 #     validation_cmd_security_opt_out: true  # explain why here
 
+# ─── Per-stage emit caps ──────────────────────────────────────────────────────
+# Per-tick emit cap per pipeline stage. Overrides MAX_CONCURRENT_HANDLERS for
+# that stage only. Falls back to MAX_CONCURRENT_HANDLERS (if set), then to 1.
+#
+# Variable name = MAX_CONCURRENT_HANDLERS_<STAGE> where <STAGE> is the event
+# type uppercased with dots replaced by underscores:
+#   event loop.po_review    → MAX_CONCURRENT_HANDLERS_LOOP_PO_REVIEW
+#   event loop.dev_issue    → MAX_CONCURRENT_HANDLERS_LOOP_DEV_ISSUE
+#   event loop.dev_rework   → MAX_CONCURRENT_HANDLERS_LOOP_DEV_REWORK
+#   event loop.pr_review    → MAX_CONCURRENT_HANDLERS_LOOP_PR_REVIEW
+#   event loop.pr_qa        → MAX_CONCURRENT_HANDLERS_LOOP_PR_QA
+#   event loop.pr_merge     → MAX_CONCURRENT_HANDLERS_LOOP_PR_MERGE
+#
+# MAX_CONCURRENT_HANDLERS=1                          # global default (all stages)
+# MAX_CONCURRENT_HANDLERS_LOOP_PO_REVIEW=1
+# MAX_CONCURRENT_HANDLERS_LOOP_DEV_ISSUE=1
+# MAX_CONCURRENT_HANDLERS_LOOP_DEV_REWORK=1
+# MAX_CONCURRENT_HANDLERS_LOOP_PR_REVIEW=2
+# MAX_CONCURRENT_HANDLERS_LOOP_PR_QA=2
+# MAX_CONCURRENT_HANDLERS_LOOP_PR_MERGE=3
+
 # ─── Reconciler ──────────────────────────────────────────────────────────────
 # Set any of these to "false" to disable the corresponding reconciler sweep.
 

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -62,6 +62,18 @@ done
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] $*"; }
 
+# _stage_cap <event_type>
+# Resolves the per-tick emit cap for a given event type.
+# Checks MAX_CONCURRENT_HANDLERS_<STAGE> (event type uppercased, dots → underscores),
+# then MAX_CONCURRENT_HANDLERS, then defaults to 1.
+_stage_cap() {
+    local stage="$1"
+    local stage_upper
+    stage_upper=$(printf '%s' "$stage" | tr '[:lower:].' '[:upper:]_')
+    local var="MAX_CONCURRENT_HANDLERS_${stage_upper}"
+    printf '%s' "${!var:-${MAX_CONCURRENT_HANDLERS:-1}}"
+}
+
 # _handler_to_event_type <handler_base_name>
 # Maps a workflow handler name (from workflow YAML) to a loop event type string.
 _handler_to_event_type() {
@@ -403,9 +415,9 @@ _scan_issue_stage() {
     fi
 
     # Simple issue stage (e.g. po-handler, senior-dev-handler).
-    # Cap new emits per tick at MAX_CONCURRENT_HANDLERS so a project with many
-    # ready issues doesn't fan out to N parallel handler runs every tick.
-    local _cap="${MAX_CONCURRENT_HANDLERS:-1}"
+    # Cap new emits per tick so a project with many ready issues doesn't fan
+    # out to N parallel handler runs every tick. Cap is per-stage configurable.
+    local _cap; _cap=$(_stage_cap "$event_type")
     local _emitted=0
     log "${event_type}: max=${_cap} (per-tick emit cap)"
     while IFS= read -r row; do
@@ -558,8 +570,8 @@ _scan_pr_stage() {
         fi
     fi
 
-    # Cap new emits per tick at MAX_CONCURRENT_HANDLERS, same as _scan_issue_stage.
-    local _cap="${MAX_CONCURRENT_HANDLERS:-1}"
+    # Cap new emits per tick, same as _scan_issue_stage but resolved per-stage.
+    local _cap; _cap=$(_stage_cap "$event_type")
     local _emitted=0
     log "${event_type}: max=${_cap} (per-tick emit cap)"
     while IFS= read -r row; do


### PR DESCRIPTION
Closes #363

## Changes

**`scanner/scanner.sh`**
- Added `_stage_cap <event_type>` helper that resolves the per-tick emit cap for a given event type by checking `MAX_CONCURRENT_HANDLERS_<STAGE>` first (event type uppercased with dots replaced by underscores), then falling back to `MAX_CONCURRENT_HANDLERS`, then to `1`.
- Replaced both hard-coded `local _cap="\${MAX_CONCURRENT_HANDLERS:-1}"` lines in `_scan_issue_stage` and `_scan_pr_stage` with `local _cap; _cap=$(_stage_cap "$event_type")`.

**`loop.env.example`**
- Added a new `Per-stage emit caps` section documenting all six per-stage env vars with the mapping formula and recommended commented-out defaults (PO=1, DEV_ISSUE=1, DEV_REWORK=1, PR_REVIEW=2, PR_QA=2, PR_MERGE=3).

Backwards-compatible: with no new env vars set, behaviour is identical to before.

## Test Plan

- [ ] `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` passes (all syntax clean)
- [ ] `shellcheck -S warning lib/*.sh scripts/*.sh scanner/*.sh install.sh` passes (no warnings)
- [ ] With no new env vars set, global `MAX_CONCURRENT_HANDLERS` (or default 1) is still used
- [ ] Setting `MAX_CONCURRENT_HANDLERS_LOOP_PR_MERGE=3` allows up to 3 merge events per tick while other stages remain at 1
- [ ] `./scanner/scanner.sh --dry-run` runs without error