### PR TITLE
[LOOP-337] jobs-cli: list/show subcommands + stable JSON contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,67 @@ scripts/loop-recover.sh 78 --to-stage dev
   already contains the recovery marker).
 - Labels only — no branch state, commits, or PRs are modified.
 
+## Jobs CLI
+
+Inspect the Loop jobs queue directly from the command line.
+
+```bash
+# List all jobs (column-aligned table)
+./scripts/jobs-cli.sh list
+
+# Filter by status
+./scripts/jobs-cli.sh list --status pending
+./scripts/jobs-cli.sh list --status in_flight
+./scripts/jobs-cli.sh list --status completed
+./scripts/jobs-cli.sh list --status failed
+
+# Filter by project slug
+./scripts/jobs-cli.sh list --project myapp
+
+# Combine filters and limit rows
+./scripts/jobs-cli.sh list --project myapp --status pending --limit 20
+
+# Emit JSON array (stable contract — see schema below)
+./scripts/jobs-cli.sh list --json
+
+# Show a single job by id (key/value block)
+./scripts/jobs-cli.sh show 42
+
+# Show a single job as JSON
+./scripts/jobs-cli.sh show 42 --json
+```
+
+### JSON Schema
+
+`list --json` emits a JSON array; `show --json` emits a single object.
+Both follow this stable contract (nullable fields use `null`, not empty string):
+
+```json
+[
+  {
+    "id": 1,
+    "project": "loop",
+    "stage": "merge",
+    "issue_or_pr": 123,
+    "status": "pending",
+    "claimed_by": null,
+    "claimed_at": null,
+    "completed_at": null,
+    "attempts": 0,
+    "last_error": null,
+    "created_at": 1715600000
+  }
+]
+```
+
+Field notes:
+- `created_at`, `claimed_at`, `completed_at` — Unix epoch seconds (integer).
+- `attempts` — integer; incremented each time the job is claimed.
+- `status` — one of `pending`, `in_flight`, `completed`, `failed`.
+
+The DB file location is controlled by the `LOOP_JOBS_DB` environment variable
+(default: `$LOOP_LOG_DIR/jobs.db`, which is typically `~/.loop/jobs.db`).
+
 ## Development
 
 ```bash

--- a/scripts/jobs-cli.sh
+++ b/scripts/jobs-cli.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# scripts/jobs-cli.sh — CLI for inspecting the Loop jobs queue.
+#
+# Usage:
+#   jobs-cli.sh list [--status STATUS] [--project SLUG] [--json] [--limit N]
+#   jobs-cli.sh show <id> [--json]
+#
+# Invocation: ./scripts/jobs-cli.sh <subcommand> [flags]
+# See README.md "Jobs CLI" section for full documentation.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+# shellcheck source=../lib/jobs.sh
+source "$LOOP_ROOT/lib/jobs.sh"
+
+_usage() {
+    cat >&2 <<'EOF'
+Usage:
+  jobs-cli.sh list [--status STATUS] [--project SLUG] [--json] [--limit N]
+  jobs-cli.sh show <id> [--json]
+
+Subcommands:
+  list    Print all jobs (default) or filter by status/project
+  show    Print a single job by id
+
+Flags (list):
+  --status STATUS    Filter: pending|in_flight|completed|failed
+  --project SLUG     Filter by project slug
+  --json             Emit JSON array matching the stable contract
+  --limit N          Max rows to return (default: 100)
+
+Flags (show):
+  --json             Emit a single JSON object matching the stable contract
+EOF
+    exit 1
+}
+
+cmd_list() {
+    local project="" status="" json=0 limit=100
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --project)
+                project="$2"; shift 2 ;;
+            --status)
+                case "$2" in
+                    pending|in_flight|completed|failed)
+                        status="$2"; shift 2 ;;
+                    *)
+                        echo "Error: unknown --status value '$2'. Valid: pending|in_flight|completed|failed" >&2
+                        exit 1 ;;
+                esac ;;
+            --json)
+                json=1; shift ;;
+            --limit)
+                limit="$2"; shift 2 ;;
+            *)
+                echo "Error: unknown flag '$1'" >&2
+                _usage ;;
+        esac
+    done
+
+    # Ensure schema exists before querying
+    jobs_init_schema
+
+    local db
+    db=$(jobs_db_path)
+
+    if [ "$json" -eq 1 ]; then
+        _JOBS_DB="$db" _JOBS_PROJECT="$project" _JOBS_STATUS="$status" \
+            _JOBS_LIMIT="$limit" python3 - <<'PY'
+import json, os, sqlite3
+
+db_path  = os.environ["_JOBS_DB"]
+project  = os.environ.get("_JOBS_PROJECT", "")
+status   = os.environ.get("_JOBS_STATUS", "")
+limit    = int(os.environ.get("_JOBS_LIMIT", "100"))
+
+conn = sqlite3.connect(db_path)
+conn.row_factory = sqlite3.Row
+
+where_parts = []
+params = []
+if project:
+    where_parts.append("project = ?")
+    params.append(project)
+if status:
+    where_parts.append("status = ?")
+    params.append(status)
+
+where = ("WHERE " + " AND ".join(where_parts)) if where_parts else ""
+sql = (
+    "SELECT id, project, stage, issue_or_pr, status, claimed_by, "
+    "claimed_at, completed_at, attempts, last_error, created_at "
+    "FROM jobs " + where + " ORDER BY id LIMIT ?"
+)
+params.append(limit)
+
+rows = conn.execute(sql, params).fetchall()
+result = [dict(r) for r in rows]
+print(json.dumps(result))
+conn.close()
+PY
+    else
+        _JOBS_DB="$db" _JOBS_PROJECT="$project" _JOBS_STATUS="$status" \
+            _JOBS_LIMIT="$limit" python3 - <<'PY'
+import os, sqlite3, sys
+
+db_path  = os.environ["_JOBS_DB"]
+project  = os.environ.get("_JOBS_PROJECT", "")
+status   = os.environ.get("_JOBS_STATUS", "")
+limit    = int(os.environ.get("_JOBS_LIMIT", "100"))
+
+conn = sqlite3.connect(db_path)
+conn.row_factory = sqlite3.Row
+
+where_parts = []
+params = []
+if project:
+    where_parts.append("project = ?")
+    params.append(project)
+if status:
+    where_parts.append("status = ?")
+    params.append(status)
+
+where = ("WHERE " + " AND ".join(where_parts)) if where_parts else ""
+sql = (
+    "SELECT id, project, stage, issue_or_pr, status, claimed_by, "
+    "attempts, created_at "
+    "FROM jobs " + where + " ORDER BY id LIMIT ?"
+)
+params.append(limit)
+
+rows = conn.execute(sql, params).fetchall()
+conn.close()
+
+if not rows:
+    print("No jobs found.")
+    sys.exit(0)
+
+headers = ["id", "project", "stage", "issue_or_pr", "status", "claimed_by", "attempts", "created_at"]
+data = [[str(r[h]) if r[h] is not None else "" for h in headers] for r in rows]
+widths = [max(len(h), max((len(row[i]) for row in data), default=0)) for i, h in enumerate(headers)]
+sep = "  "
+fmt_parts = ["{{:<{}}}".format(w) for w in widths]
+fmt = sep.join(fmt_parts)
+print(fmt.format(*headers))
+print(sep.join("-" * w for w in widths))
+for row in data:
+    print(fmt.format(*row))
+PY
+    fi
+}
+
+cmd_show() {
+    local id="" json=0
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --json)
+                json=1; shift ;;
+            [0-9]*)
+                id="$1"; shift ;;
+            *)
+                echo "Error: unknown argument '$1'" >&2
+                _usage ;;
+        esac
+    done
+
+    if [ -z "$id" ]; then
+        echo "Error: 'show' requires a job id" >&2
+        _usage
+    fi
+
+    # Ensure schema exists before querying
+    jobs_init_schema
+
+    local db
+    db=$(jobs_db_path)
+
+    if [ "$json" -eq 1 ]; then
+        _JOBS_DB="$db" _JOBS_ID="$id" python3 - <<'PY'
+import json, os, sqlite3, sys
+
+db_path = os.environ["_JOBS_DB"]
+job_id  = int(os.environ["_JOBS_ID"])
+
+conn = sqlite3.connect(db_path)
+conn.row_factory = sqlite3.Row
+row = conn.execute(
+    "SELECT id, project, stage, issue_or_pr, status, claimed_by, "
+    "claimed_at, completed_at, attempts, last_error, created_at "
+    "FROM jobs WHERE id = ?",
+    (job_id,)
+).fetchone()
+conn.close()
+
+if row is None:
+    print("Error: no job with id {}".format(job_id), file=sys.stderr)
+    sys.exit(1)
+
+print(json.dumps(dict(row)))
+PY
+    else
+        _JOBS_DB="$db" _JOBS_ID="$id" python3 - <<'PY'
+import os, sqlite3, sys
+
+db_path = os.environ["_JOBS_DB"]
+job_id  = int(os.environ["_JOBS_ID"])
+
+conn = sqlite3.connect(db_path)
+conn.row_factory = sqlite3.Row
+row = conn.execute(
+    "SELECT id, project, stage, issue_or_pr, status, claimed_by, "
+    "claimed_at, completed_at, attempts, last_error, created_at "
+    "FROM jobs WHERE id = ?",
+    (job_id,)
+).fetchone()
+conn.close()
+
+if row is None:
+    print("Error: no job with id {}".format(job_id), file=sys.stderr)
+    sys.exit(1)
+
+for key in row.keys():
+    val = row[key]
+    print("{:<16} {}".format(key, val if val is not None else ""))
+PY
+    fi
+}
+
+SUBCOMMAND="${1:-}"
+[ -n "$SUBCOMMAND" ] || _usage
+shift
+
+case "$SUBCOMMAND" in
+    list) cmd_list "$@" ;;
+    show) cmd_show "$@" ;;
+    *)
+        echo "Error: unknown subcommand '$SUBCOMMAND'" >&2
+        _usage ;;
+esac

--- a/tests/jobs-cli.bats
+++ b/tests/jobs-cli.bats
@@ -1,0 +1,244 @@
+#!/usr/bin/env bats
+# tests/jobs-cli.bats — integration tests for scripts/jobs-cli.sh
+#
+# Each test gets an isolated LOOP_JOBS_DB in a temp directory.
+# Tests cover:
+#   (a) unfiltered list shows all rows
+#   (b) --status filtering
+#   (c) --project filtering
+#   (d) --json output: valid array, all contract keys present
+#   (e) show <id> returns the row
+#   (f) show <missing> exits non-zero
+#   (g) unknown subcommand exits non-zero
+#   (h) unknown --status value exits non-zero
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+CLI="$REPO_ROOT/scripts/jobs-cli.sh"
+
+setup() {
+    export LOOP_JOBS_DB="$BATS_TMPDIR/jobs-cli-$$.db"
+    export LOOP_LOG_DIR="$BATS_TMPDIR"
+    # shellcheck source=../lib/jobs.sh
+    source "$REPO_ROOT/lib/jobs.sh"
+    jobs_init_schema
+
+    # Seed one row of each status
+    ID_PENDING=$(jobs_enqueue "alpha" "dev"    101)
+    ID_IN_FLIGHT=$(jobs_enqueue "alpha" "review" 102)
+    jobs_claim "alpha" "review" "worker-1" >/dev/null
+    ID_COMPLETED=$(jobs_enqueue "beta"  "qa"    201)
+    jobs_claim "beta" "qa" "worker-2" >/dev/null
+    jobs_complete "$ID_COMPLETED"
+    ID_FAILED=$(jobs_enqueue "beta"  "merge" 202)
+    jobs_claim "beta" "merge" "worker-3" >/dev/null
+    jobs_fail "$ID_FAILED" "something went wrong"
+
+    export ID_PENDING ID_IN_FLIGHT ID_COMPLETED ID_FAILED
+}
+
+teardown() {
+    rm -f "$LOOP_JOBS_DB"
+    unset LOOP_JOBS_DB LOOP_LOG_DIR ID_PENDING ID_IN_FLIGHT ID_COMPLETED ID_FAILED
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (a) Unfiltered list shows all rows
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "list with no filters shows all 4 rows" {
+    run "$CLI" list
+    [ "$status" -eq 0 ]
+    # 4 data rows + header + separator = 6 lines
+    [ "$(echo "$output" | wc -l | tr -d ' ')" -ge 6 ]
+    [[ "$output" == *"alpha"* ]]
+    [[ "$output" == *"beta"* ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (b) --status filtering
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "list --status pending shows only the pending row" {
+    run "$CLI" list --status pending
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"pending"* ]]
+    [[ "$output" != *"in_flight"* ]]
+    [[ "$output" != *"completed"* ]]
+    [[ "$output" != *"failed"* ]]
+}
+
+@test "list --status in_flight shows only the in_flight row" {
+    run "$CLI" list --status in_flight
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"in_flight"* ]]
+    [[ "$output" != *"pending"* ]]
+}
+
+@test "list --status completed shows only the completed row" {
+    run "$CLI" list --status completed
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"completed"* ]]
+    [[ "$output" != *"failed"* ]]
+}
+
+@test "list --status failed shows only the failed row" {
+    run "$CLI" list --status failed
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"failed"* ]]
+    [[ "$output" != *"completed"* ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (c) --project filtering
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "list --project alpha shows only alpha rows" {
+    run "$CLI" list --project alpha
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"alpha"* ]]
+    [[ "$output" != *"beta"* ]]
+}
+
+@test "list --project beta shows only beta rows" {
+    run "$CLI" list --project beta
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"beta"* ]]
+    [[ "$output" != *"alpha"* ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (d) --json output: valid array, all contract keys present
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "list --json emits a valid JSON array" {
+    run "$CLI" list --json
+    [ "$status" -eq 0 ]
+    echo "$output" | python3 -c "import json,sys; data=json.load(sys.stdin); assert isinstance(data, list)"
+}
+
+@test "list --json first element contains all contract keys" {
+    run "$CLI" list --json --limit 1
+    [ "$status" -eq 0 ]
+    JSON_DATA="$output" python3 - <<'PY'
+import json, os
+data = json.loads(os.environ["JSON_DATA"])
+assert len(data) >= 1, "expected at least one element"
+required = {"id","project","stage","issue_or_pr","status","claimed_by",
+            "claimed_at","completed_at","attempts","last_error","created_at"}
+missing = required - set(data[0].keys())
+assert not missing, "missing keys: {}".format(missing)
+PY
+}
+
+@test "list --json integer fields are integers not strings" {
+    run "$CLI" list --json --status pending
+    [ "$status" -eq 0 ]
+    JSON_DATA="$output" python3 - <<'PY'
+import json, os
+data = json.loads(os.environ["JSON_DATA"])
+row = data[0]
+assert isinstance(row["id"], int), "id must be int"
+assert isinstance(row["issue_or_pr"], int), "issue_or_pr must be int"
+assert isinstance(row["attempts"], int), "attempts must be int"
+assert isinstance(row["created_at"], int), "created_at must be int"
+PY
+}
+
+@test "list --json nullable fields use null not empty string" {
+    run "$CLI" list --json --status pending
+    [ "$status" -eq 0 ]
+    JSON_DATA="$output" python3 - <<'PY'
+import json, os
+data = json.loads(os.environ["JSON_DATA"])
+row = data[0]
+# pending row has no claimed_by, claimed_at, completed_at, last_error
+assert row["claimed_by"] is None, "claimed_by must be null for pending row"
+assert row["claimed_at"] is None, "claimed_at must be null for pending row"
+assert row["completed_at"] is None, "completed_at must be null for pending row"
+assert row["last_error"] is None, "last_error must be null for pending row"
+PY
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (e) show <id> returns the row
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "show <id> (table format) prints the job" {
+    run "$CLI" show "$ID_PENDING"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"alpha"* ]]
+    [[ "$output" == *"pending"* ]]
+}
+
+@test "show <id> --json emits a single JSON object with all contract keys" {
+    run "$CLI" show "$ID_PENDING" --json
+    [ "$status" -eq 0 ]
+    JSON_DATA="$output" python3 - <<'PY'
+import json, os
+obj = json.loads(os.environ["JSON_DATA"])
+assert isinstance(obj, dict), "expected a JSON object"
+required = {"id","project","stage","issue_or_pr","status","claimed_by",
+            "claimed_at","completed_at","attempts","last_error","created_at"}
+missing = required - set(obj.keys())
+assert not missing, "missing keys: {}".format(missing)
+PY
+}
+
+@test "show completed job --json has non-null completed_at" {
+    run "$CLI" show "$ID_COMPLETED" --json
+    [ "$status" -eq 0 ]
+    JSON_DATA="$output" python3 - <<'PY'
+import json, os
+obj = json.loads(os.environ["JSON_DATA"])
+assert obj["status"] == "completed"
+assert isinstance(obj["completed_at"], int), "completed_at must be an int"
+PY
+}
+
+@test "show failed job --json has last_error populated" {
+    run "$CLI" show "$ID_FAILED" --json
+    [ "$status" -eq 0 ]
+    JSON_DATA="$output" python3 - <<'PY'
+import json, os
+obj = json.loads(os.environ["JSON_DATA"])
+assert obj["status"] == "failed"
+assert obj["last_error"] == "something went wrong"
+PY
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (f) show <missing> exits non-zero
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "show with a non-existent id exits non-zero" {
+    run "$CLI" show 99999
+    [ "$status" -ne 0 ]
+}
+
+@test "show with a non-existent id --json exits non-zero" {
+    run "$CLI" show 99999 --json
+    [ "$status" -ne 0 ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (g) Unknown subcommand exits non-zero
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "unknown subcommand exits non-zero" {
+    run "$CLI" frobnicate
+    [ "$status" -ne 0 ]
+}
+
+@test "no subcommand exits non-zero" {
+    run "$CLI"
+    [ "$status" -ne 0 ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (h) Unknown --status value exits non-zero
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "list --status with unknown value exits non-zero" {
+    run "$CLI" list --status garbage
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
Closes #337

## Changes

- **`scripts/jobs-cli.sh`** — new CLI with `list` and `show` subcommands:
  - `list [--status pending|in_flight|completed|failed] [--project SLUG] [--json] [--limit N]` — column-aligned table or JSON array
  - `show <id> [--json]` — key/value block or JSON object
  - Exits non-zero for unknown subcommands, invalid `--status` values, and `show` on a missing id
  - Sources `lib/env.sh` + `lib/jobs.sh` for DB path resolution; JSON built via Python (`json.dumps`) for correct null/type handling
  - No changes to `install.sh` (no existing CLI-install pattern found)

- **`tests/jobs-cli.bats`** — 20 bats tests covering:
  - Unfiltered list shows all seeded rows
  - `--status` and `--project` filtering
  - `--json` output: valid array, all contract keys present, integers are integers, nullable fields use `null` not `""`
  - `show <id>` returns the row; `show <missing>` exits non-zero
  - Error cases: unknown subcommand, unknown `--status` value

- **`README.md`** — new "Jobs CLI" section with subcommands, flags, and the verbatim JSON schema

## Test Plan

- All 20 bats tests pass locally: `bats tests/jobs-cli.bats`
- `bash -n` and `shellcheck -S warning` pass on all scripts
- Personal-identifier grep returns no matches
- Invocation: `./scripts/jobs-cli.sh list` (no install.sh changes needed)