### PR TITLE
[LOOP-336] merge-handler claims from jobs table

### DIFF
--- a/scripts/merge-handler.sh
+++ b/scripts/merge-handler.sh
@@ -25,6 +25,8 @@ source "$LOOP_ROOT/lib/notify.sh"
 source "$LOOP_ROOT/lib/recovery.sh"
 # shellcheck source=../lib/failure_category.sh
 source "$LOOP_ROOT/lib/failure_category.sh"
+# shellcheck source=../lib/jobs.sh
+source "$LOOP_ROOT/lib/jobs.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-merge-handler.log"
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [merge-handler] $*" | tee -a "$LOG_FILE"; }
@@ -44,16 +46,48 @@ if [ -z "$SLUG" ] || [ -z "$PR_NUM" ]; then
     fi
 fi
 
+# Jobs-table claim — attempt to pull work from the DB before falling back to
+# the event-payload PR number.  If a row is claimed its issue_or_pr overrides
+# PR_NUM; otherwise the legacy label-driven path proceeds unchanged.
+_JOBS_CLAIMED_ID=""
+if [ -n "$SLUG" ]; then
+    jobs_init_schema 2>/dev/null || true
+    _candidate=$(jobs_claim "$SLUG" "merge" 2>/dev/null || true)
+    if [ -n "$_candidate" ]; then
+        _JOBS_CLAIMED_ID="$_candidate"
+        _jobs_pr=$(sqlite3 "$(jobs_db_path)" \
+            "SELECT issue_or_pr FROM jobs WHERE id=${_JOBS_CLAIMED_ID};" 2>/dev/null || true)
+        if [ -n "$_jobs_pr" ]; then
+            PR_NUM="$_jobs_pr"
+            log "claimed job id=${_JOBS_CLAIMED_ID} pr_num=${PR_NUM} from jobs table"
+        fi
+    fi
+fi
+
 [ -n "$SLUG" ] && [ -n "$PR_NUM" ] \
     || { log "ERROR: missing slug or pr_number"; exit 2; }
 
 loop_load_project "$SLUG" || { log "ERROR: unknown slug '$SLUG'"; exit 2; }
 loop_load_backend
 
+# Combined EXIT handler: release advisory lock + jobs_complete/fail depending on exit code.
+_merge_handler_cleanup() {
+    local _rc=$?
+    loop_release_lock "$SLUG" || true
+    if [ -n "$_JOBS_CLAIMED_ID" ]; then
+        if [ "$_rc" -eq 0 ]; then
+            jobs_complete "$_JOBS_CLAIMED_ID" || true
+        else
+            jobs_fail "$_JOBS_CLAIMED_ID" "handler exited rc=${_rc}" || true
+        fi
+    fi
+}
+
 # Per-project lock — only one Loop handler at a time per repo.
 source "$LOOP_ROOT/lib/lock.sh"
 loop_acquire_lock "$SLUG" || { log "ERROR: couldn't acquire lock for $SLUG within 1hr — exiting"; exit 1; }
 log "acquired project lock for $SLUG"
+trap '_merge_handler_cleanup' EXIT INT TERM
 
 STRATEGY_FLAG="--squash"
 case "${MERGE_STRATEGY:-squash}" in

