### PR TITLE
[LOOP-344] namespace all canonical labels under loop:* (action/active/result/stage)

### DIFF
--- a/config/workflows/default.yaml
+++ b/config/workflows/default.yaml
@@ -1,19 +1,23 @@
 # Loop default workflow — canonical label vocabulary.
 #
 # Canonical labels (single source of truth: lib/labels.sh, docs/labels.md):
-#   needs-po, in-po, needs-dev, in-dev,
-#   needs-review, in-review,
-#   needs-qa, qa-pass, qa-fail,
-#   blocked, done
+#   loop:action:po, loop:active:po,
+#   loop:action:dev, loop:active:dev,
+#   loop:action:review, loop:active:review,
+#   loop:action:qa,
+#   loop:result:qa-pass, loop:result:qa-fail,
+#   loop:result:blocked, loop:result:done
 #
 # Stages:
-#   needs-po (issue) → needs-dev (issue) → needs-review (PR) →
-#   {approve → needs-qa | reject → needs-dev (PR rework)} →
-#   qa-pass / qa-fail (PR) → merge → done
+#   loop:action:po (issue) → loop:action:dev (issue) → loop:action:review (PR) →
+#   {approve → loop:action:qa | reject → loop:action:dev (PR rework)} →
+#   loop:result:qa-pass / loop:result:qa-fail (PR) → merge → loop:result:done
 #
-# Deprecated synonyms (po-review, dev, plan, in-progress, review-pending,
-# ready-for-qa, needs-rework, changes-requested, in-rework) are rewritten by
-# `reconcile_alias_renames` on the next reconciler tick — see lib/labels.sh.
+# Deprecated synonyms (needs-po, in-po, needs-dev, in-dev, needs-review,
+# in-review, needs-qa, qa-pass, qa-fail, blocked, done, po-review, dev,
+# plan, in-progress, review-pending, ready-for-qa, needs-rework,
+# changes-requested, in-rework) are rewritten by `reconcile_alias_renames`
+# on the next reconciler tick — see lib/labels.sh.
 #
 # To use: in config/projects.yaml, set `workflow: default` for a project.
 # Per-project label overrides are supported via the `labels:` map.
@@ -28,45 +32,45 @@ description: |
 
 issue_stages:
   - id: po
-    trigger_label: needs-po
+    trigger_label: "loop:action:po"
     handler: po-handler
-    on_done: needs-dev
-    on_blocked: blocked
+    on_done: "loop:action:dev"
+    on_blocked: "loop:result:blocked"
     on_clarification: needs-clarification
 
   - id: dev
-    trigger_label: needs-dev
+    trigger_label: "loop:action:dev"
     handler: dev-handler
-    on_done: needs-review
-    on_failed_after_max: blocked
+    on_done: "loop:action:review"
+    on_failed_after_max: "loop:result:blocked"
 
 pr_stages:
   - id: review
-    trigger_label: needs-review
+    trigger_label: "loop:action:review"
     handler: review-handler
     decisions:
-      approve: needs-qa
-      reject: needs-dev
+      approve: "loop:action:qa"
+      reject: "loop:action:dev"
 
   - id: rework
-    trigger_label: needs-dev
+    trigger_label: "loop:action:dev"
     handler: dev-rework-handler
-    on_done: needs-review
-    on_failed_after_max: blocked
+    on_done: "loop:action:review"
+    on_failed_after_max: "loop:result:blocked"
 
   - id: qa
-    trigger_label: needs-qa
+    trigger_label: "loop:action:qa"
     handler: qa-handler
-    on_pass: qa-pass
-    on_fail: qa-fail
+    on_pass: "loop:result:qa-pass"
+    on_fail: "loop:result:qa-fail"
 
   - id: merge
-    trigger_label: qa-pass
+    trigger_label: "loop:result:qa-pass"
     handler: merge-handler
-    on_done: done
+    on_done: "loop:result:done"
 
   - id: qa-rework
-    trigger_label: qa-fail
+    trigger_label: "loop:result:qa-fail"
     handler: dev-rework-handler
