### PR TITLE
[LOOP-346] security: require explicit allowed_authors or LOOP_TRUSTED_PUBLIC at scanner startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ projects:
     slug: myapp
     repo: owner/my-app
     workflow: default              # references config/workflows/default.yaml
+    allowed_authors:               # required — who may trigger the pipeline
+      - your-github-login
     labels:                              # optional — sparse overrides
       loop:action:dev: dev               # repo uses 'dev' instead of canonical
       loop:result:qa-pass: approved
@@ -517,8 +519,16 @@ accordingly:
   `require code-owner approval` on `main` so even the operator's own
   PRs need a CODEOWNERS-listed reviewer.
 
+### Security baseline
+
+Set `allowed_authors` in `config/projects.yaml` for every project. Without it the
+scanner refuses to process that project unless `LOOP_TRUSTED_PUBLIC=1` is explicitly
+set in `loop.env`, acknowledging that anyone who can open a GitHub issue can trigger
+the pipeline. This is the fail-closed default: unset = deny, not allow-all.
+
 See [`docs/security-model.md`](docs/security-model.md) for the full
-security model, including prompt injection defenses and trust boundaries.
+security model, including the default-deny author gate, prompt injection defenses,
+and trust boundaries.
 
 ## Status check
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -26,12 +26,29 @@ Untrusted at code-execution level:
 
 ## Three security gates
 
-### Gate 1 — pipeline activation requires labels (collaborator-only)
+### Gate 1 — default-deny author gate (`allowed_authors`)
 
-The scanner only acts on issues/PRs carrying a workflow trigger label
-(`dev`, `needs-review`, `needs-qa`, etc.). GitHub permissions enforce
-that **only repo collaborators can apply labels**. A drive-by user can
-open an issue but cannot label it; the scanner will ignore it.
+The scanner enforces a fail-closed author gate before processing any project.
+Two conditions must hold for a project to be processed:
+
+1. **`allowed_authors` is configured** in `config/projects.yaml` for that project
+   (a non-empty list of GitHub logins who may trigger the pipeline), **OR**
+2. **`LOOP_TRUSTED_PUBLIC=1`** is set in `loop.env`, explicitly opting in to
+   public trust (anyone who can open an issue can trigger the PO handler).
+
+If neither condition holds, the scanner logs an error, emits a `LOOP_NOTIFY`
+alert, skips the project entirely, and increments the `security_misconfig`
+counter visible in the reconciler digest. This is the **default-deny posture**:
+an unconfigured project is blocked, not silently allowed.
+
+When `LOOP_TRUSTED_PUBLIC=1` is set, the scanner proceeds but logs a per-tick
+warning (`WARN: $slug runs without ALLOWED_AUTHORS — trusting public`) as
+intentional friction so operators are reminded the gate is open.
+
+Within a scan tick, per-issue author checks are also applied: issues and PRs
+opened by authors outside `ALLOWED_AUTHORS` are skipped, unless the ticket
+carries the `operator-approved` label (a per-ticket override controlled by
+GitHub collaborator permissions).
 
 If a collaborator account is compromised, the attacker can label issues
 and PRs and trigger the AI agent. Mitigations:

--- a/lib/author_gate.sh
+++ b/lib/author_gate.sh
@@ -126,3 +126,25 @@ PY
     echo "$count" > "$count_file"
     log "[$repo] author_gated_pending=$count (slug=$slug)"
 }
+
+# loop_project_has_author_gate <slug>
+# Returns 0 (success) iff ALLOWED_AUTHORS is set and non-empty for the current
+# project. Must be called after loop_load_project so ALLOWED_AUTHORS is exported.
+loop_project_has_author_gate() {
+    [ -n "${ALLOWED_AUTHORS:-}" ]
+}
+
+# security_misconfig_count_file
+# Path to the file that the scanner writes its per-tick misconfig count to.
+security_misconfig_count_file() {
+    printf '%s/security-misconfig.count\n' "${LOOP_LOG_DIR:-/tmp}"
+}
+
+# security_misconfig_total
+# Read the scanner's last-written misconfig count. Returns 0 if unset.
+security_misconfig_total() {
+    local f; f=$(security_misconfig_count_file)
+    [ -f "$f" ] || { echo 0; return 0; }
+    local n; n=$(tr -d '[:space:]' < "$f" 2>/dev/null || echo 0)
+    printf '%s\n' "${n:-0}"
+}

--- a/scanner/reconciler.sh
+++ b/scanner/reconciler.sh
@@ -3167,4 +3167,4 @@ fi
 
 orphans_gc=$(recovery_gc_stale_worktrees)
 
-log "=== reconciler done orphans_gc=${orphans_gc} ==="
+log "=== reconciler done orphans_gc=${orphans_gc} security_misconfig=$(security_misconfig_total) ==="

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -22,6 +22,10 @@ source "$LOOP_ROOT/lib/backends/backend.sh"
 source "$LOOP_ROOT/lib/labels.sh"
 # shellcheck source=../lib/jobs.sh
 source "$LOOP_ROOT/lib/jobs.sh"
