### PR TITLE
[LOOP-413] add scanner liveness heartbeat and watchdog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — kills and restarts a silently-wedged scanner.
+    # Runs every 5 min; checks heartbeat file mtime against 2×poll_interval.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -763,6 +763,19 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+
+    # Heartbeat: write current epoch to a file so the scanner-watchdog can
+    # detect a silently-wedged scanner (alive PID, no emit activity).
+    if ! $DRY_RUN; then
+        date +%s > "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+    fi
+
+    # Stdout integrity check: if the log file was rotated or is no longer
+    # writable, try to reopen it. Exit if reopen fails so launchd restarts.
+    if [ -n "${LOG_FILE:-}" ] && [ ! -w "${LOG_FILE}" ]; then
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" || exit 1
+    fi
+
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart a silently-wedged scanner.
+#
+# Checks the mtime of ${LOOP_LOG_DIR}/scanner-heartbeat written by scanner.sh
+# on every tick. If the file is older than 2×LOOP_SCANNER_INTERVAL (default
+# 10 min) the scanner is assumed wedged: its PID is killed and the stale lock
+# removed so launchd (KeepAlive) or cron can restart it cleanly.
+#
+# Designed to run every 5 min via launchd StartInterval / cron */5.
+#
+# Flags:
+#   --dry-run   report staleness but do not kill
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 ))
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+log "check (threshold=${STALE_THRESHOLD}s dry-run=${DRY_RUN})"
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "no heartbeat file found — scanner not yet started or does not support heartbeat"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+age=$(( now - mtime ))
+
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner OK"
+    exit 0
+fi
+
+log "WARN: heartbeat stale (${age}s > ${STALE_THRESHOLD}s) — scanner appears wedged"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner and remove lock"
+    exit 0
+fi
+
+# Kill the wedged scanner process.
+pid=""
+if [ -f "$LOCK_FILE" ]; then
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+fi
+
+if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    log "killing scanner PID $pid"
+    kill "$pid" 2>/dev/null || true
+    sleep 2
+fi
+
+# Remove the stale lock so the restarted scanner can acquire it.
+rm -f "$LOCK_FILE"
+
+# On macOS, nudge launchd to restart the scanner immediately rather than
+# waiting for the next KeepAlive cycle.
+if command -v launchctl >/dev/null 2>&1; then
+    if launchctl list "com.user.loop-scanner" >/dev/null 2>&1; then
+        log "kickstarting com.user.loop-scanner via launchctl"
+        launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null \
+            || launchctl start "com.user.loop-scanner" 2>/dev/null \
+            || log "WARN: launchctl kickstart failed — launchd will restart via KeepAlive"
+    fi
+fi
+
+log "restart triggered"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <!-- Run every 5 minutes -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — heartbeat file is written on every tick.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    log() { :; }
+    dispatch_direct() { :; }
+
+    # Stub out functions that hit external services.
+    loop_list_slugs() { echo ""; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+@test "run_once: writes scanner-heartbeat file on every tick" {
+    local heartbeat_file="$LOOP_LOG_DIR/scanner-heartbeat"
+    [ ! -f "$heartbeat_file" ]
+    run_once
+    [ -f "$heartbeat_file" ]
+}
+
+@test "run_once: heartbeat contains a recent epoch timestamp" {
+    local heartbeat_file="$LOOP_LOG_DIR/scanner-heartbeat"
+    run_once
+    local ts
+    ts=$(cat "$heartbeat_file")
+    local now
+    now=$(date +%s)
+    # Timestamp must be a number within 5 seconds of now.
+    [ "$ts" -gt 0 ]
+    [ $(( now - ts )) -le 5 ]
+}
+
+@test "run_once: heartbeat is refreshed on each successive tick" {
+    local heartbeat_file="$LOOP_LOG_DIR/scanner-heartbeat"
+    run_once
+    local ts1
+    ts1=$(cat "$heartbeat_file")
+    sleep 1
+    run_once
+    local ts2
+    ts2=$(cat "$heartbeat_file")
+    [ "$ts2" -ge "$ts1" ]
+}
+
+@test "run_once: heartbeat not written in dry-run mode" {
+    local heartbeat_file="$LOOP_LOG_DIR/scanner-heartbeat"
+    DRY_RUN=true
+    run_once
+    [ ! -f "$heartbeat_file" ]
+}
+
+@test "scanner-watchdog.sh: exits 0 when heartbeat is fresh" {
+    local heartbeat_file="$LOOP_LOG_DIR/scanner-heartbeat"
+    date +%s > "$heartbeat_file"
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "scanner OK"
+}
+
+@test "scanner-watchdog.sh: reports stale when heartbeat is old" {
+    local heartbeat_file="$LOOP_LOG_DIR/scanner-heartbeat"
+    # Write a timestamp from the distant past.
+    echo "1" > "$heartbeat_file"
+    touch -t 200001010000 "$heartbeat_file" 2>/dev/null || true
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "stale"
+}
+
+@test "scanner-watchdog.sh: exits 0 when no heartbeat file exists" {
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "no heartbeat"
+}


### PR DESCRIPTION
Closes #413

## Changes

**scanner/scanner.sh**
- At the start of every `run_once()` tick, write the current epoch to `${LOOP_LOG_DIR}/scanner-heartbeat` (skipped in dry-run mode). This gives the watchdog a reliable signal that the scanner is actively polling.
- Added stdout integrity check: if `LOG_FILE` exists but is no longer writable (e.g. after a log rotation that orphaned the FD), attempt to reopen it; exit if reopen fails so launchd auto-restarts the process.

**scripts/scanner-watchdog.sh** (new)
- Runs every 5 min. Reads `scanner-heartbeat` mtime; if age > `2 × LOOP_SCANNER_INTERVAL` (default 10 min), kills the scanner PID, removes the stale lock, and nudges `launchctl kickstart` on macOS. Supports `--dry-run`.
- On Linux (cron mode), killing the PID is a no-op since cron handles scheduling — the watchdog still cleans the stale lock if present.

**templates/launchd/com.user.loop-scanner-watchdog.plist.template** (new)
- launchd `StartInterval=300` plist for the watchdog (macOS).

**install.sh**
- `bootstrap_register_launchd`: registers `com.user.loop-scanner-watchdog` alongside the existing scanner/reconciler/pr-watchdog/digest agents.
- `bootstrap_register_cron`: adds a `*/5` crontab entry for `scanner-watchdog.sh` on Linux.

**tests/scanner-heartbeat.bats** (new)
- 7 tests: heartbeat file is created on first tick, contains a recent epoch, is refreshed on repeated ticks, is absent in dry-run mode, watchdog reports OK for a fresh heartbeat, reports stale for an old one, exits cleanly when the file is missing.

## Test Plan
- CI: `bash -n`, `shellcheck`, personal-identifier grep — all pass locally.
- bats `tests/scanner-heartbeat.bats` — 7/7 pass.
- Manual: `kill -STOP $SCANNER_PID` → watchdog should restart within 10 min (2×300s).
- Existing `tests/scanner.bats` and `tests/scanner-log-sighup.bats` — no regressions (same 5 pre-existing failures, no new ones).