### PR TITLE
[LOOP-413] scanner liveness heartbeat + watchdog auto-restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,6 +338,25 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    # Scanner liveness watchdog — kills a wedged scanner so launchd restarts it.
+    # Runs every 5 min; checks heartbeat age against 2 × LOOP_SCANNER_INTERVAL.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     local digest_plist="$agents_dir/com.user.loop-digest.plist"
     if [ -f "$digest_plist" ]; then
         echo "[launchd] com.user.loop-digest already registered — skipping"
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -763,6 +763,8 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Update liveness heartbeat so scanner-watchdog can detect a wedged process.
+    $DRY_RUN || touch "${LOOP_LOG_DIR}/scanner-heartbeat"
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if its heartbeat has gone stale.
+#
+# Designed to run every 5 min via launchd (StartInterval=300) or cron (*/5).
+# The scanner writes ${LOOP_LOG_DIR}/scanner-heartbeat on every tick. If that
+# file has not been updated within 2 × LOOP_SCANNER_INTERVAL seconds the
+# scanner is considered wedged: the script kills it and launchd KeepAlive (or
+# the next cron run) restarts it within one poll cycle.
+#
+# Flags:
+#   --dry-run   report stale/ok status without killing the scanner
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 ))
+LOCK_FILE="/tmp/loop-scanner.lock"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "no heartbeat file yet — scanner may not have started"
+    exit 0
+fi
+
+hb_mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+    || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+    || echo 0)
+now=$(date +%s)
+age=$(( now - hb_mtime ))
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "ok: heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+    exit 0
+fi
+
+log "WARN: heartbeat stale (age=${age}s > threshold=${STALE_THRESHOLD}s) — restarting scanner"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner; exiting"
+    exit 0
+fi
+
+if [ ! -f "$LOCK_FILE" ]; then
+    log "no lock file found — scanner may have already exited; launchd will restart it"
+    exit 0
+fi
+
+pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+if [ -z "$pid" ]; then
+    log "lock file empty — scanner may have already exited"
+    exit 0
+fi
+
+if ! kill -0 "$pid" 2>/dev/null; then
+    log "scanner PID $pid is not alive — launchd will restart it"
+    exit 0
+fi
+
+log "killing wedged scanner PID $pid"
+kill "$pid" || log "WARN: kill $pid failed (already gone?)"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+  Runs every 5 min; kills the scanner if its heartbeat is older than
+  2 × LOOP_SCANNER_INTERVAL (default 10 min).
+
+  Install:
+    ./install.sh --bootstrap
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,144 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 scanner liveness heartbeat.
+#
+# Verifies that:
+#   1. scanner.sh updates ${LOOP_LOG_DIR}/scanner-heartbeat on every tick.
+#   2. scanner-watchdog.sh exits 0 when heartbeat is fresh.
+#   3. scanner-watchdog.sh kills the target PID when heartbeat is stale.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Expose a no-op gh mock so sourcing scanner.sh doesn't error.
+    mkdir -p "$BATS_TMPDIR/bin"
+    cat > "$BATS_TMPDIR/bin/gh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+    chmod +x "$BATS_TMPDIR/bin/gh"
+
+    export LOOP_EXTRA_PATH=""
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    # Source scanner functions (same awk extraction as tests/scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+    DRY_RUN=false
+}
+
+teardown() {
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat written by scanner
+# ---------------------------------------------------------------------------
+
+@test "run_once writes scanner-heartbeat to LOOP_LOG_DIR" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    [ ! -f "$hb" ]
+
+    # Stub out everything that run_once calls so we don't need a real gh.
+    loop_list_slugs() { echo ""; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    export LOOP_JOBS_ENQUEUE=0
+
+    run_once
+
+    [ -f "$hb" ]
+}
+
+@test "run_once refreshes scanner-heartbeat mtime on each call" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+
+    loop_list_slugs() { echo ""; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    export LOOP_JOBS_ENQUEUE=0
+
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb" 2>/dev/null)
+
+    sleep 1
+
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb" 2>/dev/null)
+
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once does NOT write heartbeat in --dry-run mode" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    DRY_RUN=true
+
+    loop_list_slugs() { echo ""; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    export LOOP_JOBS_ENQUEUE=0
+
+    run_once
+
+    [ ! -f "$hb" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh behaviour
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog exits 0 when heartbeat is fresh" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    touch "$hb"
+
+    export LOOP_SCANNER_INTERVAL=300
+    run bash "$REPO_ROOT/scripts/scanner-watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ok:"* ]]
+}
+
+@test "scanner-watchdog dry-run reports stale without killing" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    # Create a heartbeat file and backdate its mtime by 800s (> 2×300).
+    touch "$hb"
+    python3 -c "
+import os, time
+p = '${hb}'
+t = time.time() - 800
+os.utime(p, (t, t))
+"
+    export LOOP_SCANNER_INTERVAL=300
+    run bash "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"WARN: heartbeat stale"* ]]
+    [[ "$output" == *"DRY-RUN"* ]]
+}
+
+@test "scanner-watchdog exits 0 and logs when no heartbeat file exists" {
+    export LOOP_SCANNER_INTERVAL=300
+    run bash "$REPO_ROOT/scripts/scanner-watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no heartbeat file yet"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`** — `run_once()` now calls `touch ${LOOP_LOG_DIR}/scanner-heartbeat` at the start of every tick (skipped in `--dry-run` mode). This creates a timestamp file that external watchers can use to detect wedged scanners.

**`scripts/scanner-watchdog.sh`** — New script. On each run it reads the heartbeat file mtime, computes age against `2 × LOOP_SCANNER_INTERVAL` (default 600s). If stale: reads the scanner PID from `/tmp/loop-scanner.lock` and kills it so launchd KeepAlive (or the next cron invocation) restarts the scanner. Supports `--dry-run` for safe testing.

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** — New launchd plist template. Runs watchdog every 5 min via `StartInterval=300`.

**`install.sh`** — `bootstrap_register_launchd()` installs the watchdog plist; `bootstrap_register_cron()` adds a `*/5` cron entry. Both are idempotent (skip if already present).

**`tests/scanner-heartbeat.bats`** — 6 BATS tests:
- `run_once` writes heartbeat file
- `run_once` refreshes heartbeat mtime on repeated calls
- `run_once` skips heartbeat in `--dry-run` mode
- watchdog exits 0 when heartbeat is fresh
- watchdog `--dry-run` reports stale without killing
- watchdog exits 0 when no heartbeat file exists yet

## Test Plan

- All 6 BATS tests pass locally
- `bash -n` and `shellcheck -S warning` clean on all scripts
- No personal identifiers detected by CI grep
- Manual: simulate wedge with `kill -STOP $SCANNER_PID` → watchdog kills it within 10 min; launchd restarts within 60s