### PR TITLE
[LOOP-371] enforce safe-to-test gate before QA validation_cmd runs

### DIFF
--- a/docs/api/bounty-events.md
+++ b/docs/api/bounty-events.md
@@ -35,7 +35,7 @@ Content-Type: application/json
 |---|---|---|---|
 | `api` | yes | string `"<MAJOR>.<MINOR>"` | API version. Loop emits `1.0`. Monitor accepts `1.x`, rejects `2.x` with HTTP 426. |
 | `core_version` | yes | string semver | Sender's loop core version, for telemetry. |
-| `event` | yes | string | One of: `dev_start`, `dev_done`, `dev_failed`, `review_start`, `review_done`, `review_request_changes`, `qa_start`, `qa_pass`, `qa_fail`, `merge_start`, `merge_done`, `merge_conflict`, `merge_failed`, `po_start`, `po_done`, `po_failed`, `rework_start`, `rework_done`, `rework_failed`, `judge_start`, `judge_done` |
+| `event` | yes | string | One of: `dev_start`, `dev_done`, `dev_failed`, `review_start`, `review_done`, `review_request_changes`, `qa_start`, `qa_pass`, `qa_fail`, `merge_start`, `merge_done`, `merge_conflict`, `merge_failed`, `po_start`, `po_done`, `po_failed`, `rework_start`, `rework_done`, `rework_failed`, `judge_start`, `judge_done`, `qa_skipped` |
 | `role` | optional | string | Free-form (e.g. `dev`, `reviewer`, `merger`, or future specialist names like `frontend`) |
 | `agent` | optional | string | The agent CLI name (`claude`, `codex`, `gemini`, `aider`) |
 | `model` | optional | string | Model id (`sonnet`, `opus`, `o4-mini`) |

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -108,6 +108,8 @@ and you need to push a hotfix, follow the regular flow.
 - **Failure mode:** Prompt injection via issue body, PR text, comments,
   commit messages, or CI logs → agent runs unintended commands.
   Operator monitors via logs and bounty scorecards.
+- **Note:** QA `validation_cmd` is gated: `external-pr` requires
+  `safe-to-test` before code-executing validation runs.
 
 ### Credential surface
 

--- a/scripts/qa-handler.sh
+++ b/scripts/qa-handler.sh
@@ -81,6 +81,49 @@ case "$PR_STATE" in
         ;;
 esac
 
+# --- Security gate: external-pr requires safe-to-test before validation_cmd runs ---
+# validation_cmd executes arbitrary project code (pytest, npm, make, ...). For PRs
+# from outside the operator account (label `external-pr`), require an explicit
+# operator-applied `safe-to-test` label first. Otherwise: skip QA cleanly so the
+# scanner does not retry. See docs/security-model.md.
+_PR_LABELS_JSON=$(backend_pr_view "$REPO" "$PR_NUM" --json labels 2>/dev/null || echo '{"labels":[]}')
+_PR_LABELS=$(echo "$_PR_LABELS_JSON" | python3 -c "import json,sys
+try:
+    d=json.load(sys.stdin)
+except Exception:
+    print(''); sys.exit(0)
+for l in d.get('labels', []):
+    name = l.get('name','') if isinstance(l, dict) else str(l)
+    if name:
+        print(name)" 2>/dev/null || echo "")
+
+_has_external_pr=0
+_has_safe_to_test=0
+while IFS= read -r _lbl; do
+    [ -z "$_lbl" ] && continue
+    _canonical=$(loop_canonical_label "$_lbl" 2>/dev/null || echo "$_lbl")
+    case "$_canonical" in
+        external-pr) _has_external_pr=1 ;;
+        safe-to-test) _has_safe_to_test=1 ;;
+    esac
+    case "$_lbl" in
+        external-pr) _has_external_pr=1 ;;
+        safe-to-test) _has_safe_to_test=1 ;;
+    esac
+done <<< "$_PR_LABELS"
+
+if [ "$_has_external_pr" = "1" ] && [ "$_has_safe_to_test" != "1" ]; then
+    log "PR #$PR_NUM has external-pr but not safe-to-test — gating QA (operator must approve)"
+    bounty_report "qa_skipped" model="${LOOP_AGENT_MODEL:-sonnet}" role=qa project="$SLUG" pr_num="$PR_NUM" \
+        detail="external-pr without safe-to-test — operator must approve" || true
+    backend_comment_pr "$REPO" "$PR_NUM" \
+        "QA blocked: this PR is labeled \`external-pr\` but not \`safe-to-test\`. An operator must apply the \`safe-to-test\` label to permit QA execution." \
+        2>/dev/null || true
+    backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_NEEDS_QA" 2>/dev/null || true
+    backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_READY_FOR_QA" 2>/dev/null || true
+    exit 0
+fi
+
 # Auto-promote drafts — PRs are no longer opened as drafts, but promote any legacy ones.
 _is_draft=$(gh pr view "$PR_NUM" --repo "$REPO" --json isDraft --jq '.isDraft' 2>/dev/null || echo "false")
 if [ "$_is_draft" = "true" ]; then

