### PR TITLE
[LOOP-382] strip pr_body from CI-rework + base-move sweep emitters

### DIFF
--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -1872,7 +1872,10 @@ for pr in prs:
         continue
     issue_num = m.group(1)
     lbls = [l['name'] if isinstance(l, dict) else l for l in pr.get('labels', [])]
-    print(f"{pr['number']}\t{head}\t{issue_num}\t{','.join(lbls)}\t{(pr.get('body') or '')[:400]}")
+    # NOTE: do NOT emit PR body — bodies contain newlines which would split the
+    # `while IFS=$'\t' read` loop into one iteration per body line, causing each
+    # markdown line (`### Changes`, `- foo.md`, etc.) to be treated as a PR number.
+    print(f"{pr['number']}\t{head}\t{issue_num}\t{','.join(lbls)}")
 PY
 )
 
@@ -1881,8 +1884,8 @@ PY
         return 0
     fi
 
-    local pr_num head_ref issue_num labels_csv pr_body
-    while IFS=$'\t' read -r pr_num head_ref issue_num labels_csv pr_body; do
+    local pr_num head_ref issue_num labels_csv
+    while IFS=$'\t' read -r pr_num head_ref issue_num labels_csv; do
         [ -z "$pr_num" ] && continue
 
         # Skip if PR already has needs-rework or changes-requested (already handled).
@@ -2265,7 +2268,10 @@ for pr in prs:
     lbls = [l['name'] if isinstance(l, dict) else l for l in pr.get('labels', [])]
     if skip_set & set(lbls):
         continue
-    print(f"{pr['number']}\t{head}\t{issue_num}\t{','.join(lbls)}\t{(pr.get('body') or '')[:400]}")
+    # NOTE: do NOT emit PR body — bodies contain newlines which would split the
+    # `while IFS=$'\t' read` loop into one iteration per body line, causing each
+    # markdown line (`### Changes`, `- foo.md`, etc.) to be treated as a PR number.
+    print(f"{pr['number']}\t{head}\t{issue_num}\t{','.join(lbls)}")
 PY
 )
 
@@ -2274,8 +2280,8 @@ PY
         return 0
     fi
 
-    local pr_num head_ref issue_num labels_csv pr_body
-    while IFS=$'\t' read -r pr_num head_ref issue_num labels_csv pr_body; do
+    local pr_num head_ref issue_num labels_csv
+    while IFS=$'\t' read -r pr_num head_ref issue_num labels_csv; do
         [ -z "$pr_num" ] && continue
 
         # Query per-PR merge state and reviews in one backend call.


### PR DESCRIPTION
Closes #382.

## Summary

#284 fixed this class of bug in the CI-promote sweep. The CI-rework and base-move sweeps still emit `pr_body[:400]` as a tab-separated field; PR bodies contain newlines, so the downstream `while IFS=$'\t' read` loop iterates once per body line and produces log spam like `base-move: PR### Changes — not diverged, skip`. `pr_body` is declared as a read receiver but never referenced. Drop it from emitter + receiver in both, matching #284 verbatim.

## Regression

- svv2014/loop-monitor PR #297 (`fix/issue-214-clickable-issue-refs`, mergeable_state=dirty, opened 2026-05-14) was skipped on the next reconciler tick because earlier multi-paragraph PR bodies broke the iteration before reaching it.

## Test plan

- [x] `bash -n scanner/reconciler.sh` passes.
- [ ] After merge + deploy, kicked reconciler run on svv2014/loop-monitor processes #297 (or whatever loop-opened PR exists) without `base-move: PR### ...` log lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)