### PR TITLE
[LOOP-405] Per-issue priority CLI (loop priority set/bump/drop)

### DIFF
--- a/bin/loop
+++ b/bin/loop
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# bin/loop — Loop operator CLI front-end.
+#
+# Usage:
+#   loop priority set  <repo> <issue#> <p0|p1|p2|p3>
+#   loop priority bump <repo> <issue#>
+#   loop priority drop <repo> <issue#>
+#   loop priority [--help]
+
+set -euo pipefail
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Priority label helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Canonical label names
+_PRIORITY_LABELS=(p0-critical p1-high p2-medium p3-low)
+
+# Map short tier (p0..p3) → full label name
+_priority_label_for_tier() {
+    local tier="$1"
+    case "$tier" in
+        p0) echo "p0-critical" ;;
+        p1) echo "p1-high"     ;;
+        p2) echo "p2-medium"   ;;
+        p3) echo "p3-low"      ;;
+        *)  echo "Unknown tier: $tier" >&2; return 1 ;;
+    esac
+}
+
+# Map full label name → short tier (p0..p3), or empty string if not a priority label
+_priority_tier_for_label() {
+    local label="$1"
+    case "$label" in
+        p0-critical) echo "p0" ;;
+        p1-high)     echo "p1" ;;
+        p2-medium)   echo "p2" ;;
+        p3-low)      echo "p3" ;;
+        *)           echo ""   ;;
+    esac
+}
+
+# Get the current priority label on an issue, or empty string if none.
+_get_current_priority() {
+    local repo="$1" issue="$2"
+    local label tier
+    while IFS= read -r label; do
+        tier=$(_priority_tier_for_label "$label")
+        if [ -n "$tier" ]; then
+            echo "$label"
+            return 0
+        fi
+    done < <(gh issue view "$issue" --repo "$repo" --json labels --jq '.labels[].name' 2>/dev/null)
+    echo ""
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# priority subcommand
+# ─────────────────────────────────────────────────────────────────────────────
+
+_priority_usage() {
+    cat <<'USAGE'
+Usage: loop priority <subcommand> <repo> <issue#> [args]
+
+Subcommands:
+  set  <repo> <issue#> <p0|p1|p2|p3>
+        Remove any existing p[0-3]-* label and add the requested priority
+        label in a single gh issue edit call.
+
+  bump <repo> <issue#>
+        Raise priority by one tier (p3->p2->p1->p0).
+        No-op (exit 0) if already p0.
+        If no priority label is present, sets p3-low.
+
+  drop <repo> <issue#>
+        Lower priority by one tier (p0->p1->p2->p3).
+        No-op (exit 0) if already p3 or no priority label is set.
+
+Priority label vocabulary:
+  p0  ->  p0-critical
+  p1  ->  p1-high
+  p2  ->  p2-medium
+  p3  ->  p3-low
+USAGE
+}
+
+_cmd_priority_set() {
+    local repo="$1" issue="$2" tier="$3"
+
+    local new_label
+    new_label=$(_priority_label_for_tier "$tier") || {
+        echo "error: unknown priority tier '$tier' (expected p0, p1, p2, or p3)" >&2
+        return 1
+    }
+
+    local args=("$issue" --repo "$repo" --add-label "$new_label")
+
+    # Gather all existing priority labels to remove them atomically
+    local current_label
+    current_label=$(_get_current_priority "$repo" "$issue")
+    if [ -n "$current_label" ] && [ "$current_label" != "$new_label" ]; then
+        args+=(--remove-label "$current_label")
+    fi
+
+    gh issue edit "${args[@]}"
+    echo "Set priority: $new_label (issue #$issue in $repo)"
+}
+
+_cmd_priority_bump() {
+    local repo="$1" issue="$2"
+
+    local current_label
+    current_label=$(_get_current_priority "$repo" "$issue")
+
+    if [ -z "$current_label" ]; then
+        # No priority set — treat bump as setting p3-low (lowest)
+        gh issue edit "$issue" --repo "$repo" --add-label "p3-low"
+        echo "No priority set; initialized to p3-low (issue #$issue in $repo)"
+        return 0
+    fi
+
+    local current_tier
+    current_tier=$(_priority_tier_for_label "$current_label")
+
+    local new_tier
+    case "$current_tier" in
+        p0) echo "Already at highest priority (p0-critical); no change." >&2; return 0 ;;
+        p1) new_tier="p0" ;;
+        p2) new_tier="p1" ;;
+        p3) new_tier="p2" ;;
+    esac
+
+    local new_label
+    new_label=$(_priority_label_for_tier "$new_tier")
+
+    gh issue edit "$issue" --repo "$repo" --remove-label "$current_label" --add-label "$new_label"
+    echo "Bumped priority: $current_label -> $new_label (issue #$issue in $repo)"
+}
+
+_cmd_priority_drop() {
+    local repo="$1" issue="$2"
+
+    local current_label
+    current_label=$(_get_current_priority "$repo" "$issue")
+
+    if [ -z "$current_label" ]; then
+        echo "No priority label set; nothing to drop." >&2
+        return 0
+    fi
+
+    local current_tier
+    current_tier=$(_priority_tier_for_label "$current_label")
+
+    local new_tier
+    case "$current_tier" in
+        p3) echo "Already at lowest priority (p3-low); no change." >&2; return 0 ;;
+        p2) new_tier="p3" ;;
+        p1) new_tier="p2" ;;
+        p0) new_tier="p1" ;;
+    esac
+
+    local new_label
+    new_label=$(_priority_label_for_tier "$new_tier")
+
+    gh issue edit "$issue" --repo "$repo" --remove-label "$current_label" --add-label "$new_label"
+    echo "Dropped priority: $current_label -> $new_label (issue #$issue in $repo)"
+}
+
+_subcmd_priority() {
+    local subcmd="${1:-}"
+
+    case "$subcmd" in
+        --help|"")
+            _priority_usage
+            return 0
+            ;;
+        set)
+            shift
+            if [ $# -lt 3 ]; then
+                echo "error: 'loop priority set' requires: <repo> <issue#> <p0|p1|p2|p3>" >&2
+                _priority_usage >&2
+                return 1
+            fi
+            _cmd_priority_set "$1" "$2" "$3"
+            ;;
+        bump)
+            shift
+            if [ $# -lt 2 ]; then
+                echo "error: 'loop priority bump' requires: <repo> <issue#>" >&2
+                _priority_usage >&2
+                return 1
+            fi
+            _cmd_priority_bump "$1" "$2"
+            ;;
+        drop)
+            shift
+            if [ $# -lt 2 ]; then
+                echo "error: 'loop priority drop' requires: <repo> <issue#>" >&2
+                _priority_usage >&2
+                return 1
+            fi
+            _cmd_priority_drop "$1" "$2"
+            ;;
+        *)
+            echo "error: unknown priority subcommand '$subcmd'" >&2
+            _priority_usage >&2
+            return 1
+            ;;
+    esac
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Main dispatcher
+# ─────────────────────────────────────────────────────────────────────────────
+
+_usage() {
+    cat <<'USAGE'
+Usage: loop <command> [args]
+
+Commands:
+  priority    Manage per-issue priority labels (set/bump/drop)
+
+Run 'loop <command> --help' for command-specific help.
+USAGE
+}
+
+main() {
+    local cmd="${1:-}"
+
+    case "$cmd" in
+        priority)
+            shift
+            _subcmd_priority "$@"
+            ;;
+        --help|"")
+            _usage
+            return 0
+            ;;
+        *)
+            echo "error: unknown command '$cmd'" >&2
+            _usage >&2
+            return 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/install.sh
+++ b/install.sh
@@ -401,6 +401,46 @@ bootstrap_chmod_scripts() {
             echo "[chmod] $(basename "$f") -> +x"
         fi
     done
+    # Ensure bin/loop is executable
+    if [ -f "$LOOP_ROOT/bin/loop" ] && [ ! -x "$LOOP_ROOT/bin/loop" ]; then
+        chmod +x "$LOOP_ROOT/bin/loop"
+        echo "[chmod] bin/loop -> +x"
+    fi
+}
+
+# Symlink bin/loop into a directory on PATH so 'loop' is available system-wide.
+# Tries $HOME/.local/bin first (XDG standard), then /usr/local/bin. Idempotent.
+bootstrap_install_cli() {
+    local cli_src="$LOOP_ROOT/bin/loop"
+    [ -f "$cli_src" ] || { echo "[cli] WARNING: bin/loop not found — skipping" >&2; return 0; }
+    chmod +x "$cli_src"
+
+    local link_dir=""
+    if [[ ":$PATH:" == *":$HOME/.local/bin:"* ]]; then
+        link_dir="$HOME/.local/bin"
+    elif [[ ":$PATH:" == *":/usr/local/bin:"* ]]; then
+        link_dir="/usr/local/bin"
+    fi
+
+    if [ -z "$link_dir" ]; then
+        echo "[cli] WARNING: neither \$HOME/.local/bin nor /usr/local/bin is in PATH" >&2
+        echo "       Add '$LOOP_ROOT/bin' to your PATH manually, or symlink bin/loop into a PATH directory." >&2
+        return 0
+    fi
+
+    mkdir -p "$link_dir"
+    local link_path="$link_dir/loop"
+
+    if [ -L "$link_path" ] && [ "$(readlink "$link_path")" = "$cli_src" ]; then
+        echo "[cli] loop CLI already symlinked at $link_path — skipping"
+        return 0
+    fi
+
+    # Remove stale symlink or file before creating
+    [ -e "$link_path" ] && rm -f "$link_path"
+    ln -s "$cli_src" "$link_path"
+    echo "[cli] Symlinked loop CLI: $link_path -> $cli_src"
+    echo "[cli] Run 'loop --help' to verify"
 }
 
 # Register scanner + reconciler for the current OS.
