### PR TITLE
[LOOP-413] scanner liveness heartbeat + auto-restart watchdog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — kills a wedged scanner every 5 min so the
+    # KeepAlive scanner plist restarts it automatically (#413).
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — Liveness watchdog for scanner.sh.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written by scanner.sh at every tick).
+# If the file is missing or its mtime is older than LOOP_SCANNER_WATCHDOG_THRESHOLD
+# seconds (default: 900 = 15 min), the scanner is considered wedged:
+#   - macOS (launchd): kills the scanner PID so KeepAlive triggers an automatic restart.
+#   - Linux (cron):    kills the scanner PID; cron will re-invoke it on the next cycle.
+#
+# Safe to run even when the scanner is healthy — exits 0 with a log line.
+#
+# Usage:
+#   scanner-watchdog.sh [--dry-run]
+#
+# Flags:
+#   --dry-run   report staleness without killing anything
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+SCANNER_LOCK_FILE="${LOOP_SCANNER_LOCK_FILE:-/tmp/loop-scanner.lock}"
+# Default threshold: 15 min (must comfortably exceed the longest possible tick).
+# Override in loop.env: LOOP_SCANNER_WATCHDOG_THRESHOLD=<seconds>
+STALE_THRESHOLD="${LOOP_SCANNER_WATCHDOG_THRESHOLD:-900}"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _file_age_seconds <path>
+# Returns the age of the file in seconds, or a very large number if missing.
+_file_age_seconds() {
+    local path="$1"
+    if [ ! -f "$path" ]; then
+        echo "999999"
+        return
+    fi
+    local mtime now
+    # stat -f%m is macOS; stat -c%Y is GNU/Linux.
+    mtime=$(stat -f%m "$path" 2>/dev/null || stat -c%Y "$path" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+# _scanner_pid — read PID from the scanner lock file (if present and alive).
+_scanner_pid() {
+    [ -f "$SCANNER_LOCK_FILE" ] || return 1
+    local pid
+    pid=$(cat "$SCANNER_LOCK_FILE" 2>/dev/null || true)
+    [ -n "$pid" ] || return 1
+    kill -0 "$pid" 2>/dev/null || return 1
+    echo "$pid"
+}
+
+age=$(_file_age_seconds "$HEARTBEAT_FILE")
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s dry-run=${DRY_RUN}"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is live — no action needed"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat is stale (${age}s > ${STALE_THRESHOLD}s) — restarting"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID and let the supervisor restart it"
+    exit 0
+fi
+
+# Remove the stale heartbeat so the next scanner invocation writes a fresh one.
+rm -f "$HEARTBEAT_FILE" 2>/dev/null || true
+
+pid=$(_scanner_pid 2>/dev/null || true)
+if [ -n "$pid" ]; then
+    log "killing scanner PID $pid"
+    kill "$pid" 2>/dev/null || true
+else
+    log "scanner PID not found in $SCANNER_LOCK_FILE — lock may already be stale; removing"
+    rm -f "$SCANNER_LOCK_FILE" 2>/dev/null || true
+fi
+
+# On Linux without launchd (cron mode), re-invoke the scanner directly in the
+# background so it picks up immediately without waiting for the next cron tick.
+if [ "$(uname -s)" != "Darwin" ]; then
+    log "Linux: relaunching scanner in background"
+    nohup "$LOOP_ROOT/scanner/scanner.sh" >> "${LOOP_LOG_DIR}/loop-scanner.log" 2>&1 &
+fi
+
+log "restart triggered"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -762,6 +763,19 @@ scan_project() {
 }
 
 run_once() {
+    # Heartbeat — written before any other work so the watchdog can detect wedges.
+    if ! $DRY_RUN; then
+        date '+%Y-%m-%d %H:%M:%S' > "$HEARTBEAT_FILE" 2>/dev/null || true
+    fi
+
+    # Stdout integrity check — if the log file is no longer writable (e.g. a
+    # dead tee child closed the pipe), reopen FDs now so writes don't block.
+    # Exit if reopen also fails; launchd/cron will restart the process.
+    if [ -n "${LOG_FILE:-}" ] && [ ! -w "$LOG_FILE" ]; then
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" \
+            || { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] FATAL: cannot reopen log — exiting for restart" >&2; exit 1; }
+    fi
+
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
@@ -772,7 +786,9 @@ run_once() {
         [ -z "$slug" ] && continue
         scan_project "$slug" || log "scan_project $slug failed (continuing)"
     done < <(loop_list_slugs)
-    log "=== scan tick done ==="
+    local _dedup_count
+    _dedup_count=$(find "$DEDUP_DIR" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
+    log "=== scan tick done === dedup_entries=${_dedup_count}"
 }
 
 acquire_lock

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+  Runs every 5 minutes and kills a wedged scanner process so launchd
+  (KeepAlive=true on com.user.loop-scanner) restarts it automatically.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- Added `HEARTBEAT_FILE` variable (`${LOOP_LOG_DIR}/scanner-heartbeat`)
- `run_once()` now writes the current timestamp to the heartbeat file at the start of every tick (before any work), so the watchdog can detect wedges even when the tick completes but the log is silent
- Added stdout integrity check: if `LOG_FILE` is not writable at tick start (dead tee child / broken pipe), the script reopens FDs 1+2 against the log path; exits if reopen fails so launchd can restart cleanly
- Logs dedup entry count at tick end (`dedup_entries=N`) as the tick-counter signal

### scanner/scanner-watchdog.sh (new)
- Reads heartbeat file mtime; if age > `LOOP_SCANNER_WATCHDOG_THRESHOLD` (default 900s / 15 min), the scanner is considered wedged
- macOS: kills the scanner PID — launchd KeepAlive triggers automatic restart
- Linux: kills the PID and relaunches `scanner.sh` in the background directly (no launchd)
- Removes stale lock file if PID is already gone so the next invocation can acquire the lock
- `--dry-run` flag for safe testing

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
- Runs `scanner-watchdog.sh` every 5 minutes via `StartInterval`

### install.sh
- `bootstrap_register_launchd()`: registers `com.user.loop-scanner-watchdog` plist (idempotent)
- `bootstrap_register_cron()`: adds `*/5 * * * *` watchdog cron entry (idempotent, Linux path)

## Test Plan
- Manual: run `scanner.sh`, verify `scanner-heartbeat` file appears in `$LOOP_LOG_DIR` after first tick
- Manual simulate wedge: `kill -STOP $SCANNER_PID`, wait > 15 min (or lower threshold via `LOOP_SCANNER_WATCHDOG_THRESHOLD`), run `scanner-watchdog.sh` → scanner restarts
- `scanner-watchdog.sh --dry-run` when scanner is healthy → exits 0, logs "scanner is live"
- `scanner-watchdog.sh --dry-run` with removed heartbeat → logs stale warning, does not kill
- Verify `bash -n` and `shellcheck` pass on all modified scripts