### PR TITLE
[LOOP-413] scanner liveness heartbeat + watchdog auto-restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — detects a silently-stalled scanner and kills
+    # it so launchd restarts it automatically. Runs every 5 min independently.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — detect a silently-stalled scanner and restart it.
+#
+# The scanner can become wedged (alive PID, sleep loop intact) while emitting
+# no events. This script is run every 5 min (launchd / cron) and checks the
+# heartbeat file written by scanner.sh on every tick. If the heartbeat is
+# older than LOOP_WATCHDOG_STALE_SECONDS (default: 900 = 15 min, i.e.
+# 3× the default 5-min poll interval), the scanner is killed and launchd /
+# the OS restarts it automatically.
+#
+# Usage:
+#   scanner/scanner-watchdog.sh   # runs a single check and exits
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+SCANNER_LOCK_FILE="/tmp/loop-scanner.lock"
+STALE_SECONDS="${LOOP_WATCHDOG_STALE_SECONDS:-900}"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+_file_age_seconds() {
+    local f="$1"
+    local mtime now
+    now=$(date +%s)
+    mtime=$(stat -f%m "$f" 2>/dev/null || stat -c%Y "$f" 2>/dev/null || echo 0)
+    echo $(( now - mtime ))
+}
+
+main() {
+    if [ ! -f "$HEARTBEAT_FILE" ]; then
+        log "no heartbeat file yet — scanner may not have started; skipping"
+        exit 0
+    fi
+
+    local age
+    age=$(_file_age_seconds "$HEARTBEAT_FILE")
+
+    if [ "$age" -lt "$STALE_SECONDS" ]; then
+        log "heartbeat OK (age=${age}s < stale=${STALE_SECONDS}s)"
+        exit 0
+    fi
+
+    log "STALE: heartbeat age=${age}s >= stale=${STALE_SECONDS}s — restarting scanner"
+
+    # Read scanner PID from lock file and kill it; launchd/cron will restart.
+    local pid=""
+    if [ -f "$SCANNER_LOCK_FILE" ]; then
+        pid=$(cat "$SCANNER_LOCK_FILE" 2>/dev/null || true)
+    fi
+
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "killing stale scanner PID $pid"
+        kill "$pid" 2>/dev/null || true
+        # Give it 3 seconds to exit cleanly, then force-kill.
+        sleep 3
+        if kill -0 "$pid" 2>/dev/null; then
+            log "PID $pid still alive — sending SIGKILL"
+            kill -9 "$pid" 2>/dev/null || true
+        fi
+    else
+        log "no live scanner PID found in lock file; cleaning up stale lock"
+        rm -f "$SCANNER_LOCK_FILE"
+    fi
+
+    log "done — launchd/cron will restart the scanner"
+}
+
+main "$@"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -761,8 +761,15 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+_write_heartbeat() {
+    $DRY_RUN && return 0
+    local hb_file="${LOOP_LOG_DIR}/scanner-heartbeat"
+    date +%s > "$hb_file" 2>/dev/null || true
+}
+
 run_once() {
     log "=== scan tick start ==="
+    _write_heartbeat
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <!-- Run every 5 minutes -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,139 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — scanner liveness heartbeat (issue #413).
+#
+# Verifies that _write_heartbeat updates the heartbeat file on every tick,
+# and that scanner-watchdog.sh kills a stale scanner PID and leaves a fresh
+# one alone.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export LOOP_EXTRA_PATH=""
+
+    # Source just the heartbeat helper from scanner.sh (stop before acquire_lock).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    log() { :; }
+    dispatch_direct() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# _write_heartbeat
+# ---------------------------------------------------------------------------
+
+@test "_write_heartbeat: creates heartbeat file" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    [ ! -f "$hb" ]
+    _write_heartbeat
+    [ -f "$hb" ]
+}
+
+@test "_write_heartbeat: file contains a unix timestamp" {
+    _write_heartbeat
+    local ts
+    ts=$(cat "$LOOP_LOG_DIR/scanner-heartbeat")
+    # Must be a number greater than 0
+    [ "$ts" -gt 0 ]
+}
+
+@test "_write_heartbeat: updates mtime on each call" {
+    _write_heartbeat
+    local mtime1
+    mtime1=$(stat -f%m "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null \
+          || stat -c%Y "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null)
+
+    # Small sleep to ensure mtime changes (1 second resolution on most FS).
+    sleep 1.1
+    _write_heartbeat
+
+    local mtime2
+    mtime2=$(stat -f%m "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null \
+          || stat -c%Y "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null)
+
+    [ "$mtime2" -gt "$mtime1" ]
+}
+
+@test "_write_heartbeat: no-ops in dry-run mode" {
+    DRY_RUN=true
+    _write_heartbeat
+    [ ! -f "$LOOP_LOG_DIR/scanner-heartbeat" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits 0 with no heartbeat file (scanner not yet started)" {
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no heartbeat file"* ]]
+}
+
+@test "scanner-watchdog: exits 0 when heartbeat is fresh" {
+    # Write a fresh heartbeat (age = 0s)
+    date +%s > "$LOOP_LOG_DIR/scanner-heartbeat"
+    LOOP_WATCHDOG_STALE_SECONDS=900 \
+        run "$REPO_ROOT/scanner/scanner-watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"heartbeat OK"* ]]
+}
+
+@test "scanner-watchdog: kills stale scanner PID and removes lock" {
+    # Write a heartbeat timestamped far in the past (simulate stale).
+    echo "1" > "$LOOP_LOG_DIR/scanner-heartbeat"
+    touch -t 200001010000 "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null \
+        || touch -d "2000-01-01 00:00:00" "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null \
+        || true
+
+    # Spawn a real sleep process as a stand-in for the stale scanner.
+    sleep 30 &
+    local fake_pid=$!
+    local lock_file="/tmp/loop-scanner.lock"
+    echo "$fake_pid" > "$lock_file"
+
+    LOOP_WATCHDOG_STALE_SECONDS=1 \
+        run "$REPO_ROOT/scanner/scanner-watchdog.sh"
+
+    # Clean up: kill the sleep if still alive (watchdog may have beaten us).
+    kill "$fake_pid" 2>/dev/null || true
+    rm -f "$lock_file"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+}
+
+@test "scanner-watchdog: handles missing lock file gracefully when stale" {
+    echo "1" > "$LOOP_LOG_DIR/scanner-heartbeat"
+    touch -t 200001010000 "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null \
+        || touch -d "2000-01-01 00:00:00" "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null \
+        || true
+
+    rm -f /tmp/loop-scanner.lock
+
+    LOOP_WATCHDOG_STALE_SECONDS=1 \
+        run "$REPO_ROOT/scanner/scanner-watchdog.sh"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`** — `_write_heartbeat()` helper writes `date +%s` to `${LOOP_LOG_DIR}/scanner-heartbeat` at the top of every `run_once()` call. Skipped in `--dry-run` mode. The file mtime is the liveness signal: watchdog checks it, monitoring can stat it.

**`scanner/scanner-watchdog.sh`** — new script (runs every 5 min via launchd/cron). Reads the heartbeat mtime; if age ≥ `LOOP_WATCHDOG_STALE_SECONDS` (default 900 s = 15 min, covering 3× the default 5-min poll interval), reads the scanner PID from `/tmp/loop-scanner.lock`, sends SIGTERM (then SIGKILL after 3 s if still alive), and exits. launchd `KeepAlive=true` on the scanner restarts it automatically within seconds.

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** — launchd plist (`StartInterval 300`) for macOS deployments. Uses the same `__LOOP_ROOT__`/`__LOG_DIR__`/`__HOME__`/`__EXTRA_PATH__` placeholders as the other templates.

**`install.sh`** — registers the watchdog on both macOS (launchd, idempotent) and Linux (cron `*/5 * * * *`, idempotent marker `# loop-scanner-watchdog`).

**`tests/scanner-heartbeat.bats`** — 8 bats tests covering: heartbeat file creation, timestamp content, mtime update on each call, dry-run no-op, and watchdog behaviour for fresh / stale / no-lock-file cases.

## Test Plan
- All 8 new bats tests pass locally
- `bash -n` and `shellcheck -S warning` pass on all scripts
- No personal identifiers in committed files
- Manual simulation: `kill -STOP $SCANNER_PID` → watchdog fires within 5 min, kills the stopped PID, launchd restarts scanner