### PR TITLE
fix(dev-handler): normalize gh issue state case (uppercase OPEN broke #396 check)

### DIFF
--- a/scripts/dev-handler.sh
+++ b/scripts/dev-handler.sh
@@ -332,7 +332,9 @@ print(m.group(2) if m else '')
         fi
 
         _closes_state=$(gh issue view "$_closes_num" --repo "$REPO" --json state --jq .state 2>/dev/null || echo "")
-        if [ "$_closes_state" != "open" ]; then
+        # gh returns "OPEN"/"CLOSED" (uppercase); normalize before comparing.
+        _closes_state_lc=$(printf '%s' "$_closes_state" | tr '[:upper:]' '[:lower:]')
+        if [ "$_closes_state_lc" != "open" ]; then
             log "ERROR: PR #$_dev_pr_num references issue #$_closes_num which is not open (state='${_closes_state:-unknown}') — closing PR"
             backend_close_pr "$REPO" "$_dev_pr_num" --delete-branch
             bounty_report "dev_failed_no_ticket" model="${LOOP_AGENT_MODEL:-sonnet}" role=dev project="$SLUG" issue_num="$ISSUE_NUM" detail="PR #${_dev_pr_num} references #${_closes_num} which is not open" || true


### PR DESCRIPTION
Related to #413 (triggered by the uppercase-OPEN bug, but fixes a separate concern)

## Problem

Every dev PR opened since #400 (LOOP-396) merged ~1h ago has been auto-closed by dev-handler with the error "`Closes` references a non-open issue" — even when the referenced issue was open. The rejection comment on PR #414 (for #413) literally read:

> Closes #413 but that issue is not open (state: `OPEN`).

`gh issue view --json state --jq .state` returns `"OPEN"` / `"CLOSED"` (uppercase). The dev-handler check at line 335 compared against `"open"` (lowercase), so the check failed for every actually-open issue.

## Fix

Normalize to lowercase before comparing. One-line change.

## Test plan
- `bash -n scripts/dev-handler.sh` → passes.
- Manual verify: `printf '%s' OPEN | tr '[:upper:]' '[:lower:]'` returns `open`; comparison passes.
- Follow-up: dev-handler should re-process #413 successfully once this lands.