### PR TITLE
[LOOP-393] enforce per-issue scope fence in dev handler

### DIFF
--- a/lib/scope.sh
+++ b/lib/scope.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# lib/scope.sh — per-issue scope fence for the dev handler.
+#
+# Parses scope declarations from an issue body and checks file paths against
+# the declared scope. Three declaration sources (in priority order):
+#   1. "## Files in scope"     — explicit allowlist (newline-delimited paths/globs)
+#   2. "## Files NOT in scope" — explicit denylist (overrides allowlist)
+#   3. Heuristic: "no production code" phrase — restrict to test files only
+#
+# If none of the above are present, all files are considered in scope and
+# loop_check_scope returns 0 without printing anything.
+#
+# Public:
+#   loop_check_scope <issue_body> <files_newline_separated>
+#     Prints out-of-scope paths to stdout (one per line).
+#     Returns 0 if clean (or no scope declared); 1 if any violation.
+
+set -euo pipefail
+
+if [ "${_LOOP_SCOPE_LOADED:-0}" = "1" ]; then
+    return 0 2>/dev/null || true
+fi
+_LOOP_SCOPE_LOADED=1
+
+# loop_check_scope <issue_body> <files_newline_separated>
+# Prints each out-of-scope file to stdout.
+# Returns 0 (clean / no scope declared) or 1 (violations found).
+loop_check_scope() {
+    local issue_body="$1"
+    local files="$2"
+
+    [ -z "$files" ] && return 0
+
+    LOOP_SCOPE_ISSUE_BODY="$issue_body" \
+    LOOP_SCOPE_FILES="$files" \
+    python3 <<'PY'
+import fnmatch
+import os
+import re
+import sys
+
+
+def extract_section(body, header):
+    """Return lines from a markdown ## section until the next ## heading."""
+    pat = re.compile(
+        r'^##\s+' + re.escape(header) + r'\s*$',
+        re.IGNORECASE | re.MULTILINE,
+    )
+    m = pat.search(body)
+    if not m:
+        return []
+    rest = body[m.end():]
+    end = re.search(r'^##\s+', rest, re.MULTILINE)
+    section = rest[: end.start()] if end else rest
+    return [
+        ln.strip()
+        for ln in section.splitlines()
+        if ln.strip() and not ln.strip().startswith('#')
+    ]
+
+
+def matches(path, patterns):
+    """True when path or its basename matches any fnmatch pattern."""
+    base = os.path.basename(path)
+    for pat in patterns:
+        if fnmatch.fnmatch(path, pat) or fnmatch.fnmatch(base, pat):
+            return True
+        # "dir/*" → match anything under dir/
+        if pat.endswith('/*'):
+            prefix = pat[:-2]
+            if path == prefix or path.startswith(prefix + '/'):
+                return True
+    return False
+
+
+issue_body = os.environ.get('LOOP_SCOPE_ISSUE_BODY', '')
+files = [f for f in os.environ.get('LOOP_SCOPE_FILES', '').splitlines() if f.strip()]
+
+if not files:
+    sys.exit(0)
+
+allowlist = extract_section(issue_body, 'Files in scope')
+denylist  = extract_section(issue_body, 'Files NOT in scope')
+no_prod   = bool(re.search(r'no\s+production\s+code', issue_body, re.IGNORECASE))
+
+# No scope declared — nothing to enforce
+if not allowlist and not denylist and not no_prod:
+    sys.exit(0)
+
+TEST_PATTERNS = [
+    'tests/*', 'test/*', 'spec/*', 'bats/*', '__tests__/*',
+    'test_*.py', '*_test.go', '*.test.ts', '*.spec.ts',
+    '*.test.js', '*.spec.js', '*.bats',
+]
+
+violations = []
+for f in files:
+    # Denylist overrides everything
+    if denylist and matches(f, denylist):
+        violations.append(f)
+        continue
+
+    # Allowlist: file must match at least one allowed pattern
+    if allowlist and not matches(f, allowlist):
+        violations.append(f)
+        continue
+
+    # Heuristic (no allowlist/denylist): only test files are allowed
+    if no_prod and not allowlist and not denylist and not matches(f, TEST_PATTERNS):
+        violations.append(f)
+
+for v in violations:
+    print(v)
+
+sys.exit(1 if violations else 0)
+PY
+}

