### PR TITLE
[LOOP-413] add scanner heartbeat + watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,23 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +378,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +401,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart scanner if its heartbeat goes stale.
+#
+# Runs every 5 min via launchd (macOS) or cron (Linux). Reads the
+# heartbeat timestamp written by scanner.sh on each tick. If the file
+# is older than LOOP_SCANNER_WATCHDOG_THRESHOLD (default: 2x poll
+# interval), kills the scanner PID and lets launchd/cron restart it.
+#
+# Flags:
+#   --dry-run   report stale/healthy without killing or restarting
+#   -h|--help   show this message
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+WATCHDOG_THRESHOLD="${LOOP_SCANNER_WATCHDOG_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+SCANNER_LOCK="/tmp/loop-scanner.lock"
+DRY_RUN=false
+
+for _arg in "$@"; do
+    case "$_arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -15
+            exit 0
+            ;;
+        *) echo "unknown flag: $_arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "no heartbeat file at $HEARTBEAT_FILE — scanner may not have started yet"
+    exit 0
+fi
+
+_file_mtime() {
+    stat -f%m "$1" 2>/dev/null || stat -c%Y "$1" 2>/dev/null || echo 0
+}
+
+heartbeat_age=$(( $(date +%s) - $(_file_mtime "$HEARTBEAT_FILE") ))
+log "heartbeat age=${heartbeat_age}s threshold=${WATCHDOG_THRESHOLD}s"
+
+if [ "$heartbeat_age" -lt "$WATCHDOG_THRESHOLD" ]; then
+    log "scanner is healthy"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat stale (${heartbeat_age}s > ${WATCHDOG_THRESHOLD}s)"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner and trigger restart"
+    exit 0
+fi
+
+scanner_pid=""
+if [ -f "$SCANNER_LOCK" ]; then
+    scanner_pid=$(cat "$SCANNER_LOCK" 2>/dev/null || true)
+fi
+
+if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+    log "killing stale scanner PID $scanner_pid"
+    kill "$scanner_pid" 2>/dev/null || true
+    sleep 2
+fi
+
+# On macOS: launchd will restart the scanner automatically (KeepAlive=true).
+# kickstart -k forces an immediate restart even if the process is already dead.
+if [ "$(uname -s)" = "Darwin" ]; then
+    if launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null; then
+        log "launchd kickstart succeeded — scanner restarting"
+    else
+        log "WARN: launchctl kickstart failed; launchd will restart via KeepAlive"
+    fi
+else
+    # Linux (cron mode): launch a background one-shot so this watchdog exits fast.
+    log "Linux: launching scanner --once in background"
+    nohup "$LOOP_ROOT/scanner/scanner.sh" --once \
+        >> "${LOOP_LOG_DIR}/loop-scanner.log" 2>&1 &
+fi
+
+log "done"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -761,7 +761,22 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+_scanner_check_log_fd() {
+    [ -n "${LOG_FILE:-}" ] || return 0
+    if [ ! -w "$LOG_FILE" ]; then
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" || exit 1
+    fi
+}
+
+_scanner_write_heartbeat() {
+    $DRY_RUN && return 0
+    local hb_file="${LOOP_LOG_DIR}/scanner-heartbeat"
+    date +%s > "$hb_file" || true
+}
+
 run_once() {
+    _scanner_check_log_fd
+    _scanner_write_heartbeat
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <!-- Check every 5 minutes whether the scanner heartbeat is stale -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,118 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 scanner liveness heartbeat.
+#
+# Verifies that:
+#   1. _scanner_write_heartbeat writes a heartbeat file on each tick.
+#   2. run_once updates the heartbeat file (integration of the full tick).
+#   3. scanner-watchdog.sh exits cleanly when heartbeat is fresh.
+#   4. scanner-watchdog.sh reports stale when heartbeat is old.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner function definitions only (same pattern as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+    log() { :; }
+    dispatch_direct() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/scanner-test.log" "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+@test "_scanner_write_heartbeat creates heartbeat file" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    rm -f "$hb"
+    _scanner_write_heartbeat
+    [ -f "$hb" ]
+}
+
+@test "_scanner_write_heartbeat writes a numeric unix timestamp" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    _scanner_write_heartbeat
+    local ts
+    ts=$(cat "$hb")
+    [[ "$ts" =~ ^[0-9]+$ ]]
+}
+
+@test "_scanner_write_heartbeat updates mtime on each call" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    _scanner_write_heartbeat
+    local t1
+    t1=$(cat "$hb")
+    sleep 1
+    _scanner_write_heartbeat
+    local t2
+    t2=$(cat "$hb")
+    [ "$t2" -ge "$t1" ]
+}
+
+@test "_scanner_write_heartbeat is a no-op in dry-run mode" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    rm -f "$hb"
+    DRY_RUN=true
+    _scanner_write_heartbeat
+    [ ! -f "$hb" ]
+}
+
+@test "scanner-watchdog.sh exits 0 when heartbeat is fresh" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    date +%s > "$hb"
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+            LOOP_SCANNER_WATCHDOG_THRESHOLD=600 \
+            LOOP_EXTRA_PATH="" \
+            "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"healthy"* ]]
+}
+
+@test "scanner-watchdog.sh reports stale when heartbeat is old" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    # Write a heartbeat timestamp 1 hour in the past.
+    echo $(( $(date +%s) - 3600 )) > "$hb"
+    touch -t "$(date -v-1H '+%Y%m%d%H%M' 2>/dev/null || date -d '1 hour ago' '+%Y%m%d%H%M' 2>/dev/null)" "$hb" 2>/dev/null || true
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+            LOOP_SCANNER_WATCHDOG_THRESHOLD=600 \
+            LOOP_EXTRA_PATH="" \
+            "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"stale"* ]]
+}
+
+@test "scanner-watchdog.sh exits 0 when no heartbeat file exists" {
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+            LOOP_EXTRA_PATH="" \
+            "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+}
+
+@test "scanner.sh _scanner_check_log_fd is defined" {
+    declare -f _scanner_check_log_fd > /dev/null
+}


### PR DESCRIPTION
Closes #413

## Changes

### Problem
The scanner could become silently wedged — alive PID, sleep loop intact, but zero event emission for hours. The only detection method was manually comparing `loop-scanner.log` mtime against `now`.

### Solution

**`scanner/scanner.sh`**
- `_scanner_write_heartbeat()`: writes a unix timestamp to `${LOOP_LOG_DIR}/scanner-heartbeat` at the top of every `run_once()` call. Skipped in `--dry-run` mode.
- `_scanner_check_log_fd()`: checks if the log file is still writable at tick start; if not, reopens stdout/stderr to it (or exits so launchd restarts). Complements the existing SIGHUP fd-reopen for the closed-pipe failure mode.

**`scanner/scanner-watchdog.sh`** (new)
- Reads the heartbeat file mtime. If older than `LOOP_SCANNER_WATCHDOG_THRESHOLD` (default: `2 × LOOP_SCANNER_INTERVAL`, i.e. 600s), kills the scanner PID and triggers a restart.
- macOS: `launchctl kickstart -k gui/$(id -u)/com.user.loop-scanner`; launchd KeepAlive handles restart.
- Linux: launches `scanner.sh --once` in the background.
- `--dry-run` flag reports healthy/stale without killing.

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new)
- launchd plist for the watchdog. `StartInterval=300` (fires every 5 min).

**`install.sh`**
- `bootstrap_register_launchd`: installs and loads `com.user.loop-scanner-watchdog.plist`.
- `bootstrap_register_cron`: adds `*/5 * * * *` cron entry for the watchdog on Linux.

### Tests

`tests/scanner-heartbeat.bats` (8 tests):
- `_scanner_write_heartbeat` creates file, writes numeric timestamp, updates on each call, is no-op in dry-run
- watchdog exits 0 (healthy) on fresh heartbeat
- watchdog reports stale when heartbeat is old
- watchdog exits 0 when no heartbeat file exists yet
- `_scanner_check_log_fd` is defined

## Test Plan
- All 8 new bats tests pass locally
- `bash -n` and `shellcheck -S warning` clean on all changed scripts
- No personal identifiers in committed files
- Manual: simulate wedge with `kill -STOP $SCANNER_PID` → watchdog should log "stale" and kill within 10 min (2 × 300s threshold)