### PR TITLE
[LOOP-420] review-handler: pre-flight idempotency guard on PR head SHA

### DIFF
--- a/scripts/review-handler.sh
+++ b/scripts/review-handler.sh
@@ -138,6 +138,28 @@ if [ "$retries" -ge "$MAX_RETRIES" ]; then
     exit 0
 fi
 
+# Idempotency guard: if the bot already posted a CHANGES_REQUESTED or APPROVED
+# review on the PR's current head SHA, skip — the PR is in "waiting for author"
+# state and the verdict still stands. Re-applying needs-review (e.g. by a stale
+# label race or a manual relabel) must not trigger a fresh review on unchanged
+# code. Companion to LOOP-418's crash-recovery fix.
+if [ "${BACKEND:-github}" = "github" ]; then
+    _HEAD_SHA=$(backend_pr_view "$REPO" "$PR_NUM" --json headRefOid --jq '.headRefOid' 2>/dev/null || echo "")
+    _BOT_LOGIN=$(gh api user --jq '.login' 2>/dev/null || echo "")
+    if [ -n "$_HEAD_SHA" ] && [ -n "$_BOT_LOGIN" ]; then
+        _PRIOR_VERDICT=$(backend_pr_view "$REPO" "$PR_NUM" --json reviews \
+            --jq --arg sha "$_HEAD_SHA" --arg login "$_BOT_LOGIN" \
+            '[.reviews[]|select(.author.login==$login and .commit.oid==$sha and (.state=="CHANGES_REQUESTED" or .state=="APPROVED"))]|last|.state // ""' \
+            2>/dev/null || echo "")
+        if [ -n "$_PRIOR_VERDICT" ]; then
+            log "idempotency: bot ($_BOT_LOGIN) already posted $_PRIOR_VERDICT on PR #$PR_NUM head ${_HEAD_SHA:0:7} — clearing $LOOP_LABEL_NEEDS_REVIEW and skipping"
+            backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_NEEDS_REVIEW" 2>/dev/null || true
+            backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_REVIEW_PENDING" 2>/dev/null || true
+            exit 0
+        fi
+    fi
+fi
+
 # External PR detection — set once, used at decision time below.
 _IS_EXTERNAL_PR=false
 if backend_pr_has_any_label "$REPO" "$PR_NUM" "$LOOP_LABEL_EXTERNAL_PR" 2>/dev/null; then