--- a/tests/merge-handler-jobs-claim.bats
+++ b/tests/merge-handler-jobs-claim.bats
@@ -1,0 +1,220 @@
+#!/usr/bin/env bats
+# tests/merge-handler-jobs-claim.bats
+#
+# Unit tests for the jobs-table claim path in merge-handler.sh.
+#
+# Tests cover:
+#   (1) Claim happy path — PR_NUM is set from claimed row's issue_or_pr
+#   (2) Double-claim safety — two parallel invocations claim at most one row
+#   (3) Complete on success — cleanup marks job completed when exit rc=0
+#   (4) Fail on error — cleanup marks job failed and attempts were incremented
+#   (5) Fallback — no pending job → PR_NUM from event payload preserved
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    if ! command -v sqlite3 >/dev/null 2>&1; then
+        skip "sqlite3 not available"
+    fi
+
+    export LOOP_JOBS_DB="$BATS_TMPDIR/merge-jobs-$$.db"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # shellcheck source=../lib/jobs.sh
+    source "$REPO_ROOT/lib/jobs.sh"
+    jobs_init_schema
+
+    LOG_FILE="$BATS_TMPDIR/merge-handler.log"
+    log() { echo "[merge-handler-test] $*" >> "$LOG_FILE" 2>/dev/null || true; }
+    loop_release_lock() { :; }
+}
+
+teardown() {
+    rm -f "$LOOP_JOBS_DB" "$BATS_TMPDIR/merge-handler.log"
+    rm -rf "$BATS_TMPDIR/logs"
+    unset LOOP_JOBS_DB LOOP_LOG_DIR
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helper: replicate the claim block from merge-handler.sh
+# ─────────────────────────────────────────────────────────────────────────────
+_run_claim_block() {
+    local slug="$1"
+    local initial_pr_num="${2:-}"
+
+    PR_NUM="$initial_pr_num"
+    _JOBS_CLAIMED_ID=""
+
+    jobs_init_schema 2>/dev/null || true
+    local _candidate
+    _candidate=$(jobs_claim "$slug" "merge" 2>/dev/null || true)
+    if [ -n "$_candidate" ]; then
+        _JOBS_CLAIMED_ID="$_candidate"
+        local _jobs_pr
+        _jobs_pr=$(sqlite3 "$(jobs_db_path)" \
+            "SELECT issue_or_pr FROM jobs WHERE id=${_JOBS_CLAIMED_ID};" 2>/dev/null || true)
+        if [ -n "$_jobs_pr" ]; then
+            PR_NUM="$_jobs_pr"
+            log "claimed job id=${_JOBS_CLAIMED_ID} pr_num=${PR_NUM} from jobs table"
+        fi
+    fi
+}
+
+# Helper: replicate the cleanup logic from _merge_handler_cleanup
+_run_cleanup() {
+    local rc="$1"
+    local claimed_id="$2"
+
+    if [ -n "$claimed_id" ]; then
+        if [ "$rc" -eq 0 ]; then
+            jobs_complete "$claimed_id" || true
+        else
+            jobs_fail "$claimed_id" "handler exited rc=${rc}" || true
+        fi
+    fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (1) Claim happy path
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "claim happy path: _JOBS_CLAIMED_ID is set when a pending job exists" {
+    jobs_enqueue "test-proj" "merge" 42 >/dev/null
+
+    _run_claim_block "test-proj" ""
+
+    [ -n "$_JOBS_CLAIMED_ID" ]
+}
+
+@test "claim happy path: PR_NUM is set from row's issue_or_pr" {
+    jobs_enqueue "test-proj" "merge" 42 >/dev/null
+
+    _run_claim_block "test-proj" ""
+
+    [ "$PR_NUM" = "42" ]
+}
+
+@test "claim happy path: row status transitions to in_flight after claim" {
+    local id
+    id=$(jobs_enqueue "test-proj" "merge" 42)
+
+    _run_claim_block "test-proj" ""
+
+    local status_val
+    status_val=$(sqlite3 "$LOOP_JOBS_DB" "SELECT status FROM jobs WHERE id=${id};")
+    [ "$status_val" = "in_flight" ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (2) Double-claim safety
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "double-claim safety: two parallel invocations claim at most one row" {
+    jobs_enqueue "test-proj" "merge" 99 >/dev/null
+
+    local out1="$BATS_TMPDIR/claim1-$$.txt"
+    local out2="$BATS_TMPDIR/claim2-$$.txt"
+
+    (LOOP_JOBS_DB="$LOOP_JOBS_DB" jobs_claim "test-proj" "merge" "worker-1" > "$out1") &
+    local pid1=$!
+    (LOOP_JOBS_DB="$LOOP_JOBS_DB" jobs_claim "test-proj" "merge" "worker-2" > "$out2") &
+    local pid2=$!
+
+    wait "$pid1"
+    wait "$pid2"
+
+    local c1 c2 non_empty
+    c1=$(cat "$out1")
+    c2=$(cat "$out2")
+    non_empty=0
+    [ -n "$c1" ] && non_empty=$((non_empty + 1))
+    [ -n "$c2" ] && non_empty=$((non_empty + 1))
+
+    rm -f "$out1" "$out2"
+    [ "$non_empty" -eq 1 ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (3) Complete on success
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "complete-on-success: cleanup marks job completed when exit rc=0" {
+    local id
+    id=$(jobs_enqueue "test-proj" "merge" 55)
+    jobs_claim "test-proj" "merge" >/dev/null
+
+    _run_cleanup 0 "$id"
+
+    local status_val
+    status_val=$(sqlite3 "$LOOP_JOBS_DB" "SELECT status FROM jobs WHERE id=${id};")
+    [ "$status_val" = "completed" ]
+}
+
+@test "complete-on-success: completed_at is recorded" {
+    local id
+    id=$(jobs_enqueue "test-proj" "merge" 55)
+    jobs_claim "test-proj" "merge" >/dev/null
+
+    _run_cleanup 0 "$id"
+
+    local completed_at
+    completed_at=$(sqlite3 "$LOOP_JOBS_DB" "SELECT completed_at FROM jobs WHERE id=${id};")
+    [[ "$completed_at" =~ ^[0-9]+$ ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (4) Fail on error — attempts incremented at claim time, status becomes failed
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "fail-on-error: cleanup marks job failed when exit rc is non-zero" {
+    local id
+    id=$(jobs_enqueue "test-proj" "merge" 66)
+    jobs_claim "test-proj" "merge" >/dev/null
+
+    _run_cleanup 1 "$id"
+
+    local status_val
+    status_val=$(sqlite3 "$LOOP_JOBS_DB" "SELECT status FROM jobs WHERE id=${id};")
+    [ "$status_val" = "failed" ]
+}
+
+@test "fail-on-error: attempts counter was incremented by claim" {
+    local id
+    id=$(jobs_enqueue "test-proj" "merge" 66)
+    jobs_claim "test-proj" "merge" >/dev/null
+
+    _run_cleanup 1 "$id"
+
+    local attempts_val
+    attempts_val=$(sqlite3 "$LOOP_JOBS_DB" "SELECT attempts FROM jobs WHERE id=${id};")
+    [ "$attempts_val" -eq 1 ]
+}
+
+@test "fail-on-error: last_error is recorded with exit code detail" {
+    local id
+    id=$(jobs_enqueue "test-proj" "merge" 66)
+    jobs_claim "test-proj" "merge" >/dev/null
+
+    _run_cleanup 1 "$id"
+
+    local last_error
+    last_error=$(sqlite3 "$LOOP_JOBS_DB" "SELECT last_error FROM jobs WHERE id=${id};")
+    [[ "$last_error" == *"rc=1"* ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (5) Fallback — no job in DB → legacy event-payload PR_NUM preserved
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "fallback: no pending job → _JOBS_CLAIMED_ID stays empty" {
+    _run_claim_block "test-proj" "77"
+
+    [ -z "$_JOBS_CLAIMED_ID" ]
+}
+
+@test "fallback: no pending job → PR_NUM from event payload is preserved" {
+    _run_claim_block "test-proj" "77"
+
+    [ "$PR_NUM" = "77" ]
+}


### PR DESCRIPTION
Closes #336

## Changes

**`scripts/merge-handler.sh`**
- Sources `lib/jobs.sh` at startup.
- After parsing the event payload, attempts `jobs_claim "$SLUG" "merge"`. If a row is claimed, its `issue_or_pr` overrides `PR_NUM`; if no row is available the legacy label-driven path proceeds unchanged.
- Adds `_merge_handler_cleanup` function (registered via `trap ... EXIT INT TERM` after `loop_acquire_lock`) that:
  - Always releases the advisory lock (`loop_release_lock`)
  - Calls `jobs_complete` on exit rc=0; `jobs_fail` on non-zero rc
- The `/tmp` lockfile logic and label-event entry path are untouched.

**`tests/merge-handler-jobs-claim.bats`** (new, 11 tests)
- Claim happy path: `_JOBS_CLAIMED_ID` set, `PR_NUM` overridden from DB, row becomes `in_flight`
- Double-claim safety: two parallel `jobs_claim` calls against one seeded row — exactly one wins
- Complete on success: cleanup marks row `completed` and records `completed_at`
- Fail on error: cleanup marks row `failed`, `last_error` contains exit code, `attempts` = 1
- Fallback: no pending job → `PR_NUM` from event payload preserved, `_JOBS_CLAIMED_ID` empty

## Test Plan
- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — all pass
- `shellcheck -S warning` — clean
- `bats tests/merge-handler-jobs-claim.bats` — 11/11 pass
- `bats tests/jobs-lib.bats tests/merge-handler-fork-gate.bats` — 23/23 pass (no regressions)