### PR TITLE
[LOOP-413] scanner liveness heartbeat + watchdog auto-restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -263,6 +263,7 @@ bootstrap_register_launchd() {
     mkdir -p "$agents_dir"
 
     local scanner_plist="$agents_dir/com.user.loop-scanner.plist"
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
     local reconciler_plist="$agents_dir/com.user.loop-reconciler.plist"
     local reconcile_plist="$agents_dir/com.user.loop-reconcile.plist"
 
@@ -297,6 +298,23 @@ bootstrap_register_launchd() {
             echo "[launchd] com.user.loop-scanner loaded (KeepAlive)"
         else
             echo "[launchd] WARNING: could not load com.user.loop-scanner (check Console.app)" >&2
+        fi
+    fi
+
+    # Scanner liveness watchdog — kills wedged scanner so launchd auto-restarts it.
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
         fi
     fi
 
@@ -361,8 +379,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/restart-scanner-if-stale.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +402,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -763,6 +764,9 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Liveness heartbeat written before any gh I/O so the watchdog can detect
+    # a wedged scanner even when the poll body itself never completes.
+    $DRY_RUN || date '+%s' > "$HEARTBEAT_FILE" 2>/dev/null || true
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scripts/restart-scanner-if-stale.sh
+++ b/scripts/restart-scanner-if-stale.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# restart-scanner-if-stale.sh — scanner liveness watchdog.
+#
+# Checks the scanner heartbeat file written at the top of every scan tick.
+# If the file is missing or older than STALE_THRESHOLD_SECONDS, the scanner
+# is considered wedged and is restarted:
+#   - macOS (launchd): kills the PID in the lock file; KeepAlive restarts it.
+#   - Linux (cron):    kills the PID; the next cron invocation runs fresh.
+#
+# Designed to run every 5 minutes via launchd or cron. Install via:
+#   ./install.sh --bootstrap
+#
+# Flags:
+#   --dry-run   check and log, but don't kill anything
+#   --help      show this help
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+SCANNER_LOCK="/tmp/loop-scanner.lock"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+# Stale threshold defaults to 2× poll interval (600s with the default 5-min poll).
+# Gives one full extra cycle before declaring a wedge to avoid false positives on
+# slow gh calls.
+STALE_THRESHOLD="${LOOP_SCANNER_STALE_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+now=$(date +%s)
+
+# Determine staleness.
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "WARN: heartbeat file missing: $HEARTBEAT_FILE"
+    stale=true
+    age="(file absent)"
+else
+    mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+        || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+        || echo 0)
+    age=$(( now - mtime ))
+    if [ "$age" -gt "$STALE_THRESHOLD" ]; then
+        stale=true
+        log "WARN: heartbeat stale: age=${age}s threshold=${STALE_THRESHOLD}s"
+    else
+        stale=false
+        log "OK: heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+    fi
+fi
+
+[ "$stale" = false ] && exit 0
+
+# Watchdog action: kill the wedged scanner.
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner (age=${age})"
+    exit 0
+fi
+
+scanner_pid=""
+if [ -f "$SCANNER_LOCK" ]; then
+    scanner_pid=$(cat "$SCANNER_LOCK" 2>/dev/null || true)
+fi
+
+if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+    log "killing wedged scanner PID $scanner_pid (age=${age}s)"
+    kill "$scanner_pid" 2>/dev/null || true
+    rm -f "$SCANNER_LOCK"
+    log "scanner killed — launchd/cron will restart it"
+else
+    log "scanner lock absent or PID dead (age=${age}s) — cleaning up stale lock"
+    rm -f "$SCANNER_LOCK"
+fi

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/restart-scanner-if-stale.sh</string>
+    </array>
+    <!-- Run every 5 minutes; stale threshold defaults to 2× poll interval (600s) -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,108 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 scanner liveness heartbeat.
+#
+# Verifies:
+#   1. scanner.sh writes HEARTBEAT_FILE at the top of every run_once() tick.
+#   2. restart-scanner-if-stale.sh exits 0 (OK) when heartbeat is fresh.
+#   3. restart-scanner-if-stale.sh detects a missing heartbeat in dry-run.
+#   4. restart-scanner-if-stale.sh detects a stale heartbeat in dry-run.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner function definitions using the same awk extraction as scanner.bats.
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    mkdir -p "$DEDUP_DIR"
+
+    # Silence noisy helpers so run_once doesn't try to actually scan.
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { printf ''; }
+    LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/scanner-test.log" "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+@test "scanner.sh: HEARTBEAT_FILE variable is defined in scanner source" {
+    grep -q 'HEARTBEAT_FILE=' "$REPO_ROOT/scanner/scanner.sh"
+}
+
+@test "scanner.sh: run_once writes heartbeat file" {
+    rm -f "$HEARTBEAT_FILE"
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "scanner.sh: heartbeat file contains a unix timestamp" {
+    run_once
+    local ts
+    ts=$(cat "$HEARTBEAT_FILE")
+    [[ "$ts" =~ ^[0-9]+$ ]]
+    [ "$ts" -gt 1700000000 ]
+}
+
+@test "scanner.sh: run_once updates heartbeat on repeated calls" {
+    run_once
+    local first
+    first=$(cat "$HEARTBEAT_FILE")
+    sleep 1
+    run_once
+    local second
+    second=$(cat "$HEARTBEAT_FILE")
+    [ "$second" -ge "$first" ]
+}
+
+# ---------------------------------------------------------------------------
+# restart-scanner-if-stale.sh
+# ---------------------------------------------------------------------------
+
+@test "restart-scanner-if-stale.sh: exits 0 and logs OK when heartbeat is fresh" {
+    date '+%s' > "$HEARTBEAT_FILE"
+    run "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"OK:"* ]]
+}
+
+@test "restart-scanner-if-stale.sh: detects missing heartbeat file in dry-run" {
+    rm -f "$HEARTBEAT_FILE"
+    run "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"WARN:"* ]]
+    [[ "$output" == *"DRY-RUN:"* ]]
+}
+
+@test "restart-scanner-if-stale.sh: detects stale heartbeat with low threshold in dry-run" {
+    date '+%s' > "$HEARTBEAT_FILE"
+    sleep 2
+    LOOP_SCANNER_STALE_THRESHOLD=1 \
+        run "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DRY-RUN:"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`**
- Added `HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"` variable.
- `run_once()` writes `date +%s` to the heartbeat file at the very top of each tick, before any `gh` I/O. A scan that wedges partway through still records its heartbeat, so the watchdog detects the wedge on the *next* interval (≤10 min with defaults).

**`scripts/restart-scanner-if-stale.sh`** (new)
- Watchdog that reads the heartbeat file mtime and compares to `now`.
- Stale threshold: `LOOP_SCANNER_STALE_THRESHOLD` (defaults to `2 × LOOP_SCANNER_INTERVAL` = 600s).
- On stale: reads the PID from `/tmp/loop-scanner.lock`, sends `SIGTERM`, removes the lock so launchd can restart clean.
- On macOS with `KeepAlive=true` the scanner restarts in seconds. On Linux with cron the next `--once` invocation proceeds normally.
- `--dry-run` flag supported for safe manual inspection.

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new)
- launchd plist running the watchdog every 5 min (`StartInterval 300`).
- Logs to `${LOG_DIR}/loop-scanner-watchdog.log`.

**`install.sh`**
- `bootstrap_register_launchd`: registers `com.user.loop-scanner-watchdog` between the scanner and reconciler plists.
- `bootstrap_register_cron`: adds a `*/5 * * * *` crontab entry for the watchdog on Linux.

**`tests/scanner-heartbeat.bats`** (new)
- 7 tests: heartbeat variable presence, file creation on `run_once()`, timestamp format, mtime refresh on repeated calls, watchdog OK/stale/missing scenarios via `--dry-run`.

## Test Plan

- `bash -n` + `shellcheck -S warning` both pass with zero warnings.
- `bats tests/scanner-heartbeat.bats` — all 7 tests pass.
- Smoke: `./scripts/restart-scanner-if-stale.sh --dry-run` while scanner is running → logs `OK: heartbeat age=...`
- Simulate wedge: `kill -STOP $SCANNER_PID` → watchdog detects stale within ≤10 min and kills it; launchd restarts automatically.