### PR TITLE
[LOOP-396] require Closes #N on every dev-handler PR + CI gate

### DIFF
--- a/.github/workflows/check-closes-ref.yml
+++ b/.github/workflows/check-closes-ref.yml
@@ -1,0 +1,52 @@
+name: Require Closes reference
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  check-closes-ref:
+    runs-on: ubuntu-latest
+    # Skip bot-authored PRs and PRs tagged as release-pr.
+    # github.actor covers the PR author; the label check below handles release-pr.
+    if: |
+      !contains(fromJSON('["github-actions[bot]","dependabot[bot]","loop-bot"]'), github.actor)
+    steps:
+      - name: Check PR body for Closes/Fixes/Resolves reference
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Skip PRs carrying the release-pr label.
+          if echo "$PR_LABELS" | python3 -c "import json,sys; labels=json.load(sys.stdin); exit(0 if 'release-pr' in labels else 1)" 2>/dev/null; then
+            echo "Skipping release-pr — exempt from Closes reference requirement."
+            exit 0
+          fi
+
+          # Extract the first Closes/Fixes/Resolves #N reference.
+          CLOSES_NUM=$(printf '%s' "$PR_BODY" | python3 -c "
+          import re, sys
+          m = re.search(r'(?im)^(closes|fixes|resolves)\s+#([0-9]+)\b', sys.stdin.read())
+          print(m.group(2) if m else '')
+          " 2>/dev/null || true)
+
+          if [ -z "$CLOSES_NUM" ]; then
+            echo "::error::PR body must contain a 'Closes #N', 'Fixes #N', or 'Resolves #N' line referencing an open issue in this repo."
+            exit 1
+          fi
+
+          echo "Found Closes reference: #${CLOSES_NUM}"
+
+          # Validate that the referenced issue exists and is open.
+          ISSUE_STATE=$(gh api "repos/${REPO}/issues/${CLOSES_NUM}" --jq '.state' 2>/dev/null || echo "")
+
+          if [ "$ISSUE_STATE" != "open" ]; then
+            echo "::error::PR references issue #${CLOSES_NUM} but it is not open (state: '${ISSUE_STATE:-not found}'). Use an open issue number."
+            exit 1
+          fi
+
+          echo "Issue #${CLOSES_NUM} is open. Check passed."

--- a/scripts/dev-handler.sh
+++ b/scripts/dev-handler.sh
@@ -257,6 +257,59 @@ if matches:
         loop_notify_human_required "$SLUG" "$ISSUE_NUM" needs-clarification "Dev agent finished without opening a PR"
     else
         log "belt-and-braces: found PR #$_dev_pr_num for issue #$ISSUE_NUM"
+
+        # Validate the PR body contains a parseable Closes/Fixes/Resolves #N
+        # reference that resolves to an open issue in the same repo.
+        _pr_body=$(backend_pr_view "$REPO" "$_dev_pr_num" --json body --jq .body 2>/dev/null || echo "")
+        _closes_num=$(printf '%s' "$_pr_body" | python3 -c "
+import re, sys
+m = re.search(r'(?im)^(closes|fixes|resolves)\s+#([0-9]+)\b', sys.stdin.read())
+print(m.group(2) if m else '')
+" 2>/dev/null || true)
+
+        if [ -z "$_closes_num" ]; then
+            log "ERROR: PR #$_dev_pr_num has no Closes/Fixes/Resolves #N line — closing PR and aborting"
+            backend_close_pr "$REPO" "$_dev_pr_num" --delete-branch
+            bounty_report "dev_failed_no_ticket" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" issue_num="$ISSUE_NUM" detail="PR #${_dev_pr_num} missing Closes/Fixes/Resolves reference" || true
+            _no_ticket_comment=$(mktemp /tmp/loop-no-ticket-XXXXXX.md)
+            {
+                echo "## Dev agent error: missing \`Closes #N\` reference"
+                echo ""
+                echo "PR #${_dev_pr_num} was opened without a \`Closes #N\` / \`Fixes #N\` / \`Resolves #N\` line in its body."
+                echo "Loop requires every automated PR to reference its originating issue so the pipeline audit trail and auto-close wiring work correctly."
+                echo ""
+                echo "The PR has been closed. Loop will retry this issue on the next cycle."
+            } > "$_no_ticket_comment"
+            backend_comment_issue "$REPO" "$ISSUE_NUM" "$(cat "$_no_ticket_comment")" 2>/dev/null || true
+            rm -f "$_no_ticket_comment"
+            loop_strip_pipeline_labels "$REPO" "$ISSUE_NUM" >/dev/null || true
+            backend_add_label "$REPO" "$ISSUE_NUM" needs-clarification
+            loop_notify_human_required "$SLUG" "$ISSUE_NUM" needs-clarification "Dev agent opened PR #${_dev_pr_num} without Closes #N"
+            cleanup_worktree
+            exit 0
+        fi
+
+        _closes_state=$(gh issue view "$_closes_num" --repo "$REPO" --json state --jq .state 2>/dev/null || echo "")
+        if [ "$_closes_state" != "open" ]; then
+            log "ERROR: PR #$_dev_pr_num references issue #$_closes_num which is not open (state='${_closes_state:-unknown}') — closing PR"
+            backend_close_pr "$REPO" "$_dev_pr_num" --delete-branch
+            bounty_report "dev_failed_no_ticket" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" issue_num="$ISSUE_NUM" detail="PR #${_dev_pr_num} references #${_closes_num} which is not open" || true
+            _bad_ref_comment=$(mktemp /tmp/loop-bad-ref-XXXXXX.md)
+            {
+                echo "## Dev agent error: \`Closes\` references a non-open issue"
+                echo ""
+                echo "PR #${_dev_pr_num} contains \`Closes #${_closes_num}\` but that issue is not open (state: \`${_closes_state:-unknown}\`)."
+                echo "The PR has been closed. Please verify the issue reference in the PR body and retry."
+            } > "$_bad_ref_comment"
+            backend_comment_issue "$REPO" "$ISSUE_NUM" "$(cat "$_bad_ref_comment")" 2>/dev/null || true
+            rm -f "$_bad_ref_comment"
+            loop_strip_pipeline_labels "$REPO" "$ISSUE_NUM" >/dev/null || true
+            backend_add_label "$REPO" "$ISSUE_NUM" needs-clarification
+            loop_notify_human_required "$SLUG" "$ISSUE_NUM" needs-clarification "Dev agent PR #${_dev_pr_num} references non-open issue #${_closes_num}"
+            cleanup_worktree
+            exit 0
+        fi
+
         if ! backend_pr_has_any_label "$REPO" "$_dev_pr_num" \
                 "$LOOP_LABEL_DEPRECATED_REVIEW_PENDING" "$LOOP_LABEL_NEEDS_REVIEW" \
                 "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" \


### PR DESCRIPTION
Closes #396

## Changes

### `scripts/dev-handler.sh`
Added a post-PR-open validation step in the belt-and-braces success path (after the agent has run and a PR has been found):

1. Fetches the PR body via `backend_pr_view`.
2. Applies regex `(?im)^(closes|fixes|resolves)\s+#([0-9]+)\b` to extract the closing issue number.
3. If no reference is found — closes the PR (with branch delete), posts an explanatory comment on the originating issue, emits `dev_failed_no_ticket` via `bounty_report`, and labels the issue `needs-clarification`.
4. If a reference is found but the referenced issue is not open (`gh issue view ... --json state`) — same abort flow with a different error message.
5. Only if both checks pass does the handler proceed to the existing label-swap logic.

### `.github/workflows/check-closes-ref.yml` (new)
CI gate — defence in depth. Runs on every non-bot `pull_request` event (opened, synchronize, reopened, edited):

- Skips PRs authored by known bot actors (`github-actions[bot]`, `dependabot[bot]`, `loop-bot`).
- Skips PRs carrying the `release-pr` label.
- Extracts the first `Closes/Fixes/Resolves #N` reference from the PR body.
- Fails with a descriptive `::error::` message if none is found.
- Validates the referenced issue is open via `gh api`; fails if it is closed or not found.

## Test Plan

- Open a PR without any `Closes #N` line → CI `check-closes-ref` job must fail.
- Open a PR with `Closes #999999` (non-existent issue) → CI job must fail.
- Open a PR with `Closes #396` (open issue) → CI job must pass.
- Open a PR authored by `github-actions[bot]` or labelled `release-pr` → CI job skips.
- Trigger dev-handler on an issue; confirm handler closes any agent-opened PR that lacks the reference and posts the expected comment.