### PR TITLE
[LOOP-397] dev handler cooldown: block PRs overlapping recently-merged files

### DIFF
--- a/config/projects.example.yaml
+++ b/config/projects.example.yaml
@@ -51,6 +51,11 @@ projects:
       # Downstream stages (review/qa/merge for existing work) still drain.
       # Omit to disable the gate. See README → "Pipeline concurrency & priority".
       # pipeline_slots: 1
+      # Optional: cooldown window in minutes. Before promoting a dev-agent PR,
+      # Loop checks whether any recently-merged PR touched the same files. If so,
+      # it blocks the new PR and labels the issue loop:result:blocked so an
+      # operator can review the overlap. Set to 0 to disable. Default: 30.
+      # cooldown_minutes: 30
 
     qa:
       # Optional: command run by QA handler to validate the PR branch.

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -73,6 +73,7 @@ for p in data.get("projects", []) or []:
         # all pipeline stages (needs-po through qa-pass). Empty = no gate.
         # Configure per-project via `dev.pipeline_slots` in projects.yaml.
         print(f"PIPELINE_SLOTS='{sh(dev.get('pipeline_slots', ''))}'")
+        print(f"DEV_COOLDOWN_MINUTES='{sh(dev.get('cooldown_minutes', 30))}'")
         # WORKTREE_EXTRA_PATHS: paths from the primary checkout to symlink into
         # each fresh worker worktree. Useful for projects with gitignored runtime
         # files (ML training data, downloaded models, large fixtures) that the
@@ -127,7 +128,7 @@ PY
         return 1
     fi
     eval "$out"
-    export NAME REPO ROOT DEFAULT_BRANCH COMMIT_PREFIX DEV_VALIDATION_CMD QA_VALIDATION_CMD QA_BROWSER_URL QA_TIMEOUT_SECONDS HANDLER_TIMEOUT_SECONDS MERGE_STRATEGY AUTO_REBASE AUTO_REWORK_ON_CI BACKEND MAX_CONCURRENT_PRS PIPELINE_SLOTS MAX_CONCURRENT_HANDLERS WORKTREE_EXTRA_PATHS LOOP_AGENT_MODEL ALLOWED_AUTHORS WORKFLOW LOOP_LABEL_OVERRIDES _PROJECT_AGENT _PROJECT_MODEL _PROJECT_FALLBACK
+    export NAME REPO ROOT DEFAULT_BRANCH COMMIT_PREFIX DEV_VALIDATION_CMD QA_VALIDATION_CMD QA_BROWSER_URL QA_TIMEOUT_SECONDS HANDLER_TIMEOUT_SECONDS MERGE_STRATEGY AUTO_REBASE AUTO_REWORK_ON_CI BACKEND MAX_CONCURRENT_PRS PIPELINE_SLOTS DEV_COOLDOWN_MINUTES MAX_CONCURRENT_HANDLERS WORKTREE_EXTRA_PATHS LOOP_AGENT_MODEL ALLOWED_AUTHORS WORKFLOW LOOP_LABEL_OVERRIDES _PROJECT_AGENT _PROJECT_MODEL _PROJECT_FALLBACK
 }
 
 # loop_list_slugs — print each project slug on its own line

