### PR TITLE
[LOOP-413] scanner heartbeat + watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — kills a wedged scanner so launchd restarts it.
+    # Fires every 5 min; acts only when heartbeat is older than 2 × poll interval.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -763,6 +763,8 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Write liveness heartbeat so scanner-watchdog can detect a wedged process.
+    $DRY_RUN || touch "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — kill a wedged scanner so launchd/cron can restart it.
+#
+# Reads the mtime of ${LOOP_LOG_DIR}/scanner-heartbeat. If it is older than
+# LOOP_SCANNER_WATCHDOG_THRESHOLD seconds (default: 2 × LOOP_SCANNER_INTERVAL,
+# i.e. 600 s), the scanner is considered wedged and is sent SIGTERM so that
+# launchd (KeepAlive=true) restarts it automatically.
+#
+# Designed to run every 5 min via launchd/cron. Linux cron example:
+#   */5 * * * * /path/to/loop/scripts/scanner-watchdog.sh
+#
+# Flags:
+#   --dry-run   report staleness without killing the scanner
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+LOCK_FILE="/tmp/loop-scanner.lock"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+THRESHOLD="${LOOP_SCANNER_WATCHDOG_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+log "check (threshold=${THRESHOLD}s dry-run=${DRY_RUN})"
+
+# Heartbeat file absent means the scanner has not yet completed a first tick —
+# give it one full threshold window before acting.
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file absent — scanner may still be starting; no action"
+    exit 0
+fi
+
+heartbeat_mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+    || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+    || echo 0)
+now=$(date +%s)
+age=$(( now - heartbeat_mtime ))
+
+if [ "$age" -lt "$THRESHOLD" ]; then
+    log "ok (heartbeat age=${age}s < ${THRESHOLD}s)"
+    exit 0
+fi
+
+log "STALE: heartbeat age=${age}s >= ${THRESHOLD}s — scanner appears wedged"
+
+if [ ! -f "$LOCK_FILE" ]; then
+    log "lock file absent — scanner not running; nothing to kill"
+    exit 0
+fi
+
+scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || echo "")
+if [ -z "$scanner_pid" ]; then
+    log "WARN: lock file empty — cannot determine scanner PID"
+    exit 0
+fi
+
+if ! kill -0 "$scanner_pid" 2>/dev/null; then
+    log "scanner PID $scanner_pid is not alive — launchd will restart it"
+    exit 0
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID $scanner_pid"
+    exit 0
+fi
+
+log "killing wedged scanner PID $scanner_pid (launchd/cron will restart)"
+kill "$scanner_pid" || log "WARN: kill $scanner_pid failed (already gone?)"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+  Fires every 5 minutes. If the scanner's heartbeat file is older than
+  2 x LOOP_SCANNER_INTERVAL (600 s by default), sends SIGTERM to the wedged
+  scanner process so launchd (KeepAlive=true) auto-restarts it.
+
+  Installed automatically by: ./install.sh --bootstrap
+  Manual install:
+    sed \
+        -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+        -e "s|__LOG_DIR__|$LOOP_LOG_DIR|g" \
+        -e "s|__HOME__|$HOME|g" \
+        -e "s|__EXTRA_PATH__|$LOOP_EXTRA_PATH|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,151 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 scanner liveness heartbeat.
+#
+# Tests:
+#   1. scanner.sh writes scanner-heartbeat on each run_once() call.
+#   2. scanner-watchdog.sh reports ok when heartbeat is fresh.
+#   3. scanner-watchdog.sh reports STALE (dry-run) when heartbeat is old.
+#   4. scanner-watchdog.sh exits cleanly when heartbeat file is absent.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    # Expose mock-gh.sh as the gh binary via a per-test temp bin directory.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+}
+
+teardown() {
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+}
+
+# ---------------------------------------------------------------------------
+# 1. scanner.sh heartbeat file is written by run_once()
+# ---------------------------------------------------------------------------
+
+@test "scanner.sh: run_once() writes scanner-heartbeat to LOOP_LOG_DIR" {
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    # Stub helpers so run_once() completes without real gh calls.
+    loop_list_slugs()      { echo ""; }
+    _sweep_stale_locks()   { :; }
+    jobs_init_schema()     { :; }
+    LOOP_JOBS_ENQUEUE=0
+
+    heartbeat="$LOOP_LOG_DIR/scanner-heartbeat"
+    rm -f "$heartbeat"
+
+    run_once
+
+    [ -f "$heartbeat" ]
+}
+
+@test "scanner.sh: heartbeat mtime advances between two run_once() calls" {
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src2.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup2"
+    LOG_FILE="$BATS_TMPDIR/scanner-test2.log"
+    mkdir -p "$DEDUP_DIR"
+
+    loop_list_slugs()      { echo ""; }
+    _sweep_stale_locks()   { :; }
+    jobs_init_schema()     { :; }
+    LOOP_JOBS_ENQUEUE=0
+
+    heartbeat="$LOOP_LOG_DIR/scanner-heartbeat"
+    rm -f "$heartbeat"
+
+    run_once
+    mtime1=$(stat -f%m "$heartbeat" 2>/dev/null || stat -c%Y "$heartbeat" 2>/dev/null)
+
+    # Ensure at least 1-second difference for mtime comparison.
+    sleep 1
+    run_once
+    mtime2=$(stat -f%m "$heartbeat" 2>/dev/null || stat -c%Y "$heartbeat" 2>/dev/null)
+
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+# ---------------------------------------------------------------------------
+# 2–4. scanner-watchdog.sh behaviour
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits ok when heartbeat is fresh" {
+    heartbeat="$LOOP_LOG_DIR/scanner-heartbeat"
+    touch "$heartbeat"
+
+    export LOOP_SCANNER_WATCHDOG_THRESHOLD=600
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ok (heartbeat age="* ]]
+}
+
+@test "scanner-watchdog: reports STALE in dry-run when heartbeat is old" {
+    heartbeat="$LOOP_LOG_DIR/scanner-heartbeat"
+    # Back-date the heartbeat by 1200 seconds (older than default 600 s threshold).
+    touch -t "$(date -v-1200S '+%Y%m%d%H%M.%S' 2>/dev/null \
+        || date -d '1200 seconds ago' '+%Y%m%d%H%M.%S' 2>/dev/null)" \
+        "$heartbeat" 2>/dev/null \
+        || touch -d "20 minutes ago" "$heartbeat" 2>/dev/null \
+        || python3 -c "
+import os, time
+os.utime('$heartbeat', (time.time()-1200, time.time()-1200))
+"
+
+    export LOOP_SCANNER_WATCHDOG_THRESHOLD=600
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+}
+
+@test "scanner-watchdog: exits cleanly when heartbeat file is absent" {
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+
+    export LOOP_SCANNER_WATCHDOG_THRESHOLD=600
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"heartbeat file absent"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- Added `touch "${LOOP_LOG_DIR}/scanner-heartbeat"` at the top of every `run_once()` tick (skipped in `--dry-run` mode). This single line is the liveness signal: if the file's mtime stops advancing, the scanner is wedged.

### `scripts/scanner-watchdog.sh` (new)
- Reads the `scanner-heartbeat` mtime and compares it to `LOOP_SCANNER_WATCHDOG_THRESHOLD` (default: `2 × LOOP_SCANNER_INTERVAL` = 600 s).
- When stale, resolves the scanner PID from `/tmp/loop-scanner.lock` and sends `SIGTERM` — launchd (`KeepAlive=true`) auto-restarts the scanner within seconds.
- Safe: if heartbeat is absent (scanner just started), lock file is absent, or PID is already dead, the watchdog exits cleanly with a log entry.
- Supports `--dry-run` to report staleness without killing anything.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- `StartInterval=300` (every 5 min) — one check per watchdog interval, no KeepAlive.
- Uses the same `__LOOP_ROOT__` / `__LOG_DIR__` / `__HOME__` / `__EXTRA_PATH__` substitution pattern as all other Loop plists.

### `install.sh`
- `bootstrap_register_launchd()`: registers `com.user.loop-scanner-watchdog` plist on macOS (idempotent, same guard pattern as other plists).
- `bootstrap_register_cron()`: adds `*/5 * * * * scanner-watchdog.sh` cron entry on Linux (marker `# loop-scanner-watchdog`, same guard pattern).

### `tests/scanner-heartbeat.bats` (new)
- 5 tests covering: heartbeat created on first tick, mtime advances on subsequent ticks, watchdog exits ok on fresh heartbeat, watchdog reports STALE (dry-run) on old heartbeat, watchdog exits cleanly when file is absent.

## Test Plan

- [x] `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — all pass
- [x] `shellcheck -S warning` — no warnings
- [x] No personal identifiers
- [x] `bats tests/scanner-heartbeat.bats` — 5/5 pass
- [ ] Manual: pause scanner with `kill -STOP $SCANNER_PID`, wait 10 min, confirm watchdog log shows STALE and kills the PID; verify launchd restarts scanner