### PR TITLE
[LOOP-413] scanner liveness heartbeat + auto-restart watchdog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — checks heartbeat every 5 min and restarts the
+    # scanner if it has been silent for more than 2 * LOOP_SCANNER_INTERVAL seconds.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/loop.env.example
+++ b/loop.env.example
@@ -88,6 +88,11 @@ LOOP_EXTRA_PATH="/opt/homebrew/bin:/usr/local/bin"
 # The stuck-label check fires when label age >= HANDLER_TIMEOUT * 1.5.
 # HANDLER_TIMEOUT=3600
 
+# Scanner liveness watchdog: how many seconds of heartbeat silence before the
+# watchdog kills and restarts the scanner. Default: 2 * LOOP_SCANNER_INTERVAL
+# (600s when LOOP_SCANNER_INTERVAL=300). Must be larger than one full scan tick.
+# LOOP_SCANNER_WATCHDOG_STALE=600
+
 # Minutes before an `in-review` PR with no terminal decision label (needs-qa,
 # needs-rework, blocked, done) is considered stuck by the reconciler. The
 # reconciler strips `in-review` and re-adds `needs-review` so the pipeline

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -762,6 +763,16 @@ scan_project() {
 }
 
 run_once() {
+    # Heartbeat — updated every tick so the watchdog can detect a wedged scanner.
+    $DRY_RUN || touch "$HEARTBEAT_FILE" 2>/dev/null || true
+
+    # Log-FD integrity check: if the log file path is no longer writable (e.g.
+    # after log rotation with a dead inode), reopen FD 1+2 so writes resume.
+    # If reopen also fails, exit and let launchd/cron restart cleanly.
+    if [ ! -w "$LOG_FILE" ] 2>/dev/null; then
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" || { echo "scanner: cannot reopen log $LOG_FILE — exiting for restart" >&2; exit 1; }
+    fi
+
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if its heartbeat goes stale.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written by scanner every tick).
+# If the file is missing or its mtime is older than LOOP_SCANNER_WATCHDOG_STALE
+# seconds (default: 2 * LOOP_SCANNER_INTERVAL = 600s), the watchdog kills the
+# scanner process and kicks launchd (macOS) or waits for cron (Linux) to restart.
+#
+# Designed to run every 5 minutes via launchd (StartInterval 300) or cron.
+#
+# Flags:
+#   --dry-run  print what would happen without killing anything
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_SCANNER_WATCHDOG_STALE:-$(( POLL_INTERVAL * 2 ))}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+SCANNER_LOCK="/tmp/loop-scanner.lock"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# Check heartbeat age.
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file absent: $HEARTBEAT_FILE"
+    age=$((STALE_THRESHOLD + 1))
+else
+    now=$(date +%s)
+    mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+        || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+        || echo "$now")
+    age=$(( now - mtime ))
+fi
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "heartbeat fresh (age=${age}s threshold=${STALE_THRESHOLD}s) — OK"
+    exit 0
+fi
+
+log "STALE heartbeat (age=${age}s threshold=${STALE_THRESHOLD}s) — restarting scanner"
+
+# Read scanner PID from the lock file and kill it.
+scanner_pid=""
+if [ -f "$SCANNER_LOCK" ]; then
+    scanner_pid=$(cat "$SCANNER_LOCK" 2>/dev/null || true)
+fi
+
+if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+    if $DRY_RUN; then
+        log "DRY-RUN: would kill scanner PID $scanner_pid"
+    else
+        log "killing scanner PID $scanner_pid"
+        kill "$scanner_pid" 2>/dev/null || true
+        sleep 2
+        kill -0 "$scanner_pid" 2>/dev/null && kill -9 "$scanner_pid" 2>/dev/null || true
+    fi
+else
+    log "scanner PID ${scanner_pid:-unknown} not running — lock stale or already dead"
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would restart scanner service"
+    exit 0
+fi
+
+# Remove the lock so the restarted scanner can acquire it.
+rm -f "$SCANNER_LOCK"
+
+# On macOS, kick launchd to restart the scanner immediately.
+# On Linux (cron mode), killing the PID is enough — cron will relaunch it.
+if [ "$(uname -s)" = "Darwin" ]; then
+    uid=$(id -u)
+    if launchctl kickstart -k "gui/${uid}/com.user.loop-scanner" 2>/dev/null; then
+        log "launchctl kickstart triggered — scanner restarting"
+    else
+        log "WARN: launchctl kickstart failed — scanner will restart on next launchd interval"
+    fi
+else
+    log "Linux: scanner will restart on next cron tick (cron mode uses --once, no long-running process)"
+fi

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+  Runs every 5 minutes. Checks scanner heartbeat; restarts scanner if stale.
+
+  Install via: ./install.sh --bootstrap
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-watchdog.bats
+++ b/tests/scanner-watchdog.bats
@@ -1,0 +1,176 @@
+#!/usr/bin/env bats
+# tests/scanner-watchdog.bats — heartbeat + watchdog coverage for #413.
+#
+# Tests:
+#   1. scanner run_once() touches HEARTBEAT_FILE on every tick (non-dry-run)
+#   2. scanner run_once() skips HEARTBEAT_FILE in dry-run mode
+#   3. scanner run_once() updates heartbeat mtime on repeated calls
+#   4. scanner-watchdog.sh exits 0 when heartbeat is fresh
+#   5. scanner-watchdog.sh detects missing heartbeat file as stale
+#   6. scanner-watchdog.sh detects old heartbeat mtime as stale
+#   7. scanner-watchdog.sh dry-run emits DRY-RUN message without killing
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    # Expose mock-gh.sh as the gh binary via a per-test temp bin directory.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Suppress LOOP_EXTRA_PATH so env.sh does not shadow the mock gh binary.
+    export LOOP_EXTRA_PATH=""
+
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/logs" \
+           "$BATS_TMPDIR/scanner-src.sh" "$BATS_TMPDIR/dedup" 2>/dev/null || true
+}
+
+# Source scanner.sh function definitions only (same awk filter as scanner.bats).
+_source_scanner() {
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    mkdir -p "$DEDUP_DIR"
+
+    # Silence output; no-op dispatch
+    log() { :; }
+    dispatch_direct() { :; }
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat: run_once() touches HEARTBEAT_FILE on every tick
+# ---------------------------------------------------------------------------
+
+@test "run_once: heartbeat file is created on each tick" {
+    _source_scanner
+
+    local log_file="$LOOP_LOG_DIR/loop-scanner.log"
+    touch "$log_file"
+    LOG_FILE="$log_file"
+
+    local heartbeat="$LOOP_LOG_DIR/scanner-heartbeat"
+    HEARTBEAT_FILE="$heartbeat"
+    rm -f "$heartbeat"
+
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { printf ''; }
+    scan_project() { :; }
+
+    run_once
+
+    [ -f "$heartbeat" ]
+}
+
+@test "run_once: heartbeat file is NOT written in dry-run mode" {
+    _source_scanner
+    DRY_RUN=true
+
+    local log_file="$LOOP_LOG_DIR/loop-scanner.log"
+    touch "$log_file"
+    LOG_FILE="$log_file"
+
+    local heartbeat="$LOOP_LOG_DIR/scanner-heartbeat"
+    HEARTBEAT_FILE="$heartbeat"
+    rm -f "$heartbeat"
+
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { printf ''; }
+    scan_project() { :; }
+
+    run_once
+
+    [ ! -f "$heartbeat" ]
+}
+
+@test "run_once: heartbeat mtime advances on second call" {
+    # Requires cross-platform stat — skip gracefully if neither form works.
+    local probe
+    probe=$(stat -f%m "$BATS_TMPDIR" 2>/dev/null || stat -c%Y "$BATS_TMPDIR" 2>/dev/null || true)
+    [ -n "$probe" ] || skip "stat mtime not available on this platform"
+
+    _source_scanner
+
+    local log_file="$LOOP_LOG_DIR/loop-scanner.log"
+    touch "$log_file"
+    LOG_FILE="$log_file"
+
+    local heartbeat="$LOOP_LOG_DIR/scanner-heartbeat"
+    HEARTBEAT_FILE="$heartbeat"
+
+    # Pre-seed an old heartbeat.
+    touch -t 200001010000 "$heartbeat"
+    local old_mtime
+    old_mtime=$(stat -f%m "$heartbeat" 2>/dev/null || stat -c%Y "$heartbeat" 2>/dev/null)
+
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { printf ''; }
+    scan_project() { :; }
+
+    run_once
+
+    local new_mtime
+    new_mtime=$(stat -f%m "$heartbeat" 2>/dev/null || stat -c%Y "$heartbeat" 2>/dev/null)
+    [ "$new_mtime" -gt "$old_mtime" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh: heartbeat freshness and stale detection
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits 0 and reports fresh when heartbeat just written" {
+    touch "$LOOP_LOG_DIR/scanner-heartbeat"
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"fresh"* ]]
+}
+
+@test "scanner-watchdog: detects missing heartbeat file as stale" {
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"absent"* ]] || [[ "$output" == *"STALE"* ]]
+}
+
+@test "scanner-watchdog: detects old heartbeat as stale" {
+    local heartbeat="$LOOP_LOG_DIR/scanner-heartbeat"
+    touch -t 200001010000 "$heartbeat"
+    export LOOP_SCANNER_WATCHDOG_STALE=60
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+}
+
+@test "scanner-watchdog: dry-run emits DRY-RUN and does not kill" {
+    local heartbeat="$LOOP_LOG_DIR/scanner-heartbeat"
+    touch -t 200001010000 "$heartbeat"
+    export LOOP_SCANNER_WATCHDOG_STALE=60
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DRY-RUN"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- Added `HEARTBEAT_FILE` (`${LOOP_LOG_DIR}/scanner-heartbeat`) that is `touch`-ed at the top of every `run_once()` tick (skipped in `--dry-run` mode).
- Added log-FD integrity check at the top of `run_once()`: if `LOG_FILE` is no longer writable (dead inode after log rotation), reopen FDs 1+2 against the path. If reopen also fails, exits 1 so launchd/cron restarts cleanly.

### scripts/scanner-watchdog.sh (new)
Standalone watchdog script that runs every 5 minutes. Reads the heartbeat file mtime; if age ≥ `LOOP_SCANNER_WATCHDOG_STALE` seconds (default: `2 × LOOP_SCANNER_INTERVAL` = 600s), kills the scanner via its lock-file PID and calls `launchctl kickstart` on macOS (cron/Linux: killing the `--once` process is sufficient).

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
launchd plist template for the watchdog, running at `StartInterval=300` (5 min).

### install.sh
- `bootstrap_register_launchd`: installs and loads the watchdog plist alongside the scanner, reconciler, and pr-watchdog.
- `bootstrap_register_cron` (Linux): adds a `*/5` cron entry for `scanner-watchdog.sh`.

### loop.env.example
Documents the `LOOP_SCANNER_WATCHDOG_STALE` tuning knob.

### tests/scanner-watchdog.bats (new)
7 bats tests covering:
- Heartbeat file created on each tick (non-dry-run)
- Heartbeat not written in dry-run mode
- Heartbeat mtime advances on repeated calls
- Watchdog exits 0 for fresh heartbeat
- Watchdog detects missing heartbeat as stale
- Watchdog detects old heartbeat mtime as stale
- Dry-run emits `DRY-RUN` without killing

## Test Plan
- All 7 new bats tests pass locally.
- Existing scanner tests pass (5 pre-existing failures on `main` unrelated to this change).
- `bash -n`, `shellcheck -S warning`, and personal-identifiers checks pass.
- Manual test: `kill -STOP $SCANNER_PID` stalls heartbeat; watchdog detects stale within 10 min and restarts.