### PR TITLE
[LOOP-413] scanner heartbeat + watchdog: detect and restart a wedged scanner

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,24 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — fires every 5 min, kills/restarts a wedged scanner.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +379,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +402,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner when its heartbeat goes stale.
+#
+# Fired by launchd (StartInterval 300) or cron (*/5 * * * *).
+# If the scanner's heartbeat file hasn't been touched in 2 * POLL_INTERVAL
+# seconds, kill the scanner PID so launchd KeepAlive=true can restart it.
+# On Linux (cron mode) the scanner is started directly if no lock PID is alive.
+#
+# Usage: scanner-watchdog.sh [--dry-run]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 ))
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# No heartbeat file yet — scanner may not have completed its first tick.
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "no heartbeat file yet — waiting for first scanner tick"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+    || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+    || echo 0)
+age=$(( now - mtime ))
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "heartbeat ok (age=${age}s, threshold=${STALE_THRESHOLD}s)"
+    exit 0
+fi
+
+log "WARN: heartbeat stale (age=${age}s >= threshold=${STALE_THRESHOLD}s) — restarting scanner"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner and remove heartbeat"
+    exit 0
+fi
+
+# Kill the scanner PID from the lock file; launchd KeepAlive restarts it.
+if [ -f "$LOCK_FILE" ]; then
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || echo "")
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "killing stale scanner PID $pid"
+        kill "$pid" || true
+    else
+        log "lock PID ${pid:-unknown} not alive — scanner may already be restarting"
+        rm -f "$LOCK_FILE"
+    fi
+fi
+
+# Remove the stale heartbeat so the next watchdog check doesn't fire again
+# before the restarted scanner writes its first fresh heartbeat.
+rm -f "$HEARTBEAT_FILE"
+
+# Linux fallback: if running under cron (not launchd), restart scanner inline
+# since there is no KeepAlive daemon manager.
+if [ "$(uname -s)" != "Darwin" ]; then
+    log "Linux: launching scanner (once) inline"
+    nohup "$LOOP_ROOT/scanner/scanner.sh" --once \
+        >> "${LOOP_LOG_DIR}/loop-scanner.log" 2>&1 &
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -708,6 +708,19 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+
+    # Liveness heartbeat — write current timestamp so scanner-watchdog.sh can
+    # detect a wedged scanner (alive PID, no emit activity) and kill+restart it.
+    if ! $DRY_RUN; then
+        printf '%s\n' "$(date +%s)" > "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+    fi
+
+    # Stdout/log integrity check — if the log file has become unwritable (e.g.
+    # deleted from under us without a SIGHUP) exit so launchd can restart us.
+    if [ -n "${LOG_FILE:-}" ] && [ ! -w "$LOG_FILE" ] 2>/dev/null; then
+        exit 1
+    fi
+
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes to check whether the scanner's heartbeat file has been
+  updated recently. If the scanner is wedged (alive PID, no heartbeat write),
+  the watchdog kills the PID so launchd KeepAlive=true can restart it.
+
+  Install via: ./install.sh --bootstrap (handled automatically)
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,117 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 liveness heartbeat.
+#
+# Verifies that run_once() writes a fresh heartbeat file on every tick, and
+# that scanner-watchdog.sh correctly detects fresh vs. stale heartbeats.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    touch "$LOG_FILE"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    # Silence noisy output; short-circuit scan_project so run_once exits fast.
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { echo ""; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/scanner-src.sh" "$BATS_TMPDIR/scanner-test.log" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat write
+# ---------------------------------------------------------------------------
+
+@test "run_once: writes scanner-heartbeat to LOOP_LOG_DIR" {
+    run_once
+    [ -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+@test "run_once: heartbeat contains a unix timestamp (all digits)" {
+    run_once
+    content=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+    [[ "$content" =~ ^[0-9]+$ ]]
+}
+
+@test "run_once: heartbeat mtime is recent (within 5s)" {
+    run_once
+    now=$(date +%s)
+    mtime=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+        || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null)
+    age=$(( now - mtime ))
+    [ "$age" -le 5 ]
+}
+
+@test "run_once: DRY_RUN skips heartbeat write" {
+    DRY_RUN=true
+    run_once
+    [ ! -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+@test "run_once: overwrites stale heartbeat on each tick" {
+    # Write an old timestamp
+    printf '1000000000\n' > "${LOOP_LOG_DIR}/scanner-heartbeat"
+    run_once
+    content=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+    now=$(date +%s)
+    [ "$content" -gt 1000000000 ]
+    [ "$content" -le "$now" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh logic
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits 0 (no heartbeat file = first start)" {
+    rm -f "${LOOP_LOG_DIR}/scanner-heartbeat"
+    run bash "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+}
+
+@test "scanner-watchdog: exits 0 when heartbeat is fresh" {
+    printf '%s\n' "$(date +%s)" > "${LOOP_LOG_DIR}/scanner-heartbeat"
+    run bash "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"heartbeat ok"* ]]
+}
+
+@test "scanner-watchdog: detects stale heartbeat and logs WARN" {
+    # Touch the heartbeat file then backdate it well past the threshold (2x POLL_INTERVAL).
+    printf '1000000000\n' > "${LOOP_LOG_DIR}/scanner-heartbeat"
+    touch -t 200001010000 "${LOOP_LOG_DIR}/scanner-heartbeat"
+    run bash "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"WARN"* ]]
+    [[ "$output" == *"stale"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- At the top of every `run_once()` tick, write `$(date +%s)` to `${LOOP_LOG_DIR}/scanner-heartbeat`. Skipped in `--dry-run` mode.
- Added stdout/log integrity check: if `$LOG_FILE` is no longer writable (e.g. deleted without a SIGHUP), the scanner exits so launchd KeepAlive can restart it.

### `scanner/scanner-watchdog.sh` _(new)_
- Fires every 5 minutes (launchd `StartInterval 300` / cron `*/5`).
- Reads `scanner-heartbeat` mtime; if age ≥ `2 * LOOP_SCANNER_INTERVAL` (default 600 s), kills the scanner PID from the lock file and removes the stale heartbeat file. launchd `KeepAlive=true` restarts the scanner automatically.
- On Linux (no launchd), re-launches `scanner.sh --once` inline after killing the wedged process.
- Supports `--dry-run` for safe testing.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` _(new)_
- `StartInterval 300`, logs to `loop-scanner-watchdog.log`.

### `install.sh`
- `bootstrap_register_launchd`: installs `com.user.loop-scanner-watchdog` plist.
- `bootstrap_register_cron`: adds `*/5 * * * *` watchdog cron entry for Linux.

### `tests/scanner-heartbeat.bats` _(new)_
- 8 tests covering: heartbeat write on tick, timestamp content, mtime freshness, DRY_RUN skip, overwrite of stale value, watchdog fresh/stale detection.

## Test Plan
- All 8 new bats tests pass (`bats tests/scanner-heartbeat.bats`).
- `bash -n` and `shellcheck -S warning` clean on all shell files.
- No personal identifiers introduced.
- Manual: simulate wedge via `kill -STOP $SCANNER_PID` → watchdog detects stale heartbeat within 5–10 min and kills/restarts the scanner.