### PR TITLE
[LOOP-418] prevent external-pr review loop and zombie PR queue starvation

### DIFF
--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -180,6 +180,29 @@ _dedup_key() {
     printf '%s' "${hash%% *}"
 }
 
+# Stage-age cache — tracks when a PR first appeared at a given stage.
+# Prevents a stuck PR from winning the per-tick cap slot indefinitely.
+# Key: "stage-age:<event_type>:<slug>:<num>". Never auto-expires; clear
+# /tmp/loop-stage-age/ manually (or delete a specific entry) to reset.
+STAGE_AGE_DIR="/tmp/loop-stage-age"
+mkdir -p "$STAGE_AGE_DIR"
+
+# _stage_age_exceeded <key> <max_seconds>
+# Returns 0 (true) if this key was first recorded more than max_seconds ago.
+# Side-effect: creates the tracking file on first call for a new key.
+_stage_age_exceeded() {
+    local key="$1" max_age="$2"
+    local key_file
+    key_file="$STAGE_AGE_DIR/$(_dedup_key "$key")"
+    if [ ! -f "$key_file" ]; then
+        touch "$key_file"
+        return 1
+    fi
+    local age
+    age=$(( $(date +%s) - $(stat -f%m "$key_file" 2>/dev/null || stat -c%Y "$key_file" 2>/dev/null || echo 0) ))
+    [ "$age" -ge "$max_age" ]
+}
+
 # emit <json> <dedup_id>
 # Only emits if this dedup_id hasn't been emitted in the last 30 minutes.
 # Dispatches via event queue (LOOP_DISPATCH_MODE=event-queue) or direct script (default).
@@ -592,17 +615,44 @@ _scan_pr_stage() {
     while IFS= read -r row; do
         [ "$_emitted" -ge "$_cap" ] && break
         [ -z "$row" ] && continue
-        local num title url
-        num=$(printf '%s' "$row"   | python3 -c "import json,sys; print(json.load(sys.stdin)['number'])")
-        title=$(printf '%s' "$row" | python3 -c "import json,sys; print(json.load(sys.stdin)['title'])")
-        url=$(printf '%s' "$row"   | python3 -c "import json,sys; print(json.load(sys.stdin)['url'])")
+        local num title url labels
+        num=$(printf '%s' "$row"    | python3 -c "import json,sys; print(json.load(sys.stdin)['number'])")
+        title=$(printf '%s' "$row"  | python3 -c "import json,sys; print(json.load(sys.stdin)['title'])")
+        url=$(printf '%s' "$row"    | python3 -c "import json,sys; print(json.load(sys.stdin)['url'])")
+        labels=$(printf '%s' "$row" | python3 -c "import json,sys; print(' '.join(json.load(sys.stdin).get('labels') or []))")
+
+        # Refuse to dispatch loop-handlers on external PRs unless operator-approved.
+        # External PRs carry `external-pr` (set by repo auto-label action); Loop should
+        # never auto-review them unless the operator explicitly adds `operator-approved`.
+        case " $labels " in
+            *" $LOOP_LABEL_EXTERNAL_PR "*)
+                case " $labels " in
+                    *" operator-approved "*) ;;
+                    *)
+                        log "skip ${event_type} #${num}: ${LOOP_LABEL_EXTERNAL_PR} without operator-approved"
+                        continue
+                        ;;
+                esac
+                ;;
+        esac
 
         # Skip if the PR has moved to a downstream stage or is actively being handled.
         # in-review / deprecated rework-alias are handler-set operational labels (not in workflow YAML).
         # shellcheck disable=SC2086
         if backend_pr_has_any_label "$repo" "$num" \
-               in-review "$LOOP_LABEL_DEPRECATED_IN_REWORK" 'done' blocked \
+               in-review "$LOOP_LABEL_DEPRECATED_IN_REWORK" \
+               "$LOOP_LABEL_BLOCKED" blocked "$LOOP_LABEL_DONE" 'done' \
                ${downstream}; then
