### PR TITLE
[LOOP-413] scanner liveness heartbeat + auto-restart watchdog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — fires every 5 min; restarts scanner when
+    # heartbeat is stale (default: >2× poll interval = 600 s).
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/loop.env.example
+++ b/loop.env.example
@@ -81,6 +81,14 @@ LOOP_DISPATCH_MODE="direct"
 # macOS (Homebrew): /opt/homebrew/bin:/usr/local/bin — Linux: /usr/local/bin or similar.
 LOOP_EXTRA_PATH="/opt/homebrew/bin:/usr/local/bin"
 
+# ─── Scanner liveness ────────────────────────────────────────────────────────
+# Poll cadence (seconds) for the continuous scanner. Default: 300 (5 min).
+# LOOP_SCANNER_INTERVAL=300
+
+# Seconds after which the scanner-watchdog considers the scanner wedged and
+# restarts it. Default: 2 × LOOP_SCANNER_INTERVAL = 600.
+# LOOP_SCANNER_STALE_SECONDS=600
+
 # ─── Recovery ────────────────────────────────────────────────────────────────
 # Seconds before an operational label (in-progress, in-rework, in-review) with
 # no live handler process is considered stuck. Recovery strips the label and

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart a wedged scanner process.
+#
+# Reads the heartbeat file written by scanner.sh on every tick. If the file
+# is older than LOOP_SCANNER_STALE_SECONDS (default: 2 × poll interval), the
+# scanner is considered wedged. The watchdog kills the scanner PID from the
+# lock file and, on macOS, issues a launchctl kickstart to restart it.
+# launchd's KeepAlive=true would restart it anyway on exit, so the kill alone
+# is sufficient; kickstart is belt-and-suspenders for faster recovery.
+#
+# Usage:
+#   scanner-watchdog.sh           # one-shot check (run via launchd/cron every 5 min)
+#   scanner-watchdog.sh --dry-run # report stale state without killing anything
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_SCANNER_STALE_SECONDS:-$(( POLL_INTERVAL * 2 ))}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _file_age_seconds <path>
+# Returns the age of the file in seconds, or a very large number if it does not exist.
+_file_age_seconds() {
+    local path="$1"
+    if [ ! -f "$path" ]; then
+        echo "999999"
+        return
+    fi
+    local mtime now
+    mtime=$(stat -f%m "$path" 2>/dev/null || stat -c%Y "$path" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+age=$(_file_age_seconds "$HEARTBEAT_FILE")
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s file=$HEARTBEAT_FILE"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is healthy — no action needed"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat is stale (age=${age}s > threshold=${STALE_THRESHOLD}s)"
+
+scanner_pid=""
+if [ -f "$LOCK_FILE" ]; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID ${scanner_pid:-<unknown>} and trigger restart"
+    exit 0
+fi
+
+if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+    log "killing wedged scanner PID $scanner_pid"
+    kill "$scanner_pid" 2>/dev/null || true
+    sleep 2
+else
+    log "scanner PID ${scanner_pid:-<unknown>} not alive — lock file stale or missing"
+    rm -f "$LOCK_FILE"
+fi
+
+# On macOS, kickstart the launchd service so it restarts immediately rather
+# than waiting for KeepAlive's ThrottleInterval.
+if command -v launchctl >/dev/null 2>&1; then
+    local_uid=$(id -u)
+    if launchctl kickstart -k "gui/${local_uid}/com.user.loop-scanner" 2>/dev/null; then
+        log "launchctl kickstart triggered for com.user.loop-scanner"
+    else
+        log "launchctl kickstart failed or not applicable — launchd will restart on next ThrottleInterval"
+    fi
+fi
+
+log "restart triggered — watchdog done"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -32,6 +32,7 @@ LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 
 # SIGHUP-reopen contract (#194): logrotate-style tools truncate or rename
 # the on-disk log file. The launchd plist redirects stdout/stderr to a
@@ -63,6 +64,17 @@ for arg in "$@"; do
 done
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] $*"; }
+
+# _scanner_check_log_fd — exit if the log file is no longer writable so launchd
+# restarts the process and opens a fresh descriptor. This handles the case where
+# a closed pipe upstream (e.g. a dead tee child) causes echo in log() to hang.
+_scanner_check_log_fd() {
+    [ -n "${LOG_FILE:-}" ] || return 0
+    if [ ! -w "$LOG_FILE" ]; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] FATAL: log file not writable ($LOG_FILE) — exiting for restart" >&2
+        exit 1
+    fi
+}
 
 # _scanner_jobs_enqueue <slug> <stage> <num>
 # Best-effort dual-write to the jobs table alongside the legacy label-event path.