--- a/tests/review-handler-idempotency-guard.bats
+++ b/tests/review-handler-idempotency-guard.bats
@@ -1,0 +1,112 @@
+#!/usr/bin/env bats
+# tests/review-handler-idempotency-guard.bats
+#
+# Pre-flight idempotency guard: when the bot already posted a
+# CHANGES_REQUESTED or APPROVED review on the PR's current head SHA,
+# review-handler must skip — clear loop:action:review and exit 0 — rather
+# than invoke the reviewer agent again.
+#
+# Companion to LOOP-418's crash-recovery fix. LOOP-418 stopped the trap
+# from re-queueing; this guard prevents *any* re-entry path (manual
+# relabel, scanner race, operator action) from triggering a re-review on
+# unchanged code. Together they make the pipeline consistent even when
+# the reviewer agent's verdict is non-deterministic.
+
+setup() {
+    export OPS_LOG="$BATS_TMPDIR/ops.log"
+    rm -f "$OPS_LOG"
+    export REPO="owner/test-repo"
+    export PR_NUM="42"
+    export BACKEND="github"
+    export LOOP_LABEL_NEEDS_REVIEW="loop:action:review"
+    export LOOP_LABEL_DEPRECATED_REVIEW_PENDING="review-pending"
+}
+
+teardown() {
+    rm -f "$OPS_LOG"
+}
+
+# Replicates the guard block from scripts/review-handler.sh (the inserted
+# block between loop_handler_guard and in-review labeling). Inputs are
+# injected via the stubs below.
+_run_guard() {
+    local head_sha="$1"          # value backend_pr_view returns for --json headRefOid
+    local bot_login="$2"         # value `gh api user` returns
+    local prior_verdict="$3"     # "" | "CHANGES_REQUESTED" | "APPROVED" (what the jq filter returns)
+
+    backend_pr_view() {
+        # First arg pattern: <repo> <number> --json <field> --jq <expr> ...
+        # We dispatch on the --json field name.
+        local args=("$@")
+        local i
+        for ((i=0; i<${#args[@]}; i++)); do
+            if [ "${args[i]}" = "--json" ]; then
+                case "${args[i+1]}" in
+                    headRefOid) echo "$head_sha"; return 0 ;;
+                    reviews)    echo "$prior_verdict"; return 0 ;;
+                esac
+            fi
+        done
+        return 0
+    }
+    gh() {
+        if [ "$1" = "api" ] && [ "$2" = "user" ]; then
+            echo "$bot_login"; return 0
+        fi
+        return 0
+    }
+    backend_remove_label() { echo "remove $3" >> "$OPS_LOG"; }
+    log() { :; }
+
+    # Block under test — kept in sync with scripts/review-handler.sh
+    if [ "${BACKEND:-github}" = "github" ]; then
+        _HEAD_SHA=$(backend_pr_view "$REPO" "$PR_NUM" --json headRefOid --jq '.headRefOid' 2>/dev/null || echo "")
+        _BOT_LOGIN=$(gh api user --jq '.login' 2>/dev/null || echo "")
+        if [ -n "$_HEAD_SHA" ] && [ -n "$_BOT_LOGIN" ]; then
+            _PRIOR_VERDICT=$(backend_pr_view "$REPO" "$PR_NUM" --json reviews \
+                --jq --arg sha "$_HEAD_SHA" --arg login "$_BOT_LOGIN" \
+                '...' \
+                2>/dev/null || echo "")
+            if [ -n "$_PRIOR_VERDICT" ]; then
+                log "idempotency: skip"
+                backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_NEEDS_REVIEW" 2>/dev/null || true
+                backend_remove_label "$REPO" "$PR_NUM" "$LOOP_LABEL_DEPRECATED_REVIEW_PENDING" 2>/dev/null || true
+                return 0   # in real script this is `exit 0`
+            fi
+        fi
+    fi
+    return 1   # fell through — handler would continue to the reviewer agent
+}
+
+@test "guard: skips and clears needs-review when prior CHANGES_REQUESTED exists on head SHA" {
+    run _run_guard "deadbeefdeadbeef" "review-bot" "CHANGES_REQUESTED"
+    [ "$status" -eq 0 ]
+    grep -q "remove loop:action:review" "$OPS_LOG"
+}
+
+@test "guard: skips and clears needs-review when prior APPROVED exists on head SHA" {
+    run _run_guard "deadbeefdeadbeef" "review-bot" "APPROVED"
+    [ "$status" -eq 0 ]
+    grep -q "remove loop:action:review" "$OPS_LOG"
+}
+
+@test "guard: falls through (no skip) when no prior verdict on this head SHA" {
+    run _run_guard "deadbeefdeadbeef" "review-bot" ""
+    [ "$status" -eq 1 ]
+    [ ! -f "$OPS_LOG" ] || ! grep -q "remove" "$OPS_LOG"
+}
+
+@test "guard: falls through when head SHA cannot be resolved" {
+    run _run_guard "" "review-bot" "CHANGES_REQUESTED"
+    [ "$status" -eq 1 ]
+}
+
+@test "guard: falls through when bot login cannot be resolved" {
+    run _run_guard "deadbeefdeadbeef" "" "CHANGES_REQUESTED"
+    [ "$status" -eq 1 ]
+}
+
+@test "guard: no-ops on non-github backend" {
+    BACKEND="gitlab" run _run_guard "deadbeefdeadbeef" "review-bot" "CHANGES_REQUESTED"
+    [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
## Summary
- Skip reviewer agent + clear `loop:action:review` when the bot has already posted a CHANGES_REQUESTED or APPROVED review on the PR's current head SHA.
- Closes the consistency gap left by #419 (LOOP-418): that PR fixed the cleanup-trap re-queue path; this PR closes *every* re-entry path (stale labels, scanner races, manual relabels) by short-circuiting before the agent is invoked.

## Why now
Observed in [loop-monitor#302](https://github.com/svv2014/loop-monitor/pull/302): one commit, six bot reviews in three hours, five CHANGES_REQUESTED → one APPROVED on identical code. LOOP-418 stopped *future* loops via the cleanup trap; this PR makes the handler itself defensive so reviewer-agent non-determinism cannot produce contradictory verdicts on unchanged input.

## Where it lives
`scripts/review-handler.sh` — block inserted between `loop_handler_guard` and the `in-review` label add, so a skip leaves no `in-review` flicker. Guard is `BACKEND=github`-gated and degrades gracefully if either head SHA or bot login lookup fails (falls through to existing behavior).

## Test plan
- [x] `bash -n scripts/review-handler.sh`
- [x] `shellcheck -S warning scripts/review-handler.sh`
- [x] `bats tests/review-handler-idempotency-guard.bats` — 6 new tests covering prior CHANGES_REQUESTED, prior APPROVED, no prior, missing head SHA, missing bot login, non-github backend
- [x] `bats tests/review-handler-blocked-cleanup.bats tests/review-handler-crash-recovery.bats` — 14 existing tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Closes #434
