### PR TITLE
[LOOP-413] add scanner liveness heartbeat and watchdog auto-restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,23 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    local watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$watchdog_plist"
+        if launchctl load "$watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +378,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +401,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if its heartbeat goes stale.
+#
+# Designed to run every 5 minutes via launchd (macOS) or cron (Linux).
+# Reads the heartbeat file written by scanner.sh on every tick.
+# If the file is absent or its mtime is older than STALE_THRESHOLD_SECONDS,
+# kills the scanner process (launchd KeepAlive then restarts it automatically
+# on macOS; on Linux the cron next tick fires a fresh --once run).
+#
+# Usage:
+#   scanner-watchdog.sh           # normal operation
+#   scanner-watchdog.sh --dry-run # report only, no kill/restart
+#
+# Environment:
+#   LOOP_SCANNER_INTERVAL          poll interval in seconds (default 300)
+#   LOOP_WATCHDOG_STALE_MULTIPLIER multiplier applied to poll interval (default 2)
+#   LOOP_SCANNER_LABEL             launchd label (default com.user.loop-scanner)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_MULTIPLIER="${LOOP_WATCHDOG_STALE_MULTIPLIER:-2}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * STALE_MULTIPLIER ))
+# Clamp to at least 600s to avoid false positives on slow ticks.
+[ "$STALE_THRESHOLD" -lt 600 ] && STALE_THRESHOLD=600
+SCANNER_LABEL="${LOOP_SCANNER_LABEL:-com.user.loop-scanner}"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _heartbeat_age — print seconds since heartbeat file was last modified.
+# If the file does not exist, prints a very large number so the stale check
+# always triggers (absence == scanner never ticked since last restart).
+_heartbeat_age() {
+    if [ ! -f "$HEARTBEAT_FILE" ]; then
+        echo "9999999"
+        return 0
+    fi
+    local mtime now
+    mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+         || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+         || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+# _scanner_pid — return the PID recorded in the lock file, or empty if
+# the lock file is absent or the recorded PID is no longer alive.
+_scanner_pid() {
+    [ -f "$LOCK_FILE" ] || return 0
+    local pid
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    [ -n "$pid" ] || return 0
+    kill -0 "$pid" 2>/dev/null && echo "$pid" || true
+}
+
+# _restart_scanner — kill the scanner (if alive) and signal launchd/cron
+# to restart it. On macOS: launchctl kickstart -k. On Linux: the scanner
+# uses --once mode via cron, so just killing the PID is sufficient (the
+# next cron tick brings up a fresh run).
+_restart_scanner() {
+    local pid
+    pid=$(_scanner_pid)
+
+    if [ -n "$pid" ]; then
+        log "killing wedged scanner PID $pid"
+        $DRY_RUN || kill -TERM "$pid" 2>/dev/null || true
+        sleep 2
+        # Force-kill if still alive after SIGTERM.
+        $DRY_RUN || kill -0 "$pid" 2>/dev/null && \
+            { $DRY_RUN || kill -KILL "$pid" 2>/dev/null || true; }
+    else
+        log "scanner PID not found (lock absent or already dead)"
+    fi
+
+    if [ "$(uname -s)" = "Darwin" ]; then
+        local uid
+        uid=$(id -u)
+        log "kickstarting via launchctl gui/$uid/$SCANNER_LABEL"
+        $DRY_RUN || launchctl kickstart -k "gui/$uid/$SCANNER_LABEL" 2>/dev/null || \
+            log "WARN: launchctl kickstart failed — launchd will restart on next cycle"
+    else
+        log "Linux: scanner will restart on next cron tick"
+    fi
+}
+
+age=$(_heartbeat_age)
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s file=${HEARTBEAT_FILE}"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner healthy — no action needed"
+    exit 0
+fi
+
+log "STALE: scanner heartbeat is ${age}s old (threshold ${STALE_THRESHOLD}s) — restarting"
+_restart_scanner

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -763,6 +764,8 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Heartbeat: update mtime so the watchdog can detect a wedged scanner.
+    $DRY_RUN || touch "$HEARTBEAT_FILE"
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes. Reads ${LOOP_LOG_DIR}/scanner-heartbeat and
+  restarts the scanner (via launchctl kickstart) if the heartbeat is
+  stale by more than 2 * LOOP_SCANNER_INTERVAL (default 10 min).
+
+  Installed by: ./install.sh --bootstrap  (macOS only)
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <!-- Run every 5 minutes -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,127 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 scanner liveness heartbeat.
+#
+# Verifies that:
+# 1. scanner.sh writes scanner-heartbeat on every tick.
+# 2. scanner-watchdog.sh exits 0 when heartbeat is fresh.
+# 3. scanner-watchdog.sh detects a stale (or absent) heartbeat.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner.sh function definitions only (same strategy as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    log() { :; }
+    dispatch_direct() { :; }
+
+    # Stub out all the scan functions so run_once only exercises the heartbeat.
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { :; }
+    scan_project() { :; }
+    LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/scanner-test.log" "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat write
+# ---------------------------------------------------------------------------
+
+@test "run_once: heartbeat file is created on first tick" {
+    [ ! -f "$HEARTBEAT_FILE" ]
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: heartbeat file mtime is updated on each tick" {
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE")
+    sleep 1
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE")
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once: DRY_RUN skips heartbeat write" {
+    DRY_RUN=true
+    run_once
+    [ ! -f "$HEARTBEAT_FILE" ]
+}
+
+# ---------------------------------------------------------------------------
+# Watchdog: heartbeat age detection
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits 0 when heartbeat is fresh" {
+    touch "$HEARTBEAT_FILE"
+    run env \
+        LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        LOOP_SCANNER_INTERVAL=300 \
+        LOOP_WATCHDOG_STALE_MULTIPLIER=2 \
+        LOOP_EXTRA_PATH="" \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner healthy"* ]]
+}
+
+@test "scanner-watchdog: reports stale when heartbeat is absent" {
+    rm -f "$HEARTBEAT_FILE"
+    run env \
+        LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        LOOP_SCANNER_INTERVAL=300 \
+        LOOP_WATCHDOG_STALE_MULTIPLIER=2 \
+        LOOP_EXTRA_PATH="" \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+}
+
+@test "scanner-watchdog: reports stale when heartbeat mtime is old" {
+    # Create a heartbeat file with a very old mtime (epoch 1 = 1970).
+    touch -t 197001010000 "$HEARTBEAT_FILE" 2>/dev/null \
+        || touch -d "1970-01-01 00:00:00" "$HEARTBEAT_FILE" 2>/dev/null \
+        || { echo "cannot set old mtime — skipping"; skip; }
+    run env \
+        LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        LOOP_SCANNER_INTERVAL=300 \
+        LOOP_WATCHDOG_STALE_MULTIPLIER=2 \
+        LOOP_EXTRA_PATH="" \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

**scanner/scanner.sh** — Added `HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"` and a `touch "$HEARTBEAT_FILE"` at the top of every `run_once()` call (skipped in dry-run mode). This gives the watchdog a reliable mtime-based signal that the scanner is alive and making progress through its tick loop.

**scanner/scanner-watchdog.sh** (new) — A standalone script that reads the heartbeat file mtime. If the heartbeat is absent or older than `LOOP_SCANNER_INTERVAL * LOOP_WATCHDOG_STALE_MULTIPLIER` seconds (default 2× = 600s, clamped to ≥ 600s to avoid false positives), it kills the wedged scanner process and restarts it:
- macOS: `launchctl kickstart -k gui/<uid>/com.user.loop-scanner` (launchd KeepAlive takes over)
- Linux: SIGTERM the lock-holding PID; next cron tick starts a fresh `--once` run

**templates/launchd/com.user.loop-scanner-watchdog.plist.template** (new) — launchd plist that fires the watchdog every 5 minutes (`StartInterval=300`).

**install.sh** — `bootstrap_register_launchd` loads the watchdog plist on macOS; `bootstrap_register_cron` adds a `*/5 * * * *` cron entry on Linux. Both are idempotent (skip if already registered).

**tests/scanner-heartbeat.bats** (new) — 6 bats tests covering:
- heartbeat file is created on first tick
- heartbeat mtime is updated on every subsequent tick
- DRY_RUN suppresses the heartbeat write
- watchdog exits 0 when heartbeat is fresh
- watchdog detects absent heartbeat as stale
- watchdog detects old-mtime heartbeat as stale

## Test Plan

- Run `bats tests/scanner-heartbeat.bats` — all 6 should pass
- Manual smoke test: start scanner, confirm `${LOOP_LOG_DIR}/scanner-heartbeat` is created within the first tick
- Simulate wedge: `kill -STOP $SCANNER_PID`, wait >10 min, watchdog should log STALE and restart
- Dry-run watchdog: `scanner/scanner-watchdog.sh --dry-run` prints healthy/stale without killing anything