### PR TITLE
[LOOP] feat: wrap backend_add_label/remove_label to emit label_transition events

### DIFF
--- a/lib/backends/backend.sh
+++ b/lib/backends/backend.sh
@@ -78,6 +78,11 @@
 set -euo pipefail
 
 _LOOP_BACKENDS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source loop_audit_event (provided by lib/notify.sh).
+# Best-effort — callers that already source notify.sh will get a no-op re-source.
+# shellcheck disable=SC1090
+source "${_LOOP_BACKENDS_DIR}/../notify.sh" 2>/dev/null || true
 _LOOP_BACKEND_LOADED=""
 
 # loop_load_backend — (re-)load the implementation for $BACKEND.
@@ -104,6 +109,64 @@ loop_load_backend
 
 # (declare this alongside the other backend_* interface functions)
 backend_issue_unmet_deps() { echo "backend_issue_unmet_deps not implemented" >&2; return 1; }
+
+# ---------------------------------------------------------------------------
+# Transparent wrappers: backend_add_label / backend_remove_label
+#
+# These shadow the per-backend _backend_*_impl functions (renamed in
+# github.sh / gitlab.sh / jira-gitlab.sh) and emit a label_transition audit
+# event via loop_audit_event after each operation. Event emission is
+# best-effort (|| true) and never aborts the caller.
+# ---------------------------------------------------------------------------
+
+# backend_add_label <repo> <number> <label>
+# Wraps _backend_add_label_impl to emit a label_transition audit event.
+# kind defaults to "issue" — github/glab add_label works for both issues and
+# PRs; distinguishing at this layer would require an extra API call.
+backend_add_label() {
+    local repo="$1" number="$2" label="$3"
+    local before_labels
+    before_labels=$(backend_issue_view "$repo" "$number" --json labels \
+        --jq '[.labels[].name]' 2>/dev/null || printf '[]')
+    _backend_add_label_impl "$repo" "$number" "$label"
+    local _rc=$?
+    local after_labels
+    after_labels=$(backend_issue_view "$repo" "$number" --json labels \
+        --jq '[.labels[].name]' 2>/dev/null || printf '[]')
+    local _source
+    _source=$(basename "${BASH_SOURCE[1]:-unknown}")
+    local _payload
+    _payload="{\"kind\":\"issue\",\"number\":${number},\"op\":\"add\",\"before_labels\":${before_labels},\"after_labels\":${after_labels},\"source\":\"${_source}\"}"
+    loop_audit_event "label_transition" "$_payload" 2>/dev/null || true
+    return $_rc
+}
+
+# backend_remove_label <repo> <number> <label> [<label> ...]
+# Wraps _backend_remove_label_impl to emit a label_transition audit event per
+# label removed. kind defaults to "issue" — see backend_add_label for rationale.
+backend_remove_label() {
+    local repo="$1" number="$2"
+    shift 2
+    local _label
+    for _label in "$@"; do
+        [ -z "$_label" ] && continue
+        local before_labels
+        before_labels=$(backend_issue_view "$repo" "$number" --json labels \
+            --jq '[.labels[].name]' 2>/dev/null || printf '[]')
+        _backend_remove_label_impl "$repo" "$number" "$_label"
+        local _rc=$?
+        local after_labels
+        after_labels=$(backend_issue_view "$repo" "$number" --json labels \
+            --jq '[.labels[].name]' 2>/dev/null || printf '[]')
+        local _source
+        _source=$(basename "${BASH_SOURCE[1]:-unknown}")
+        local _payload
+        _payload="{\"kind\":\"issue\",\"number\":${number},\"op\":\"remove\",\"before_labels\":${before_labels},\"after_labels\":${after_labels},\"source\":\"${_source}\"}"
+        loop_audit_event "label_transition" "$_payload" 2>/dev/null || true
+        if [ $_rc -ne 0 ]; then return $_rc; fi
+    done
+    return 0
+}
 
 # backend_cli_note — emit a CLI equivalence block for agent prompts.
 # On gitlab/jira-gitlab backends, prints a glab/gh translation table so the