+            continue
+        fi
+
+        # Skip PRs stuck at this stage longer than LOOP_MAX_AGE_IN_STAGE_SECONDS (default 1h).
+        # Prevents a zombie PR from consuming the per-tick cap slot indefinitely and
+        # starving all other PRs at this stage. Operator must clear /tmp/loop-stage-age/
+        # (or the specific entry) to re-enable dispatch for the affected PR.
+        local _max_stage_age="${LOOP_MAX_AGE_IN_STAGE_SECONDS:-3600}"
+        if _stage_age_exceeded "${event_type}:${slug}:${num}" "$_max_stage_age"; then
+            log "skip ${event_type} #${num}: stuck at ${trigger_label} for >${_max_stage_age}s — round-robin skip; operator action needed"
             continue
         fi
 

--- a/scripts/review-handler.sh
+++ b/scripts/review-handler.sh
@@ -112,14 +112,16 @@ _review_handler_cleanup() {
                 "$LOOP_LABEL_NEEDS_QA" "$LOOP_LABEL_DEPRECATED_READY_FOR_QA" \
                 "$_REWORK_LABEL" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" \
                 "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" \
-                blocked 'done' 2>/dev/null; then
-            log "CLEANUP: PR #$PR_NUM still has in-review on exit (rc=$rc) — re-queuing as ${_REVIEW_LABEL}"
+                "$LOOP_LABEL_EXTERNAL_REVIEW_FAIL" "$LOOP_LABEL_EXTERNAL_REVIEW_PASS" \
+                "$LOOP_LABEL_BLOCKED" blocked "$LOOP_LABEL_DONE" 'done' 2>/dev/null; then
+            log "CLEANUP: PR #$PR_NUM still has in-review on exit (rc=$rc) — marking blocked for operator review"
             backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_IN_REVIEW" 2>/dev/null || true
-            backend_add_label    "$REPO" "$PR_NUM" "$_REVIEW_LABEL" 2>/dev/null || true
+            backend_remove_label "$REPO" "$PR_NUM" "$_REVIEW_LABEL" 2>/dev/null || true
+            backend_add_label    "$REPO" "$PR_NUM" "$LOOP_LABEL_BLOCKED" 2>/dev/null || true
             backend_comment_pr "$REPO" "$PR_NUM" \
-                "Automated review aborted (exit=${rc}). Re-queued for review." \
+                "Automated review aborted without a verdict (exit=${rc}). Marked as blocked — operator action needed." \
                 2>/dev/null || true
-            loop_notify "⚠️ [$SLUG] PR#$PR_NUM review aborted (exit=$rc) — re-queued" || true
+            loop_notify "⚠️ [$SLUG] PR#$PR_NUM review aborted (exit=$rc) — blocked, operator action needed" || true
         fi
     fi
     return $rc
@@ -302,7 +304,7 @@ if loop_run_agent "$TASK_PROMPT" "$ROOT" 2>&1 | tee -a "$LOG_FILE"; then
     if [ "$_IS_EXTERNAL_PR" != "true" ] && ! backend_pr_has_any_label "$REPO" "$PR_NUM" \
             "$LOOP_LABEL_NEEDS_QA" "$LOOP_LABEL_DEPRECATED_READY_FOR_QA" \
             "$_REWORK_LABEL" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" \
-            blocked 'done'; then
+            "$LOOP_LABEL_BLOCKED" blocked "$LOOP_LABEL_DONE" 'done'; then
         log "WARN: PR #$PR_NUM has no decision label after review agent — defaulting to '${_REWORK_LABEL}'"
         backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED"
         backend_add_label "$REPO" "$PR_NUM" "$_REWORK_LABEL"

--- a/tests/review-handler-blocked-cleanup.bats
+++ b/tests/review-handler-blocked-cleanup.bats
@@ -1,0 +1,141 @@
+#!/usr/bin/env bats
+# tests/review-handler-blocked-cleanup.bats
+#
+# QA-driven tests for the PR #419 cleanup-trap change:
+# when review-handler exits without a verdict, cleanup must apply
+# loop:result:blocked (not re-add loop:action:review).
+#
+# Also verifies that external-review-fail / external-review-pass and the
+# canonical loop:result:blocked / loop:result:done labels are treated as
+# terminal (no cleanup fires when they are present).
+
+setup() {
+    export OPS_LOG="$BATS_TMPDIR/ops.log"
+    export COMMENT_LOG="$BATS_TMPDIR/comment.log"
+    rm -f "$OPS_LOG" "$COMMENT_LOG"
+
+    export REPO="owner/test-repo"
+    export PR_NUM="42"
+    export SLUG="test-proj"
+}
+
+teardown() {
+    rm -f "$OPS_LOG" "$COMMENT_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: replicate _review_handler_cleanup (new behavior from PR #419).
+# Mirrors scripts/review-handler.sh lines 105-128 after the PR change.
+# ---------------------------------------------------------------------------
+_run_cleanup() {
+    local rc="$1"
+    local has_in_review="$2"     # "yes" | "no"
+    local terminal_label="$3"    # "" | label name that is present on the PR
+
+    local LOOP_LABEL_IN_REVIEW="in-review"
+    local LOOP_LABEL_NEEDS_QA="needs-qa"
+    local LOOP_LABEL_DEPRECATED_READY_FOR_QA="ready-for-qa"
+    local _REWORK_LABEL="loop:action:rework"
+    local LOOP_LABEL_DEPRECATED_NEEDS_REWORK="needs-rework"
+    local LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED="changes-requested"
+    local _REVIEW_LABEL="loop:action:review"
+    local LOOP_LABEL_BLOCKED="loop:result:blocked"
+    local LOOP_LABEL_DONE="loop:result:done"
+    local LOOP_LABEL_EXTERNAL_REVIEW_FAIL="external-review-fail"
+    local LOOP_LABEL_EXTERNAL_REVIEW_PASS="external-review-pass"
+
+    backend_remove_label() { echo "remove $3" >> "$OPS_LOG"; }
+    backend_add_label()    { echo "add $3"    >> "$OPS_LOG"; }
+    backend_comment_pr()   { echo "comment: $4" >> "$COMMENT_LOG"; }
+    loop_notify()          { :; }
+    log()                  { :; }
+
+    backend_pr_has_any_label() {
+        shift 2
+        for lbl in "$@"; do
+            [ "$lbl" = "in-review" ] && [ "$has_in_review" = "yes" ] && return 0
+            [ -n "$terminal_label" ] && [ "$lbl" = "$terminal_label" ] && return 0
+        done
+        return 1
+    }
+
+    # Replicate the updated _review_handler_cleanup body
+    if backend_pr_has_any_label "$REPO" "$PR_NUM" "$LOOP_LABEL_IN_REVIEW" 2>/dev/null; then
+        if ! backend_pr_has_any_label "$REPO" "$PR_NUM" \
+                "$LOOP_LABEL_NEEDS_QA" "$LOOP_LABEL_DEPRECATED_READY_FOR_QA" \
+                "$_REWORK_LABEL" "$LOOP_LABEL_DEPRECATED_NEEDS_REWORK" \
+                "$LOOP_LABEL_DEPRECATED_CHANGES_REQUESTED" \
+                "$LOOP_LABEL_EXTERNAL_REVIEW_FAIL" "$LOOP_LABEL_EXTERNAL_REVIEW_PASS" \
+                "$LOOP_LABEL_BLOCKED" blocked "$LOOP_LABEL_DONE" 'done' 2>/dev/null; then
+            backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_IN_REVIEW" 2>/dev/null || true
+            backend_remove_label "$REPO" "$PR_NUM" "$_REVIEW_LABEL" 2>/dev/null || true
+            backend_add_label    "$REPO" "$PR_NUM" "$LOOP_LABEL_BLOCKED" 2>/dev/null || true
+            backend_comment_pr "$REPO" "$PR_NUM" "" \
+                "Automated review aborted without a verdict (exit=${rc}). Marked as blocked — operator action needed." \
+                2>/dev/null || true
+        fi
+    fi
+    return "$rc"
+}
+
+# ---------------------------------------------------------------------------
+# AC2 — no-verdict exit applies loop:result:blocked, NOT loop:action:review
+# ---------------------------------------------------------------------------
+
+@test "cleanup: no-verdict exit applies loop:result:blocked" {
+    _run_cleanup 0 yes ""
+    grep -q "add loop:result:blocked" "$OPS_LOG"
+}
+
+@test "cleanup: no-verdict exit removes loop:action:review" {
+    _run_cleanup 0 yes ""
+    grep -q "remove loop:action:review" "$OPS_LOG"
+}
+
+@test "cleanup: no-verdict exit does NOT re-add loop:action:review" {
+    _run_cleanup 0 yes ""
+    ! grep -q "add loop:action:review" "$OPS_LOG"
+}
+
+@test "cleanup: no-verdict exit posts operator comment" {
+    _run_cleanup 0 yes ""
+    grep -q "blocked — operator action needed" "$COMMENT_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Terminal labels that must suppress cleanup (extended list from PR #419)
+# ---------------------------------------------------------------------------
+
+@test "cleanup: external-review-fail is terminal — no cleanup action" {
+    _run_cleanup 0 yes "external-review-fail"
+    [ ! -f "$OPS_LOG" ] || ! grep -q "add\|remove" "$OPS_LOG"
+}
+
+@test "cleanup: external-review-pass is terminal — no cleanup action" {
+    _run_cleanup 0 yes "external-review-pass"
+    [ ! -f "$OPS_LOG" ] || ! grep -q "add\|remove" "$OPS_LOG"
+}
+
+@test "cleanup: loop:result:blocked already present — no cleanup action" {
+    _run_cleanup 0 yes "loop:result:blocked"
+    [ ! -f "$OPS_LOG" ] || ! grep -q "add\|remove" "$OPS_LOG"
+}
+
+@test "cleanup: loop:result:done already present — no cleanup action" {
+    _run_cleanup 0 yes "loop:result:done"
+    [ ! -f "$OPS_LOG" ] || ! grep -q "add\|remove" "$OPS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Unchanged guard conditions
+# ---------------------------------------------------------------------------
+
+@test "cleanup: no-op when in-review is absent" {
+    _run_cleanup 0 no ""
+    [ ! -f "$OPS_LOG" ] || ! grep -q "add\|remove" "$OPS_LOG"
+}
+
+@test "cleanup: needs-qa present — no cleanup action" {
+    _run_cleanup 0 yes "needs-qa"
+    [ ! -f "$OPS_LOG" ] || ! grep -q "add\|remove" "$OPS_LOG"
+}

--- a/tests/scanner-stage-age.bats
+++ b/tests/scanner-stage-age.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+# tests/scanner-stage-age.bats — unit tests for _stage_age_exceeded in scanner/scanner.sh.
+# Added by QA for PR #419 (issue #418): verifies round-robin skip logic.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_EXTRA_PATH=""
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Override STAGE_AGE_DIR so tests don't touch /tmp/loop-stage-age.
+    export STAGE_AGE_DIR="$BATS_TMPDIR/stage-age"
+    mkdir -p "$STAGE_AGE_DIR"
+
+    # Extract _dedup_key and _stage_age_exceeded from scanner.sh.
+    local _src="$BATS_TMPDIR/stage-age-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        printf "STAGE_AGE_DIR='%s'\n" "$STAGE_AGE_DIR"
+        # Pull in _dedup_key
+        awk '/^_dedup_key\(\)/{p=1} p; p && /^\}/{p=0; exit}' \
+            "$REPO_ROOT/scanner/scanner.sh"
+        # Pull in _stage_age_exceeded (stop before 'emit')
+        awk '/^_stage_age_exceeded\(\)/{p=1} p; p && /^\}/{exit}' \
+            "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/stage-age" "$BATS_TMPDIR/logs" "$BATS_TMPDIR/stage-age-src.sh"
+}
+
+@test "_stage_age_exceeded: first call creates tracking file and returns 1 (not exceeded)" {
+    run _stage_age_exceeded "loop.pr_review:myslug:42" 3600
+    [ "$status" -eq 1 ]
+    # File must now exist
+    local key_file
+    key_file="$STAGE_AGE_DIR/$(_dedup_key "loop.pr_review:myslug:42")"
+    [ -f "$key_file" ]
+}
+
+@test "_stage_age_exceeded: second call within max_age returns 1 (still not exceeded)" {
+    _stage_age_exceeded "loop.pr_review:myslug:99" 3600 || true  # first call: creates file
+    run _stage_age_exceeded "loop.pr_review:myslug:99" 3600
+    [ "$status" -eq 1 ]
+}
+
+@test "_stage_age_exceeded: returns 0 when file is older than max_age" {
+    local key="loop.pr_review:myslug:7"
+    _stage_age_exceeded "$key" 3600 || true  # creates file
+    local key_file
+    key_file="$STAGE_AGE_DIR/$(_dedup_key "$key")"
+    # Backdate the file by 2 hours
+    touch -t "$(date -v-2H +%Y%m%d%H%M.%S 2>/dev/null || date -d '2 hours ago' +%Y%m%d%H%M.%S)" "$key_file"
+    run _stage_age_exceeded "$key" 3600
+    [ "$status" -eq 0 ]
+}
+
+@test "_stage_age_exceeded: max_age=0 always exceeded on second call" {
+    local key="loop.pr_review:myslug:zero"
+    _stage_age_exceeded "$key" 0 || true  # first call: creates file
+    run _stage_age_exceeded "$key" 0
+    [ "$status" -eq 0 ]
+}
+
+@test "_stage_age_exceeded: different keys are tracked independently" {
+    _stage_age_exceeded "loop.pr_review:slug:1" 3600 || true
+    _stage_age_exceeded "loop.pr_review:slug:2" 3600 || true
+
+    local kf1 kf2
+    kf1="$STAGE_AGE_DIR/$(_dedup_key "loop.pr_review:slug:1")"
+    kf2="$STAGE_AGE_DIR/$(_dedup_key "loop.pr_review:slug:2")"
+    # Backdate only key 1
+    touch -t "$(date -v-2H +%Y%m%d%H%M.%S 2>/dev/null || date -d '2 hours ago' +%Y%m%d%H%M.%S)" "$kf1"
+
+    run _stage_age_exceeded "loop.pr_review:slug:1" 3600
+    [ "$status" -eq 0 ]
+
+    run _stage_age_exceeded "loop.pr_review:slug:2" 3600
+    [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
Closes #418

## Changes

### 1. Scanner: refuse to dispatch external PRs without `operator-approved` (`scanner/scanner.sh`)
- `_scan_pr_stage` now extracts the labels from each PR row (already present in the JSON from `loop_gh_prs_with_label`)
- PRs carrying `external-pr` are skipped unless they also carry `operator-approved`
- Matches the existing `author_is_allowed` / `operator-approved` security model documented in the codebase

### 2. Scanner: stage-age tracking to prevent zombie starvation (`scanner/scanner.sh`)
- Added `STAGE_AGE_DIR` (`/tmp/loop-stage-age`) and `_stage_age_exceeded` helper
- Each PR-at-a-stage gets a tracking file on first sight; if it's been there longer than `LOOP_MAX_AGE_IN_STAGE_SECONDS` (env var, default 3600s / 1h) without progressing, it is skipped on that tick with a log warning
- Frees the per-tick cap slot so other PRs at the same stage can advance (round-robin effect)
- To re-enable dispatch after manual operator fix: delete the entry from `/tmp/loop-stage-age/`
- Also added `loop:result:blocked` and `loop:result:done` to the downstream-stage skip check so canonically-labelled PRs are caught too

### 3. Review-handler cleanup trap: blocked instead of re-queue (`scripts/review-handler.sh`)
- Previously, when the handler exited without applying a verdict label, cleanup re-applied `loop:action:review` — creating an infinite re-queue loop
- Now applies `loop:result:blocked` and removes `loop:action:review`, so a human must decide next steps
- Added `external-review-fail` and `external-review-pass` to the terminal-label check, so properly-handled external PRs don't trigger the cleanup fallback
- Belt-and-braces also updated to recognise canonical `loop:result:blocked` and `loop:result:done`

## Test Plan
- [ ] An external-pr PR with `loop:action:review` label: scanner tick should log "skip … external-pr without operator-approved" and not dispatch the review handler
- [ ] Same PR with `operator-approved` added: scanner should dispatch normally
- [ ] A PR that review-handler exits without a verdict: cleanup should apply `loop:result:blocked` (not `loop:action:review`), and subsequent scanner ticks should skip it (blocked label in downstream check)
- [ ] A PR at `loop:action:review` for >1h with no forward movement: scanner logs "round-robin skip" and dispatches the next PR in the queue instead
- [ ] A PR that gets `external-review-fail` set by the review-handler: cleanup should not fire (terminal label recognised)
- [ ] All existing CI checks: bash -n, shellcheck, lint-workflow, no-personal-identifiers