### PR TITLE
[LOOP-413] scanner liveness heartbeat + watchdog auto-restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — restarts the scanner if its heartbeat goes stale.
+    # Runs every 5 min; kills + restarts the scanner if no heartbeat for 15 min.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -763,6 +763,10 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Heartbeat: write current epoch to let scanner-watchdog.sh detect stalls.
+    if ! $DRY_RUN; then
+        printf '%s\n' "$(date +%s)" > "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+    fi
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the Loop scanner when its heartbeat goes stale.
+#
+# scanner.sh writes ${LOOP_LOG_DIR}/scanner-heartbeat at the start of every tick.
+# If that file is missing or its mtime exceeds STALE_THRESHOLD_SECONDS the scanner
+# is considered wedged: its PID is killed and launchd/cron auto-restarts it.
+#
+# Designed to run every 5 minutes via launchd (macOS) or cron (Linux).
+# Install via: ./install.sh --bootstrap  (adds a launchd plist / crontab entry)
+#
+# Flags:
+#   --dry-run   report status without killing or restarting
+#
+# Env overrides:
+#   STALE_THRESHOLD_SECONDS   — max heartbeat age before restart (default 900 = 15 min)
+#   LOOP_SCANNER_LAUNCHD_LABEL — launchd service label (default com.user.loop-scanner)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+STALE_THRESHOLD="${STALE_THRESHOLD_SECONDS:-900}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+SCANNER_LOCK="${LOOP_LOCK_DIR:-/tmp/loop-locks}/../loop-scanner.lock"
+# The scanner lock lives at /tmp/loop-scanner.lock (hard-coded in scanner.sh).
+SCANNER_LOCK="/tmp/loop-scanner.lock"
+LAUNCHD_LABEL="${LOOP_SCANNER_LAUNCHD_LABEL:-com.user.loop-scanner}"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _file_age_seconds <path>
+# Prints age in seconds (now - mtime), or 999999 if the file is missing.
+_file_age_seconds() {
+    local f="$1"
+    [ -f "$f" ] || { echo "999999"; return 0; }
+    local mtime now
+    mtime=$(stat -f%m "$f" 2>/dev/null || stat -c%Y "$f" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+heartbeat_age=$(_file_age_seconds "$HEARTBEAT_FILE")
+log "heartbeat_file=${HEARTBEAT_FILE} age=${heartbeat_age}s threshold=${STALE_THRESHOLD}s dry_run=${DRY_RUN}"
+
+if [ "$heartbeat_age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner healthy — no action needed"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat stale (${heartbeat_age}s > ${STALE_THRESHOLD}s) — restarting"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID from $SCANNER_LOCK and kickstart $LAUNCHD_LABEL"
+    exit 0
+fi
+
+# Kill the wedged scanner process so launchd/cron can restart a clean instance.
+if [ -f "$SCANNER_LOCK" ]; then
+    local_pid=$(cat "$SCANNER_LOCK" 2>/dev/null || echo "")
+    if [ -n "$local_pid" ] && kill -0 "$local_pid" 2>/dev/null; then
+        log "killing wedged scanner PID $local_pid"
+        kill "$local_pid" 2>/dev/null || true
+        sleep 1
+    fi
+    rm -f "$SCANNER_LOCK"
+fi
+
+# On macOS, kick launchd to restart the scanner immediately (KeepAlive=true means
+# launchd would restart it anyway on next check-in, but kickstart is instant).
+# On Linux the scanner runs via cron --once or a systemd unit that auto-restarts.
+if command -v launchctl >/dev/null 2>&1; then
+    log "kickstarting launchd service $LAUNCHD_LABEL"
+    launchctl kickstart -k "gui/$(id -u)/${LAUNCHD_LABEL}" 2>/dev/null \
+        || log "WARN: launchctl kickstart failed — service will restart on next launchd check-in"
+else
+    log "launchctl unavailable — scanner will restart on next cron/systemd cycle"
+fi

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <!-- Check every 5 minutes; two missed heartbeats (10 min) trigger restart. -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verify scanner writes heartbeat on every tick.
+#
+# Sourcing strategy mirrors tests/scanner.bats: awk extracts function/variable
+# definitions from scanner.sh and stops before the bare "acquire_lock" call.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+
+    # Build a sourceable version of scanner.sh (same awk filter as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-hb-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    # Stub out heavy dependencies so run_once() completes without side effects.
+    log()              { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs()  { :; }
+    LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-hb-src.sh" 2>/dev/null || true
+}
+
+@test "run_once: writes scanner-heartbeat file" {
+    DRY_RUN=false
+    run_once
+    [ -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+@test "run_once: heartbeat contains a unix timestamp" {
+    DRY_RUN=false
+    run_once
+    local ts
+    ts=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+    # Must be a non-empty string of digits (epoch seconds).
+    [[ "$ts" =~ ^[0-9]+$ ]]
+}
+
+@test "run_once: heartbeat is updated on every tick" {
+    DRY_RUN=false
+
+    run_once
+    local ts1
+    ts1=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+
+    # Ensure the clock advances before the second tick.
+    sleep 1
+
+    run_once
+    local ts2
+    ts2=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+
+    # Second timestamp must be >= first (monotonically non-decreasing).
+    [ "$ts2" -ge "$ts1" ]
+}
+
+@test "run_once: does NOT write heartbeat in dry-run mode" {
+    DRY_RUN=true
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    rm -f "$hb"
+    run_once
+    [ ! -f "$hb" ]
+}


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- Write `$(date +%s)` to `${LOOP_LOG_DIR}/scanner-heartbeat` at the start of every `run_once()` tick.
- Skipped in `--dry-run` mode so tests don't pollute the real log dir.

### scripts/scanner-watchdog.sh (new)
- Reads the heartbeat file mtime; if age ≥ `STALE_THRESHOLD_SECONDS` (default 900 = 15 min), kills the scanner PID from `/tmp/loop-scanner.lock` and removes the stale lock.
- On macOS calls `launchctl kickstart -k gui/<uid>/com.user.loop-scanner` for an instant restart (KeepAlive=true also auto-restarts, but kickstart is immediate).
- On Linux, killing the PID is sufficient — cron or systemd restarts the next `--once` run within the next scheduled interval.
- `--dry-run` flag: reports stale status without taking any action.

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
- Runs `scanner-watchdog.sh` every 5 minutes (`StartInterval: 300`).
- Uses the standard `__LOOP_ROOT__`/`__LOG_DIR__`/`__HOME__`/`__EXTRA_PATH__` placeholders.

### install.sh
- `bootstrap_register_launchd`: registers the scanner watchdog plist alongside the existing scanner/reconciler/pr-watchdog plists.
- `bootstrap_register_cron`: adds a `*/5 * * * *` watchdog cron entry on Linux.

### tests/scanner-heartbeat.bats (new, 4 tests)
- Verifies heartbeat file is created by `run_once()`
- Verifies content is a unix timestamp
- Verifies the timestamp is updated between successive ticks
- Verifies dry-run mode does **not** write the heartbeat

## Test Plan

- [ ] `bats tests/scanner-heartbeat.bats` — all 4 tests pass
- [ ] `bash -n` and `shellcheck -S warning` pass on all scripts
- [ ] No personal identifiers introduced (`git grep` check)
- [ ] Simulate wedge: `kill -STOP $SCANNER_PID` → after ≤15 min the watchdog should detect stale heartbeat and restart
- [ ] Manual dry-run: `STALE_THRESHOLD_SECONDS=1 scripts/scanner-watchdog.sh --dry-run` → should report stale