### PR TITLE
[LOOP-413] add scanner liveness heartbeat and auto-restart watchdog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — checks heartbeat every 5 min and restarts the
+    # scanner if it has been silent for more than 2 * LOOP_SCANNER_INTERVAL seconds.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/loop.env.example
+++ b/loop.env.example
@@ -88,6 +88,11 @@ LOOP_EXTRA_PATH="/opt/homebrew/bin:/usr/local/bin"
 # The stuck-label check fires when label age >= HANDLER_TIMEOUT * 1.5.
 # HANDLER_TIMEOUT=3600
 
+# Scanner liveness watchdog: how many seconds of heartbeat silence before the
+# watchdog kills and restarts the scanner. Default: 2 * LOOP_SCANNER_INTERVAL
+# (600s when LOOP_SCANNER_INTERVAL=300). Must be larger than one full scan tick.
+# LOOP_SCANNER_WATCHDOG_STALE=600
+
 # Minutes before an `in-review` PR with no terminal decision label (needs-qa,
 # needs-rework, blocked, done) is considered stuck by the reconciler. The
 # reconciler strips `in-review` and re-adds `needs-review` so the pipeline

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -762,6 +763,16 @@ scan_project() {
 }
 
 run_once() {
+    # Heartbeat — updated every tick so the watchdog can detect a wedged scanner.
+    $DRY_RUN || touch "$HEARTBEAT_FILE" 2>/dev/null || true
+
+    # Log-FD integrity check: if the log file path is no longer writable (e.g.
+    # after log rotation with a dead inode), reopen FD 1+2 so writes resume.
+    # If reopen also fails, exit and let launchd/cron restart cleanly.
+    if [ ! -w "$LOG_FILE" ] 2>/dev/null; then
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" || { echo "scanner: cannot reopen log $LOG_FILE — exiting for restart" >&2; exit 1; }
+    fi
+
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if its heartbeat goes stale.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written by scanner every tick).
+# If the file is missing or its mtime is older than LOOP_SCANNER_WATCHDOG_STALE
+# seconds (default: 2 * LOOP_SCANNER_INTERVAL = 600s), the watchdog kills the
+# scanner process and kicks launchd (macOS) or waits for cron (Linux) to restart.
+#
+# Designed to run every 5 minutes via launchd (StartInterval 300) or cron.
+#
+# Flags:
+#   --dry-run  print what would happen without killing anything
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_SCANNER_WATCHDOG_STALE:-$(( POLL_INTERVAL * 2 ))}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+SCANNER_LOCK="/tmp/loop-scanner.lock"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# Check heartbeat age.
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file absent: $HEARTBEAT_FILE"
+    age=$((STALE_THRESHOLD + 1))
+else
+    now=$(date +%s)
+    mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+        || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+        || echo "$now")
+    age=$(( now - mtime ))
+fi
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "heartbeat fresh (age=${age}s threshold=${STALE_THRESHOLD}s) — OK"
+    exit 0
+fi
+
+log "STALE heartbeat (age=${age}s threshold=${STALE_THRESHOLD}s) — restarting scanner"
+
+# Read scanner PID from the lock file and kill it.
+scanner_pid=""
+if [ -f "$SCANNER_LOCK" ]; then
+    scanner_pid=$(cat "$SCANNER_LOCK" 2>/dev/null || true)
+fi
+
+if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+    if $DRY_RUN; then
+        log "DRY-RUN: would kill scanner PID $scanner_pid"
+    else
+        log "killing scanner PID $scanner_pid"
+        kill "$scanner_pid" 2>/dev/null || true
+        sleep 2
+        kill -0 "$scanner_pid" 2>/dev/null && kill -9 "$scanner_pid" 2>/dev/null || true
+    fi
+else
+    log "scanner PID ${scanner_pid:-unknown} not running — lock stale or already dead"
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would restart scanner service"
+    exit 0
+fi
+
+# Remove the lock so the restarted scanner can acquire it.
+rm -f "$SCANNER_LOCK"
+
+# On macOS, kick launchd to restart the scanner immediately.
+# On Linux (cron mode), killing the PID is enough — cron will relaunch it.
+if [ "$(uname -s)" = "Darwin" ]; then
+    uid=$(id -u)
+    if launchctl kickstart -k "gui/${uid}/com.user.loop-scanner" 2>/dev/null; then
+        log "launchctl kickstart triggered — scanner restarting"
+    else
+        log "WARN: launchctl kickstart failed — scanner will restart on next launchd interval"
+    fi
+else
+    log "Linux: scanner will restart on next cron tick (cron mode uses --once, no long-running process)"
+fi

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+  Runs every 5 minutes. Checks scanner heartbeat; restarts scanner if stale.
+
+  Install via: ./install.sh --bootstrap
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Closes #413

## Changes

**scanner/scanner.sh**
- Added `HEARTBEAT_FILE` written via `touch` at the start of every `run_once()` tick (skipped in --dry-run mode).
- Added log-FD integrity check at the top of each tick: if LOG_FILE is no longer writable, reopens FDs 1+2; if that fails, exits so launchd/cron can restart cleanly.

**scripts/scanner-watchdog.sh** (new)
- Reads heartbeat file mtime; if absent or older than LOOP_SCANNER_WATCHDOG_STALE seconds (default: 2 * LOOP_SCANNER_INTERVAL = 600s), kills scanner PID from the lock file.
- On macOS: calls launchctl kickstart -k for immediate restart.
- On Linux: removes stale lock; cron restarts scanner on next 5-min tick.
- Supports --dry-run flag.

**templates/launchd/com.user.loop-scanner-watchdog.plist.template** (new)
- Runs scanner-watchdog.sh every 5 minutes (StartInterval 300).

**install.sh**
- bootstrap_register_launchd: registers com.user.loop-scanner-watchdog.plist.
- bootstrap_register_cron: adds watchdog cron entry (*/5 min) for Linux.

**loop.env.example**
- Documents LOOP_SCANNER_WATCHDOG_STALE (commented out; default is 2x poll interval).

## Test Plan

- bash -n and shellcheck pass on all scripts
- No personal identifiers in committed files
- Simulate wedge: kill -STOP $SCANNER_PID -> heartbeat goes stale -> watchdog kills and restarts within one 5-min tick
- Verify scanner-heartbeat file is updated on every scanner tick
- scanner-watchdog.sh --dry-run prints intended actions without killing anything
- ./install.sh --bootstrap registers the watchdog plist on macOS and cron entry on Linux (idempotent)