### PR TITLE
[LOOP-345] update docs to reflect loop:* label namespace migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ projects.yaml schema, bounty event API, CLI flags, lock dir, log dir).
 
 ## [Unreleased]
 
+### Changed
+
+- **Label namespace migration** (#344, #345). All Loop-owned pipeline state
+  labels are now canonical under `loop:*`: `loop:action:*` for operator-set
+  queue triggers, `loop:active:*` for agent-set claim labels, `loop:result:*`
+  for outcome labels, and `loop:stage:*` for reconciler-derived stage markers
+  (unchanged). Legacy names (`needs-po`, `needs-dev`, `needs-review`,
+  `needs-qa`, `qa-pass`, `qa-fail`, and all prior aliases) remain fully
+  functional via the alias map in `lib/labels.sh` — the reconciler rewrites
+  them on its next sweep with no manual migration required.
+
 ## [0.5.0] - 2026-05-14
 
 A security + self-convergence batch. The pipeline now (a) refuses to

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ The name is a nod to _loup_, French for wolf — a predator that hunts in packs,
   └──────────┘   └──────────┘   └───────────┘   └──────────────┘
         │             │              │
         ▼             ▼              ▼
-       blocked   needs-rework    qa-fail → dev-rework
+   loop:result:    loop:action:  loop:result:
+    blocked          dev         qa-fail → dev-rework
 ```
 
 **What's different about Loop:**
@@ -60,10 +61,12 @@ Then label an issue to start the pipeline:
 
 ```bash
 # Rough idea — PO agent expands the spec, then implements:
-gh issue edit <number> --repo owner/repo --add-label po-review
+gh issue edit <number> --repo owner/repo --add-label loop:action:po
+# (legacy alias still works: --add-label needs-po)
 
 # Already have a full spec — skip PO and go straight to implementation:
-gh issue edit <number> --repo owner/repo --add-label dev
+gh issue edit <number> --repo owner/repo --add-label loop:action:dev
+# (legacy alias still works: --add-label needs-dev)
 ```
 
 The scanner picks it up within 5 minutes and opens a PR automatically.
@@ -96,18 +99,18 @@ see [docs/quick-start.md](docs/quick-start.md).
 
 ## How a feature flows through Loop
 
-1. **You** open an issue, write what you want, label it `po-review` (rough idea — PO agent expands the spec first) or `dev` (pre-written spec — skip straight to implementation).
+1. **You** open an issue, write what you want, label it `loop:action:po` (rough idea — PO agent expands the spec first) or `loop:action:dev` (pre-written spec — skip straight to implementation).
 2. **Scanner** notices the label within 5 minutes, fires the dev handler.
 3. **Dev handler** invokes your AI agent in an isolated git worktree.
    Agent reads the issue, writes code, opens a PR, labels it
-   `needs-review`.
+   `loop:action:review`.
 4. **Review handler** sends the diff back to an AI agent for an
-   approve/reject decision. On approve → `needs-qa`. On reject →
-   `needs-rework` and back to step 3.
+   approve/reject decision. On approve → `loop:action:qa`. On reject →
+   `loop:action:dev` and back to step 3.
 5. **QA handler** runs four-phase smart QA: verifies acceptance criteria,
    creates targeted tests, runs regression on touched modules, then runs
    the project's `validation_cmd`. Posts a structured `### QA verification`
-   comment. On pass → `qa-pass`. On fail → `qa-fail` → dev-rework.
+   comment. On pass → `loop:result:qa-pass`. On fail → `loop:result:qa-fail` → dev-rework.
 6. **Merge handler** squash-merges, closes the linked issue, records a
    bounty event, triggers the judge for a PR scorecard.
 7. **Reconciler** runs every 15 minutes to clean up stuck states,
@@ -122,9 +125,9 @@ Loop ships three starter workflows in `config/workflows/`:
 
 | Workflow | When to use |
 |---|---|
-| `default.yaml` | New repos. Clean canonical labels: `po-review` / `dev` / `needs-review` / `needs-qa` / `qa-pass`. Five-stage pipeline with PO expansion + rework loop. |
-| `minimal.yaml` | Solo prototypes. Two stages: `plan → merge`. No review, no QA. |
-| `docs-only.yaml` | Documentation and content PRs. Three stages: `plan → review → merge`. No QA gate. |
+| `default.yaml` | New repos. Five-stage pipeline with PO expansion + rework loop. Entry: `loop:action:po`. |
+| `minimal.yaml` | Solo prototypes. Two stages: `loop:action:dev → merge`. No review, no QA. |
+| `docs-only.yaml` | Documentation and content PRs. Three stages: `loop:action:dev → review → merge`. No QA gate. |
 
 `current.yaml` is an operator-local workflow (gitignored). If you're migrating from a repo that already uses legacy labels (`dev` / `review-pending` / `ready-for-qa`), create it locally — see [`docs/migration-from-asdlc.md`](docs/migration-from-asdlc.md) for a full label mapping and setup instructions.
 
@@ -137,9 +140,9 @@ projects:
     slug: myapp
     repo: owner/my-app
     workflow: default              # references config/workflows/default.yaml
-    labels:                        # optional — sparse overrides
-      plan: dev                    # repo uses 'dev' instead of 'plan'
-      qa-pass: approved
+    labels:                              # optional — sparse overrides
+      loop:action:dev: dev               # repo uses 'dev' instead of canonical
+      loop:result:qa-pass: approved
 ```
 
 Author your own — see [`config/workflows/README.md`](config/workflows/README.md).
@@ -157,13 +160,13 @@ Author your own — see [`config/workflows/README.md`](config/workflows/README.m
 Operator-filed issues sometimes land in a repo without any pipeline label —
 a priority tag at best, sometimes nothing — and the scanner skips them
 silently because no trigger label fires. The reconciler now picks these
-orphans up on each tick and applies `needs-po` so the PO handler claims
+orphans up on each tick and applies `loop:action:po` so the PO handler claims
 them on the following scan.
 
 The sweep is conservative: it acts only on open issues with no workflow
-trigger label (`needs-po`, `in-po`, `po-review`, `dev`, `plan`,
-`needs-dev`, `in-progress`), no terminal label (`needs-clarification`,
-`blocked`, `done`), and no `epic` / `tracker` umbrella tags. Issues whose
+trigger label (`loop:action:po`, `loop:active:po`, and all legacy aliases),
+no terminal label (`needs-clarification`, `loop:result:blocked`,
+`loop:result:done`), and no `epic` / `tracker` umbrella tags. Issues whose
 author is outside `ALLOWED_AUTHORS` are skipped unless they carry the
 `operator-approved` override label. An `auto_labeled_needs_po` event is
 posted to loop-monitor (when `LOOP_MONITOR_URL` is set) for observability.
@@ -202,11 +205,11 @@ proof. A `tracker_closed` event is posted to loop-monitor (when
 ## Auto-rework on red CI
 
 When Loop opens a PR (branch convention `feat/issue-N-*`) and a **required**
-CI check fails, the reconciler automatically applies `needs-rework` to the PR
-and strips the parent issue's trigger label so the dev agent can fix the
+CI check fails, the reconciler automatically applies `loop:action:dev` to the
+PR and strips the parent issue's trigger label so the dev agent can fix the
 failures on the next cycle. The reconciler is a no-op when:
 
-- The PR already carries `needs-rework` or `changes-requested`.
+- The PR already carries `loop:action:dev` or legacy rework aliases.
 - A human reviewer has approved or requested changes.
 - The failing check is not marked as **required** in the repository settings.
 
@@ -228,12 +231,12 @@ projects:
 
 When Loop opens a PR (branch convention `feat/issue-N-*`) and **all required**
 CI checks reach `SUCCESS`, the reconciler automatically promotes the PR from
-`needs-dev` to the project's review-stage trigger label (typically
-`needs-review`) so it enters the human-review phase without manual
+`loop:action:dev` to the project's review-stage trigger label (typically
+`loop:action:review`) so it enters the human-review phase without manual
 intervention. The reconciler is a no-op when:
 
-- The PR does not carry `needs-dev`.
-- The PR already carries `needs-review`, `changes-requested`, or `needs-rework`.
+- The PR does not carry `loop:action:dev` (or a legacy alias).
+- The PR already carries `loop:action:review`, `loop:result:qa-fail`, or a legacy rework alias.
 - A human reviewer has left an `APPROVED`, `CHANGES_REQUESTED`, or `COMMENTED`
   review (reviewers in `ALLOWED_AUTHORS` are excluded from this check).
 - Any required check is not yet `SUCCESS` (e.g. `PENDING`, `IN_PROGRESS`,
@@ -273,21 +276,21 @@ posted on the PR listing each conflicted file and the most recent base commit
 that touched it:
 
 ```
-Reconciler: auto-rebase onto `origin/<base>` failed with conflicts. Routing to `needs-rework`.
+Reconciler: auto-rebase onto `origin/<base>` failed with conflicts. Routing to `loop:action:dev`.
 
 Conflicted files:
 - `lib/runner.sh` — recent base commit: `abc1234 update runner fallback logic`
 - `scanner/reconciler.sh` — recent base commit: `def5678 add ci-red sweep`
 ```
 
-`needs-rework` is applied to the PR; trigger labels (`needs-dev`, `in-dev`,
-`dev`, `in-progress`) are stripped from the linked issue so the dev agent
-handles the conflict on the next cycle. A `pr_rebase_conflict` event is
-emitted to loop-monitor (if `LOOP_MONITOR_URL` is set).
+`loop:action:dev` is applied to the PR; trigger labels (`loop:action:dev`,
+`loop:active:dev`, and legacy aliases) are stripped from the linked issue so
+the dev agent handles the conflict on the next cycle. A `pr_rebase_conflict`
+event is emitted to loop-monitor (if `LOOP_MONITOR_URL` is set).
 
 **No-op conditions:**
 
-- The PR already carries `needs-rework`, `changes-requested`, or `blocked`.
+- The PR already carries `loop:action:dev`, `loop:result:blocked`, or legacy rework aliases.
 - A human reviewer has approved or requested changes on the PR.
 - `mergeStateStatus` is not `DIRTY` and `mergeable` is not `CONFLICTING`.
 
@@ -306,10 +309,11 @@ projects:
 ### Label-state convergence
 
 Stage handlers each touch a narrow set of labels, and occasionally leave a
-ticket in a workflow-illegal combination — e.g. a PR with both `qa-pass` AND
-`needs-dev`, or a PR carrying `qa-fail` but no `needs-rework`. These
-combinations confuse the next handler: sometimes the wrong role claims,
-sometimes nothing claims and the ticket stalls.
+ticket in a workflow-illegal combination — e.g. a PR with both
+`loop:result:qa-pass` AND `loop:action:dev`, or a PR carrying
+`loop:result:qa-fail` but no `loop:action:dev`. These combinations confuse
+the next handler: sometimes the wrong role claims, sometimes nothing claims
+and the ticket stalls.
 
 Every reconciler tick runs `reconcile_label_consistency`, which enforces
 per-stage exclusivity rules so the label state always represents a single
@@ -317,21 +321,21 @@ workflow stage.
 
 **PR rules:**
 
-- `qa-pass` present → strip `needs-dev`, `needs-review`, `needs-rework`,
-  `changes-requested`, `qa-fail`, `in-review`, `in-rework`.
-- `qa-fail` or `changes-requested` present → ensure `needs-rework` is set
-  (add if missing); strip `qa-pass` and `needs-review`.
-- `needs-review` present → never co-exists with `needs-dev`, `needs-rework`,
-  or `changes-requested`. On conflict, the rework signal wins and
-  `needs-review` is removed.
-- `ready-for-qa` present → strip `needs-review`, `needs-dev`.
+- `loop:result:qa-pass` present → strip `loop:action:dev`, `loop:action:review`,
+  `loop:result:qa-fail`, `loop:active:review`, `loop:active:dev`, and all legacy aliases.
+- `loop:result:qa-fail` present → ensure `loop:action:dev` is set (add if missing);
+  strip `loop:result:qa-pass` and `loop:action:review`.
+- `loop:action:review` present → never co-exists with `loop:action:dev` or
+  `loop:result:qa-fail`. On conflict, the rework signal wins and
+  `loop:action:review` is removed.
+- `loop:action:qa` present → strip `loop:action:review`, `loop:action:dev`.
 
 **Issue rules:**
 
-- `needs-dev` present → strip `needs-po`, `in-po`, `po-review`, `plan`.
-- `needs-po` present → strip `needs-dev`, `in-progress`, `dev`.
-- `blocked` present → terminal state; strip every trigger label
-  (`needs-po`, `needs-dev`, `in-po`, `in-progress`, `dev`, etc).
+- `loop:action:dev` present → strip `loop:action:po`, `loop:active:po`, and legacy aliases.
+- `loop:action:po` present → strip `loop:action:dev`, `loop:active:dev`, and legacy aliases.
+- `loop:result:blocked` present → terminal state; strip every trigger label
+  (`loop:action:po`, `loop:action:dev`, `loop:active:po`, `loop:active:dev`, and legacy aliases).
 
 Each convergence emits a `label_state_converged` event to loop-monitor (if
 `LOOP_MONITOR_URL` is set) with the added/removed labels for observability.
@@ -340,25 +344,61 @@ Each convergence emits a `label_state_converged` event to loop-monitor (if
 sweep. The check honours `DRY_RUN` (logs intended mutations, makes no API
 calls).
 
-## Stage labels (`loop:stage:*`)
+## Label namespaces
+
+All Loop-owned labels live under a `loop:` prefix, split into four
+sub-namespaces:
+
+| Sub-namespace | Set by | Purpose |
+|---|---|---|
+| `loop:action:*` | Operator | Queue-trigger labels — apply to start a pipeline stage |
+| `loop:active:*` | Agent | Claim labels — agent sets while handling the work |
+| `loop:result:*` | Agent / operator | Outcome labels — terminal or transition signals |
+| `loop:stage:*` | Reconciler | Derived stage markers — read-only, never trigger handlers |
+
+### `loop:action:*` — operator-set queue triggers
+
+| Label | Object | Start this to… |
+|---|---|---|
+| `loop:action:po` | issue | Expand a rough idea into a spec via the PO handler |
+| `loop:action:dev` | issue / PR | Implement (issue) or rework after review rejection (PR) |
+| `loop:action:review` | PR | Trigger AI code review |
+| `loop:action:qa` | PR | Trigger QA gate after review approval |
+
+### `loop:active:*` — agent-set claim labels
+
+| Label | Set by |
+|---|---|
+| `loop:active:po` | po-handler while expanding the spec |
+| `loop:active:dev` | dev-handler or dev-rework-handler while implementing |
+| `loop:active:review` | review-handler while reviewing |
+
+### `loop:result:*` — agent-set outcome labels
+
+| Label | Meaning |
+|---|---|
+| `loop:result:qa-pass` | QA passed; triggers merge-handler |
+| `loop:result:qa-fail` | QA failed; triggers dev rework |
+| `loop:result:blocked` | Terminal — human attention required |
+| `loop:result:done` | Terminal — issue closed or PR merged |
+
+### `loop:stage:*` — reconciler-derived stage markers
 
 Every open issue carries a single `loop:stage:<name>` label that names its
-current pipeline stage.  The reconciler derives and maintains this label
+current pipeline stage. The reconciler derives and maintains this label
 automatically — no handler needs to set it.
 
-### Stage namespace
+| Stage label | Meaning | Primary trigger label |
+|---|---|---|
+| `loop:stage:po` | PO triage queue | `loop:action:po` |
+| `loop:stage:dev` | Development queue | `loop:action:dev` |
+| `loop:stage:review` | Waiting for code review | `loop:action:review` |
+| `loop:stage:qa` | QA / build gate | `loop:action:qa` |
+| `loop:stage:merge` | Approved, ready to merge | `loop:result:qa-pass` |
+| `loop:stage:blocked` | Blocked / needs clarification | `loop:result:blocked` |
+| `loop:stage:done` | Merged / closed | — |
 
-| Stage label          | Meaning                        | Primary trigger label |
-|----------------------|--------------------------------|-----------------------|
-| `loop:stage:po`      | PO triage queue                | `needs-po`            |
-| `loop:stage:dev`     | Development queue              | `needs-dev`           |
-| `loop:stage:review`  | Waiting for human review       | `needs-review`        |
-| `loop:stage:qa`      | QA / build gate                | `needs-qa`            |
-| `loop:stage:merge`   | Approved, ready to merge       | `qa-pass`             |
-| `loop:stage:blocked` | Blocked / needs clarification  | `blocked`             |
-| `loop:stage:done`    | Merged / closed                | —                     |
-
-The stage label is a **derived, read-only** marker.  Trigger labels remain
+The stage label is a **derived, read-only** marker. Trigger labels remain
 the scanner's dispatch mechanism — the `loop:stage:*` label exists purely so
 tooling can answer "what stage is this ticket in?" with a single label lookup.
 
@@ -401,7 +441,7 @@ it picks:
 
 **`dev.pipeline_slots`** (per-project, optional) — cap the number of
 in-flight tickets per project across *all* pipeline stages
-(`needs-po` through `needs-qa` / `qa-pass`). When the project already has
+(`loop:action:po` through `loop:action:qa` / `loop:result:qa-pass`). When the project already has
 that many tickets in flight, the scanner refuses to emit fresh claims at
 the first issue stage; downstream stages (review / qa / merge for existing
 work) keep flowing so in-flight tickets drain to completion.
@@ -468,8 +508,8 @@ on your machine, with your shell, and your `gh` credentials. Treat it
 accordingly:
 
 - **Pipeline labels are collaborator-only.** Anyone with write access to
-  the repo can apply `plan`, `needs-qa`, etc. and trigger the pipeline.
-  External users cannot.
+  the repo can apply `loop:action:po`, `loop:action:qa`, etc. and trigger
+  the pipeline. External users cannot.
 - **Fork PRs are gated.** `qa-handler` refuses to run a project's
   `validation_cmd` against external-fork PR code unless a maintainer
   applies the `safe-to-test` label first.
@@ -543,10 +583,10 @@ recent `*_done` event for the ticket, and computes the stage to restore:
 
 | Last event | Restored stage | Label applied |
 |---|---|---|
-| `po_done` | `dev` | `needs-dev` |
-| `dev_done` | `review` | `needs-review` |
-| `review_done` | `qa` | `needs-qa` |
-| `qa_done` | `merge` | `qa-pass` |
+| `po_done` | `dev` | `loop:action:dev` |
+| `dev_done` | `review` | `loop:action:review` |
+| `review_done` | `qa` | `loop:action:qa` |
+| `qa_done` | `merge` | `loop:result:qa-pass` |
 
 If no matching event exists, the script exits with a message asking you to
 use `--to-stage` explicitly.

--- a/config/workflows/README.md
+++ b/config/workflows/README.md
@@ -11,9 +11,9 @@ This dir contains starter workflows. Operators can author their own.
 
 | File | Ships? | Purpose |
 |---|---|---|
-| `default.yaml` | Yes | Recommended for new repos. Clean canonical labels: `plan` / `needs-review` / `needs-qa` / `qa-pass` / `qa-fail`. |
-| `minimal.yaml` | Yes | Two-stage pipeline (`plan → merge`). No review, no QA. Solo prototypes only. |
-| `docs-only.yaml` | Yes | Three-stage pipeline (`plan → review → merge`). No QA. For documentation and content-only PRs. |
+| `default.yaml` | Yes | Recommended for new repos. Entry: `loop:action:po` / `loop:action:dev` / `loop:action:review` / `loop:action:qa` / `loop:result:qa-pass`. |
+| `minimal.yaml` | Yes | Two-stage pipeline (`loop:action:dev → merge`). No review, no QA. Solo prototypes only. |
+| `docs-only.yaml` | Yes | Three-stage pipeline (`loop:action:dev → review → merge`). No QA. For documentation and content-only PRs. |
 | `current.yaml` | **No — gitignored** | Operator-local legacy-vocabulary mirror. Not committed to this repo. See [Operator-local workflows](#operator-local-workflows) and [docs/migration-from-asdlc.md](../../docs/migration-from-asdlc.md). |
 
 ## Schema (v1)
@@ -26,33 +26,33 @@ description: |                # free-text; surfaces in `loop --workflows`
 
 # Polled on issues
 issue_stages:
-  - id: plan                  # stable identifier within the workflow
-    trigger_label: plan       # label that, when applied, fires this stage
-    handler: dev-handler      # base name of scripts/<handler>.sh
-    on_done: needs-review     # label applied to PR (or issue) on success
-    on_failed_after_max: blocked
-    on_blocked: blocked       # only meaningful on po stage
+  - id: dev                       # stable identifier within the workflow
+    trigger_label: loop:action:dev # label that, when applied, fires this stage
+    handler: dev-handler           # base name of scripts/<handler>.sh
+    on_done: loop:action:review    # label applied to PR (or issue) on success
+    on_failed_after_max: loop:result:blocked
+    on_blocked: loop:result:blocked    # only meaningful on po stage
     on_clarification: needs-clarification   # only meaningful on po stage
 
 # Polled on PRs
 pr_stages:
   - id: review
-    trigger_label: needs-review
+    trigger_label: loop:action:review
     handler: review-handler
     decisions:                # used by stages with binary outcomes
-      approve: needs-qa
-      reject: needs-rework
+      approve: loop:action:qa
+      reject: loop:action:dev
 
   - id: qa
-    trigger_label: needs-qa
+    trigger_label: loop:action:qa
     handler: qa-handler
-    on_pass: qa-pass
-    on_fail: qa-fail
+    on_pass: loop:result:qa-pass
+    on_fail: loop:result:qa-fail
 
   - id: merge
-    trigger_label: qa-pass
+    trigger_label: loop:result:qa-pass
     handler: merge-handler
-    on_done: done
+    on_done: loop:result:done
 ```
 
 ### Required fields
@@ -71,11 +71,11 @@ which may not match your project's label vocabulary.
 
 | Stage ID | Used by | Fallback label if absent |
 |---|---|---|
-| `po` | po-handler (trigger strip) | `po-review` |
-| `dev` | dev-handler (trigger strip) | `plan` |
-| `review` | dev-handler, dev-rework-handler | `review-pending` |
-| `rework` | review-handler (reject path) | `changes-requested` |
-| `qa` | review-handler (approve path) | `ready-for-qa` |
+| `po` | po-handler (trigger strip) | `loop:action:po` |
+| `dev` | dev-handler (trigger strip) | `loop:action:dev` |
+| `review` | dev-handler, dev-rework-handler | `loop:action:review` |
+| `rework` | review-handler (reject path) | `loop:action:dev` |
+| `qa` | review-handler (approve path) | `loop:action:qa` |
 
 Custom workflows that rename a stage must either keep one of these `id` values or
 add a matching `labels:` override in `config/projects.yaml` so the fallback
@@ -106,11 +106,11 @@ state machine and fails CI when it finds either of these gaps:
   `on_pass`, `on_fail`, `on_blocked`, `on_clarification`,
   `on_failed_after_max`, or one of `decisions.*`) but no stage triggers
   on. Tickets reaching that label sit forever because no handler claims