--- a/scripts/dev-handler.sh
+++ b/scripts/dev-handler.sh
@@ -36,6 +36,8 @@ source "$LOOP_ROOT/lib/failure_classifier.sh"
 source "$LOOP_ROOT/lib/failure_category.sh"
 # shellcheck source=../lib/prompt-untrust.sh
 source "$LOOP_ROOT/lib/prompt-untrust.sh"
+# shellcheck source=../lib/scope.sh
+source "$LOOP_ROOT/lib/scope.sh"
 
 LOG_FILE="${LOOP_LOG_DIR}/loop-dev-handler.log"
 MAX_RETRIES=3
@@ -193,6 +195,22 @@ Your job:
 5. Before committing, verify there are actual staged changes:
    git diff --cached --quiet && echo 'WARNING: no staged changes' || true
    If there are no changes to commit, comment on the issue explaining why (e.g. already implemented, out of scope) and add label 'needs-clarification' instead of opening an empty PR.
+5b. SCOPE FENCE — after staging files (git add) and before committing, enforce
+   the declared issue scope. Run these commands exactly:
+      STAGED_FILES=\$(git diff --cached --name-only 2>/dev/null || true)
+      if [ -n "\$STAGED_FILES" ]; then
+        ISSUE_BODY_LIVE=\$(gh issue view ${ISSUE_NUM} --repo ${REPO} --json body --jq .body 2>/dev/null || echo "")
+        source ${LOOP_ROOT}/lib/scope.sh
+        SCOPE_VIOLATIONS=\$(loop_check_scope "\$ISSUE_BODY_LIVE" "\$STAGED_FILES" || true)
+        if [ -n "\$SCOPE_VIOLATIONS" ]; then
+          echo "SCOPE VIOLATION: staged files outside declared issue scope:" >&2
+          echo "\$SCOPE_VIOLATIONS" >&2
+          _block_body="## Scope violation\n\nStaged files outside the scope declared in this issue:\n\n\$SCOPE_VIOLATIONS\n\nNot committing. Remove out-of-scope changes and retry."
+          gh issue comment ${ISSUE_NUM} --repo ${REPO} --body "\$_block_body" 2>/dev/null || true
+          gh issue edit ${ISSUE_NUM} --repo ${REPO} --remove-label in-progress --add-label loop:result:blocked 2>/dev/null || true
+          exit 1
+        fi
+      fi
 6. Commit: git commit -m '[${COMMIT_PREFIX}-${ISSUE_NUM}] <short description>'
 7. Push the branch and open a PR:
    gh pr create --repo ${REPO} --title '[${COMMIT_PREFIX}-${ISSUE_NUM}] <short description>' \\
@@ -257,6 +275,35 @@ if matches:
         loop_notify_human_required "$SLUG" "$ISSUE_NUM" needs-clarification "Dev agent finished without opening a PR"
     else
         log "belt-and-braces: found PR #$_dev_pr_num for issue #$ISSUE_NUM"