+# shellcheck source=../lib/notify.sh
+source "$LOOP_ROOT/lib/notify.sh"
+# shellcheck source=../lib/author_gate.sh
+source "$LOOP_ROOT/lib/author_gate.sh"
 # workflow helpers (loop_polled_labels, loop_handler_for_label, loop_stage_trigger,
 # loop_workflow_for_project) are already loaded via lib/env.sh → lib/workflow.sh.
 # The line below is for shellcheck only.
@@ -630,6 +634,18 @@ scan_project() {
 
     loop_load_project "$slug" || { log "skip: slug '$slug' unloadable"; return; }
     loop_load_backend
+
+    # Author-gate precondition: require ALLOWED_AUTHORS or LOOP_TRUSTED_PUBLIC opt-in.
+    if ! loop_project_has_author_gate "$slug"; then
+        if [ -z "${LOOP_TRUSTED_PUBLIC:-}" ]; then
+            log "ERROR: $slug skipped — no allowed_authors configured; set LOOP_TRUSTED_PUBLIC=1 to opt in to public trust"
+            loop_notify "Loop scanner: $slug — skipped (no allowed_authors configured; set LOOP_TRUSTED_PUBLIC=1 to opt in to public trust)"
+            SECURITY_MISCONFIG_COUNT=$(( ${SECURITY_MISCONFIG_COUNT:-0} + 1 ))
+            return
+        fi
+        log "WARN: $slug runs without ALLOWED_AUTHORS — trusting public"
+    fi
+
     local repo="$REPO"
 
     local wf_name
@@ -685,6 +701,7 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    SECURITY_MISCONFIG_COUNT=0
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \
             || log "WARN: jobs schema init failed — jobs DB disabled for this tick"
@@ -693,7 +710,9 @@ run_once() {
         [ -z "$slug" ] && continue
         scan_project "$slug" || log "scan_project $slug failed (continuing)"
     done < <(loop_list_slugs)
-    log "=== scan tick done ==="
+    # Persist security_misconfig counter for the reconciler digest.
+    printf '%s\n' "$SECURITY_MISCONFIG_COUNT" > "$(security_misconfig_count_file)" 2>/dev/null || true
+    log "=== scan tick done security_misconfig=${SECURITY_MISCONFIG_COUNT} ==="
 }
 
 acquire_lock


### PR DESCRIPTION
Closes #346

## Changes

**`lib/author_gate.sh`** — added three helpers:
- `loop_project_has_author_gate <slug>` — returns 0 iff `ALLOWED_AUTHORS` is set and non-empty (called after `loop_load_project`). Keeps author-gate logic isolated per the issue spec.
- `security_misconfig_count_file` — returns the path where the scanner writes its per-tick misconfig count.
- `security_misconfig_total` — reads the count for the reconciler digest.

**`scanner/scanner.sh`** — three changes:
- Source `lib/notify.sh` and `lib/author_gate.sh`.
- Added author-gate preamble in `scan_project()` (after `loop_load_backend`): if no `allowed_authors` AND `LOOP_TRUSTED_PUBLIC` unset → log ERROR, call `loop_notify`, increment `SECURITY_MISCONFIG_COUNT`, return early. If `LOOP_TRUSTED_PUBLIC=1` → proceed with per-tick WARN line.
- Updated `run_once()` to initialize `SECURITY_MISCONFIG_COUNT=0`, persist it to file after the scan loop, and include it in the tick-done log line.

**`scanner/reconciler.sh`** — one-line change: the done log line now includes `security_misconfig=$(security_misconfig_total)`.

**`README.md`** — two additions:
- `allowed_authors:` field added to the projects.yaml quickstart snippet as a required field.
- "Security baseline" subsection added to the Security model section, explaining the default-deny posture and `LOOP_TRUSTED_PUBLIC` opt-out.

**`docs/security-model.md`** — Gate 1 section rewritten to describe the default-deny + `LOOP_TRUSTED_PUBLIC` opt-out flow, per-tick WARN friction, and reconciler digest surfacing.

## Test Plan

- `bash -n` and `shellcheck -S warning` pass clean on all touched shell files (verified locally).
- No personal identifiers in changed files (verified locally).
- **Unset `LOOP_TRUSTED_PUBLIC`, remove `allowed_authors` from a project in `projects.yaml`**: scanner logs `ERROR: <slug> skipped — no allowed_authors configured; set LOOP_TRUSTED_PUBLIC=1 to opt in to public trust`, sends `loop_notify` alert, skips the project. No issues from that project enter the pipeline.
- **Same scenario with `LOOP_TRUSTED_PUBLIC=1`**: scanner proceeds and logs `WARN: <slug> runs without ALLOWED_AUTHORS — trusting public` each tick.
- **Project with `allowed_authors` configured**: zero behavioural change — no extra log lines, no skip.
- **Reconciler tick**: done log line includes `security_misconfig=N` from the scanner's persisted counter.