### PR TITLE
[LOOP-395] Tag handler-authored comments with [loop:<stage>] prefix

### DIFF
--- a/lib/github.sh
+++ b/lib/github.sh
@@ -118,6 +118,16 @@ loop_gh_prs_with_label() {
         ' 2>/dev/null || true
 }
 
+# loop_gh_comment <repo> <pr_num> <handler_id> <body>
+# Posts a PR comment whose body is prefixed with [loop:<handler_id>] so the
+# PR timeline is forensically readable without per-handler bot tokens (Path A).
+loop_gh_comment() {
+    local repo="$1" pr_num="$2" handler_id="$3" body="$4"
+    local tagged_body
+    tagged_body="[loop:${handler_id}] ${body}"
+    gh pr comment "$pr_num" --repo "$repo" --body "$tagged_body" 2>/dev/null || true
+}
+
 loop_add_label() {
     local repo="$1" number="$2" label="$3"
     gh issue edit "$number" --repo "$repo" --add-label "$label" 2>/dev/null \

--- a/scripts/dev-rework-handler.sh
+++ b/scripts/dev-rework-handler.sh
@@ -287,11 +287,11 @@ if [ "$REWORK_CONTEXT" = "qa-fail" ]; then
    ---
    ${QA_FAILURE_DETAILS}
    ---"
-    _STEP7="   gh pr comment ${PR_NUM} --repo ${REPO} --body 'Fixed QA failure: <summary of what was fixed>'"
+    _STEP7="   gh pr comment ${PR_NUM} --repo ${REPO} --body '[loop:rework] Fixed QA failure: <summary of what was fixed>'"
 else
     _REWORK_TRIGGER="reviewer feedback or CI failure"
     _STEP2="2. ${_FULL_PR_DIAGNOSTICS}"
-    _STEP7="   gh pr comment ${PR_NUM} --repo ${REPO} --body 'Addressed feedback / fixed CI: <summary>'"
+    _STEP7="   gh pr comment ${PR_NUM} --repo ${REPO} --body '[loop:rework] Addressed feedback / fixed CI: <summary>'"
 fi
 
 _VALIDATION_STEP="4. Validate locally before committing — match CI exactly. Discover what CI runs by reading the project itself:
@@ -399,7 +399,7 @@ if [ "$_POST_DIRTY" = "true" ]; then
         if [ -n "$LINKED_ISSUE" ]; then
             _BLOCK_BODY=$(printf '%s\nParent: #%s' "$_BLOCK_BODY" "$LINKED_ISSUE")
         fi
-        gh pr comment "$PR_NUM" --repo "$REPO" --body "$_BLOCK_BODY" 2>/dev/null || true
+        loop_gh_comment "$REPO" "$PR_NUM" rework "$_BLOCK_BODY"
     fi
     _rework_blocked_diag="$(bounty_truncate_detail "$_rework_tail")"
     bounty_report "rework_blocked" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" \

--- a/scripts/judge.sh
+++ b/scripts/judge.sh
@@ -8,6 +8,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$LOOP_ROOT/lib/env.sh"
 source "$LOOP_ROOT/lib/bounty.sh"
+# shellcheck source=../lib/github.sh
+source "$LOOP_ROOT/lib/github.sh"
 
 PR_NUM="${1:-}"
 REPO="${2:-}"
@@ -153,6 +155,6 @@ PR_COMMENT=$(cat <<COMMENT
 COMMENT
 )
 
-gh pr comment "$PR_NUM" --repo "$REPO" --body "$PR_COMMENT" 2>/dev/null || true
+loop_gh_comment "$REPO" "$PR_NUM" judge "$PR_COMMENT"
 
 echo "Judge verdict: outcome=${OUTCOME} points=${POINTS}"

--- a/scripts/po-handler.sh
+++ b/scripts/po-handler.sh
@@ -265,12 +265,12 @@ ${_pr_reviews}
 "
         _MR_PATHS="
 G - REFINE-WITH-ACTIVE-MR (spec adjustment small enough the current MR can absorb it):
-   - Comment on the MR: gh pr comment ${_IN_FLIGHT_PR} --repo ${REPO} --body 'PO: spec refinement: [details]'
+   - Comment on the MR: gh pr comment ${_IN_FLIGHT_PR} --repo ${REPO} --body '[loop:po] PO: spec refinement: [details]'
    - Flag MR for rework: gh pr edit ${_IN_FLIGHT_PR} --repo ${REPO} --add-label ${_REWORK_LABEL}
    - Leave issue label at dev (no label change on issue)
 
 H - SUPERSEDE (requirements changed enough the MR is wrong — wrong approach or stale spec):
-   - Comment on MR: gh pr comment ${_IN_FLIGHT_PR} --repo ${REPO} --body 'PO: closing — superseded by new spec. [Explanation].'
+   - Comment on MR: gh pr comment ${_IN_FLIGHT_PR} --repo ${REPO} --body '[loop:po] PO: closing — superseded by new spec. [Explanation].'
    - Close MR: gh pr close ${_IN_FLIGHT_PR} --repo ${REPO}
    - Rewrite issue spec using SPEC FORMAT below
    - gh issue edit ${ISSUE_NUM} --repo ${REPO} --remove-label in-progress --add-label dev

--- a/scripts/qa-handler.sh
+++ b/scripts/qa-handler.sh
@@ -311,7 +311,7 @@ ${_PHASE4_COMMENT_TEMPLATE}
 \`\`\`
 
 Post the comment:
-   gh pr comment ${PR_NUM} --repo ${REPO} --body '<comment text>'
+   gh pr comment ${PR_NUM} --repo ${REPO} --body '[loop:qa] <comment text>'
 
 Then apply the label:
 

--- a/scripts/review-handler.sh
+++ b/scripts/review-handler.sh
@@ -220,11 +220,11 @@ ${_PR_TRUSTED_CONTEXT:-   (no trusted comments)}
 7. Decide: APPROVE or REQUEST_CHANGES.
 
 If APPROVE:
-   gh pr review ${PR_NUM} --repo ${REPO} --approve --body '<2-4 sentence summary of what looks good>'
+   gh pr review ${PR_NUM} --repo ${REPO} --approve --body '[loop:review] <2-4 sentence summary of what looks good>'
    gh pr edit ${PR_NUM} --repo ${REPO} --remove-label in-review --remove-label ${_REVIEW_LABEL} --remove-label ${_QA_LABEL} --add-label ${_QA_LABEL}
 
 If REQUEST_CHANGES:
-   gh pr review ${PR_NUM} --repo ${REPO} --request-changes --body '<specific, actionable feedback -- what to change and why>'
+   gh pr review ${PR_NUM} --repo ${REPO} --request-changes --body '[loop:review] <specific, actionable feedback -- what to change and why>'
    gh pr edit ${PR_NUM} --repo ${REPO} --remove-label in-review --remove-label ${_REVIEW_LABEL} --remove-label ${_REWORK_LABEL} --add-label ${_REWORK_LABEL}
 
 Be strict but fair. Approve content-adjacent bookkeeping (formatting, docs) liberally. Push back on logic errors, security issues, missing tests where the issue asked for tests, or content that contradicts the cited source (e.g. a lesson that miscites CAR Part X).

--- a/tests/github.bats
+++ b/tests/github.bats
@@ -115,3 +115,32 @@ enhancement"
     run loop_remove_label "owner/repo" 1 "dev"
     [ "$status" -eq 0 ]
 }
+
+# ---------------------------------------------------------------------------
+# loop_gh_comment
+# ---------------------------------------------------------------------------
+
+@test "loop_gh_comment: body is prefixed with [loop:<handler_id>]" {
+    export GH_MOCK_LOG="$BATS_TMPDIR/gh.log"
+    run loop_gh_comment "owner/repo" 42 "judge" "Great work"
+    [ "$status" -eq 0 ]
+    grep -q '\[loop:judge\]' "$GH_MOCK_LOG"
+}
+
+@test "loop_gh_comment: review stage tag" {
+    export GH_MOCK_LOG="$BATS_TMPDIR/gh.log"
+    run loop_gh_comment "owner/repo" 7 "review" "LGTM"
+    [ "$status" -eq 0 ]
+    grep -q '\[loop:review\]' "$GH_MOCK_LOG"
+}
+
+@test "loop_gh_comment: succeeds even when gh returns non-zero" {
+    export GH_MOCK_EXIT=1
+    run loop_gh_comment "owner/repo" 1 "qa" "all good"
+    [ "$status" -eq 0 ]
+}
+
+@test "no direct gh pr comment/review calls at line start in scripts/" {
+    run grep -rE '^gh pr (comment|review)' "$REPO_ROOT/scripts/"
+    [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
Closes #395

## Changes

- **`lib/github.sh`**: Added `loop_gh_comment <repo> <pr_num> <handler_id> <body>` — prepends `[loop:<handler_id>]` to the body before calling `gh pr comment`, making every handler-authored comment forensically identifiable (Path A from the issue).

- **`scripts/judge.sh`**: Sources `lib/github.sh`; replaced direct `gh pr comment` call with `loop_gh_comment … judge`.

- **`scripts/dev-rework-handler.sh`**: Replaced direct `gh pr comment` call (rebase-conflict block notice) with `loop_gh_comment … rework`. Updated agent prompt template (`_STEP7`) to instruct the agent to prefix its summary comment with `[loop:rework]`.

- **`scripts/review-handler.sh`**: Updated agent prompt template for both APPROVE and REQUEST_CHANGES review bodies to include `[loop:review]` prefix.

- **`scripts/qa-handler.sh`**: Updated agent prompt template comment body to include `[loop:qa]` prefix.

- **`scripts/po-handler.sh`**: Updated agent prompt templates for REFINE-WITH-ACTIVE-MR and SUPERSEDE paths to include `[loop:po]` prefix.

- **`tests/github.bats`**: Added 4 tests — tag prefix for judge/review stages, gh failure tolerance, and a grep assertion that no line in `scripts/` starts with a bare `gh pr (comment|review)` call.

## Test Plan

- All 17 `tests/github.bats` tests pass locally.
- `bash -n` and `shellcheck -S warning` clean on all scripts.
- `grep -rE '^gh pr (comment|review)' scripts/` returns exit 1 (no bare callers).
- QA: open a PR in a Loop-managed repo, trigger review → confirm the review comment starts with `[loop:review]`; trigger judge → confirm verdict comment starts with `[loop:judge]`.