### PR TITLE
[LOOP-413] scanner liveness heartbeat + auto-restart watchdog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,6 +338,25 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    # Scanner liveness watchdog — checks heartbeat every 5 min and restarts
+    # the scanner if it has been silent for more than 2 * POLL_INTERVAL.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     local digest_plist="$agents_dir/com.user.loop-digest.plist"
     if [ -f "$digest_plist" ]; then
         echo "[launchd] com.user.loop-digest already registered — skipping"
@@ -364,6 +383,8 @@ bootstrap_register_cron() {
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
 
+    local watchdog_marker="# loop-scanner-watchdog"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
     new_cron="$current_cron"
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — Restart the scanner if its heartbeat goes stale.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat mtime. If the file is older than
+# LOOP_SCANNER_WATCHDOG_STALE_THRESHOLD seconds (default: 2 * POLL_INTERVAL = 600),
+# the scanner is considered wedged: kill its PID (from /tmp/loop-scanner.lock)
+# and, on macOS, kickstart it via launchctl so it restarts immediately.
+# On Linux with no KeepAlive equivalent, just killing the PID is enough when
+# cron re-spawns the scanner on the next interval.
+#
+# Run every 5 minutes via launchd StartInterval (macOS) or cron */5 (Linux).
+#
+# Flags:
+#   --dry-run   report staleness without killing or restarting
+#   --once      single check (default; reserved for future loop mode)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_SCANNER_WATCHDOG_STALE_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+LOCK_FILE="/tmp/loop-scanner.lock"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOG_FILE="${LOOP_LOG_DIR}/loop-scanner-watchdog.log"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        --once)    : ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*" | tee -a "$LOG_FILE"; }
+
+# _file_age_seconds <path>
+# Returns the age in seconds of the file's mtime, or a large number if missing.
+_file_age_seconds() {
+    local path="$1"
+    if [ ! -f "$path" ]; then
+        echo 999999
+        return 0
+    fi
+    local now mtime
+    now=$(date +%s)
+    mtime=$(stat -f%m "$path" 2>/dev/null || stat -c%Y "$path" 2>/dev/null || echo 0)
+    echo $(( now - mtime ))
+}
+
+age=$(_file_age_seconds "$HEARTBEAT_FILE")
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is alive — no action needed"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat is stale (${age}s > ${STALE_THRESHOLD}s) — triggering restart"
+
+# Read the scanner PID from the lock file.
+scanner_pid=""
+if [ -f "$LOCK_FILE" ]; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill PID ${scanner_pid:-<none>} and restart scanner"
+    exit 0
+fi
+
+# Kill the wedged scanner so launchd/cron can restart it.
+if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+    log "killing wedged scanner PID $scanner_pid"
+    kill "$scanner_pid" 2>/dev/null || true
+    # Give it a moment; if still alive, force-kill.
+    sleep 2
+    if kill -0 "$scanner_pid" 2>/dev/null; then
+        log "scanner still alive after SIGTERM — sending SIGKILL"
+        kill -9 "$scanner_pid" 2>/dev/null || true
+    fi
+else
+    log "no live scanner PID found in lock file — lock may be stale"
+    rm -f "$LOCK_FILE"
+fi
+
+# On macOS, kickstart the scanner immediately rather than waiting for launchd
+# to notice the process exited.
+if [ "$(uname -s)" = "Darwin" ]; then
+    if launchctl list "com.user.loop-scanner" >/dev/null 2>&1; then
+        log "kickstarting com.user.loop-scanner via launchctl"
+        launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null \
+            || launchctl start "com.user.loop-scanner" 2>/dev/null \
+            || log "WARN: launchctl kickstart failed — launchd KeepAlive will restart on its own"
+    fi
+fi
+
+log "restart triggered"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -761,8 +761,25 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+
+# _scanner_check_log_writable — exit (triggering launchd restart) if the log
+# file is no longer writable. Happens when logrotate replaces the file while
+# we hold an FD to the old inode; SIGHUP reopens, but if that failed we exit.
+_scanner_check_log_writable() {
+    [ -n "${LOG_FILE:-}" ] || return 0
+    if ! true >> "$LOG_FILE" 2>/dev/null; then
+        # Try to reopen stdout/stderr before giving up; exit lets launchd restart.
+        exec 1>>"$LOG_FILE" || exit 1
+        exec 2>>"$LOG_FILE" || true
+    fi
+}
+
 run_once() {
+    $DRY_RUN || _scanner_check_log_writable
     log "=== scan tick start ==="
+    # Touch heartbeat so the watchdog knows we are alive.
+    $DRY_RUN || touch "$HEARTBEAT_FILE"
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+  Fires every 5 minutes to check the scanner heartbeat and restart if stale.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <!-- Check every 5 minutes -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,112 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — scanner writes heartbeat on every tick (#413).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    TMP_DIR="$(mktemp -d)"
+    export LOOP_LOG_DIR="$TMP_DIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+@test "scanner-watchdog: heartbeat file is absent before first tick" {
+    [ ! -f "$HEARTBEAT_FILE" ]
+}
+
+@test "scanner: run_once touches heartbeat file" {
+    # Source scanner internals in a minimal stub environment so run_once can run
+    # without real GitHub access.  We override the functions that would call out.
+    (
+        export LOOP_LOG_DIR
+        export LOOP_ROOT
+        # Minimal stubs so scanner.sh sources without errors
+        loop_list_slugs() { :; }
+        loop_load_backend() { :; }
+        loop_workflow_for_project() { echo "default"; }
+        loop_polled_labels() { :; }
+        jobs_init_schema() { :; }
+        _sweep_stale_locks() { :; }
+
+        # Extract and eval only the functions we need from scanner.sh,
+        # skipping the acquire_lock + main loop at the bottom.
+        eval "$(awk '
+            /^HEARTBEAT_FILE=/ { print; next }
+            /^_scanner_check_log_writable\(\)/{p=1}
+            /^run_once\(\)/{p=1}
+            p
+            p && /^\}$/{p=0}
+        ' "$LOOP_ROOT/scanner/scanner.sh")"
+
+        DRY_RUN=false
+        LOOP_JOBS_ENQUEUE=0
+        LOG_FILE="$LOOP_LOG_DIR/loop-scanner.log"
+        log() { :; }
+
+        run_once
+    )
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "scanner: run_once updates heartbeat mtime each call" {
+    (
+        export LOOP_LOG_DIR
+        export LOOP_ROOT
+
+        loop_list_slugs() { :; }
+        loop_load_backend() { :; }
+        loop_workflow_for_project() { echo "default"; }
+        loop_polled_labels() { :; }
+        jobs_init_schema() { :; }
+        _sweep_stale_locks() { :; }
+
+        eval "$(awk '
+            /^HEARTBEAT_FILE=/ { print; next }
+            /^_scanner_check_log_writable\(\)/{p=1}
+            /^run_once\(\)/{p=1}
+            p
+            p && /^\}$/{p=0}
+        ' "$LOOP_ROOT/scanner/scanner.sh")"
+
+        DRY_RUN=false
+        LOOP_JOBS_ENQUEUE=0
+        LOG_FILE="$LOOP_LOG_DIR/loop-scanner.log"
+        log() { :; }
+
+        run_once
+        mtime1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+        sleep 1
+        run_once
+        mtime2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+        [ "$mtime2" -ge "$mtime1" ]
+    )
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "scanner-watchdog: exits 0 when heartbeat is fresh" {
+    touch "$HEARTBEAT_FILE"
+    # threshold of 600s, file just touched — should be alive
+    LOOP_SCANNER_WATCHDOG_STALE_THRESHOLD=600 \
+    LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+    run bash "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner is alive"* ]]
+}
+
+@test "scanner-watchdog: detects stale heartbeat and reports in dry-run" {
+    # Create a heartbeat file and backdate its mtime by 1200s
+    touch "$HEARTBEAT_FILE"
+    # Use a threshold of 10s so we can compare against any recent mtime
+    # by simply not touching the file and using a tiny threshold.
+    # Instead: set threshold to 0 so any file age is stale.
+    LOOP_SCANNER_WATCHDOG_STALE_THRESHOLD=0 \
+    LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+    run bash "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"stale"* ]]
+    [[ "$output" == *"DRY-RUN"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- Added `HEARTBEAT_FILE` variable pointing to `${LOOP_LOG_DIR}/scanner-heartbeat`
- Added `_scanner_check_log_writable()`: at the top of each tick tests the log file is still writable; tries to reopen stdout/stderr or exits (so launchd restarts)
- `run_once()` calls the above check then `touch "$HEARTBEAT_FILE"` before any work — a fresh mtime on every tick proves the main loop is alive

### `scanner/scanner-watchdog.sh` (new)
- Reads the heartbeat file mtime; if older than `LOOP_SCANNER_WATCHDOG_STALE_THRESHOLD` (default: `2 * POLL_INTERVAL = 600s`) the scanner is considered wedged
- Reads scanner PID from `/tmp/loop-scanner.lock`, sends SIGTERM (then SIGKILL if needed)
- On macOS runs `launchctl kickstart` so the service restarts immediately
- Supports `--dry-run` for safe manual testing

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- `StartInterval 300` (every 5 min); uses same `__LOOP_ROOT__`/`__LOG_DIR__`/`__HOME__`/`__EXTRA_PATH__` tokens as other plist templates

### `install.sh`
- `bootstrap_register_launchd()`: registers `com.user.loop-scanner-watchdog` alongside other launchd services
- `bootstrap_register_cron()`: adds `*/5 * * * *` watchdog cron entry for Linux

### `tests/scanner-heartbeat.bats` (new)
- 5 bats tests: absence before first tick, heartbeat touched by `run_once`, mtime advances on successive calls, watchdog exits 0 on fresh heartbeat, watchdog reports stale in `--dry-run`

Note: PR #426 implemented the same changes but was incorrectly closed by the reconciler ("already resolved by PR#416"). PR#416 fixed a dev-handler state comparison bug — unrelated to this issue.

## Test Plan
- `bash -n` + shellcheck + personal-identifiers grep — all pass locally
- `bats tests/scanner-heartbeat.bats` — 5/5 pass
- Manual wedge simulation: `kill -STOP $SCANNER_PID` → watchdog detects stale after threshold and reports via `--dry-run`