--- a/lib/dev_cooldown.sh
+++ b/lib/dev_cooldown.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# lib/dev_cooldown.sh — cooldown guard: block PRs that overlap recently-merged files.
+#
+# Public surface:
+#   loop_dev_cooldown_check <repo> <issue_body> <worktree_root> <default_branch> <cooldown_minutes>
+#   Returns 0 if the new PR is clear to open, 1 if it must be blocked.
+#   On block, exports DEV_COOLDOWN_BLOCK_PR (conflicting PR number) and
+#   DEV_COOLDOWN_BLOCK_MINS (approximate minutes since that PR merged).
+#
+# Per-project configuration: dev.cooldown_minutes in projects.yaml (default 30).
+# Set to 0 to disable the guard entirely for a project.
+#
+# Override bypass: if the issue body contains "## Follow-up of #<pr_number>" for
+# the conflicting PR, the guard is skipped for that PR.
+
+set -euo pipefail
+
+# _loop_cooldown_cutoff_iso <minutes>
+# Prints an ISO 8601 UTC timestamp for <minutes> ago.
+_loop_cooldown_cutoff_iso() {
+    python3 -c "
+import datetime, sys
+mins = int(sys.argv[1])
+t = datetime.datetime.utcnow() - datetime.timedelta(minutes=mins)
+print(t.strftime('%Y-%m-%dT%H:%M:%SZ'))
+" "$1"
+}
+
+# _loop_cooldown_merged_prs <repo> <cutoff_iso>
+# Prints "pr_number merged_at_iso" pairs, one per line.
+# Mockable in tests by overriding this function.
+_loop_cooldown_merged_prs() {
+    local repo="$1" cutoff="$2"
+    gh pr list --repo "$repo" --state merged \
+        --search "merged:>=${cutoff}" \
+        --json number,mergedAt --limit 20 2>/dev/null \
+    | python3 -c "
+import json, sys
+prs = json.load(sys.stdin) or []
+for p in prs:
+    print(str(p.get('number', '')) + ' ' + str(p.get('mergedAt', '')))
+" 2>/dev/null || true
+}
+
+# _loop_cooldown_pr_files <repo> <pr_number>
+# Prints one changed file path per line for the given PR.
+# Mockable in tests by overriding this function.
+_loop_cooldown_pr_files() {
+    local repo="$1" pr_num="$2"
+    gh pr view "$pr_num" --repo "$repo" \
+        --json files --jq '.files[].path' 2>/dev/null || true
+}
+
+# _loop_cooldown_local_files <worktree_root> <default_branch>
+# Prints one file path per line for all changes in the worktree vs origin/<branch>.
+# Mockable in tests by overriding this function.
+_loop_cooldown_local_files() {
+    local worktree="$1" branch="$2"
+    git -C "$worktree" diff --name-only "origin/${branch}" 2>/dev/null || true
+}
+
+# _loop_cooldown_minutes_since <merged_at_iso>
+# Prints the number of whole minutes elapsed since the given ISO timestamp.
+_loop_cooldown_minutes_since() {
+    python3 -c "
+import datetime, sys
+merged = sys.argv[1]
+if not merged:
+    print('?')
+    sys.exit(0)
+try:
+    t = datetime.datetime.fromisoformat(merged.replace('Z', '+00:00'))
+    now = datetime.datetime.now(datetime.timezone.utc)
+    print(int((now - t).total_seconds() / 60))
+except Exception:
+    print('?')
+" "$1" 2>/dev/null || echo "?"
+}
+
+# _loop_cooldown_files_overlap <newline_list_a> <newline_list_b>
+# Returns 0 if at least one file appears in both lists, 1 if not.
+_loop_cooldown_files_overlap() {
+    local files_a="$1" files_b="$2"
+    local fa fb
+    while IFS= read -r fa; do
+        [ -z "$fa" ] && continue
+        while IFS= read -r fb; do
+            [ -z "$fb" ] && continue
+            [ "$fa" = "$fb" ] && return 0
+        done <<< "$files_b"
+    done <<< "$files_a"
+    return 1
+}
+
+# loop_dev_cooldown_check <repo> <issue_body> <worktree_root> <default_branch> <cooldown_minutes>
+#
+# Pre-PR guard: compares the worktree's committed diff against the file sets of
+# recently-merged PRs. If any file appears in both sets and the issue body does
+# not declare an explicit follow-up annotation, the guard blocks.
+#
+# Returns 0 — clear, safe to open the PR.
+# Returns 1 — blocked; DEV_COOLDOWN_BLOCK_PR and DEV_COOLDOWN_BLOCK_MINS are exported.
+loop_dev_cooldown_check() {
+    local repo="$1"
+    local issue_body="$2"
+    local worktree_root="$3"
+    local default_branch="$4"
+    local cooldown_minutes="${5:-30}"
+
+    # Cooldown disabled for this project.
+    [ "$cooldown_minutes" -eq 0 ] 2>/dev/null && return 0
+
+    local cutoff
+    cutoff=$(_loop_cooldown_cutoff_iso "$cooldown_minutes")
+
+    local merged_list
+    merged_list=$(_loop_cooldown_merged_prs "$repo" "$cutoff") || true
+    [ -z "$merged_list" ] && return 0
+
+    local local_files
+    local_files=$(_loop_cooldown_local_files "$worktree_root" "$default_branch") || true
+    [ -z "$local_files" ] && return 0
+
+    local pr_num merged_at
+    while IFS=' ' read -r pr_num merged_at; do
+        [ -z "$pr_num" ] && continue
+
+        # Allow explicit follow-up annotation to bypass the guard.
+        if printf '%s' "$issue_body" | grep -qE "^## Follow-up of #${pr_num}([^0-9]|$)"; then
+            continue
+        fi
+
+        local merged_files
+        merged_files=$(_loop_cooldown_pr_files "$repo" "$pr_num") || true
+        [ -z "$merged_files" ] && continue
+
+        if _loop_cooldown_files_overlap "$local_files" "$merged_files"; then
+            export DEV_COOLDOWN_BLOCK_PR="$pr_num"
+            export DEV_COOLDOWN_BLOCK_MINS
+            DEV_COOLDOWN_BLOCK_MINS=$(_loop_cooldown_minutes_since "$merged_at")
+            return 1
+        fi
+    done <<< "$merged_list"
+
+    return 0
+}

