### PR TITLE
[LOOP-413] add scanner liveness heartbeat and watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — restarts a wedged scanner (alive PID, no
+    # heartbeat updates) before it causes a silent multi-hour outage.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -763,6 +763,9 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Liveness heartbeat — updated every tick so the scanner watchdog can detect
+    # a wedged scanner (alive PID, no emits) and trigger a launchd/cron restart.
+    $DRY_RUN || touch "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if its heartbeat file goes stale.
+#
+# Run every 5 min via launchd (macOS) or cron (Linux).
+# If ${LOOP_LOG_DIR}/scanner-heartbeat has not been touched within
+# LOOP_SCANNER_STALE_THRESHOLD seconds (default: 2 * LOOP_SCANNER_INTERVAL),
+# the scanner is considered wedged and is restarted.
+#
+# macOS: restarts via `launchctl kickstart`; assumes the scanner is managed
+#        under the label com.user.loop-scanner.
+# Linux: kills the PID recorded in /tmp/loop-scanner.lock (launchd-equivalent
+#        supervision or a simple restart-on-exit wrapper restarts it).
+#
+# Flags:
+#   --dry-run   print what would happen; don't kill or restart
+#   --once      single check (default; future loop mode reserved)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        --once)    : ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+# Allow 2× the poll interval before declaring the scanner wedged.
+STALE_THRESHOLD="${LOOP_SCANNER_STALE_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+
+# Bail out if the heartbeat file has never been created — the scanner may not
+# have started yet. Log at debug level and exit cleanly.
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file not found (${HEARTBEAT_FILE}) — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+# Compute age of heartbeat file in seconds.
+heartbeat_mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+    || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+    || echo 0)
+now=$(date +%s)
+age=$(( now - heartbeat_mtime ))
+
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s file=${HEARTBEAT_FILE}"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is healthy"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat stale (${age}s > ${STALE_THRESHOLD}s) — triggering restart"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would restart scanner"
+    exit 0
+fi
+
+LOCK_FILE="/tmp/loop-scanner.lock"
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    # macOS: restart via launchctl. KeepAlive=true in the plist means kickstart
+    # will relaunch the job immediately after the old process is killed.
+    LAUNCHD_LABEL="${LOOP_SCANNER_LAUNCHD_LABEL:-com.user.loop-scanner}"
+    if launchctl kickstart -k "gui/$(id -u)/${LAUNCHD_LABEL}" 2>/dev/null; then
+        log "restarted scanner via launchctl kickstart (label=${LAUNCHD_LABEL})"
+    else
+        # Fallback: kill the PID from the lock file.
+        if [ -f "$LOCK_FILE" ]; then
+            local_pid=$(cat "$LOCK_FILE" 2>/dev/null || echo "")
+            if [ -n "$local_pid" ] && kill -0 "$local_pid" 2>/dev/null; then
+                kill "$local_pid" 2>/dev/null && log "killed scanner PID ${local_pid} (launchd will restart)"
+            else
+                log "WARN: launchctl kickstart failed and no live PID in lock file — manual restart may be needed"
+            fi
+        else
+            log "WARN: launchctl kickstart failed and lock file absent — manual restart may be needed"
+        fi
+    fi
+else
+    # Linux: kill the PID from the lock file. A process supervisor (systemd,
+    # runit, or a cron-based restart-on-exit wrapper) should restart the scanner.
+    if [ -f "$LOCK_FILE" ]; then
+        linux_pid=$(cat "$LOCK_FILE" 2>/dev/null || echo "")
+        if [ -n "$linux_pid" ] && kill -0 "$linux_pid" 2>/dev/null; then
+            kill "$linux_pid" 2>/dev/null && log "killed scanner PID ${linux_pid} — supervisor should restart"
+        else
+            log "WARN: no live scanner PID found in lock file — scanner may already be stopped"
+        fi
+    else
+        log "WARN: lock file not found (${LOCK_FILE}) — scanner may not be running"
+    fi
+fi

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Runs every 5 minutes. Reads ${LOOP_LOG_DIR}/scanner-heartbeat; if the file
+  has not been updated within 2 × LOOP_SCANNER_INTERVAL, the scanner is
+  considered wedged and is restarted via launchctl kickstart.
+
+  Install (via ./install.sh --bootstrap):
+    Substitution variables are replaced automatically by install.sh.
+
+  Manual install:
+    sed "s|__LOOP_ROOT__|$(pwd)|g; s|__LOG_DIR__|$LOOP_LOG_DIR|g; \
+         s|__HOME__|$HOME|g; s|__EXTRA_PATH__|/opt/homebrew/bin:/usr/local/bin|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <!-- Fire every 5 minutes (300 seconds). -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,108 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verify scanner heartbeat behaviour.
+#
+# Sourcing strategy mirrors tests/scanner.bats: awk extracts function/variable
+# definitions, stops before the bare "acquire_lock" call, and injects LOOP_ROOT
+# so lib/ sources resolve.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+
+    # Mock gh and python3 dependencies via a per-test bin dir.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    # Source scanner functions (same awk extraction used in scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-hb-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    # Silence log() and no-op dispatch_direct so run_once completes without side effects.
+    log() { :; }
+    dispatch_direct() { :; }
+
+    # Stub out scan_project so run_once doesn't try to iterate real projects.
+    loop_list_slugs() { echo ""; }
+    jobs_init_schema() { return 0; }
+    _sweep_stale_locks() { return 0; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-hb-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat: run_once must touch ${LOOP_LOG_DIR}/scanner-heartbeat
+# ---------------------------------------------------------------------------
+
+@test "run_once: creates scanner-heartbeat file on first tick" {
+    local hb_file="${LOOP_LOG_DIR}/scanner-heartbeat"
+    [ ! -f "$hb_file" ]
+
+    run_once
+
+    [ -f "$hb_file" ]
+}
+
+@test "run_once: updates scanner-heartbeat mtime on every tick" {
+    local hb_file="${LOOP_LOG_DIR}/scanner-heartbeat"
+    # Create the file with an old timestamp.
+    touch -t 200001010000 "$hb_file" 2>/dev/null \
+        || touch "$hb_file"
+
+    local before_mtime
+    before_mtime=$(stat -f%m "$hb_file" 2>/dev/null \
+        || stat -c%Y "$hb_file" 2>/dev/null \
+        || echo 0)
+
+    # Sleep 1s to guarantee a mtime difference on filesystems with 1s granularity.
+    sleep 1
+
+    run_once
+
+    local after_mtime
+    after_mtime=$(stat -f%m "$hb_file" 2>/dev/null \
+        || stat -c%Y "$hb_file" 2>/dev/null \
+        || echo 0)
+
+    [ "$after_mtime" -gt "$before_mtime" ]
+}
+
+@test "run_once: does NOT create scanner-heartbeat in dry-run mode" {
+    DRY_RUN=true
+    local hb_file="${LOOP_LOG_DIR}/scanner-heartbeat"
+    [ ! -f "$hb_file" ]
+
+    run_once
+
+    [ ! -f "$hb_file" ]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- At the top of `run_once()`, `touch "${LOOP_LOG_DIR}/scanner-heartbeat"` on every tick (skipped in `--dry-run` mode).

### `scripts/scanner-watchdog.sh` (new)
- Standalone script that reads the heartbeat file mtime.
- If `age > LOOP_SCANNER_STALE_THRESHOLD` (default: `2 × LOOP_SCANNER_INTERVAL`, i.e. 600s), declares the scanner wedged and restarts it.
- macOS path: `launchctl kickstart -k gui/<uid>/com.user.loop-scanner` (KeepAlive plist re-launches immediately); falls back to killing the PID from `/tmp/loop-scanner.lock`.
- Linux path: kills the PID from the lock file (process supervisor or cron restarts it).
- Supports `--dry-run` flag; safe to run even when the scanner has never started.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- `StartInterval 300` (every 5 min).
- Writes to `${LOOP_LOG_DIR}/loop-scanner-watchdog.log`.

### `install.sh`
- `bootstrap_register_launchd`: installs `com.user.loop-scanner-watchdog.plist` alongside the scanner plist.
- `bootstrap_register_cron` (Linux): adds `*/5 * * * *` cron entry for `scanner-watchdog.sh`.

## Test Plan

- `tests/scanner-heartbeat.bats` (new, 3 tests):
  1. `run_once` creates `scanner-heartbeat` on first tick.
  2. `run_once` updates the file mtime on every subsequent tick.
  3. `run_once` does **not** create the file in `--dry-run` mode.
- All existing `scanner.bats` tests pass (pre-existing unrelated failures are unchanged).
- Manual simulation: `kill -STOP $SCANNER_PID` → watchdog detects stale heartbeat after `STALE_THRESHOLD` seconds and restarts.