### PR TITLE
[LOOP-349] Emit judge start/done bounty events

### DIFF
--- a/docs/api/bounty-events.md
+++ b/docs/api/bounty-events.md
@@ -24,6 +24,7 @@ Content-Type: application/json
   "issue_num": 42,
   "pr_num": 100,
   "detail": "optional human-readable note",
+  "duration_seconds": 12,
   "timestamp": "2026-04-27T04:00:00Z"
 }
 ```
@@ -34,7 +35,7 @@ Content-Type: application/json
 |---|---|---|---|
 | `api` | yes | string `"<MAJOR>.<MINOR>"` | API version. Loop emits `1.0`. Monitor accepts `1.x`, rejects `2.x` with HTTP 426. |
 | `core_version` | yes | string semver | Sender's loop core version, for telemetry. |
-| `event` | yes | string | One of: `dev_start`, `dev_done`, `dev_failed`, `review_start`, `review_done`, `review_request_changes`, `qa_start`, `qa_pass`, `qa_fail`, `merge_start`, `merge_done`, `merge_conflict`, `merge_failed`, `po_start`, `po_done`, `po_failed`, `rework_start`, `rework_done`, `rework_failed` |
+| `event` | yes | string | One of: `dev_start`, `dev_done`, `dev_failed`, `review_start`, `review_done`, `review_request_changes`, `qa_start`, `qa_pass`, `qa_fail`, `merge_start`, `merge_done`, `merge_conflict`, `merge_failed`, `po_start`, `po_done`, `po_failed`, `rework_start`, `rework_done`, `rework_failed`, `judge_start`, `judge_done` |
 | `role` | optional | string | Free-form (e.g. `dev`, `reviewer`, `merger`, or future specialist names like `frontend`) |
 | `agent` | optional | string | The agent CLI name (`claude`, `codex`, `gemini`, `aider`) |
 | `model` | optional | string | Model id (`sonnet`, `opus`, `o4-mini`) |
@@ -42,6 +43,7 @@ Content-Type: application/json
 | `issue_num` | optional | integer | At least one of `issue_num` / `pr_num` required |
 | `pr_num` | optional | integer | At least one of `issue_num` / `pr_num` required |
 | `detail` | optional | string | Human-readable context (e.g. `attempt 2/3`, `merge conflict`) |
+| `duration_seconds` | optional | integer | Runtime duration for terminal `*_done` / failure events when a handler can measure it. |
 | `timestamp` | yes | string ISO 8601 UTC | e.g. `2026-04-27T04:00:00Z` |
 
 ## Versioning rules

--- a/lib/bounty.sh
+++ b/lib/bounty.sh
@@ -58,13 +58,13 @@ bounty_truncate_detail() {
 }
 
 # bounty_report <event> [key=value ...]
-# Keys: agent model role project issue_num pr_num detail
+# Keys: agent model role project issue_num pr_num detail duration_seconds
 # Example: bounty_report "dev_start" role=dev model=sonnet project=myapp issue_num=42
 bounty_report() {
     local event="${1:-unknown}"
     shift || true
 
-    local agent="" model="" role="" project="" issue_num="" pr_num="" detail="" failure_reason=""
+    local agent="" model="" role="" project="" issue_num="" pr_num="" detail="" failure_reason="" duration_seconds=""
     for kv in "$@"; do
         case "$kv" in
             agent=*)          agent="${kv#agent=}" ;;
@@ -75,6 +75,7 @@ bounty_report() {
             pr_num=*)         pr_num="${kv#pr_num=}" ;;
             detail=*)         detail="${kv#detail=}" ;;
             failure_reason=*) failure_reason="${kv#failure_reason=}" ;;
+            duration_seconds=*) duration_seconds="${kv#duration_seconds=}" ;;
         esac
     done
 
@@ -89,7 +90,7 @@ bounty_report() {
         _API="$api_ver" _CV="$(_bounty_core_version)" _LI="$(_bounty_loop_id)" \
         _BE="$event" _BA="$agent" _BM="$model" _BR="$role" \
         _BP="$project" _BD="$detail" _BI="$issue_num" _BPN="$pr_num" \
-        _BFR="$failure_reason" \
+        _BFR="$failure_reason" _BDS="$duration_seconds" \
         python3 - <<'PY'
 import json, os, datetime
 d = {
@@ -109,6 +110,9 @@ for k, env in [("issue_num", "_BI"), ("pr_num", "_BPN")]:
     v = os.environ.get(env, "")
     if v and v.strip().isdigit():
         d[k] = int(v.strip())
+duration = os.environ.get("_BDS", "")
+if duration and duration.strip().isdigit():
+    d["duration_seconds"] = int(duration.strip())
 print(json.dumps(d))
 PY
     ) 2>/dev/null || true

--- a/scripts/judge.sh
+++ b/scripts/judge.sh
@@ -11,14 +11,20 @@ source "$LOOP_ROOT/lib/bounty.sh"
 
 PR_NUM="${1:-}"
 REPO="${2:-}"
-MODEL="${3:-}"
-ROLE="${4:-}"
+JUDGE_MODEL="${LOOP_JUDGE_MODEL:-sonnet}"
+MODEL="${3:-$JUDGE_MODEL}"
+ROLE="${4:-judge}"
 PROJECT="${5:-}"
 
 if [ -z "$PR_NUM" ] || [ -z "$REPO" ]; then
     echo "Usage: $0 <pr_number> <repo> [model] [role] [project]" >&2
     exit 1
 fi
+
+JUDGE_STARTED_AT=$(date +%s)
+bounty_report "judge_start" \
+    model="$MODEL" role="$ROLE" project="$PROJECT" \
+    pr_num="$PR_NUM" || true
 
 # ── Fetch PR timeline via gh ──────────────────────────────────────────────────
 
@@ -67,7 +73,7 @@ EOF
 
 # ── Invoke claude to classify ─────────────────────────────────────────────────
 
-VERDICT_JSON=$(claude -p --model sonnet --output-format text \
+VERDICT_JSON=$(claude -p --model "$MODEL" --output-format text \
     "$JUDGE_PROMPT" 2>/dev/null) || VERDICT_JSON=""
 
 # Strip markdown fences if present
@@ -115,9 +121,16 @@ if [ -n "$VERDICT_PAYLOAD" ]; then
 fi
 
 # Also report as a feed event
-bounty_report "judge" \
+JUDGE_FINISHED_AT=$(date +%s)
+JUDGE_DURATION_SECONDS=$((JUDGE_FINISHED_AT - JUDGE_STARTED_AT))
+if [ "$JUDGE_DURATION_SECONDS" -lt 0 ]; then
+    JUDGE_DURATION_SECONDS=0
+fi
+
+bounty_report "judge_done" \
     model="$MODEL" role="$ROLE" project="$PROJECT" \
     pr_num="$PR_NUM" \
+    duration_seconds="$JUDGE_DURATION_SECONDS" \
     detail="outcome=${OUTCOME} points=${POINTS} ${SUMMARY}" || true
 
 # ── Comment on PR ─────────────────────────────────────────────────────────────

--- a/scripts/merge-handler.sh
+++ b/scripts/merge-handler.sh
@@ -394,6 +394,6 @@ else
 fi
 
 # Auto-invoke judge to classify the merged PR and post a verdict.
-"$LOOP_ROOT/scripts/judge.sh" "$PR_NUM" "$REPO" "" "dev" "$SLUG" 2>&1 | tee -a "$LOG_FILE" || true
+"$LOOP_ROOT/scripts/judge.sh" "$PR_NUM" "$REPO" "${LOOP_JUDGE_MODEL:-sonnet}" "judge" "$SLUG" 2>&1 | tee -a "$LOG_FILE" || true
 
 log "merge-handler done for PR #${PR_NUM}"

--- a/tests/judge.bats
+++ b/tests/judge.bats
@@ -4,7 +4,22 @@
 setup() {
     REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
     BIN_DIR="$BATS_TMPDIR/bin"
-    mkdir -p "$BIN_DIR" "$BATS_TMPDIR/home"
+    BAD_BIN_DIR="$BATS_TMPDIR/bad-bin"
+    LOOP_ENV_FILE="$REPO_ROOT/loop.env"
+    LOOP_ENV_BACKUP="$BATS_TMPDIR/loop.env.backup"
+    LOOP_ENV_HAD_FILE=0
+    if [ -f "$LOOP_ENV_FILE" ]; then
+        cp "$LOOP_ENV_FILE" "$LOOP_ENV_BACKUP"
+        LOOP_ENV_HAD_FILE=1
+    fi
+
+    mkdir -p "$BIN_DIR" "$BAD_BIN_DIR" "$BATS_TMPDIR/home"
+    printf '#!/usr/bin/env bash\nexit 1\n' > "$BAD_BIN_DIR/gh"
+    chmod +x "$BAD_BIN_DIR/gh"
+
+    # Simulate a local operator loop.env that would shadow test mocks unless
+    # this test owns loop.env for the duration of the run.
+    printf 'LOOP_EXTRA_PATH=%s\n' "$BAD_BIN_DIR" > "$REPO_ROOT/loop.env"
 
     cat > "$BIN_DIR/gh" <<'SH'
 #!/usr/bin/env bash
@@ -55,6 +70,7 @@ printf '%s\t%s\n' "$url" "$payload" >> "${CURL_CALLS:?}"
 SH
 
     chmod +x "$BIN_DIR/gh" "$BIN_DIR/claude" "$BIN_DIR/curl"
+    printf 'LOOP_EXTRA_PATH=%s\nLOOP_LOG_DIR=%s\n' "$BIN_DIR" "$BATS_TMPDIR/logs" > "$LOOP_ENV_FILE"
     export PATH="$BIN_DIR:$PATH"
     export LOOP_EXTRA_PATH="$BIN_DIR"
     export HOME="$BATS_TMPDIR/home"
@@ -65,7 +81,13 @@ SH
 }
 
 teardown() {
-    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/home" \
+    if [ "${LOOP_ENV_HAD_FILE:-0}" = "1" ]; then
+        cp "$LOOP_ENV_BACKUP" "$LOOP_ENV_FILE"
+    else
+        rm -f "$LOOP_ENV_FILE" 2>/dev/null || true
+    fi
+
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/bad-bin" "$BATS_TMPDIR/home" \
            "$BATS_TMPDIR/curl-calls.tsv" "$BATS_TMPDIR/gh-comments.log" 2>/dev/null || true
 }
 

--- a/tests/judge.bats
+++ b/tests/judge.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+# tests/judge.bats - regression coverage for judge bounty feed events.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    BIN_DIR="$BATS_TMPDIR/bin"
+    mkdir -p "$BIN_DIR" "$BATS_TMPDIR/home"
+
+    cat > "$BIN_DIR/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "pr" ] && [ "${2:-}" = "view" ]; then
+    printf '{"number":123,"title":"Test PR","state":"MERGED","labels":[],"reviews":[],"commits":[],"comments":[],"headRefName":"feature","baseRefName":"main"}'
+    exit 0
+fi
+if [ "${1:-}" = "api" ]; then
+    printf '[]'
+    exit 0
+fi
+if [ "${1:-}" = "pr" ] && [ "${2:-}" = "comment" ]; then
+    printf 'gh pr comment %s\n' "$*" >> "${GH_COMMENT_LOG:?}"
+    exit 0
+fi
+printf 'unexpected gh call: %s\n' "$*" >&2
+exit 1
+SH
+
+    cat > "$BIN_DIR/claude" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '{"outcome":"clean","points":3,"summary":"Looks good."}'
+SH
+
+    cat > "$BIN_DIR/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+payload=""
+url=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -d)
+            payload="$2"
+            shift 2
+            ;;
+        http://*|https://*)
+            url="$1"
+            shift
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+printf '%s\t%s\n' "$url" "$payload" >> "${CURL_CALLS:?}"
+SH
+
+    chmod +x "$BIN_DIR/gh" "$BIN_DIR/claude" "$BIN_DIR/curl"
+    export PATH="$BIN_DIR:$PATH"
+    export LOOP_EXTRA_PATH="$BIN_DIR"
+    export HOME="$BATS_TMPDIR/home"
+    export BOUNTY_URL="http://127.0.0.1:18792"
+    export BOUNTY_TIMEOUT="1"
+    export CURL_CALLS="$BATS_TMPDIR/curl-calls.tsv"
+    export GH_COMMENT_LOG="$BATS_TMPDIR/gh-comments.log"
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/home" \
+           "$BATS_TMPDIR/curl-calls.tsv" "$BATS_TMPDIR/gh-comments.log" 2>/dev/null || true
+}
+
+@test "judge.sh emits judge_start and judge_done with judge role, model, and duration" {
+    run "$REPO_ROOT/scripts/judge.sh" 123 owner/repo "" "judge" "test-proj"
+
+    [ "$status" -eq 0 ]
+    [ -f "$CURL_CALLS" ]
+
+    run python3 - "$CURL_CALLS" <<'PY'
+import json
+import sys
+
+events = []
+for line in open(sys.argv[1], encoding="utf-8"):
+    url, payload = line.rstrip("\n").split("\t", 1)
+    if not url.endswith("/api/report"):
+        continue
+    events.append(json.loads(payload))
+
+assert [e["event"] for e in events] == ["judge_start", "judge_done"], events
+for event in events:
+    assert event["role"] == "judge", event
+    assert event["model"] == "sonnet", event
+    assert event["project"] == "test-proj", event
+    assert event["pr_num"] == 123, event
+done = events[1]
+assert isinstance(done.get("duration_seconds"), int), done
+assert done["duration_seconds"] >= 0, done
+assert "outcome=clean points=3" in (done.get("detail") or ""), done
+PY
+    [ "$status" -eq 0 ]
+}
+
+@test "merge-handler invokes judge with judge role and non-empty model" {
+    grep -F '"$LOOP_ROOT/scripts/judge.sh" "$PR_NUM" "$REPO" "${LOOP_JUDGE_MODEL:-sonnet}" "judge" "$SLUG"' \
+        "$REPO_ROOT/scripts/merge-handler.sh"
+
+    ! grep -F '"$LOOP_ROOT/scripts/judge.sh" "$PR_NUM" "$REPO" "" "dev" "$SLUG"' \
+        "$REPO_ROOT/scripts/merge-handler.sh"
+}


### PR DESCRIPTION
## Summary

Fixes the judge bounty feed events so loop-monitor can surface judge activity correctly.

Closes #349.

## Root cause

- `merge-handler.sh` invoked `judge.sh` with an empty model argument and role `dev`.
- `judge.sh` hardcoded the Claude invocation to `sonnet`, but reported the positional model argument to bounty telemetry, so monitor rows could record an empty model.
- `judge.sh` emitted a single `judge` feed event, while the monitor/UI filters expect stage-style start/done events.
- `bounty_report` did not pass through `duration_seconds`, so a terminal judge event could not carry runtime duration.

## Changes

- Emit `judge_start` after argument parsing and `judge_done` after verdict generation.
- Default the judge role to `judge` and make merge-handler pass `judge` explicitly.
- Use one judge model value for both Claude invocation and bounty telemetry, defaulting to `sonnet` via `${LOOP_JUDGE_MODEL:-sonnet}`.
- Add optional `duration_seconds` support to the bounty report payload.
- Document the new judge events and duration field in the bounty event API.
- Add Bats regression coverage for the judge event sequence, role, model, and duration.

## Test Plan

- `bats tests/judge.bats tests/bounty.bats`
- `bats tests/` (`708/708` in Ubuntu container)
- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh`
- `shellcheck -S warning lib/*.sh scripts/*.sh scanner/*.sh install.sh`
- `git diff --check HEAD~1..HEAD`