--- a/tests/qa-handler-external-pr-gate.bats
+++ b/tests/qa-handler-external-pr-gate.bats
@@ -1,0 +1,156 @@
+#!/usr/bin/env bats
+# tests/qa-handler-external-pr-gate.bats
+# Regression tests for the safe-to-test gate in scripts/qa-handler.sh.
+#
+# The gate ensures that QA's validation_cmd (which executes arbitrary project
+# code) never runs against an external-pr unless an operator has explicitly
+# approved it with the safe-to-test label.
+
+setup() {
+    OPS_LOG="$BATS_TMPDIR/label-ops.log"
+    COMMENT_LOG="$BATS_TMPDIR/comment.log"
+    BOUNTY_LOG="$BATS_TMPDIR/bounty.log"
+    AGENT_LOG="$BATS_TMPDIR/agent.log"
+    rm -f "$OPS_LOG" "$COMMENT_LOG" "$BOUNTY_LOG" "$AGENT_LOG"
+
+    export REPO="owner/test-repo"
+    export PR_NUM="42"
+    export SLUG="test-proj"
+    export LOOP_AGENT_MODEL="sonnet"
+    export LOOP_LABEL_NEEDS_QA="needs-qa"
+    export LOOP_LABEL_DEPRECATED_READY_FOR_QA="ready-for-qa"
+}
+
+teardown() {
+    rm -f "$OPS_LOG" "$COMMENT_LOG" "$BOUNTY_LOG" "$AGENT_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: replicate the gate block from scripts/qa-handler.sh in isolation so
+# we can exercise it without booting the full handler (which needs project
+# config, locks, runner, etc.).
+# ---------------------------------------------------------------------------
+_run_gate() {
+    local labels_csv="$1"
+    # Build labels JSON from CSV
+    local labels_json
+    labels_json=$(python3 -c "
+import json, sys
+items = [s for s in '''$labels_csv'''.split(',') if s.strip()]
+print(json.dumps({'labels': [{'name': s.strip()} for s in items]}))
+")
+
+    backend_pr_view() { printf '%s' "$labels_json"; }
+    backend_remove_label() { echo "remove $3" >> "$OPS_LOG"; }
+    backend_comment_pr()   { echo "comment: $3" >> "$COMMENT_LOG"; }
+    bounty_report() { echo "bounty $1: $*" >> "$BOUNTY_LOG"; }
+    loop_canonical_label() { echo "$1"; }
+    log() { true; }
+    loop_run_agent() { echo "agent-invoked" >> "$AGENT_LOG"; return 0; }
+
+    # --- The gate (mirrors scripts/qa-handler.sh) ---
+    local _PR_LABELS_JSON _PR_LABELS _has_external_pr=0 _has_safe_to_test=0
+    _PR_LABELS_JSON=$(backend_pr_view "$REPO" "$PR_NUM" --json labels 2>/dev/null || echo '{"labels":[]}')
+    _PR_LABELS=$(echo "$_PR_LABELS_JSON" | python3 -c "import json,sys
+try:
+    d=json.load(sys.stdin)
+except Exception:
+    print(''); sys.exit(0)
+for l in d.get('labels', []):
+    name = l.get('name','') if isinstance(l, dict) else str(l)
+    if name:
+        print(name)" 2>/dev/null || echo "")
+
+    while IFS= read -r _lbl; do
+        [ -z "$_lbl" ] && continue
+        case "$_lbl" in
+            external-pr) _has_external_pr=1 ;;
+            safe-to-test) _has_safe_to_test=1 ;;
+        esac
+    done <<< "$_PR_LABELS"
+
+    if [ "$_has_external_pr" = "1" ] && [ "$_has_safe_to_test" != "1" ]; then
+        bounty_report "qa_skipped" model="sonnet" role=qa project="$SLUG" pr_num="$PR_NUM" \
+            detail="external-pr without safe-to-test — operator must approve"
+        backend_comment_pr "$REPO" "$PR_NUM" \
+            "QA blocked: this PR is labeled \`external-pr\` but not \`safe-to-test\`. An operator must apply the \`safe-to-test\` label to permit QA execution."
+        backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_NEEDS_QA"
+        backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_READY_FOR_QA"
+        return 0
+    fi
+
+    # Otherwise: proceed to "agent dispatch" (mocked).
+    loop_run_agent "prompt" "/tmp"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: external-pr + safe-to-test → gate passes, agent dispatched
+# ---------------------------------------------------------------------------
+
+@test "external-pr + safe-to-test: gate proceeds (agent invoked)" {
+    _run_gate "external-pr,safe-to-test,needs-qa"
+    [ -f "$AGENT_LOG" ]
+    grep -q "agent-invoked" "$AGENT_LOG"
+}
+
+@test "external-pr + safe-to-test: no qa_skipped bounty" {
+    _run_gate "external-pr,safe-to-test,needs-qa"
+    [ ! -f "$BOUNTY_LOG" ] || ! grep -q "qa_skipped" "$BOUNTY_LOG"
+}
+
+@test "external-pr + safe-to-test: no QA-blocked comment" {
+    _run_gate "external-pr,safe-to-test,needs-qa"
+    [ ! -f "$COMMENT_LOG" ] || ! grep -q "QA blocked" "$COMMENT_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Case 2: external-pr WITHOUT safe-to-test → gate trips, exit 0
+# ---------------------------------------------------------------------------
+
+@test "external-pr without safe-to-test: emits qa_skipped" {
+    _run_gate "external-pr,needs-qa"
+    grep -q "qa_skipped" "$BOUNTY_LOG"
+}
+
+@test "external-pr without safe-to-test: posts QA-blocked comment" {
+    _run_gate "external-pr,needs-qa"
+    grep -q "QA blocked" "$COMMENT_LOG"
+    grep -q "safe-to-test" "$COMMENT_LOG"
+}
+
+@test "external-pr without safe-to-test: removes needs-qa and ready-for-qa" {
+    _run_gate "external-pr,needs-qa"
+    grep -q "remove needs-qa" "$OPS_LOG"
+    grep -q "remove ready-for-qa" "$OPS_LOG"
+}
+
+@test "external-pr without safe-to-test: agent NOT invoked" {
+    _run_gate "external-pr,needs-qa"
+    [ ! -f "$AGENT_LOG" ] || ! grep -q "agent-invoked" "$AGENT_LOG"
+}
+
+@test "external-pr without safe-to-test: clean exit (status 0)" {
+    run _run_gate "external-pr,needs-qa"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Case 3: No external-pr label → gate is transparent, agent dispatched
+# ---------------------------------------------------------------------------
+
+@test "no external-pr label: gate proceeds (agent invoked)" {
+    _run_gate "needs-qa"
+    [ -f "$AGENT_LOG" ]
+    grep -q "agent-invoked" "$AGENT_LOG"
+}
+
+@test "no external-pr label: no qa_skipped bounty" {
+    _run_gate "needs-qa"
+    [ ! -f "$BOUNTY_LOG" ] || ! grep -q "qa_skipped" "$BOUNTY_LOG"
+}
+
+@test "no external-pr label: no comment posted" {
+    _run_gate "needs-qa"
+    [ ! -f "$COMMENT_LOG" ] || ! grep -q "QA blocked" "$COMMENT_LOG"
+}


### PR DESCRIPTION
Closes #371

## Summary

QA's `validation_cmd` runs arbitrary project code (pytest, npm, make, ...). The `safe-to-test` label was documented as the gate for external PRs but nothing enforced it — an `external-pr` without `safe-to-test` would still execute unsandboxed code in the operator's shell.

This change adds an early gate in `scripts/qa-handler.sh`, before any prompt construction or agent dispatch:
- Fetch the PR's labels via `backend_pr_view`.
- If labels include `external-pr` AND NOT `safe-to-test`:
  - Emit `bounty_report qa_skipped` with detail explaining why.
  - Post a comment on the PR telling the operator to apply `safe-to-test`.
  - Remove `needs-qa` / `ready-for-qa` so the scanner does not retry.
  - Exit 0 cleanly.
- Otherwise: proceed unchanged.

## Threat model

- **Surface:** `validation_cmd` invocation against PR head code (Code execution surface in `docs/security-model.md`).
- **Pre-fix:** any PR landing in `needs-qa` ran validation, including PRs from forks/external authors. A malicious external PR with hijacked test commands could exfiltrate or destroy operator-shell state.
- **Post-fix:** external PRs require explicit operator approval (`safe-to-test`) before any code-executing step. Same-owner PRs (no `external-pr` label) are unaffected.
- The gate runs **before** the prompt is constructed, so neither the agent nor the validation command observes any side effect of an external PR until approved.
- Fail-safe: if `backend_pr_view` returns nothing or label parsing fails, the gate variables stay 0 and the handler proceeds — matching pre-existing behavior. The `external-pr` label is the operator's signal; the gate only adds restriction when that signal is present.

## Tests

`tests/qa-handler-external-pr-gate.bats` — 11 cases, all passing:
- `external-pr` + `safe-to-test` → gate proceeds, agent dispatched, no `qa_skipped` bounty, no block comment.
- `external-pr` without `safe-to-test` → emits `qa_skipped`, posts QA-blocked comment, removes `needs-qa` + `ready-for-qa`, agent NOT invoked, clean exit.
- No `external-pr` label → gate transparent, agent dispatched.

## Other changes

- `docs/api/bounty-events.md`: list new event `qa_skipped` (same pattern as `judge_start` / `judge_done` from #370).
- `docs/security-model.md`: short note under the prompt-injection / agent autonomy section pointing to the new gate.

## Test plan

- [x] `bash -n scripts/qa-handler.sh`
- [x] `shellcheck -S warning scripts/qa-handler.sh`
- [x] `bats tests/qa-handler-external-pr-gate.bats` (11/11 pass)