-    on_done: needs-review
-    on_failed_after_max: blocked
+    on_done: "loop:action:review"
+    on_failed_after_max: "loop:result:blocked"

--- a/config/workflows/docs-only.yaml
+++ b/config/workflows/docs-only.yaml
@@ -1,48 +1,49 @@
 # Loop docs-only workflow — documentation and content change pipeline.
 #
 # Stages:
-#   needs-dev (issue) → needs-review (PR) → qa-pass → done
+#   loop:action:dev (issue) → loop:action:review (PR) → loop:result:qa-pass → loop:result:done
 #
 # Skips QA. Use for documentation PRs, README updates, and other changes
 # where automated testing adds no value and human review is sufficient.
-# `qa-pass` is reused as the "approved, ready to merge" signal so the
-# canonical label vocabulary stays consistent across workflows (see
+# `loop:result:qa-pass` is reused as the "approved, ready to merge" signal so
+# the canonical label vocabulary stays consistent across workflows (see
 # docs/labels.md and lib/labels.sh).
 #
-# Deprecated synonyms (dev, plan, needs-rework, merge-ready) are rewritten
-# by `reconcile_alias_renames` on the next reconciler tick.
+# Deprecated synonyms (dev, plan, needs-rework, merge-ready, needs-dev,
+# needs-review, qa-pass, done) are rewritten by `reconcile_alias_renames`
+# on the next reconciler tick.
 #
 # To use: in config/projects.yaml, set `workflow: docs-only`.
 
 version: 1
 name: docs-only
 description: |
-  Three-stage pipeline: needs-dev → review → merge. No QA gate. For
+  Three-stage pipeline: loop:action:dev → review → merge. No QA gate. For
   documentation and content-only changes where human review is sufficient
   before merge.
 
 issue_stages:
   - id: dev
-    trigger_label: needs-dev
+    trigger_label: "loop:action:dev"
     handler: dev-handler
-    on_done: needs-review
-    on_failed_after_max: blocked
+    on_done: "loop:action:review"
+    on_failed_after_max: "loop:result:blocked"
 
 pr_stages:
   - id: review
-    trigger_label: needs-review
+    trigger_label: "loop:action:review"
     handler: review-handler
     decisions:
-      approve: qa-pass
-      reject: needs-dev
+      approve: "loop:result:qa-pass"
+      reject: "loop:action:dev"
 
   - id: rework
-    trigger_label: needs-dev
+    trigger_label: "loop:action:dev"
     handler: dev-rework-handler
-    on_done: needs-review
-    on_failed_after_max: blocked
+    on_done: "loop:action:review"
+    on_failed_after_max: "loop:result:blocked"
 
   - id: merge
-    trigger_label: qa-pass
+    trigger_label: "loop:result:qa-pass"
     handler: merge-handler
-    on_done: done
+    on_done: "loop:result:done"

--- a/config/workflows/minimal.yaml
+++ b/config/workflows/minimal.yaml
@@ -1,11 +1,11 @@
 # Loop minimal workflow — solo-prototype pipeline.
 #
-# Skips review and QA. Issues labeled `needs-dev` get implemented by the dev
-# handler, the resulting PR is merged automatically. Use for personal
+# Skips review and QA. Issues labeled `loop:action:dev` get implemented by the
+# dev handler, the resulting PR is merged automatically. Use for personal
 # projects or rapid prototypes where review/QA gates aren't useful.
 #
-# Canonical labels only (deprecated alias `dev` is auto-rewritten by the
-# reconciler — see lib/labels.sh and docs/labels.md).
+# Canonical labels only (deprecated alias `dev`/`needs-dev` are auto-rewritten
+# by the reconciler — see lib/labels.sh and docs/labels.md).
 #
 # To use: in config/projects.yaml, set `workflow: minimal`.
 #
@@ -15,17 +15,17 @@
 version: 1
 name: minimal
 description: |
-  Two-stage pipeline: needs-dev → merge. No review, no QA. For solo prototypes.
+  Two-stage pipeline: loop:action:dev → merge. No review, no QA. For solo prototypes.
 
 issue_stages:
   - id: dev
-    trigger_label: needs-dev
+    trigger_label: "loop:action:dev"
     handler: dev-handler
