### PR TITLE
[LOOP-361] watchdog: try clean rebase before labeling CONFLICTING PRs needs-rework

### DIFF
--- a/scripts/pr-watchdog.sh
+++ b/scripts/pr-watchdog.sh
@@ -46,6 +46,56 @@ done
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [pr-watchdog] $*"; }
 
+# _try_clean_rebase <repo> <pr_num> <head_branch>
+# Attempts a cheap clean rebase of the PR head onto its base branch.
+# Returns 0 and pushes if rebase is clean; returns non-zero otherwise (no side effects).
+_try_clean_rebase() {
+    local repo="$1" pr_num="$2" head_branch="$3"
+    local tmp_dir
+    tmp_dir="${TMPDIR:-/tmp}/loop-rebase-$(printf '%s' "$repo" | tr '/' '-')-${pr_num}"
+    rm -rf "$tmp_dir"
+
+    if ! gh repo clone "$repo" "$tmp_dir" -- --depth=50 --quiet 2>/dev/null; then
+        log "WARN: PR #${pr_num} clone failed, skipping auto-rebase"
+        return 1
+    fi
+
+    local base
+    base=$(gh pr view "$pr_num" --repo "$repo" --json baseRefName --jq .baseRefName 2>/dev/null) || {
+        rm -rf "$tmp_dir"
+        return 1
+    }
+    if [ -z "$base" ]; then
+        rm -rf "$tmp_dir"
+        return 1
+    fi
+
+    local rebase_ok=1
+    (
+        cd "$tmp_dir" || exit 1
+        git fetch origin "$head_branch" --quiet 2>/dev/null || exit 1
+        git fetch origin "$base" --quiet 2>/dev/null || exit 1
+        git checkout "$head_branch" --quiet 2>/dev/null || exit 1
+        behind=$(git rev-list --count "origin/${base}...HEAD" 2>/dev/null || echo "999")
+        if [ "$behind" -gt 50 ]; then
+            log "pr-watchdog: PR #${pr_num} too far behind base (${behind} commits), deferring to dev-rework"
+            exit 1
+        fi
+        if git rebase "origin/$base" 2>/dev/null; then
+            git push origin "$head_branch" --force-with-lease 2>/dev/null || exit 1
+            exit 0
+        fi
+        git rebase --abort 2>/dev/null || true
+        exit 1
+    ) && rebase_ok=0
+
+    rm -rf "$tmp_dir"
+    if [ "$rebase_ok" -eq 0 ]; then
+        log "pr-watchdog: auto-rebased PR #${pr_num} onto ${base}"
+    fi
+    return "$rebase_ok"
+}
+
 log "tick start (conflict-grace=${CONFLICT_GRACE_SECONDS}s ci-grace=${CI_GRACE_SECONDS}s dry-run=${DRY_RUN})"
 
 # Walk every project. loop_load_project sets REPO and ALLOWED_AUTHORS.
@@ -70,6 +120,20 @@ while IFS= read -r slug; do
 
     while IFS=$'\t' read -r num reason; do
         [ -z "$num" ] && continue
+
+        # For CONFLICTING PRs, try a cheap clean rebase before triggering dev-rework.
+        case "$reason" in
+            conflict*)
+                if ! $DRY_RUN; then
+                    head_branch=$(gh pr view "$num" --repo "$REPO" \
+                        --json headRefName --jq .headRefName 2>/dev/null || echo "")
+                    if [ -n "$head_branch" ] && _try_clean_rebase "$REPO" "$num" "$head_branch"; then
+                        continue
+                    fi
+                fi
+                ;;
+        esac
+
         if $DRY_RUN; then
             log "DRY $slug #$num would-rework ($rework_label): $reason"
             continue


### PR DESCRIPTION
Closes #361

## Changes

Added `_try_clean_rebase <repo> <pr_num> <head_branch>` helper to `scripts/pr-watchdog.sh` and a call site in the main PR-processing loop.

**Helper behaviour:**
- Shallow-clones the repo (`--depth=50`) into a unique temp dir under `${TMPDIR:-/tmp}/loop-rebase-<repo>-<pr_num>`; always cleaned up on exit.
- Fetches the PR head branch and its base branch, checks out the head.
- If the head is >50 commits behind base: logs `pr-watchdog: PR #N too far behind base (N commits), deferring to dev-rework` and returns non-zero.
- Runs `git rebase origin/<base>`. On clean exit: `git push origin <head_branch> --force-with-lease`. Returns 0.
- On rebase conflict or push failure: aborts rebase, returns non-zero (no label touched).
- On `gh repo clone` failure: logs a warning and returns non-zero immediately (network hiccups don't block rework labeling).

**Call site:**
Before the existing label step, when `reason` starts with `conflict` (i.e. `mergeable=CONFLICTING`), the watchdog fetches the PR head branch name via `gh pr view` and calls `_try_clean_rebase`. On success it `continue`s (PR is already unblocked, no label needed). On failure it falls through to the existing `needs-rework` labeling path unchanged.

**Non-CONFLICTING PRs (CI-failure path):** untouched — the `case` block only matches `conflict*` reasons.

**`--dry-run` mode:** rebase attempt is skipped entirely (no network calls, no mutations), existing dry-run logging is preserved.

## Test Plan

- Open a PR off `main`, then push an unrelated commit to `main` (no file overlap with the PR). Trigger a watchdog tick — the PR should be auto-rebased and force-pushed; no `needs-rework` label appears.
- Open a PR with a deliberate conflict with `main`. Trigger a watchdog tick — rebase attempt fails, PR gets `needs-rework` label as before.
- Verify `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` and `shellcheck -S warning` both pass (confirmed locally).
- Verify `--dry-run` flag still logs `DRY ... would-rework` without making any API calls.