### PR TITLE
[LOOP-376] use generic placeholder in projects-yaml-reference example

### DIFF
--- a/docs/projects-yaml-reference.md
+++ b/docs/projects-yaml-reference.md
@@ -78,13 +78,13 @@ If `true` and a merge attempt fails, the merge handler retries with `--rebase`. 
 
 ```yaml
 projects:
-  - name: PPL Study
-    slug: ppl
-    repo: svv2014/ppl-study
+  - name: My Project
+    slug: myproj
+    repo: my-org/my-project
     root: /path/to/your/project
     default_branch: main
     dev:
-      commit_prefix: PPL
+      commit_prefix: MYPROJ
     merge:
       strategy: squash
       auto_rebase: true


### PR DESCRIPTION
Closes #376

## Summary
- Replaced `svv2014/ppl-study` (operator-specific private repo) with the generic placeholder `my-org/my-project` in the minimal example in `docs/projects-yaml-reference.md`. Also updated the surrounding sample fields (`name`, `slug`, `commit_prefix`) for internal consistency.
- Verified no other operator-specific names (`pa-scanner`, `vrefm-classifier`, `boba-event`, `boba-orchestrator`, `boba-memory`, `boba-reconcile`, `NanoTraderCopilot`, `suprun`) appear under `docs/`.
- `svv2014/loop` and `svv2014/loop-monitor` are intentionally preserved — they are the canonical repos this doc is for.