+
+        # Scope fence: verify PR files don't exceed the issue's declared scope.
+        _pr_files=$(gh pr diff "$_dev_pr_num" --repo "$REPO" --name-only 2>/dev/null || true)
+        if [ -n "$_pr_files" ]; then
+            _scope_violations=$(loop_check_scope "$ISSUE_BODY" "$_pr_files" || true)
+            if [ -n "$_scope_violations" ]; then
+                log "SCOPE VIOLATION on PR #$_dev_pr_num for issue #$ISSUE_NUM: $_scope_violations"
+                _scope_body=$(mktemp /tmp/loop-scope-XXXXXX.md)
+                {
+                    echo "## Scope violation — PR blocked"
+                    echo ""
+                    echo "The following files in this PR exceed the scope declared in the issue:"
+                    echo ""
+                    echo '```'
+                    echo "$_scope_violations"
+                    echo '```'
+                    echo ""
+                    echo "The PR has not been merged. Remove out-of-scope changes and re-open."
+                } > "$_scope_body"
+                backend_comment_issue "$REPO" "$_dev_pr_num" "$(cat "$_scope_body")" 2>/dev/null || true
+                rm -f "$_scope_body"
+                loop_strip_pipeline_labels "$REPO" "$ISSUE_NUM" >/dev/null || true
+                backend_add_label "$REPO" "$ISSUE_NUM" "$LOOP_LABEL_BLOCKED"
+                loop_notify_human_required "$SLUG" "$ISSUE_NUM" blocked "Scope violation in PR #$_dev_pr_num: $_scope_violations"
+                cleanup_worktree
+                exit 0
+            fi
+        fi
+
         if ! backend_pr_has_any_label "$REPO" "$_dev_pr_num" \
                 "$LOOP_LABEL_DEPRECATED_REVIEW_PENDING" "$LOOP_LABEL_NEEDS_REVIEW" \
                 "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" \