@@ -762,6 +774,14 @@ scan_project() {
 }
 
 run_once() {
+    _scanner_check_log_fd
+    # Write heartbeat so the scanner-watchdog can detect a wedged scanner.
+    if ! $DRY_RUN; then
+        local _dedup_count
+        _dedup_count=$(find "$DEDUP_DIR" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
+        printf '%s dedup_count=%s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$_dedup_count" \
+            > "$HEARTBEAT_FILE" 2>/dev/null || true
+    fi
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Runs every 5 minutes. Checks the scanner heartbeat file; if older than
+  LOOP_SCANNER_STALE_SECONDS (default: 2 × poll interval = 600s), kills
+  the wedged scanner process and issues a launchctl kickstart so the scanner
+  restarts immediately rather than waiting for KeepAlive's ThrottleInterval.
+
+  Install (LOOP_ROOT and LOG_DIR must be set):
+    sed -e "s|__LOOP_ROOT__|$(cd "$(dirname "$0")/.." && pwd)|g" \
+        -e "s|__LOG_DIR__|$LOOP_LOG_DIR|g" \
+        -e "s|__HOME__|$HOME|g" \
+        -e "s|__EXTRA_PATH__|$LOOP_EXTRA_PATH|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <!-- Fire every 5 minutes -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,144 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verify scanner heartbeat + watchdog behavior.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    # Expose mock-gh.sh as the gh binary.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    mkdir -p "$DEDUP_DIR"
+    touch "$LOG_FILE"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { echo ""; }
+    LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat file
+# ---------------------------------------------------------------------------
+
+@test "run_once: writes heartbeat file on each tick" {
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: heartbeat file contains timestamp and dedup_count" {
+    run_once
+    content=$(cat "$HEARTBEAT_FILE")
+    [[ "$content" =~ dedup_count= ]]
+}
+
+@test "run_once: heartbeat mtime is recent (within 5s)" {
+    run_once
+    age=$(( $(date +%s) - $(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0) ))
+    [ "$age" -le 5 ]
+}
+
+@test "run_once: heartbeat is updated on second tick" {
+    run_once
+    sleep 1
+    first_content=$(cat "$HEARTBEAT_FILE")
+    run_once
+    second_content=$(cat "$HEARTBEAT_FILE")
+    # Content will differ because timestamp changes each tick.
+    [ "$first_content" != "$second_content" ]
+}
+
+@test "run_once: dry-run does NOT write heartbeat" {
+    DRY_RUN=true
+    run_once
+    [ ! -f "$HEARTBEAT_FILE" ]
+}
+
+# ---------------------------------------------------------------------------
+# Log fd integrity check
+# ---------------------------------------------------------------------------
+
+@test "_scanner_check_log_fd: passes when LOG_FILE is writable" {
+    run _scanner_check_log_fd
+    [ "$status" -eq 0 ]
+}
+
+@test "_scanner_check_log_fd: exits non-zero when LOG_FILE is not writable" {
+    chmod 000 "$LOG_FILE"
+    # Run in a subshell so the test process doesn't exit.
+    run bash -c "
+        source '$BATS_TMPDIR/scanner-src.sh'
+        LOG_FILE='$LOG_FILE'
+        _scanner_check_log_fd
+    "
+    chmod 644 "$LOG_FILE"
+    [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh source-level checks
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog.sh: script passes bash -n syntax check" {
+    bash -n "$REPO_ROOT/scanner/scanner-watchdog.sh"
+}
+
+@test "scanner-watchdog.sh: _file_age_seconds returns large value for missing file" {
+    # Source only the helper from the watchdog (avoid full execution).
+    local _src="$BATS_TMPDIR/watchdog-helpers.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        printf "LOOP_LOG_DIR='%s'\n" "$LOOP_LOG_DIR"
+        # Extract just _file_age_seconds function definition.
+        awk '
+            /^_file_age_seconds\(\)/ { in_fn=1 }
+            in_fn { print }
+            in_fn && /^\}$/ { in_fn=0; exit }
+        ' "$REPO_ROOT/scanner/scanner-watchdog.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    result=$(_file_age_seconds "/nonexistent/path/scanner-heartbeat")
+    [ "$result" -gt 9000 ]
+}


### PR DESCRIPTION
Closes #413

## Changes

Three self-healing mechanisms for a wedged scanner:

1. **Heartbeat file** (scanner.sh) — writes ${LOOP_LOG_DIR}/scanner-heartbeat with timestamp and dedup_count on every tick (skipped in dry-run).
2. **Log fd integrity check** (scanner.sh) — _scanner_check_log_fd() exits with code 1 at tick start if log file is not writable, so launchd/cron restarts with fresh fds (handles broken-pipe/EPIPE hang).
3. **scanner-watchdog.sh** (new) — kills wedged scanner when heartbeat is older than LOOP_SCANNER_STALE_SECONDS (default 2x poll = 600s); issues launchctl kickstart for immediate restart on macOS. Runs every 5 min independently via launchd/cron.

Also: com.user.loop-scanner-watchdog.plist.template, install.sh wiring, loop.env.example docs, tests/scanner-heartbeat.bats (9 tests, all pass).

## Test Plan
- bats tests/scanner-heartbeat.bats — 9/9 pass
- bash -n and shellcheck -S warning pass on all files
- Manual: kill -STOP scanner PID; watchdog detects stale heartbeat within 5 min