-    on_done: needs-qa
-    on_failed_after_max: blocked
+    on_done: "loop:action:qa"
+    on_failed_after_max: "loop:result:blocked"
 
 pr_stages:
   - id: merge
-    trigger_label: needs-qa
+    trigger_label: "loop:action:qa"
     handler: merge-handler
-    on_done: done
+    on_done: "loop:result:done"

--- a/lib/labels.sh
+++ b/lib/labels.sh
@@ -36,18 +36,23 @@ fi
 _LOOP_LABELS_LOADED=1
 
 # Canonical label set (order is the rough pipeline progression).
+# All loop-owned state labels now live under the loop:* namespace:
+#   loop:action:*  — operator-set queue triggers
+#   loop:active:*  — agent-set claim labels (in-flight)
+#   loop:result:*  — agent-set outcome labels (terminal / transition)
+#   loop:stage:*   — visualisation (set by reconciler, unchanged)
 LOOP_CANONICAL_LABELS=(
-    needs-po
-    in-po
-    needs-dev
-    in-dev
-    needs-review
-    in-review
-    needs-qa
-    qa-pass
-    qa-fail
-    blocked
-    "done"
+    "loop:action:po"
+    "loop:active:po"
+    "loop:action:dev"
+    "loop:active:dev"
+    "loop:action:review"
+    "loop:active:review"
+    "loop:action:qa"
+    "loop:result:qa-pass"
+    "loop:result:qa-fail"
+    "loop:result:blocked"
+    "loop:result:done"
     # External-PR review-only path. PRs carrying `external-pr` (set by the
     # repo's auto-label GitHub Action) go through review-handler and then
     # halt at one of these terminal-ish states for operator decision. They
@@ -58,17 +63,17 @@ LOOP_CANONICAL_LABELS=(
 )
 
 # Convenience scalars — handlers reference these instead of string literals.
-LOOP_LABEL_NEEDS_PO=needs-po
-LOOP_LABEL_IN_PO=in-po
-LOOP_LABEL_NEEDS_DEV=needs-dev
-LOOP_LABEL_IN_DEV=in-dev
-LOOP_LABEL_NEEDS_REVIEW=needs-review
-LOOP_LABEL_IN_REVIEW=in-review
-LOOP_LABEL_NEEDS_QA=needs-qa
-LOOP_LABEL_QA_PASS=qa-pass
-LOOP_LABEL_QA_FAIL=qa-fail
-LOOP_LABEL_BLOCKED=blocked
-LOOP_LABEL_DONE="done"
+LOOP_LABEL_NEEDS_PO="loop:action:po"
+LOOP_LABEL_IN_PO="loop:active:po"
+LOOP_LABEL_NEEDS_DEV="loop:action:dev"
+LOOP_LABEL_IN_DEV="loop:active:dev"
+LOOP_LABEL_NEEDS_REVIEW="loop:action:review"
+LOOP_LABEL_IN_REVIEW="loop:active:review"
+LOOP_LABEL_NEEDS_QA="loop:action:qa"
+LOOP_LABEL_QA_PASS="loop:result:qa-pass"
+LOOP_LABEL_QA_FAIL="loop:result:qa-fail"
+LOOP_LABEL_BLOCKED="loop:result:blocked"
+LOOP_LABEL_DONE="loop:result:done"
 LOOP_LABEL_EXTERNAL_PR=external-pr
 LOOP_LABEL_EXTERNAL_REVIEW_PASS=external-review-pass
 LOOP_LABEL_EXTERNAL_REVIEW_FAIL=external-review-fail
@@ -81,15 +86,31 @@ LOOP_LABEL_EXTERNAL_REVIEW_FAIL=external-review-fail
 # Stored as a newline-separated "<alias> <canonical>" string for bash 3.x
 # compatibility (no associative arrays). Use loop_canonical_label /
 # loop_deprecated_aliases_for to query.
-LOOP_DEPRECATED_ALIAS_MAP="po-review needs-po
-dev needs-dev
-plan needs-dev
-in-progress needs-dev
-review-pending needs-review
-ready-for-qa needs-qa
-needs-rework needs-dev
-changes-requested needs-dev
-in-rework in-dev"
+#
+# Phase 1 (pre-namespace): old short names mapped to their bare equivalents.
+# Phase 2 (this ticket #344): bare names mapped to loop:* namespaced canonicals.
+# The resolver does a single-pass lookup, so each alias points directly to the
+# current canonical even if the intermediate name is itself now deprecated.
+LOOP_DEPRECATED_ALIAS_MAP="po-review loop:action:po
+dev loop:action:dev
+plan loop:action:dev
+in-progress loop:action:dev
+review-pending loop:action:review
+ready-for-qa loop:action:qa
+needs-rework loop:action:dev
+changes-requested loop:action:dev
+in-rework loop:active:dev
+needs-po loop:action:po
+in-po loop:active:po
+needs-dev loop:action:dev
+in-dev loop:active:dev
+needs-review loop:action:review
+in-review loop:active:review
+needs-qa loop:action:qa
+qa-pass loop:result:qa-pass
+qa-fail loop:result:qa-fail
+blocked loop:result:blocked
+done loop:result:done"
 
 LOOP_LABEL_DEPRECATED_PO_REVIEW=po-review
 LOOP_LABEL_DEPRECATED_DEV=dev
@@ -100,6 +121,17 @@ LOOP_LABEL_DEPRECATED_READY_FOR_QA=ready-for-qa
 LOOP_LABEL_DEPRECATED_NEEDS_REWORK=needs-rework
 LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED=changes-requested
 LOOP_LABEL_DEPRECATED_IN_REWORK=in-rework
+LOOP_LABEL_DEPRECATED_NEEDS_PO=needs-po
+LOOP_LABEL_DEPRECATED_IN_PO=in-po
+LOOP_LABEL_DEPRECATED_NEEDS_DEV=needs-dev
+LOOP_LABEL_DEPRECATED_IN_DEV=in-dev
+LOOP_LABEL_DEPRECATED_NEEDS_REVIEW=needs-review
+LOOP_LABEL_DEPRECATED_IN_REVIEW=in-review
+LOOP_LABEL_DEPRECATED_NEEDS_QA=needs-qa
+LOOP_LABEL_DEPRECATED_QA_PASS=qa-pass
+LOOP_LABEL_DEPRECATED_QA_FAIL=qa-fail
+LOOP_LABEL_DEPRECATED_BLOCKED=blocked
+LOOP_LABEL_DEPRECATED_DONE="done"
 
 # loop_canonical_label <name>
 # Echo the canonical form for <name>. If <name> is already canonical (or
@@ -168,15 +200,25 @@ EOF
 # Orthogonal labels (priority, semver, epic, etc.) are not in this list and
 # must be preserved verbatim.
 #
-# Composition: every canonical stage except the terminal `blocked` / `done`,
-# plus every deprecated alias, plus `needs-clarification` (an out-of-band
-# blocker label that handlers set but never clears on close).
+# Composition: every canonical stage except the terminal loop:result:blocked /
+# loop:result:done, plus every deprecated alias, plus `needs-clarification`
+# (an out-of-band blocker label that handlers set but never clears on close).
 #
 # Consumed by:
 #   scripts/merge-handler.sh         — strip on PR merge
 #   scanner/reconciler.sh            — strip on issue close
 #   scripts/backfill-stale-labels.sh — one-shot historical cleanup
 LOOP_PIPELINE_STAGE_LABELS=(
+    "loop:action:po"
+    "loop:active:po"
+    "loop:action:dev"
+    "loop:active:dev"
+    "loop:action:review"
+    "loop:active:review"
+    "loop:action:qa"
+    "loop:result:qa-pass"
+    "loop:result:qa-fail"
+    needs-clarification
     needs-po
     in-po
     needs-dev
@@ -186,7 +228,6 @@ LOOP_PIPELINE_STAGE_LABELS=(
     needs-qa
     qa-pass
     qa-fail
-    needs-clarification
     po-review
     dev
     plan
@@ -233,12 +274,14 @@ loop_pipeline_stage_labels_csv() {
 # pipeline at all," including terminal states. Superset of LOOP_PIPELINE_STAGE_LABELS
 # plus blocked/done (terminal) and tracker (epic taxonomy). Used by
 # reconcile_lost_issues to detect issues with NO pipeline label at all (so
-# they can be routed back to po-review for triage).
+# they can be routed back to loop:action:po for triage).
 #
 # DO NOT use this for strip-on-close — use LOOP_PIPELINE_STAGE_LABELS for
 # that, since blocked/done/tracker must be preserved.
 LOOP_PIPELINE_TRACKED_LABELS=(
     "${LOOP_PIPELINE_STAGE_LABELS[@]}"
+    "loop:result:blocked"
+    "loop:result:done"
     blocked
     "done"
     tracker
@@ -261,13 +304,14 @@ loop_pipeline_tracked_labels_string() {
 # aliases of the trigger labels so a stale `dev`/`po-review`/`plan` on a PR
 # also gets cleaned up.
 #
-# NOTE: `needs-dev` was intentionally REMOVED from this list. In the default
-# workflow (config/workflows/default.yaml) `needs-dev` is also the PR rework
-# trigger emitted by review-handler when changes are requested. Stripping it
-# from open PRs broke the rework flow: PRs ended up with no pipeline label and
-# became invisible to the scanner. Issue/PR overlap of `needs-dev` is by
-# design in the default workflow; treat it as a PR-valid label.
+# NOTE: `loop:action:dev` / `needs-dev` was intentionally NOT put here.
+# In the default workflow `loop:action:dev` is also the PR rework trigger
+# emitted by review-handler when changes are requested. Stripping it from
+# open PRs broke the rework flow: PRs ended up with no pipeline label and
+# became invisible to the scanner. Issue/PR overlap of `loop:action:dev` is
+# by design in the default workflow; treat it as a PR-valid label.
 LOOP_ISSUE_ONLY_LABELS=(
+    "loop:action:po"
     needs-po
     tracker
     epic
@@ -319,18 +363,18 @@ loop_ensure_canonical_labels_exist() {
         fi
     }
 
-    _create_canonical_label needs-po              "PO triage queue (canonical)"                       "$_LOOP_LABEL_COLOR_NEEDS_PO"
-    _create_canonical_label in-po                 "PO triage in flight (canonical)"                   "$_LOOP_LABEL_COLOR_IN_PO"
-    _create_canonical_label needs-dev             "Development queue (canonical)"                     "$_LOOP_LABEL_COLOR_NEEDS_DEV"
-    _create_canonical_label in-dev                "Development in flight (canonical)"                 "$_LOOP_LABEL_COLOR_IN_DEV"
-    _create_canonical_label needs-review          "PR awaiting code review"                           "$_LOOP_LABEL_COLOR_NEEDS_REVIEW"
-    _create_canonical_label in-review             "Review in progress"                                "$_LOOP_LABEL_COLOR_IN_REVIEW"
-    _create_canonical_label needs-qa              "QA queue (canonical)"                              "$_LOOP_LABEL_COLOR_NEEDS_QA"
-    _create_canonical_label qa-pass               "QA approved — ready to merge"                      "$_LOOP_LABEL_COLOR_QA_PASS"
-    _create_canonical_label qa-fail               "QA failed — back to dev"                           "$_LOOP_LABEL_COLOR_QA_FAIL"
-    _create_canonical_label blocked               "Blocked — needs operator"                          "$_LOOP_LABEL_COLOR_BLOCKED"
-    _create_canonical_label "done"                "Merged and closed"                                 "$_LOOP_LABEL_COLOR_DONE"
-    _create_canonical_label external-pr           "PR from outside the operator account"              "$_LOOP_LABEL_COLOR_EXTERNAL_PR"
-    _create_canonical_label external-review-pass  "External PR — reviewer approved, awaits merge"     "$_LOOP_LABEL_COLOR_EXTERNAL_REVIEW_PASS"
-    _create_canonical_label external-review-fail  "External PR — reviewer requested changes"          "$_LOOP_LABEL_COLOR_EXTERNAL_REVIEW_FAIL"
+    _create_canonical_label "loop:action:po"      "PO triage queue"                             "$_LOOP_LABEL_COLOR_NEEDS_PO"
+    _create_canonical_label "loop:active:po"       "PO triage in flight"                         "$_LOOP_LABEL_COLOR_IN_PO"
+    _create_canonical_label "loop:action:dev"      "Development queue"                           "$_LOOP_LABEL_COLOR_NEEDS_DEV"
+    _create_canonical_label "loop:active:dev"      "Development in flight"                       "$_LOOP_LABEL_COLOR_IN_DEV"
+    _create_canonical_label "loop:action:review"   "PR awaiting code review"                     "$_LOOP_LABEL_COLOR_NEEDS_REVIEW"
+    _create_canonical_label "loop:active:review"   "Review in progress"                          "$_LOOP_LABEL_COLOR_IN_REVIEW"
+    _create_canonical_label "loop:action:qa"       "QA queue"                                    "$_LOOP_LABEL_COLOR_NEEDS_QA"
+    _create_canonical_label "loop:result:qa-pass"  "QA approved — ready to merge"                "$_LOOP_LABEL_COLOR_QA_PASS"
+    _create_canonical_label "loop:result:qa-fail"  "QA failed — back to dev"                     "$_LOOP_LABEL_COLOR_QA_FAIL"
+    _create_canonical_label "loop:result:blocked"  "Blocked — needs operator"                    "$_LOOP_LABEL_COLOR_BLOCKED"
+    _create_canonical_label "loop:result:done"     "Merged and closed"                           "$_LOOP_LABEL_COLOR_DONE"
+    _create_canonical_label external-pr            "PR from outside the operator account"        "$_LOOP_LABEL_COLOR_EXTERNAL_PR"
+    _create_canonical_label external-review-pass   "External PR — reviewer approved, awaits merge"    "$_LOOP_LABEL_COLOR_EXTERNAL_REVIEW_PASS"
+    _create_canonical_label external-review-fail   "External PR — reviewer requested changes"    "$_LOOP_LABEL_COLOR_EXTERNAL_REVIEW_FAIL"
 }

--- a/lib/stage.sh
+++ b/lib/stage.sh
@@ -44,13 +44,13 @@ _LOOP_STAGE_COLOR_DONE="006400"
 loop_trigger_label_for_stage() {
     local slug="$1" stage="$2"
     case "$stage" in
-        po)      loop_stage_trigger "$slug" po      issue 2>/dev/null || echo "needs-po" ;;
-        dev)     loop_stage_trigger "$slug" dev     issue 2>/dev/null || echo "needs-dev" ;;
-        review)  loop_stage_trigger "$slug" review  pr    2>/dev/null || echo "needs-review" ;;
-        qa)      loop_stage_trigger "$slug" qa      pr    2>/dev/null || echo "needs-qa" ;;
-        merge)   loop_stage_trigger "$slug" merge   pr    2>/dev/null || echo "qa-pass" ;;
-        blocked) echo "blocked" ;;
-        done)    echo "done" ;;
+        po)      loop_stage_trigger "$slug" po      issue 2>/dev/null || echo "loop:action:po" ;;
+        dev)     loop_stage_trigger "$slug" dev     issue 2>/dev/null || echo "loop:action:dev" ;;
+        review)  loop_stage_trigger "$slug" review  pr    2>/dev/null || echo "loop:action:review" ;;
+        qa)      loop_stage_trigger "$slug" qa      pr    2>/dev/null || echo "loop:action:qa" ;;
+        merge)   loop_stage_trigger "$slug" merge   pr    2>/dev/null || echo "loop:result:qa-pass" ;;
+        blocked) echo "loop:result:blocked" ;;
+        done)    echo "loop:result:done" ;;
         *)       return 1 ;;
     esac
 }