@@ -432,6 +472,7 @@ bootstrap_pipeline() {
     bootstrap_detect_agent || return 1
     bootstrap_write_projects_yaml
     bootstrap_chmod_scripts
+    bootstrap_install_cli
     bootstrap_register_services
 
     local log_dir

--- a/tests/loop_cli_priority.bats
+++ b/tests/loop_cli_priority.bats
@@ -1,0 +1,233 @@
+#!/usr/bin/env bats
+# tests/loop_cli_priority.bats — tests for bin/loop priority subcommands.
+#
+# Mocks 'gh' as a shell function that:
+#   - Records arguments to $GH_CALLS_FILE
+#   - For 'gh issue view ... --json labels', returns canned JSON
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+CLI="$REPO_ROOT/bin/loop"
+
+setup() {
+    export GH_CALLS_FILE="$BATS_TMPDIR/gh_calls_$$.txt"
+    # Canned label name output (one name per line, as jq '.labels[].name' would produce)
+    # p2-medium present
+    export GH_LABELS_JSON=$'p2-medium\nbug'
+    # No priority label
+    export GH_LABELS_NONE_JSON='bug'
+    # p0 present
+    export GH_LABELS_P0_JSON='p0-critical'
+    # p3 present
+    export GH_LABELS_P3_JSON='p3-low'
+
+    > "$GH_CALLS_FILE"
+
+    # Mock gh as a script available to the CLI via PATH
+    export GH_MOCK_DIR="$BATS_TMPDIR/mock_bin_$$"
+    mkdir -p "$GH_MOCK_DIR"
+
+    # Default mock: p2-medium present
+    export GH_LABELS_RESPONSE="$GH_LABELS_JSON"
+
+    cat > "$GH_MOCK_DIR/gh" <<'MOCK'
+#!/usr/bin/env bash
+echo "$@" >> "$GH_CALLS_FILE"
+# Detect 'gh issue view ... --json labels' and return canned label names (one per line)
+found_view=false
+found_json=false
+for arg in "$@"; do
+    [ "$arg" = "view" ]   && found_view=true
+    [ "$arg" = "--json" ] && found_json=true
+done
+if $found_view && $found_json; then
+    printf '%s\n' $GH_LABELS_RESPONSE
+    exit 0
+fi
+exit 0
+MOCK
+    chmod +x "$GH_MOCK_DIR/gh"
+    export PATH="$GH_MOCK_DIR:$PATH"
+}
+
+teardown() {
+    rm -rf "$GH_CALLS_FILE" "$GH_MOCK_DIR"
+    unset GH_CALLS_FILE GH_LABELS_JSON GH_LABELS_NONE_JSON GH_LABELS_P0_JSON \
+          GH_LABELS_P3_JSON GH_MOCK_DIR GH_LABELS_RESPONSE
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# --help / bare priority
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "loop priority --help exits 0 and prints usage" {
+    run "$CLI" priority --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"set"* ]]
+    [[ "$output" == *"bump"* ]]
+    [[ "$output" == *"drop"* ]]
+}
+
+@test "bare 'loop priority' exits 0 and prints usage" {
+    run "$CLI" priority
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"set"* ]]
+    [[ "$output" == *"bump"* ]]
+    [[ "$output" == *"drop"* ]]
+}
+
+@test "bare 'loop' exits 0 and prints commands" {
+    run "$CLI"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"priority"* ]]
+}
+
+@test "loop --help exits 0" {
+    run "$CLI" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"priority"* ]]
+}
+
+@test "loop unknown-command exits non-zero" {
+    run "$CLI" unknown-command
+    [ "$status" -ne 0 ]
+}
+
+@test "loop priority unknown-subcmd exits non-zero" {
+    run "$CLI" priority frobnicate
+    [ "$status" -ne 0 ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# priority set
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "priority set calls gh issue edit with --add-label and --remove-label" {
+    export GH_LABELS_RESPONSE="$GH_LABELS_JSON"   # current: p2-medium
+    run "$CLI" priority set owner/repo 42 p0
+    [ "$status" -eq 0 ]
+    calls=$(cat "$GH_CALLS_FILE")
+    [[ "$calls" == *"--add-label"* ]]
+    [[ "$calls" == *"p0-critical"* ]]
+    [[ "$calls" == *"--remove-label"* ]]
+    [[ "$calls" == *"p2-medium"* ]]
+}
+
+@test "priority set p1 adds p1-high" {
+    export GH_LABELS_RESPONSE="$GH_LABELS_NONE_JSON"   # no priority label
+    run "$CLI" priority set owner/repo 10 p1
+    [ "$status" -eq 0 ]
+    calls=$(cat "$GH_CALLS_FILE")
+    [[ "$calls" == *"p1-high"* ]]
+}
+
+@test "priority set p2 adds p2-medium" {
+    export GH_LABELS_RESPONSE="$GH_LABELS_NONE_JSON"
+    run "$CLI" priority set owner/repo 10 p2
+    [ "$status" -eq 0 ]
+    calls=$(cat "$GH_CALLS_FILE")
+    [[ "$calls" == *"p2-medium"* ]]
+}
+
+@test "priority set p3 adds p3-low" {
+    export GH_LABELS_RESPONSE="$GH_LABELS_NONE_JSON"
+    run "$CLI" priority set owner/repo 10 p3
+    [ "$status" -eq 0 ]
+    calls=$(cat "$GH_CALLS_FILE")
+    [[ "$calls" == *"p3-low"* ]]
+}
+
+@test "priority set unknown tier exits non-zero" {
+    run "$CLI" priority set owner/repo 10 p9
+    [ "$status" -ne 0 ]
+}
+
+@test "priority set with missing args exits non-zero" {
+    run "$CLI" priority set owner/repo 10
+    [ "$status" -ne 0 ]
+}
+
+@test "priority set with no args exits non-zero" {
+    run "$CLI" priority set
+    [ "$status" -ne 0 ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# priority bump
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "priority bump from p2 adds p1-high and removes p2-medium" {
+    export GH_LABELS_RESPONSE="$GH_LABELS_JSON"   # current: p2-medium
+    run "$CLI" priority bump owner/repo 42
+    [ "$status" -eq 0 ]
+    calls=$(cat "$GH_CALLS_FILE")
+    [[ "$calls" == *"p1-high"* ]]
+    [[ "$calls" == *"--remove-label"* ]]
+    [[ "$calls" == *"p2-medium"* ]]
+}
+
+@test "priority bump from p0 is a no-op (exit 0, message to stderr)" {
+    export GH_LABELS_RESPONSE="$GH_LABELS_P0_JSON"   # current: p0-critical
+    run "$CLI" priority bump owner/repo 42
+    [ "$status" -eq 0 ]
+    # No edit call should be made
+    calls=$(cat "$GH_CALLS_FILE")
+    [[ "$calls" != *"issue edit"* ]]
+}
+
+@test "priority bump with no priority label sets p3-low" {
+    export GH_LABELS_RESPONSE="$GH_LABELS_NONE_JSON"
+    run "$CLI" priority bump owner/repo 42
+    [ "$status" -eq 0 ]
+    calls=$(cat "$GH_CALLS_FILE")
+    [[ "$calls" == *"p3-low"* ]]
+}
+
+@test "priority bump with missing args exits non-zero" {
+    run "$CLI" priority bump owner/repo
+    [ "$status" -ne 0 ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# priority drop
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "priority drop from p2 adds p3-low and removes p2-medium" {
+    export GH_LABELS_RESPONSE="$GH_LABELS_JSON"   # current: p2-medium
+    run "$CLI" priority drop owner/repo 42
+    [ "$status" -eq 0 ]
+    calls=$(cat "$GH_CALLS_FILE")
+    [[ "$calls" == *"p3-low"* ]]
+    [[ "$calls" == *"--remove-label"* ]]
+    [[ "$calls" == *"p2-medium"* ]]
+}
+
+@test "priority drop from p3 is a no-op (exit 0, message to stderr)" {
+    export GH_LABELS_RESPONSE="$GH_LABELS_P3_JSON"   # current: p3-low
+    run "$CLI" priority drop owner/repo 42
+    [ "$status" -eq 0 ]
+    calls=$(cat "$GH_CALLS_FILE")
+    [[ "$calls" != *"issue edit"* ]]
+}
+
+@test "priority drop with no priority label is a no-op (exit 0)" {
+    export GH_LABELS_RESPONSE="$GH_LABELS_NONE_JSON"
+    run "$CLI" priority drop owner/repo 42
+    [ "$status" -eq 0 ]
+    calls=$(cat "$GH_CALLS_FILE")
+    [[ "$calls" != *"issue edit"* ]]
+}
+
+@test "priority drop from p0 adds p1-high and removes p0-critical" {
+    export GH_LABELS_RESPONSE="$GH_LABELS_P0_JSON"
+    run "$CLI" priority drop owner/repo 42
+    [ "$status" -eq 0 ]
+    calls=$(cat "$GH_CALLS_FILE")
+    [[ "$calls" == *"p1-high"* ]]
+    [[ "$calls" == *"--remove-label"* ]]
+    [[ "$calls" == *"p0-critical"* ]]
+}
+
+@test "priority drop with missing args exits non-zero" {
+    run "$CLI" priority drop owner/repo
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
Closes #405

## Changes

**New file: `bin/loop`**
- Operator CLI front-end with `#!/usr/bin/env bash` + `set -euo pipefail`
- Dispatches subcommands via `case "$1" in priority) ... ;; esac`
- `loop priority set <repo> <issue#> <p0|p1|p2|p3>` — atomically swaps priority labels via a single `gh issue edit` call (removes old `p[0-3]-*` label, adds new one)
- `loop priority bump <repo> <issue#>` — raises priority one tier (p3→p2→p1→p0); no-op at p0; initializes to p3-low if no label is set
- `loop priority drop <repo> <issue#>` — lowers priority one tier (p0→p1→p2→p3); no-op at p3 or if no label is set
- `loop priority [--help]` and bare `loop` print usage and exit 0
- Uses canonical label names: `p0-critical`, `p1-high`, `p2-medium`, `p3-low`

**Updated: `install.sh`**
- Added `bootstrap_install_cli` function that symlinks `bin/loop` into `$HOME/.local/bin` or `/usr/local/bin` (whichever is on PATH), with a fallback warning if neither directory is in PATH
- Also ensures `bin/loop` gets `+x` in `bootstrap_chmod_scripts`
- `bootstrap_install_cli` is called from `bootstrap_pipeline` after `bootstrap_chmod_scripts`

**New file: `tests/loop_cli_priority.bats`**
- 22 bats tests covering all subcommands and edge cases
- `gh` mocked as a PATH script that records args to a file and returns canned label-name output for `view` calls
- All 22 tests pass locally

## Test Plan

- Run `bats tests/loop_cli_priority.bats` — all 22 tests should pass
- Run `bash -n bin/loop install.sh` — no syntax errors
- Run `shellcheck -S warning bin/loop install.sh` — no warnings
- Run `git grep -iE 'vadim|openclaw|suprun' -- ':!LICENSE'` — no personal identifiers