### PR TITLE
[LOOP-384] _reconcile_rebase_one_pr: use per-project ROOT not LOOP_ROOT

### DIFF
--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -2198,12 +2198,16 @@ except Exception:
 # next reconciler tick will remove the stale entry from .git/worktrees.
 _reconcile_rebase_one_pr() {
     local repo="$1" pr_num="$2" base="$3" head="$4"
+    # ROOT is set by loop_load_project at the per-project reconciler entry
+    # point and points at the target project's local clone. LOOP_ROOT is the
+    # loop checkout itself and cannot fetch refs from a different repo (#384).
+    local repo_root="${ROOT:-$LOOP_ROOT}"
     local wt
     wt=$(mktemp -d "/tmp/loop-rebase-${repo//\//-}-${pr_num}-XXXXXX")
     # shellcheck disable=SC2064
-    trap "git -C '$LOOP_ROOT' worktree remove --force '$wt' 2>/dev/null || true; rm -rf '$wt'" RETURN
-    git -C "$LOOP_ROOT" fetch --quiet origin "$base" "$head" || return 1
-    git -C "$LOOP_ROOT" worktree add --quiet "$wt" "origin/$head" || return 1
+    trap "git -C '$repo_root' worktree remove --force '$wt' 2>/dev/null || true; rm -rf '$wt'" RETURN
+    git -C "$repo_root" fetch --quiet origin "$base" "$head" || return 1
+    git -C "$repo_root" worktree add --quiet "$wt" "origin/$head" || return 1
     if git -C "$wt" rebase --quiet "origin/$base"; then
         git -C "$wt" push --force-with-lease origin "HEAD:$head" || return 2
         return 0


### PR DESCRIPTION
Closes #384.

## Summary

The rebase helper ran every git command against `$LOOP_ROOT` (loop's own checkout). For any cross-project PR the initial fetch failed with `fatal: couldn't find remote ref <head>` (return 128), and the caller logged `transient git error (ret=1) — skipping, will retry next tick` on every reconciler tick.

Use the per-project `$ROOT` (set by `loop_load_project` at ~L3083 before `reconcile_pr_base_moved` runs); fall back to `$LOOP_ROOT` only if `ROOT` is unset.

## Regression

Auto-rebase on base-move (#283) has been logging transient errors but never actually performing a rebase end-to-end on any project other than svv2014/loop. Observed today on svv2014/loop-monitor PRs #297 and #299 after #383 unblocked the body-bleed bug that was hiding this issue.

## Test plan

- [x] `bash -n scanner/reconciler.sh` passes.
- [ ] After merge + deploy, a kicked reconciler run on loop-monitor #297 either rebases cleanly or routes to `needs-rework` with conflicted-file diagnostic — no more `ret=1` outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)