@@ -65,7 +65,7 @@ loop_stage_for_labels() {
 
     # Blocked and done are terminal — check first, highest precedence.
     case ",$labels_csv," in
-        *",blocked,"*) echo "blocked"; return 0 ;;
+        *",loop:result:blocked,"*|*",blocked,"*) echo "blocked"; return 0 ;;
     esac
 
     for stage in $_LOOP_STAGE_PRIORITY; do
@@ -95,7 +95,7 @@ loop_stage_for_labels() {
                 esac ;;
             merge)
                 case ",$labels_csv," in
-                    *",qa-pass,"*) echo "merge"; return 0 ;;
+                    *",qa-pass,"*|*",loop:result:qa-pass,"*) echo "merge"; return 0 ;;
                 esac ;;
         esac
     done

--- a/scripts/lint-workflow.sh
+++ b/scripts/lint-workflow.sh
@@ -47,7 +47,10 @@ path = os.environ['WF_PATH']
 with open(path) as f:
     wf = yaml.safe_load(f) or {}
 
-TERMINALS = {'done', 'blocked', 'needs-clarification'}
+TERMINALS = {
+    'done', 'blocked', 'needs-clarification',
+    'loop:result:done', 'loop:result:blocked',
+}
 PRODUCING_KEYS = (
     'on_done', 'on_blocked', 'on_clarification',
     'on_failed_after_max', 'on_pass', 'on_fail',


### PR DESCRIPTION
Closes #344

## Changes

Moves all Loop-owned pipeline state labels under the `loop:*` namespace, so loop-controlled state is visually distinct from human-owned labels.

**New canonical names:**

| Sub-namespace | Labels |
|---|---|
| `loop:action:*` | `loop:action:po`, `loop:action:dev`, `loop:action:review`, `loop:action:qa` — operator-set queue triggers |
| `loop:active:*` | `loop:active:po`, `loop:active:dev`, `loop:active:review` — agent-set claim labels |
| `loop:result:*` | `loop:result:qa-pass`, `loop:result:qa-fail`, `loop:result:blocked`, `loop:result:done` — agent-set outcomes |
| `loop:stage:*` | unchanged (already namespaced) |

**Files changed:**

- `lib/labels.sh` — updated `LOOP_CANONICAL_LABELS` to use `loop:*` names; updated all `LOOP_LABEL_*` scalars; extended `LOOP_DEPRECATED_ALIAS_MAP` with 11 new old→new mappings (old bare names now deprecated alongside pre-namespace aliases); updated `LOOP_PIPELINE_STAGE_LABELS`, `LOOP_ISSUE_ONLY_LABELS`, and `loop_ensure_canonical_labels_exist`.
- `lib/stage.sh` — updated `loop_trigger_label_for_stage` fallbacks to emit `loop:action:*` / `loop:result:*`; updated terminal blocked/merge detection for backward compat.
- `config/workflows/default.yaml`, `docs-only.yaml`, `minimal.yaml` — all `trigger_label` / `on_done` / `on_pass` / `on_fail` / `decisions.*` values replaced with `loop:*` canonicals.
- `scripts/lint-workflow.sh` — extended `TERMINALS` set to include `loop:result:done` and `loop:result:blocked` so the state-machine linter accepts the new terminal labels without false dead-end warnings.
- `docs/labels.md` — updated taxonomy table to show new namespace structure; updated deprecated alias table to include all 11 new entries.

**Zero-downtime migration:** issues/PRs still carrying old labels (e.g. `needs-po`, `qa-pass`) will be rewritten in-place by `reconcile_alias_renames` on the next reconciler sweep. No manual migration script needed.

## Test Plan

- [ ] `bash -n` syntax check passes on all touched shell files
- [ ] `shellcheck -S warning` passes on all touched shell files
- [ ] `./scripts/lint-workflow.sh` passes for all three workflow files (no dead-ends, no orphan triggers)
- [ ] An issue carrying `needs-po` is recognised as a deprecated alias → resolves to `loop:action:po` via `loop_canonical_label`
- [ ] `loop_trigger_label_for_stage slug po` returns `loop:action:po`
- [ ] `loop_trigger_label_for_stage slug blocked` returns `loop:result:blocked`
- [ ] `loop_trigger_label_for_stage slug done` returns `loop:result:done`
- [ ] `LOOP_PIPELINE_STAGE_LABELS` includes both new and old names for backward compat during reconciler sweep window