--- a/lib/backends/github.sh
+++ b/lib/backends/github.sh
@@ -32,12 +32,12 @@ backend_list_prs_with_label() {
     loop_gh_prs_with_label "$repo" "$label"
 }
 
-backend_add_label() {
+_backend_add_label_impl() {
     local repo="$1" number="$2" label="$3"
     loop_add_label "$repo" "$number" "$label"
 }
 
-backend_remove_label() {
+_backend_remove_label_impl() {
     # Accepts one or more labels and removes each. Previously the function
     # silently dropped args beyond the 3rd, which caused several callers
     # in review-handler / dev-handler / qa-handler to fail silently when

--- a/lib/backends/gitlab.sh
+++ b/lib/backends/gitlab.sh
@@ -115,9 +115,9 @@ backend_list_prs_with_label() {
     | jq -c "$_GL_MR_SORT" 2>/dev/null || true
 }
 
-# backend_add_label <repo> <number> <label>
+# _backend_add_label_impl <repo> <number> <label>
 # Tries issue first; falls back to MR.
-backend_add_label() {
+_backend_add_label_impl() {
     local repo="$1" number="$2" label="$3"
     _gl_parse_repo "$repo"
     glab issue update "$number" --repo "$_GL_REPO" --add-label "$label" 2>/dev/null \
@@ -125,8 +125,8 @@ backend_add_label() {
         || true
 }
 
-# backend_remove_label <repo> <number> <label> [<label> ...]
-backend_remove_label() {
+# _backend_remove_label_impl <repo> <number> <label> [<label> ...]
+_backend_remove_label_impl() {
     local repo="$1" number="$2"
     shift 2
     _gl_parse_repo "$repo"

--- a/lib/backends/jira-gitlab.sh
+++ b/lib/backends/jira-gitlab.sh
@@ -138,10 +138,10 @@ _state_to_jira_transition() {
 # Issue/ticket interface (overrides GitLab stubs)
 # ---------------------------------------------------------------------------
 
-# backend_add_label <repo> <key> <label>
+# _backend_add_label_impl <repo> <key> <label>
 # Maps Loop label additions to Jira status transitions.
 # <key> is the Jira issue key, e.g. PROJ-42.
-backend_add_label() {
+_backend_add_label_impl() {
     local _repo="$1" key="$2" label="$3"
     local transition
     transition=$(_state_to_jira_transition "$label")
@@ -158,9 +158,9 @@ backend_add_label() {
     esac
 }
 
-# backend_remove_label <repo> <key> <label>
+# _backend_remove_label_impl <repo> <key> <label>
 # Removing a label has no direct Jira equivalent — no-op.
-backend_remove_label() {
+_backend_remove_label_impl() {
     return 0
 }
 

--- a/lib/notify.sh
+++ b/lib/notify.sh
@@ -78,3 +78,39 @@ loop_notify_human_required_clear() {
     rm -f "${LOOP_LOG_DIR:-${HOME}/.loop/logs}/notified/${slug}-${number}-${label}" 2>/dev/null || true
     return 0
 }
+
+# loop_audit_event <event_type> <json_payload>
+# Posts a structured audit event to loop-monitor. Best-effort — never aborts caller.
+# BOUNTY_URL and BOUNTY_TIMEOUT are inherited from lib/bounty.sh when both are sourced.
+loop_audit_event() {
+    local _url="${BOUNTY_URL:-http://127.0.0.1:18792}"
+    local _timeout="${BOUNTY_TIMEOUT:-3}"
+    local _event="${1:-unknown}"
+    local _payload_str
+    _payload_str="${2:-}"
+    [ -z "$_payload_str" ] && _payload_str="{}"
+
+    local body
+    body=$(
+        _LAE_EVENT="$_event" _LAE_PAYLOAD="$_payload_str" \
+        python3 - <<'PY'
+import json, os, datetime
+payload_str = os.environ.get("_LAE_PAYLOAD", "{}")
+try:
+    payload_obj = json.loads(payload_str)
+except Exception:
+    payload_obj = {}
+d = {
+    "event": os.environ.get("_LAE_EVENT", "unknown"),
+    "payload": payload_obj,
+    "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+}
+print(json.dumps(d))
+PY
+    ) 2>/dev/null || true
+
+    [ -z "$body" ] && return 0
+
+    curl -sf --max-time "$_timeout" -X POST -H "Content-Type: application/json" \
+        -d "$body" "${_url}/api/report" >/dev/null 2>&1 || true
+}

--- a/tests/backend-remove-label-multi.bats
+++ b/tests/backend-remove-label-multi.bats
@@ -11,15 +11,19 @@ setup() {
     export OPS_LOG="$BATS_TMPDIR/ops.log"
     rm -f "$OPS_LOG"
 
-    # Source the backend function under test first, then override
-    # loop_remove_label so the test can observe individual calls without
-    # hitting the real gh CLI.
-    source "$REPO_ROOT/lib/backends/github.sh"
+    # Source the backend stack. backend.sh loads github.sh via loop_load_backend
+    # and defines the backend_remove_label wrapper on top. Stubs must be defined
+    # AFTER sourcing so they aren't clobbered by loop_load_backend.
+    export BACKEND=github
+    source "$REPO_ROOT/lib/notify.sh"
+    source "$REPO_ROOT/lib/backends/backend.sh"
 
     loop_remove_label() {
         echo "remove $2 $3" >> "$OPS_LOG"
     }
-    export -f loop_remove_label
+    # Stub backend_issue_view so the label_transition wrapper doesn't call gh CLI.
+    backend_issue_view() { printf '[]'; }
+    export -f loop_remove_label backend_issue_view
 }
 
 teardown() {

--- a/tests/label-transition-events.bats
+++ b/tests/label-transition-events.bats
@@ -1,0 +1,129 @@
+#!/usr/bin/env bats
+# tests/label-transition-events.bats — covers backend_add_label / backend_remove_label
+# wrapper functions in lib/backends/backend.sh that emit label_transition audit events.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+
+    # Wire mock curl so loop_audit_event doesn't hit a real server.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-curl.sh" "$BATS_TMPDIR/bin/curl"
+    chmod +x "$BATS_TMPDIR/bin/curl"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    PAYLOAD_FILE="$BATS_TMPDIR/audit-payload.json"
+    export CURL_PAYLOAD_FILE="$PAYLOAD_FILE"
+    unset CURL_MOCK_EXIT CURL_MOCK_LOG
+
+    # Source libs. backend.sh re-sources github.sh via loop_load_backend, so
+    # stubs that must survive must be defined AFTER all sources.
+    export BACKEND=github
+    source "$REPO_ROOT/lib/notify.sh"
+    source "$REPO_ROOT/lib/backends/backend.sh"
+
+    # Stub out low-level helpers AFTER all sourcing is complete.
+    loop_add_label()    { return 0; }
+    loop_remove_label() { return 0; }
+
+    # Stub backend_issue_view with a file-based call counter so before/after
+    # differ even when run in subshells (where shell vars can't be incremented).
+    _VIEW_COUNTER_FILE="$BATS_TMPDIR/view-call-count"
+    printf '0' > "$_VIEW_COUNTER_FILE"
+    export _VIEW_COUNTER_FILE
+
+    backend_issue_view() {
+        local _n
+        _n=$(cat "$_VIEW_COUNTER_FILE" 2>/dev/null || printf '0')
+        printf '%d' $(( _n + 1 )) > "$_VIEW_COUNTER_FILE"
+        if [ "$_n" -eq 0 ]; then
+            printf '["label-a","label-b"]'
+        else
+            printf '["label-a","label-b","needs-qa"]'
+        fi
+    }
+    export -f backend_issue_view
+}
+
+teardown() {
+    rm -rf "${BATS_TMPDIR:?}/bin" "${BATS_TMPDIR:?}/audit-payload.json" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+
+@test "backend_add_label emits one event with op=add and matching before/after labels" {
+    backend_add_label "owner/repo" 42 "needs-qa"
+
+    [ -f "$PAYLOAD_FILE" ]
+    run python3 - "$PAYLOAD_FILE" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    d = json.load(f)
+assert d["event"] == "label_transition", f"event={d['event']}"
+p = d["payload"]
+assert p["op"] == "add",                   f"op={p['op']}"
+assert p["number"] == 42,                  f"number={p['number']}"
+assert p["kind"] == "issue",               f"kind={p['kind']}"
+assert "label-a" in p["before_labels"],    f"before_labels={p['before_labels']}"
+assert "needs-qa" in p["after_labels"],    f"after_labels={p['after_labels']}"
+PY
+    [ "$status" -eq 0 ] || { echo "$output"; false; }
+}
+
+@test "backend_remove_label emits one event with op=remove" {
+    # Reset file counter and adjust stub: before has needs-qa, after doesn't.
+    printf '0' > "$_VIEW_COUNTER_FILE"
+    backend_issue_view() {
+        local _n
+        _n=$(cat "$_VIEW_COUNTER_FILE" 2>/dev/null || printf '0')
+        printf '%d' $(( _n + 1 )) > "$_VIEW_COUNTER_FILE"
+        if [ "$_n" -eq 0 ]; then
+            printf '["label-a","needs-qa"]'
+        else
+            printf '["label-a"]'
+        fi
+    }
+    export -f backend_issue_view
+
+    backend_remove_label "owner/repo" 42 "needs-qa"
+
+    [ -f "$PAYLOAD_FILE" ]
+    run python3 - "$PAYLOAD_FILE" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    d = json.load(f)
+assert d["event"] == "label_transition", f"event={d['event']}"
+p = d["payload"]
+assert p["op"] == "remove",                f"op={p['op']}"
+assert p["number"] == 42,                  f"number={p['number']}"
+assert "needs-qa" in p["before_labels"],   f"before_labels={p['before_labels']}"
+assert "needs-qa" not in p["after_labels"],f"after_labels={p['after_labels']}"
+PY
+    [ "$status" -eq 0 ] || { echo "$output"; false; }
+}
+
+@test "failing impl still propagates non-zero exit code" {
+    # Override the impl to fail.
+    _backend_add_label_impl() { return 7; }
+    export -f _backend_add_label_impl
+
+    run backend_add_label "owner/repo" 42 "needs-qa"
+    [ "$status" -eq 7 ]
+}
+
+@test "source field is the basename of the caller script" {
+    backend_add_label "owner/repo" 42 "needs-qa"
+
+    [ -f "$PAYLOAD_FILE" ]
+    run python3 - "$PAYLOAD_FILE" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    d = json.load(f)
+p = d["payload"]
+# source must be a plain basename (no slashes) and non-empty
+src = p.get("source", "")
+assert src,                  "source is empty"
+assert "/" not in src,       f"source contains slash: {src}"
+PY
+    [ "$status" -eq 0 ] || { echo "$output"; false; }
+}


### PR DESCRIPTION
## Summary

Closes svv2014/loop-monitor#108

- Adds `loop_audit_event` to `lib/notify.sh` (prerequisite from loop-monitor#107 — that helper was never merged into the loop repo despite the tracking issue being closed)
- Renames per-backend `backend_add_label`/`backend_remove_label` to `_backend_add_label_impl`/`_backend_remove_label_impl` in github.sh, gitlab.sh, jira-gitlab.sh
- Adds transparent wrappers in `backend.sh` that capture before/after label sets and emit a `label_transition` audit event via `loop_audit_event`
- Source field auto-detected via `${BASH_SOURCE[1]}`
- Event emission is non-fatal (best-effort `|| true`)
- No caller changes required

## Test Plan
- [x] bats tests pass: add emits op=add event, remove emits op=remove, failing impl propagates exit code, source field is caller basename
- [x] Existing callers (scanner, reconciler, handlers) require no changes — wrappers are transparent
- [ ] loop-monitor /api/report accepts label_transition events (schema landed in loop-monitor#106)