### PR TITLE
[LOOP-413] scanner heartbeat + watchdog to detect and restart wedged scanner

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — kills a wedged scanner (alive PID but no
+    # heartbeat activity) so launchd KeepAlive can restart it. Runs every 5 min.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — detect and restart a wedged scanner process.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat. If the file's mtime is older than
+# LOOP_SCANNER_WATCHDOG_STALE seconds (default: 2 * poll_interval = 600s),
+# the scanner is considered wedged and is killed so launchd (macOS) or cron
+# (Linux) restarts it on the next tick.
+#
+# Designed to run every 5 min via launchd StartInterval or cron */5.
+#
+# Flags:
+#   --dry-run   report stale/alive status but do not kill the scanner
+#   -h|--help   show this help
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_SCANNER_WATCHDOG_STALE:-$(( POLL_INTERVAL * 2 ))}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -15
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+log "check: heartbeat=${HEARTBEAT_FILE} threshold=${STALE_THRESHOLD}s dry=${DRY_RUN}"
+
+# No heartbeat file — scanner may not have started yet or just restarted.
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "no heartbeat file found — scanner not yet started or recovering"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+    || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+    || echo 0)
+age=$(( now - mtime ))
+
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is alive"
+    exit 0
+fi
+
+log "STALE: scanner heartbeat is ${age}s old (threshold=${STALE_THRESHOLD}s)"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would restart scanner — exiting without action"
+    exit 0
+fi
+
+# Kill scanner via PID from lock file; launchd KeepAlive (or cron) restarts it.
+if [ -f "$LOCK_FILE" ]; then
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "killing wedged scanner PID $pid"
+        kill "$pid" 2>/dev/null || true
+        # Give launchd a moment to notice the exit before kickstart.
+        sleep 2
+    else
+        log "WARN: lock PID '${pid:-}' is not alive — removing stale lock"
+        rm -f "$LOCK_FILE"
+    fi
+fi
+
+# On macOS, kickstart the service explicitly so it does not wait for
+# ThrottleInterval if it exited very recently.
+if command -v launchctl >/dev/null 2>&1; then
+    local_uid=$(id -u)
+    if launchctl list com.user.loop-scanner >/dev/null 2>&1; then
+        log "launchctl kickstart gui/${local_uid}/com.user.loop-scanner"
+        launchctl kickstart -k "gui/${local_uid}/com.user.loop-scanner" 2>/dev/null \
+            || log "WARN: kickstart failed — KeepAlive will handle restart"
+    fi
+fi
+
+log "watchdog done — scanner should restart momentarily"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -763,6 +763,17 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+
+    # Heartbeat: update mtime so scanner-watchdog can detect a wedged scanner.
+    $DRY_RUN || touch "${LOOP_LOG_DIR}/scanner-heartbeat"
+
+    # Stdout integrity: if the log file is no longer writable (e.g. after log
+    # rotation removed or replaced the inode), reopen FDs and exit so launchd
+    # can restart with a fresh file descriptor against the current inode.
+    if [ -n "${LOG_FILE:-}" ] && [ ! -w "$LOG_FILE" ] 2>/dev/null; then
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" || { printf '[scanner] FATAL: cannot reopen log\n' >&2; exit 1; }
+    fi
+
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \
@@ -772,7 +783,11 @@ run_once() {
         [ -z "$slug" ] && continue
         scan_project "$slug" || log "scan_project $slug failed (continuing)"
     done < <(loop_list_slugs)
-    log "=== scan tick done ==="
+
+    # Tick telemetry: log dedup cache size alongside tick completion.
+    local _dedup_count
+    _dedup_count=$(find "$DEDUP_DIR" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
+    log "=== scan tick done === (dedup_entries=${_dedup_count})"
 }
 
 acquire_lock

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Runs scanner-watchdog.sh every 5 minutes. The watchdog checks the scanner
+  heartbeat file; if it is older than LOOP_SCANNER_WATCHDOG_STALE seconds
+  (default 600 = 2 × poll interval), it kills the wedged scanner and lets
+  KeepAlive restart it.
+
+  Install via:  ./install.sh --bootstrap
+  Manual install:
+    sed "s|__LOOP_ROOT__|$(pwd)|g; s|__LOG_DIR__|$LOOP_LOG_DIR|g; \
+         s|__HOME__|$HOME|g; s|__EXTRA_PATH__|/opt/homebrew/bin:/usr/local/bin|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <!-- Fire every 5 minutes -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — heartbeat file is updated on every tick.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    # Silence output; stub out heavy calls.
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+@test "run_once: creates heartbeat file on first tick" {
+    [ ! -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+    run_once
+    [ -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+@test "run_once: updates heartbeat mtime on subsequent ticks" {
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+        || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat")
+    sleep 1
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+        || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat")
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once: does not create heartbeat file in dry-run mode" {
+    DRY_RUN=true
+    run_once
+    [ ! -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- **Heartbeat file**: at the start of every tick `run_once()` calls `touch "${LOOP_LOG_DIR}/scanner-heartbeat"` (skipped in dry-run). The watchdog reads this file's mtime to detect a wedged scanner.
- **Stdout integrity check**: at the top of each tick, if `$LOG_FILE` is no longer writable (e.g. after log rotation), the script reopens FD 1+2 or exits so launchd can restart with a fresh descriptor.
- **Tick telemetry**: the tick-done log line now includes `dedup_entries=N` for visibility.

### scanner/scanner-watchdog.sh (new)
Runs every 5 min via launchd or cron. Reads the heartbeat file; if mtime is older than `LOOP_SCANNER_WATCHDOG_STALE` seconds (default: `2 x LOOP_SCANNER_INTERVAL = 600s`), the scanner is considered wedged:
1. Kills the PID stored in `/tmp/loop-scanner.lock`.
2. On macOS, issues `launchctl kickstart -k gui/<uid>/com.user.loop-scanner` for immediate restart.
3. Logs all actions to `${LOOP_LOG_DIR}/loop-scanner-watchdog.log`.

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
launchd plist for the watchdog (`StartInterval 300`). Installed by `install.sh --bootstrap`.

### install.sh
- `bootstrap_register_launchd()`: registers `com.user.loop-scanner-watchdog` alongside the existing plists.
- `bootstrap_register_cron()`: adds a `*/5` watchdog cron entry for Linux.

### tests/scanner-heartbeat.bats (new)
- `run_once` creates the heartbeat file on first tick.
- `run_once` updates the heartbeat mtime on subsequent ticks.
- `run_once` does NOT create the heartbeat file in dry-run mode.

## Test Plan
- All 3 new bats tests pass.
- `bash -n` and `shellcheck -S warning` pass on all scripts.
- No personal identifiers in committed files.
- Manual: `kill -STOP $SCANNER_PID` -> watchdog should log STALE and restart within 10 min.