--- a/scripts/dev-handler.sh
+++ b/scripts/dev-handler.sh
@@ -36,6 +36,8 @@ source "$LOOP_ROOT/lib/failure_classifier.sh"
 source "$LOOP_ROOT/lib/failure_category.sh"
 # shellcheck source=../lib/prompt-untrust.sh
 source "$LOOP_ROOT/lib/prompt-untrust.sh"
+# shellcheck source=../lib/dev_cooldown.sh
+source "$LOOP_ROOT/lib/dev_cooldown.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-dev-handler.log"
 MAX_RETRIES=3
@@ -232,6 +234,46 @@ if loop_run_agent "$TASK_PROMPT" "$WORKTREE_ROOT" 2>&1 | tee -a "$LOG_FILE"; the
     loop_notify "✅ [$SLUG] #$ISSUE_NUM dev done"
     retry_clear
     loop_backoff_clear "$SLUG" "$ISSUE_NUM" dev
+
+    # Cooldown guard: block if the committed changes overlap files from a
+    # recently-merged PR. Runs post-agent so we have an actual diff to inspect.
+    # If triggered, any PR the agent opened is closed before we exit.
+    _cooldown_mins="${DEV_COOLDOWN_MINUTES:-30}"
+    if [ "$_cooldown_mins" -gt 0 ] && \
+       ! loop_dev_cooldown_check "$REPO" "$ISSUE_BODY" "$WORKTREE_ROOT" "$DEFAULT_BRANCH" "$_cooldown_mins"; then
+        log "cooldown: blocked — file overlap with PR #${DEV_COOLDOWN_BLOCK_PR}, merged ~${DEV_COOLDOWN_BLOCK_MINS}m ago"
+
+        # Close the PR opened by the agent, if any.
+        _cooldown_pr_num=$(backend_list_open_prs_raw "$REPO" | python3 -c "
+import json, re, sys
+num = '${ISSUE_NUM}'
+prs = json.load(sys.stdin)
+matches = [
+    pr['number'] for pr in prs
+    if re.match(r'^(fix|feat)/issue-' + re.escape(num) + r'-', pr.get('headRefName', ''))
+    or re.search(r'Closes #' + re.escape(num) + r'([^0-9]|\$)', pr.get('body', ''), re.IGNORECASE)
+]
+if matches:
+    print(sorted(matches)[-1])
+" 2>/dev/null || true)
+        if [ -n "${_cooldown_pr_num:-}" ]; then
+            gh pr close "$_cooldown_pr_num" --repo "$REPO" \
+               --comment "Closed by Loop cooldown guard — file overlap with PR #${DEV_COOLDOWN_BLOCK_PR}." \
+               2>/dev/null || true
+            log "cooldown: closed PR #$_cooldown_pr_num"
+        fi
+
+        _cooldown_msg="Conflicts with recent merge — file overlap with PR #${DEV_COOLDOWN_BLOCK_PR}, merged ~${DEV_COOLDOWN_BLOCK_MINS}m ago. Mark as follow-up if intentional by adding \`## Follow-up of #${DEV_COOLDOWN_BLOCK_PR}\` to the issue body."
+        backend_comment_issue "$REPO" "$ISSUE_NUM" "$_cooldown_msg" 2>/dev/null || true
+        loop_strip_pipeline_labels "$REPO" "$ISSUE_NUM" >/dev/null || true
+        backend_add_label "$REPO" "$ISSUE_NUM" "loop:result:blocked"
+        loop_notify_human_required "$SLUG" "$ISSUE_NUM" "loop:result:blocked" \
+            "Dev cooldown: file overlap with PR #${DEV_COOLDOWN_BLOCK_PR}"
+        loop_notify "🚧 [$SLUG] #$ISSUE_NUM blocked by cooldown guard (PR #${DEV_COOLDOWN_BLOCK_PR})"
+        cleanup_worktree
+        exit 0
+    fi
+
     # Belt-and-braces: if the agent forgot to swap labels, clean up here.
     backend_remove_label "$REPO" "$ISSUE_NUM" in-progress
     # Locate the PR opened for this issue (by head ref pattern or Closes reference).

--- a/tests/dev-cooldown.bats
+++ b/tests/dev-cooldown.bats
@@ -1,0 +1,163 @@
+#!/usr/bin/env bats
+# tests/dev-cooldown.bats — unit tests for lib/dev_cooldown.sh (#397).
+#
+# All external calls (gh, git) are intercepted by overriding the internal
+# helper functions (_loop_cooldown_merged_prs, _loop_cooldown_pr_files,
+# _loop_cooldown_local_files) so tests run without network or git access.
+
+setup() {
+    LOOP_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    # shellcheck source=../lib/dev_cooldown.sh
+    source "$LOOP_ROOT/lib/dev_cooldown.sh"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: build a fake merged-prs list string ("pr_num merged_at" per line).
+# ---------------------------------------------------------------------------
+_fake_merged_prs() {
+    local pr_num="$1" merged_at="${2:-2026-05-14T10:45:00Z}"
+    printf '%s %s\n' "$pr_num" "$merged_at"
+}
+
+# ---------------------------------------------------------------------------
+# No merged PRs in window → clear
+# ---------------------------------------------------------------------------
+
+@test "no merged PRs in window → clear" {
+    _loop_cooldown_merged_prs() { true; }
+    _loop_cooldown_local_files() { printf 'scripts/dashboard.py\n'; }
+
+    run loop_dev_cooldown_check "owner/repo" "" "/fake/worktree" "main" 30
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Merged PR with overlapping file → blocked
+# ---------------------------------------------------------------------------
+
+@test "merged PR with overlapping file → blocked" {
+    _loop_cooldown_merged_prs() { _fake_merged_prs 285 "2026-05-14T10:45:00Z"; }
+    _loop_cooldown_pr_files()   { printf 'scripts/dashboard.py\nlib/util.py\n'; }
+    _loop_cooldown_local_files() { printf 'scripts/dashboard.py\n'; }
+
+    run loop_dev_cooldown_check "owner/repo" "" "/fake/worktree" "main" 30
+    [ "$status" -eq 1 ]
+}
+
+@test "blocked: DEV_COOLDOWN_BLOCK_PR is set to the conflicting PR number" {
+    _loop_cooldown_merged_prs() { _fake_merged_prs 285 "2026-05-14T10:45:00Z"; }
+    _loop_cooldown_pr_files()   { printf 'scripts/dashboard.py\n'; }
+    _loop_cooldown_local_files() { printf 'scripts/dashboard.py\nlib/other.py\n'; }
+
+    loop_dev_cooldown_check "owner/repo" "" "/fake/worktree" "main" 30 || true
+    [ "${DEV_COOLDOWN_BLOCK_PR:-}" = "285" ]
+}
+
+# ---------------------------------------------------------------------------
+# Non-overlapping files → clear
+# ---------------------------------------------------------------------------
+
+@test "merged PR touches different files → clear" {
+    _loop_cooldown_merged_prs() { _fake_merged_prs 285 "2026-05-14T10:45:00Z"; }
+    _loop_cooldown_pr_files()   { printf 'lib/util.py\nlib/config.py\n'; }
+    _loop_cooldown_local_files() { printf 'scripts/dashboard.py\n'; }
+
+    run loop_dev_cooldown_check "owner/repo" "" "/fake/worktree" "main" 30
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Follow-up annotation bypasses the guard
+# ---------------------------------------------------------------------------
+
+@test "follow-up annotation for the conflicting PR → clear" {
+    _loop_cooldown_merged_prs() { _fake_merged_prs 285 "2026-05-14T10:45:00Z"; }
+    _loop_cooldown_pr_files()   { printf 'scripts/dashboard.py\n'; }
+    _loop_cooldown_local_files() { printf 'scripts/dashboard.py\n'; }
+
+    local issue_body
+    issue_body=$(printf 'Some task\n\n## Follow-up of #285\n\nDoing more work.')
+    run loop_dev_cooldown_check "owner/repo" "$issue_body" "/fake/worktree" "main" 30
+    [ "$status" -eq 0 ]
+}
+
+@test "follow-up annotation for a different PR does not bypass guard" {
+    _loop_cooldown_merged_prs() { _fake_merged_prs 285 "2026-05-14T10:45:00Z"; }
+    _loop_cooldown_pr_files()   { printf 'scripts/dashboard.py\n'; }
+    _loop_cooldown_local_files() { printf 'scripts/dashboard.py\n'; }
+
+    local issue_body
+    issue_body=$(printf 'Some task\n\n## Follow-up of #999\n\nDoing more work.')
+    run loop_dev_cooldown_check "owner/repo" "$issue_body" "/fake/worktree" "main" 30
+    [ "$status" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# cooldown_minutes=0 disables the guard entirely
+# ---------------------------------------------------------------------------
+
+@test "cooldown_minutes=0 → guard disabled, always clear" {
+    _loop_cooldown_merged_prs() { _fake_merged_prs 285 "2026-05-14T10:45:00Z"; }
+    _loop_cooldown_pr_files()   { printf 'scripts/dashboard.py\n'; }
+    _loop_cooldown_local_files() { printf 'scripts/dashboard.py\n'; }
+
+    run loop_dev_cooldown_check "owner/repo" "" "/fake/worktree" "main" 0
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Empty local diff → clear (nothing to overlap)
+# ---------------------------------------------------------------------------
+
+@test "empty local diff → clear" {
+    _loop_cooldown_merged_prs() { _fake_merged_prs 285 "2026-05-14T10:45:00Z"; }
+    _loop_cooldown_pr_files()   { printf 'scripts/dashboard.py\n'; }
+    _loop_cooldown_local_files() { true; }
+
+    run loop_dev_cooldown_check "owner/repo" "" "/fake/worktree" "main" 30
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Multiple merged PRs: only the overlapping one triggers block
+# ---------------------------------------------------------------------------
+
+@test "multiple merged PRs: block only when file overlap exists" {
+    _loop_cooldown_merged_prs() {
+        printf '100 2026-05-14T10:00:00Z\n'
+        printf '285 2026-05-14T10:45:00Z\n'
+    }
+    _loop_cooldown_pr_files() {
+        local pr="$2"
+        case "$pr" in
+            100) printf 'lib/unrelated.py\n' ;;
+            285) printf 'scripts/dashboard.py\n' ;;
+        esac
+    }
+    _loop_cooldown_local_files() { printf 'scripts/dashboard.py\n'; }
+
+    # Call directly (not via `run`) so exported DEV_COOLDOWN_BLOCK_PR is visible.
+    local rc=0
+    loop_dev_cooldown_check "owner/repo" "" "/fake/worktree" "main" 30 || rc=$?
+    [ "$rc" -eq 1 ]
+    [ "${DEV_COOLDOWN_BLOCK_PR:-}" = "285" ]
+}
+
+# ---------------------------------------------------------------------------
+# _loop_cooldown_files_overlap unit tests
+# ---------------------------------------------------------------------------
+
+@test "_loop_cooldown_files_overlap: match found → returns 0" {
+    run _loop_cooldown_files_overlap $'foo.py\nbar.py' $'baz.py\nfoo.py'
+    [ "$status" -eq 0 ]
+}
+
+@test "_loop_cooldown_files_overlap: no match → returns 1" {
+    run _loop_cooldown_files_overlap $'foo.py\nbar.py' $'baz.py\nqux.py'
+    [ "$status" -eq 1 ]
+}
+
+@test "_loop_cooldown_files_overlap: empty list a → returns 1" {
+    run _loop_cooldown_files_overlap '' $'foo.py'
+    [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
Closes #397

## Changes

- **`lib/dev_cooldown.sh`** (new): standalone cooldown guard library with `loop_dev_cooldown_check`. Queries `gh pr list --state merged --search "merged:>=<cutoff>"` for recent merges, gets each PR's file set via `gh pr view --json files`, compares against the worktree diff, and returns blocked/clear. Each internal helper (`_loop_cooldown_merged_prs`, `_loop_cooldown_pr_files`, `_loop_cooldown_local_files`) is separately overridable for bats unit testing.

- **`lib/config.sh`**: exports `DEV_COOLDOWN_MINUTES` parsed from `dev.cooldown_minutes` in `projects.yaml` (default 30). Set to 0 to disable the guard for a project.

- **`scripts/dev-handler.sh`**: sources the new lib; after the agent succeeds and commits, calls `loop_dev_cooldown_check` before the belt-and-braces label section. If blocked: closes the agent-opened PR (if any), posts a comment explaining the overlap, strips pipeline labels, adds `loop:result:blocked`, and exits cleanly.

- **`tests/dev-cooldown.bats`** (new): 12 unit tests covering — no merged PRs, file overlap, no overlap, follow-up annotation bypass, per-PR bypass specificity, cooldown disabled (0), empty local diff, multiple merged PRs, and `_loop_cooldown_files_overlap` directly.

- **`config/projects.example.yaml`**: documents `dev.cooldown_minutes`.

## Bypass mechanism

Add `## Follow-up of #<pr_number>` to the issue body to bypass the guard for a specific conflicting PR. This is checked per-PR so multiple recent merges are handled independently.

## Test Plan

- `bash -n` and `shellcheck -S warning` pass on all shell files
- `bats tests/dev-cooldown.bats` → 12/12 pass
- Manual: trigger two `loop:action:dev` issues touching the same file within the cooldown window; second issue should receive `loop:result:blocked` and a comment
- Adding `## Follow-up of #N` to the blocked issue body and re-triggering should allow it through