--- a/tests/scope.bats
+++ b/tests/scope.bats
@@ -1,0 +1,195 @@
+#!/usr/bin/env bats
+# tests/scope.bats — unit tests for lib/scope.sh::loop_check_scope.
+#
+# No network or gh CLI required. Pure logic tests against the Python parser.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    # shellcheck source=../lib/scope.sh
+    source "$REPO_ROOT/lib/scope.sh"
+}
+
+# ─── no scope declared ────────────────────────────────────────────────────────
+
+@test "no scope declaration → all files pass" {
+    body="## Summary
+Just a regular issue with no file scope."
+    files="src/main.py
+README.md"
+    run loop_check_scope "$body" "$files"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "empty staged files → passes (nothing to check)" {
+    body="## Files in scope
+tests/foo.py"
+    run loop_check_scope "$body" ""
+    [ "$status" -eq 0 ]
+}
+
+# ─── Files in scope (allowlist) ───────────────────────────────────────────────
+
+@test "allowlist: file in scope → passes" {
+    body="## Files in scope
+tests/foo.py"
+    files="tests/foo.py"
+    run loop_check_scope "$body" "$files"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "allowlist: file outside scope → violation" {
+    body="## Files in scope
+tests/foo.py"
+    files="src/main.py"
+    run loop_check_scope "$body" "$files"
+    [ "$status" -eq 1 ]
+    [ "$output" = "src/main.py" ]
+}
+
+@test "allowlist: glob pattern matches → passes" {
+    body="## Files in scope
+tests/*"
+    files="tests/foo.py
+tests/bar.py"
+    run loop_check_scope "$body" "$files"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "allowlist: glob pattern — non-matching file → violation" {
+    body="## Files in scope
+tests/*"
+    files="tests/foo.py
+src/helper.py"
+    run loop_check_scope "$body" "$files"
+    [ "$status" -eq 1 ]
+    [ "$output" = "src/helper.py" ]
+}
+
+@test "allowlist: multiple patterns — all files covered → passes" {
+    body="## Files in scope
+tests/*
+lib/scope.sh"
+    files="tests/foo.py
+lib/scope.sh"
+    run loop_check_scope "$body" "$files"
+    [ "$status" -eq 0 ]
+}
+
+# ─── Files NOT in scope (denylist) ────────────────────────────────────────────
+
+@test "denylist: denied file → violation" {
+    body="## Files NOT in scope
+backtest/v5_rules.py"
+    files="backtest/v5_rules.py"
+    run loop_check_scope "$body" "$files"
+    [ "$status" -eq 1 ]
+    [ "$output" = "backtest/v5_rules.py" ]
+}
+
+@test "denylist: non-denied file → passes" {
+    body="## Files NOT in scope
+backtest/v5_rules.py"
+    files="tests/test_scope.py"
+    run loop_check_scope "$body" "$files"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "denylist overrides allowlist: file in both → violation" {
+    body="## Files in scope
+backtest/*
+## Files NOT in scope
+backtest/v5_rules.py"
+    files="backtest/v5_rules.py"
+    run loop_check_scope "$body" "$files"
+    [ "$status" -eq 1 ]
+    [ "$output" = "backtest/v5_rules.py" ]
+}
+
+@test "denylist: glob denies directory tree → violation" {
+    body="## Files NOT in scope
+src/*"
+    files="src/main.py"
+    run loop_check_scope "$body" "$files"
+    [ "$status" -eq 1 ]
+    [ "$output" = "src/main.py" ]
+}
+
+# ─── No production code heuristic ─────────────────────────────────────────────
+
+@test "no-prod heuristic: test file → passes" {
+    body="## Summary
+No production code was modified. Tests only."
+    files="tests/test_foo.py"
+    run loop_check_scope "$body" "$files"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "no-prod heuristic: bats file → passes" {
+    body="No production code changes in this issue."
+    files="tests/scope.bats"
+    run loop_check_scope "$body" "$files"
+    [ "$status" -eq 0 ]
+}
+
+@test "no-prod heuristic: test_*.py basename → passes" {
+    body="No production code was modified."
+    files="lib/tests/test_scope.py"
+    run loop_check_scope "$body" "$files"
+    [ "$status" -eq 0 ]
+}
+
+@test "no-prod heuristic: production file → violation" {
+    body="No Production Code was modified."
+    files="src/main.py"
+    run loop_check_scope "$body" "$files"
+    [ "$status" -eq 1 ]
+    [ "$output" = "src/main.py" ]
+}
+
+@test "no-prod heuristic: mixed staged files — only prod file blocked" {
+    body="No production code modified."
+    files="tests/test_foo.py
+src/helper.py"
+    run loop_check_scope "$body" "$files"
+    [ "$status" -eq 1 ]
+    [ "$output" = "src/helper.py" ]
+}
+
+@test "no-prod heuristic: case-insensitive match" {
+    body="NO PRODUCTION CODE touched here."
+    files="lib/utils.sh"
+    run loop_check_scope "$body" "$files"
+    [ "$status" -eq 1 ]
+    [ "$output" = "lib/utils.sh" ]
+}
+
+# ─── edge cases ───────────────────────────────────────────────────────────────
+
+@test "multiple violations → all printed" {
+    body="## Files in scope
+tests/*"
+    files="tests/foo.py
+src/a.py
+src/b.py"
+    run loop_check_scope "$body" "$files"
+    [ "$status" -eq 1 ]
+    echo "$output" | grep -q "src/a.py"
+    echo "$output" | grep -q "src/b.py"
+}
+
+@test "section with blank lines and comments is parsed correctly" {
+    body="## Files in scope
+
+tests/scope.bats
+
+# this is a comment, ignored
+"
+    files="tests/scope.bats"
+    run loop_check_scope "$body" "$files"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #393

## Changes

New lib/scope.sh: loop_check_scope helper that parses three scope sources from the issue body (Files in scope allowlist, Files NOT in scope denylist, "no production code" heuristic) and prints out-of-scope files.

Updated scripts/dev-handler.sh with two enforcement layers:
1. Agent-side: step 5b in TASK_PROMPT runs scope check after git add, before commit; on violation posts issue comment and adds loop:result:blocked
2. Handler belt-and-braces: after agent success, checks PR diff; on violation posts PR comment and adds loop:result:blocked to issue

New tests/scope.bats: 19 bats unit tests covering all scope modes and edge cases.

## Test Plan
- All 19 bats tests pass locally
- bash -n and shellcheck -S warning pass on all scripts
- Verify scope enforcement blocks out-of-scope files in agent workflow