### PR TITLE
fix(security): strip private-project leaks from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Discussion or design question
-    url: https://github.com/svv2014/ppl-study/discussions
+    url: https://github.com/svv2014/loop/discussions
     about: For open-ended discussion, curriculum design debates, or questions not yet concrete enough for a ticket.

--- a/lib/runner.sh
+++ b/lib/runner.sh
@@ -101,7 +101,7 @@ loop_run_agent() {
         # LOOP_AGENT_MODEL_OVERRIDE to give specific roles (e.g. PO) a
         # stronger model without changing the orchestrator's global config.
         # Requires the orchestrator to support `--model <id>`
-        # (svv2014/boba-orchestrator#30).
+        # (see internal orchestrator history).
         if [ -n "${LOOP_AGENT_MODEL_OVERRIDE:-}" ]; then
             "$LOOP_ORCHESTRATOR" "$prompt" --mode quick --cwd "$cwd" --model "$LOOP_AGENT_MODEL_OVERRIDE"
         else

--- a/templates/ISSUE_TEMPLATE/config.yml
+++ b/templates/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Discussion or design question
-    url: https://github.com/svv2014/ppl-study/discussions
+    url: https://github.com/svv2014/loop/discussions
     about: For open-ended discussion, curriculum design debates, or questions not yet concrete enough for a ticket.


### PR DESCRIPTION
Three remaining leaks not caught by #376:

- `.github/ISSUE_TEMPLATE/config.yml:4` — redirected new-issue UI to `svv2014/ppl-study/discussions` (private project's discussions page)
- `templates/ISSUE_TEMPLATE/config.yml:4` — same redirect
- `lib/runner.sh:104` — comment referenced `svv2014/boba-orchestrator#30`

All three patched. After this PR: `git grep` for any of the operator-private project names returns 0 hits outside CHANGELOG.md and docs/migration-from-asdlc.md (historical migration doc, intentional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)