-  them. (Terminals `done`, `blocked`, `needs-clarification` are valid
+  them. (Terminals `loop:result:done`, `loop:result:blocked`, `needs-clarification` are valid
   sinks and ignored.)
 - **Orphan trigger** — a `trigger_label` that no handler in the same
   workflow ever produces, *unless* it is the workflow's entry point
-  (the first issue stage's trigger, e.g. `needs-po` or `needs-dev`).
+  (the first issue stage's trigger, e.g. `loop:action:po` or `loop:action:dev`).
 
 ```bash
 ./scripts/lint-workflow.sh                          # audit every file
@@ -125,62 +125,68 @@ This check runs in CI on every PR. See the
 These are the canonical label names used in `default.yaml`. Projects may
 override any of them via the `labels:` map in `config/projects.yaml`.
 
+All Loop-owned labels use the `loop:*` namespace (see
+[docs/labels.md](../../docs/labels.md) for the full taxonomy).
+
 **Issue labels** (drive `issue_stages`):
 
 | Label | Role |
 |---|---|
-| `po-review` | PO expansion stage — turns a rough idea into a spec |
-| `plan` | Dev implementation stage |
-| `blocked` | Terminal: issue cannot proceed; human attention required |
+| `loop:action:po` | PO expansion stage — turns a rough idea into a spec |
+| `loop:action:dev` | Dev implementation stage |
+| `loop:result:blocked` | Terminal: issue cannot proceed; human attention required |
 | `needs-clarification` | Terminal: issue body is ambiguous; awaiting author reply |
 
 **PR labels** (drive `pr_stages`):
 
 | Label | Role |
 |---|---|
-| `needs-review` | Code review stage |
-| `needs-rework` | Sent back to dev after review rejection |
-| `needs-qa` | QA / automated test stage |
-| `qa-pass` | QA passed; triggers merge |
-| `qa-fail` | QA failed; triggers rework or close |
-| `done` | Terminal: PR merged and issue closed |
+| `loop:action:review` | Code review stage |
+| `loop:action:dev` | Sent back to dev after review rejection (rework) |
+| `loop:action:qa` | QA / automated test stage |
+| `loop:result:qa-pass` | QA passed; triggers merge |
+| `loop:result:qa-fail` | QA failed; triggers rework or close |
+| `loop:result:done` | Terminal: PR merged and issue closed |
 
 **Terminal labels** (valid transition targets, never trigger a stage):
-`done`, `blocked`, `needs-clarification`, `qa-fail`
+`loop:result:done`, `loop:result:blocked`, `needs-clarification`, `loop:result:qa-fail`
 
 ## `current` workflow label vocabulary
 
-`current.yaml` is the operator-local legacy-vocabulary mirror. It uses a
-different set of label names from `default.yaml` to preserve in-flight
-labels on repos that were already running under the original svv2014 label
-scheme before Loop's `default` workflow was introduced.
+`current.yaml` is the operator-local legacy-vocabulary mirror. It uses
+pre-namespace label names from earlier Loop releases. All of those names are
+now deprecated aliases — the reconciler rewrites them to canonical `loop:*`
+names on its next sweep. New repos should use `default.yaml`.
 
-**Pipeline flow:**
+**Pipeline flow (legacy names):**
 
 ```
 po-review (issue) → dev (issue) → review-pending (PR) → ready-for-qa (PR)
     → qa-pass / qa-fail (PR) → merge → done
 ```
 
+All of these are deprecated aliases; see [docs/labels.md](../../docs/labels.md)
+for the canonical `loop:*` equivalents.
+
 **Issue labels:**
 
-| Label | Role |
-|---|---|
-| `po-review` | PO expansion stage (same as `default`) |
-| `dev` | Dev implementation stage (`plan` in `default`) |
-| `blocked` | Terminal: issue cannot proceed |
-| `needs-clarification` | Terminal: awaiting author reply |
+| Label | Canonical equivalent | Role |
+|---|---|---|
+| `po-review` | `loop:action:po` | PO expansion stage |
+| `dev` | `loop:action:dev` | Dev implementation stage |
+| `blocked` | `loop:result:blocked` | Terminal: issue cannot proceed |
+| `needs-clarification` | — (unchanged) | Terminal: awaiting author reply |
 
 **PR labels:**
 
-| Label | Role |
-|---|---|
-| `review-pending` | Code review stage (`needs-review` in `default`) |
-| `changes-requested` | Sent back to dev after review rejection (`needs-rework` in `default`) |
-| `ready-for-qa` | QA / automated test stage (`needs-qa` in `default`) |
-| `qa-pass` | QA passed; triggers merge (same as `default`) |
-| `qa-fail` | QA failed; triggers rework or close (same as `default`) |
-| `done` | Terminal: PR merged and issue closed (same as `default`) |
+| Label | Canonical equivalent | Role |
+|---|---|---|
+| `review-pending` | `loop:action:review` | Code review stage |
+| `changes-requested` | `loop:action:dev` | Sent back to dev after review rejection |
+| `ready-for-qa` | `loop:action:qa` | QA / automated test stage |
+| `qa-pass` | `loop:result:qa-pass` | QA passed; triggers merge |
+| `qa-fail` | `loop:result:qa-fail` | QA failed; triggers rework or close |
+| `done` | `loop:result:done` | Terminal: PR merged and issue closed |
 
 See [docs/migration-from-asdlc.md](../../docs/migration-from-asdlc.md) for a full
 side-by-side mapping and instructions for creating your own `current.yaml`.
@@ -198,46 +204,46 @@ Notation: `LABEL --(stage.field)--> LABEL`. Terminal states (`done`,
 
 ### `default`
 
-Entry: `needs-po` (set externally when a new issue is filed).
+Entry: `loop:action:po` (set externally when a new issue is filed).
 
 ```
-needs-po       --(po.on_done)-->            needs-dev (issue)
-needs-po       --(po.on_blocked)-->         blocked
-needs-po       --(po.on_clarification)-->   needs-clarification
-needs-dev      --(dev.on_done)-->           needs-review
-needs-dev      --(dev.on_failed_after_max)--> blocked
-needs-review   --(review.approve)-->        needs-qa
-needs-review   --(review.reject)-->         needs-dev      (PR rework)
-needs-dev (PR) --(rework.on_done)-->        needs-review
-needs-dev (PR) --(rework.on_failed_after_max)--> blocked
-needs-qa       --(qa.on_pass)-->            qa-pass
-needs-qa       --(qa.on_fail)-->            qa-fail
-qa-pass        --(merge.on_done)-->         done
-qa-fail        --(qa-rework.on_done)-->     needs-review
-qa-fail        --(qa-rework.on_failed_after_max)--> blocked
+loop:action:po       --(po.on_done)-->            loop:action:dev (issue)
+loop:action:po       --(po.on_blocked)-->         loop:result:blocked
+loop:action:po       --(po.on_clarification)-->   needs-clarification
+loop:action:dev      --(dev.on_done)-->           loop:action:review
+loop:action:dev      --(dev.on_failed_after_max)--> loop:result:blocked
+loop:action:review   --(review.approve)-->        loop:action:qa
+loop:action:review   --(review.reject)-->         loop:action:dev      (PR rework)
+loop:action:dev (PR) --(rework.on_done)-->        loop:action:review
+loop:action:dev (PR) --(rework.on_failed_after_max)--> loop:result:blocked
+loop:action:qa       --(qa.on_pass)-->            loop:result:qa-pass
+loop:action:qa       --(qa.on_fail)-->            loop:result:qa-fail
+loop:result:qa-pass  --(merge.on_done)-->         loop:result:done
+loop:result:qa-fail  --(qa-rework.on_done)-->     loop:action:review
+loop:result:qa-fail  --(qa-rework.on_failed_after_max)--> loop:result:blocked
 ```
 
 Every produced label is either a trigger or a terminal. No dead-ends.
 
 ### `current` (operator-local, gitignored)
 
-Entry: `po-review`.
+Entry: `po-review` (deprecated alias for `loop:action:po`).
 
 ```
-po-review        --(po.on_done)-->            dev
-po-review        --(po.on_blocked)-->         blocked
+po-review        --(po.on_done)-->            dev                 (→ loop:action:dev)
+po-review        --(po.on_blocked)-->         blocked             (→ loop:result:blocked)
 po-review        --(po.on_clarification)-->   needs-clarification
-dev              --(dev.on_done)-->           review-pending
-dev              --(dev.on_failed_after_max)--> blocked
-review-pending   --(review.approve)-->        ready-for-qa
-review-pending   --(review.reject)-->         changes-requested
-changes-requested --(rework.on_done)-->       review-pending
-changes-requested --(rework.on_failed_after_max)--> blocked
-ready-for-qa     --(qa.on_pass)-->            qa-pass
-ready-for-qa     --(qa.on_fail)-->            qa-fail
-qa-pass          --(merge.on_done)-->         done
-qa-fail          --(qa-rework.on_done)-->     review-pending
-qa-fail          --(qa-rework.on_failed_after_max)--> blocked
+dev              --(dev.on_done)-->           review-pending      (→ loop:action:review)
+dev              --(dev.on_failed_after_max)--> blocked           (→ loop:result:blocked)
+review-pending   --(review.approve)-->        ready-for-qa        (→ loop:action:qa)
+review-pending   --(review.reject)-->         changes-requested   (→ loop:action:dev)
+changes-requested --(rework.on_done)-->       review-pending      (→ loop:action:review)
+changes-requested --(rework.on_failed_after_max)--> blocked       (→ loop:result:blocked)
+ready-for-qa     --(qa.on_pass)-->            qa-pass             (→ loop:result:qa-pass)
+ready-for-qa     --(qa.on_fail)-->            qa-fail             (→ loop:result:qa-fail)
+qa-pass          --(merge.on_done)-->         done                (→ loop:result:done)
+qa-fail          --(qa-rework.on_done)-->     review-pending      (→ loop:action:review)
+qa-fail          --(qa-rework.on_failed_after_max)--> blocked     (→ loop:result:blocked)
 ```
 
 The `qa-rework` stage was added to close the `qa-fail` dead-end found
@@ -246,29 +252,29 @@ claim and the PR stalled.
 
 ### `docs-only`
 
-Entry: `needs-dev`.
+Entry: `loop:action:dev`.
 
 ```
-needs-dev      --(dev.on_done)-->           needs-review
-needs-dev      --(dev.on_failed_after_max)--> blocked
-needs-review   --(review.approve)-->        qa-pass
-needs-review   --(review.reject)-->         needs-dev    (PR rework)
-needs-dev (PR) --(rework.on_done)-->        needs-review
-needs-dev (PR) --(rework.on_failed_after_max)--> blocked
-qa-pass        --(merge.on_done)-->         done
+loop:action:dev      --(dev.on_done)-->           loop:action:review
+loop:action:dev      --(dev.on_failed_after_max)--> loop:result:blocked
+loop:action:review   --(review.approve)-->        loop:result:qa-pass
+loop:action:review   --(review.reject)-->         loop:action:dev    (PR rework)
+loop:action:dev (PR) --(rework.on_done)-->        loop:action:review
+loop:action:dev (PR) --(rework.on_failed_after_max)--> loop:result:blocked
+loop:result:qa-pass  --(merge.on_done)-->         loop:result:done
 ```
 
-No QA stage; `qa-pass` is the "approved, ready to merge" signal. No
-dead-ends.
+No QA stage; `loop:result:qa-pass` is the "approved, ready to merge" signal.
+No dead-ends.
 
 ### `minimal`
 
-Entry: `needs-dev`.
+Entry: `loop:action:dev`.
 
 ```
-needs-dev --(dev.on_done)-->               needs-qa
-needs-dev --(dev.on_failed_after_max)-->   blocked
-needs-qa  --(merge.on_done)-->             done
+loop:action:dev --(dev.on_done)-->               loop:action:qa
+loop:action:dev --(dev.on_failed_after_max)-->   loop:result:blocked
+loop:action:qa  --(merge.on_done)-->             loop:result:done
 ```
 
 No review or QA stage. No dead-ends.
@@ -282,10 +288,10 @@ projects:
   - name: My App
     slug: myapp
     repo: owner/my-app
-    workflow: default                # which workflow file to use
-    labels:                          # OPTIONAL — overrides for this repo
-      plan: dev                      # this repo uses 'dev' instead of 'plan'
-      qa-pass: approved              # different name for the merge gate
+    workflow: default                      # which workflow file to use
+    labels:                                # OPTIONAL — overrides for this repo
+      loop:action:dev: dev                 # this repo uses 'dev' instead of canonical
+      loop:result:qa-pass: approved        # different name for the merge gate
 ```
 
 Overrides are sparse: include only the labels whose names differ from
@@ -303,7 +309,7 @@ translation transparently.
 
 Possible custom workflow shapes:
 
-- **Strict**: add a `spec-validator` stage between `qa-pass` and `merge`
+- **Strict**: add a `spec-validator` stage between `loop:result:qa-pass` and `merge`
   (planned: see roadmap)
 - **Docs-only**: drop the `qa` stage; merge after review
 - **Compliance**: add a `security-audit` stage with required human

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,12 +73,12 @@ actual work.
 
 | Handler | Trigger | What it does |
 |---|---|---|
-| `po-handler.sh` | `po-review` on issue | Expands rough idea into structured spec; relabels for dev |
-| `dev-handler.sh` | `dev` (or workflow-equivalent) on issue | Implements in worktree, opens PR, labels `needs-review` |
-| `review-handler.sh` | `needs-review` on PR | AI reviewer reads diff, approves or requests changes |
-| `dev-rework-handler.sh` | `needs-rework` or `qa-fail` on PR | Re-runs dev agent with rework context |
-| `qa-handler.sh` | `needs-qa` on PR | Four-phase smart QA: AC verification, targeted test creation, module regression, `validation_cmd`; posts structured `### QA verification` comment; applies `qa-pass` or `qa-fail` |
-| `merge-handler.sh` | `qa-pass` on PR | Squash-merges, closes linked issue, records bounty; if PR carries `release-pr` label, tags the merged commit and publishes a GitHub release |
+| `po-handler.sh` | `loop:action:po` on issue | Expands rough idea into structured spec; relabels for dev |
+| `dev-handler.sh` | `loop:action:dev` on issue | Implements in worktree, opens PR, labels `loop:action:review` |
+| `review-handler.sh` | `loop:action:review` on PR | AI reviewer reads diff, approves or requests changes |
+| `dev-rework-handler.sh` | `loop:action:dev` or `loop:result:qa-fail` on PR | Re-runs dev agent with rework context |
+| `qa-handler.sh` | `loop:action:qa` on PR | Four-phase smart QA: AC verification, targeted test creation, module regression, `validation_cmd`; posts structured `### QA verification` comment; applies `loop:result:qa-pass` or `loop:result:qa-fail` |
+| `merge-handler.sh` | `loop:result:qa-pass` on PR | Squash-merges, closes linked issue, records bounty; if PR carries `release-pr` label, tags the merged commit and publishes a GitHub release |
 
 Each handler also has a short-name alias (`builder.sh`, `planner.sh`,
 `reviewer.sh`, `reviser.sh`, `tester.sh`, `merger.sh`) that is a thin
@@ -99,7 +99,7 @@ doesn't self-correct. Two distinct classes of check:
 
 **Mutating checks** (corroboration-gated, never speculative):
 - Required-label bootstrap — creates any missing canonical Loop labels
-  on the repo (`needs-po`, `needs-dev`, `needs-review`, `needs-qa`, etc.)
+  on the repo (`loop:action:po`, `loop:action:dev`, `loop:action:review`, `loop:action:qa`, etc.)
 - Synonym + alias renames — rewrites deprecated label names to the
   workflow's live trigger labels. Workflow-aware (won't strip a label
   that IS a trigger for the project; won't apply one that isn't).
@@ -179,12 +179,12 @@ read per project.
                                                  Time →
 operator
   │
-  └─ labels issue #42 "dev"   ····························
+  └─ labels issue #42 "loop:action:dev"   ····················
                                                             │
   scanner (next tick, ≤5 min)   ◀──────────────────────────┤
   │                                                         │
   ├─ load workflow for project ··                           │
-  ├─ poll issues with trigger_label="dev"                  │
+  ├─ poll issues with trigger_label="loop:action:dev"      │
   └─ emit loop.dev_issue PR#42                              │
                                                             │
   dev-handler.sh                ◀──────────────────────────┤
@@ -194,8 +194,8 @@ operator
   ├─ invoke $LOOP_AGENT with issue body + CLAUDE.md ·······│
   │                                                         │ (agent
   ├─ agent commits, opens PR #100                           │  thinks
-  ├─ relabel issue #42 in-progress→done                     │  ~5 min)
-  ├─ label PR #100 needs-review                             │
+  ├─ relabel issue #42 loop:active:dev→loop:result:done     │  ~5 min)
+  ├─ label PR #100 loop:action:review                       │
   ├─ bounty_report dev_done                                 │
   └─ release lock                                           │
                                                             │
@@ -207,10 +207,10 @@ operator
   │                                                         │
   ├─ invoke agent with diff + acceptance criteria           │
   ├─ agent says APPROVE                                     │
-  ├─ relabel PR #100 needs-review→needs-qa                  │
+  ├─ relabel PR #100 loop:action:review→loop:action:qa      │
   └─ bounty_report review_done                              │
                                                             │
-  ... (qa-handler runs validation_cmd, on pass labels qa-pass)
+  ... (qa-handler runs validation_cmd, on pass labels loop:result:qa-pass)
                                                             │
   merge-handler.sh               ◀──────────────────────────┤
   │                                                         │

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -6,23 +6,54 @@ defined in `lib/labels.sh` (`LOOP_CANONICAL_LABELS`). Workflow YAMLs in
 `config/workflows/` reference only canonical names; older synonyms still in
 the wild are auto-renamed by the reconciler on its next tick.
 
+## Label namespaces
+
+All Loop-owned labels live under a `loop:` prefix, split across four
+sub-namespaces:
+
+| Sub-namespace | Set by | Purpose |
+|---|---|---|
+| `loop:action:*` | Operator | Queue-trigger labels — apply to start a pipeline stage |
+| `loop:active:*` | Agent | Claim labels — agent sets while handling the work |
+| `loop:result:*` | Agent / operator | Outcome labels — terminal or transition signals |
+| `loop:stage:*` | Reconciler | Derived stage markers — read-only, never trigger handlers |
+
 ## Canonical taxonomy
 
-Eleven labels cover every Loop pipeline state.
+Fifteen labels cover every Loop pipeline state.
 
-| Canonical label | Object | Triggers / role | Set by |
-|---|---|---|---|
-| `needs-po` | issue | Rough idea — PO handler will expand into a full spec | operator |
-| `in-po` | issue | PO handler has claimed the issue and is expanding the spec | agent (po-handler) |
-| `needs-dev` | issue / PR | Issue: queued for implementation. PR: review rejected, queued for rework. | operator (issue) / agent (PR, via review-handler reject) |
-| `in-dev` | issue / PR | Dev or rework handler has claimed the work | agent (dev-handler / dev-rework-handler) |
-| `needs-review` | PR | PR is open and waiting for code review | agent (dev-handler on PR open; dev-rework-handler on rework done) |
-| `in-review` | PR | Review handler has claimed the PR | agent (review-handler) |
-| `needs-qa` | PR | Review approved; queued for the QA gate | agent (review-handler on approve) |
-| `qa-pass` | PR | QA passed; queued for merge. Also used by docs-only workflow as the "approved, ready to merge" signal. | agent (qa-handler) / operator (manual override) |
-| `qa-fail` | PR | QA failed; queued for dev rework | agent (qa-handler) |
-| `blocked` | issue / PR | Terminal until a human intervenes | agent (after max retries) / operator |
-| `done` | issue / PR | Terminal — issue closed or PR merged | agent (merge-handler) |
+### `loop:action:*` — operator-set queue triggers
+
+| Canonical label | Object | Role |
+|---|---|---|
+| `loop:action:po` | issue | Rough idea — PO handler expands into a full spec |
+| `loop:action:dev` | issue / PR | Issue: queued for implementation. PR: queued for rework after review rejection. |
+| `loop:action:review` | PR | PR is open and waiting for code review |
+| `loop:action:qa` | PR | Review approved; queued for the QA gate |
+
+### `loop:active:*` — agent-set claim labels
+
+| Canonical label | Object | Role |
+|---|---|---|
+| `loop:active:po` | issue | PO handler has claimed the issue and is expanding the spec |
+| `loop:active:dev` | issue / PR | Dev or rework handler has claimed the work |
+| `loop:active:review` | PR | Review handler has claimed the PR |
+
+### `loop:result:*` — agent-set outcome labels
+
+| Canonical label | Object | Role |
+|---|---|---|
+| `loop:result:qa-pass` | PR | QA passed; queued for merge. Also the "approved, ready to merge" signal in docs-only workflow. |
+| `loop:result:qa-fail` | PR | QA failed; queued for dev rework |
+| `loop:result:blocked` | issue / PR | Terminal until a human intervenes |
+| `loop:result:done` | issue / PR | Terminal — issue closed or PR merged |
+
+### `loop:stage:*` — reconciler-derived stage markers
+
+Stage labels are maintained automatically by the reconciler. They are
+read-only from the handler perspective — handlers must not set or strip them.
+See the [Stage labels section in README.md](../README.md#label-namespaces) for
+the full mapping.
 
 A handful of orthogonal labels (`needs-clarification`, `safe-to-test`, plus
 priority / semver / epic markers) are preserved as-is — they coexist with the
@@ -33,34 +64,50 @@ than the strict pipeline-stage set in `LOOP_PIPELINE_STAGE_LABELS`.
 
 The taxonomy splits cleanly:
 
-- **Operator-set**: `needs-po`, `needs-dev` on issues, `blocked` (when
-  humans intervene), occasional `qa-pass` to force-merge.
-- **Agent-set**: every `in-*` claim label, every `needs-*` transition that a
-  handler emits on completion (`needs-review`, `needs-qa`), every terminal
-  outcome (`qa-pass`, `qa-fail`, `done`), and `blocked` after max retries.
+- **Operator-set**: `loop:action:po`, `loop:action:dev` on issues,
+  `loop:result:blocked` (when humans intervene), occasional
+  `loop:result:qa-pass` to force-merge.
+- **Agent-set**: every `loop:active:*` claim label, every `loop:action:*`
+  transition that a handler emits on completion (`loop:action:review`,
+  `loop:action:qa`), every terminal outcome (`loop:result:qa-pass`,
+  `loop:result:qa-fail`, `loop:result:done`), and `loop:result:blocked`
+  after max retries.
 
 This split exists so handlers can race safely: only one party owns a given
-transition. Operators set the queue labels (`needs-po` / `needs-dev`) and
-nothing else; agents own the in-flight (`in-*`) and outcome states.
+transition. Operators set the queue labels (`loop:action:po` /
+`loop:action:dev`) and nothing else; agents own the in-flight (`loop:active:*`)
+and outcome states.
 
 ## Deprecated alias table
 
 These names are still recognised in the wild — `lib/labels.sh::LOOP_DEPRECATED_ALIAS_MAP`
-is the source of truth, and `reconcile_alias_renames` (see #168) rewrites
-them on every reconciler tick. New code, new workflow YAMLs, and new
-handlers must reference the canonical name only.
+is the source of truth, and `reconcile_alias_renames` rewrites them on every
+reconciler tick. New code, new workflow YAMLs, and new handlers must reference
+the canonical name only. Legacy names still work during the transition; the
+reconciler rewrites them on its next sweep.
 
 | Deprecated alias | Canonical replacement | Notes |
 |---|---|---|
-| `po-review` | `needs-po` | Old PO trigger label |
-| `dev` | `needs-dev` | Old dev trigger label |
-| `plan` | `needs-dev` | Old plan-stage trigger (minimal / docs-only) |
-| `in-progress` | `needs-dev` | Pre-canonical claim label; handler now uses `in-dev` |
-| `review-pending` | `needs-review` | Synonym for the review queue |
-| `ready-for-qa` | `needs-qa` | Synonym for the QA queue |
-| `needs-rework` | `needs-dev` | Rework collapses back into the dev queue (PR-side trigger) |
-| `changes-requested` | `needs-dev` | GitHub-style synonym for review rejection |
-| `in-rework` | `in-dev` | Pre-canonical claim label for rework; unified with dev claim |
+| `needs-po` | `loop:action:po` | Previous canonical name before namespace migration |
+| `in-po` | `loop:active:po` | Previous claim label for PO stage |
+| `needs-dev` | `loop:action:dev` | Previous canonical name before namespace migration |
+| `in-dev` | `loop:active:dev` | Previous claim label for dev stage |
+| `needs-review` | `loop:action:review` | Previous canonical name before namespace migration |
+| `in-review` | `loop:active:review` | Previous claim label for review stage |
+| `needs-qa` | `loop:action:qa` | Previous canonical name before namespace migration |
+| `qa-pass` | `loop:result:qa-pass` | Previous canonical name before namespace migration |
+| `qa-fail` | `loop:result:qa-fail` | Previous canonical name before namespace migration |
+| `blocked` | `loop:result:blocked` | Previous canonical name before namespace migration |
+| `done` | `loop:result:done` | Previous canonical name before namespace migration |
+| `po-review` | `loop:action:po` | Old PO trigger label |
+| `dev` | `loop:action:dev` | Old dev trigger label |
+| `plan` | `loop:action:dev` | Old plan-stage trigger (minimal / docs-only) |
+| `in-progress` | `loop:active:dev` | Pre-canonical claim label |
+| `review-pending` | `loop:action:review` | Synonym for the review queue |
+| `ready-for-qa` | `loop:action:qa` | Synonym for the QA queue |
+| `needs-rework` | `loop:action:dev` | Rework collapses back into the dev queue (PR-side trigger) |
+| `changes-requested` | `loop:action:dev` | GitHub-style synonym for review rejection |
+| `in-rework` | `loop:active:dev` | Pre-canonical claim label for rework; unified with dev claim |
 
 ## Per-project label remapping
 
@@ -75,8 +122,8 @@ projects:
     repo: org/example
     workflow: default
     labels:
-      needs-dev: backlog          # canonical → project-local
-      needs-review: review-please
+      loop:action:dev: backlog           # canonical → project-local
+      loop:action:review: review-please
 ```
 
 `lib/workflow.sh::loop_label_for` and `loop_polled_labels` apply the

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2,6 +2,20 @@
 
 Practical reference for unsticking loop when something goes wrong. Pair this with `docs/failure-handling.md` (handler-internal classification) and `docs/architecture.md` (component overview).
 
+## Label namespace
+
+Loop uses a `loop:*` label namespace for all pipeline state labels. The four
+sub-namespaces are `loop:action:*` (operator-set queue triggers),
+`loop:active:*` (agent-set claim labels), `loop:result:*` (agent-set outcome
+labels), and `loop:stage:*` (reconciler-derived stage markers). See
+[docs/labels.md](labels.md) for the full taxonomy.
+
+**Legacy label names** (`needs-po`, `needs-dev`, `needs-review`, `needs-qa`,
+`qa-pass`, `qa-fail`, and earlier aliases) still work via the alias map in
+`lib/labels.sh`. The reconciler rewrites them on its next sweep — no manual
+migration needed. The canonical names in this doc use the new `loop:*` style;
+the inline comments show the legacy equivalent during the transition.
+
 ## State locations
 
 Every piece of mutable state loop creates, in one place:
@@ -44,7 +58,8 @@ Symptoms: many tickets failing with the same generic error; PO `needs-clarificat
    ```
 5. Re-queue any ticket sitting in `needs-clarification` whose root cause is fixed:
    ```bash
-   gh issue edit <num> --remove-label needs-clarification --add-label needs-po
+   gh issue edit <num> --remove-label needs-clarification --add-label loop:action:po
+   # legacy alias still works: --add-label needs-po
    ```
 
 ### "PRs are piling up with conflicts or failing CI"
@@ -61,10 +76,11 @@ $LOOP_ROOT/scripts/pr-watchdog.sh              # do it
 Without the watchdog, label manually:
 
 ```bash
-gh pr edit <num> --repo <owner/repo> --add-label needs-rework
+gh pr edit <num> --repo <owner/repo> --add-label loop:action:dev
+# legacy alias still works: --add-label needs-rework
 ```
 
-The dev-rework handler picks up `needs-rework` PRs at the next scanner tick.
+The dev-rework handler picks up `loop:action:dev` PRs at the next scanner tick.
 
 ### "Tokens are spiking — slow loop down"
 


### PR DESCRIPTION
Closes #345

> **Depends on #344** — this PR documents the canonical label names introduced by that code change. It is ready to review and can merge immediately after #344 lands.

## Changes

Sweeps all in-scope documentation to use the new canonical `loop:*` label namespace from #344, replacing narrative uses of `needs-po`, `needs-dev`, `needs-review`, `needs-qa`, `qa-pass`, and `qa-fail` with their `loop:action:*`, `loop:active:*`, and `loop:result:*` equivalents.

**Files changed:**

- `docs/labels.md` — full rewrite: new canonical taxonomy table split by sub-namespace (`loop:action:*`, `loop:active:*`, `loop:result:*`, `loop:stage:*`); operator-set vs agent-set section updated; deprecated alias table expanded with all 20 aliases (11 new + 9 pre-existing).
- `docs/architecture.md` — handlers table trigger labels updated; reconciler bootstrap label list updated; data flow diagram label references updated.
- `docs/operations.md` — added label-namespace section with back-compat note (legacy names still work via alias map); recovery recipe commands updated to canonical names with inline legacy-alias comments.
- `README.md` — `Stage labels (loop:stage:*)` section expanded into a full `Label namespaces` section covering all four sub-namespaces and which party sets each; all narrative label references updated throughout.
- `config/workflows/README.md` — schema example, canonical label set table, reserved-stage-ID fallback table, and all state machine diagrams updated to canonical names; `current` workflow section annotated with canonical equivalents.
- `CHANGELOG.md` — `[Unreleased]` entry added noting the rename and back-compat guarantee.

## Verification

Acceptance grep from the issue passes — no stray narrative references to legacy names in the touched files:
```
grep -rn 'needs-po\|needs-dev\|needs-review\|needs-qa\|qa-pass\|qa-fail\b' \
  docs/labels.md docs/architecture.md docs/operations.md README.md config/workflows/README.md
```
All remaining hits are either new `loop:result:*` canonical names, inside the deprecated-alias table, or inside migration-note callouts.

## Test Plan

- [ ] All remaining `qa-pass`/`qa-fail` grep hits in scope files are new canonical `loop:result:qa-pass`/`loop:result:qa-fail` or inside the deprecated-alias table
- [ ] `docs/labels.md` deprecated alias table has 20 entries covering all old label names
- [ ] `README.md` Label namespaces section explains all four sub-namespaces and who sets each
- [ ] `CHANGELOG.md` [Unreleased] entry mentions both the rename and the back-compat guarantee
- [ ] No code files modified — pure docs change
- [ ] No personal identifiers introduced