### PR TITLE
[LOOP-441] disambiguate loop_handler_for_label by issue/pr kind

### DIFF
--- a/lib/workflow.sh
+++ b/lib/workflow.sh
@@ -13,7 +13,7 @@
 #   loop_workflow_for_project <slug>            # echo workflow name for a project
 #   loop_label_for <slug> <canonical>           # echo label name with overrides applied
 #   loop_polled_labels <slug> <issue|pr>        # list labels the scanner should poll
-#   loop_handler_for_label <slug> <label>       # echo handler base name
+#   loop_handler_for_label <slug> <label> <kind>  # echo handler base name (kind: issue|pr)
 #   loop_workflow_validate <path>               # exit 0 if file is schema-v1 valid
 
 # Sourced libs should not enable -u (would crash callers); leave shell defaults.
@@ -240,19 +240,25 @@ sys.exit(1)
 PY
 }
 
-# loop_handler_for_label <slug> <label>
+# loop_handler_for_label <slug> <label> [kind]
 # Given an actually-applied label (post-override), returns the handler script base name.
+# `kind` is "issue" or "pr" — required when a label is reused across both stage
+# kinds (e.g. `loop:action:dev` triggers `dev-handler` on issues and
+# `dev-rework-handler` on PRs in the default workflow). Omitting `kind`
+# preserves legacy behaviour (first match wins across both sections) — but new
+# callers should always pass it.
 loop_handler_for_label() {
-    local slug="$1" label="$2"
+    local slug="$1" label="$2" kind="${3:-}"
     local wf
     wf=$(loop_workflow_for_project "$slug")
     local wf_file="$_LOOP_WORKFLOW_DIR/${wf}.yaml"
     [ -f "$wf_file" ] || return 1
-    SLUG="$slug" WF="$wf_file" LBL="$label" \
+    SLUG="$slug" WF="$wf_file" LBL="$label" KIND="$kind" \
     CFG="${LOOP_CONFIG:-${LOOP_ROOT:-.}/config/projects.yaml}" python3 - <<'PY'
 import os, sys, yaml
 slug = os.environ['SLUG']
 label = os.environ['LBL']
+kind = os.environ.get('KIND', '')
 with open(os.environ['WF']) as f:
     wf = yaml.safe_load(f) or {}
 overrides = {}
@@ -266,7 +272,13 @@ if cfg_path and os.path.isfile(cfg_path):
             break
 reverse = {v: k for k, v in overrides.items()}
 canonical = reverse.get(label, label)
-for section in ('issue_stages', 'pr_stages'):
+if kind == 'issue':
+    sections = ('issue_stages',)
+elif kind == 'pr':
+    sections = ('pr_stages',)
+else:
+    sections = ('issue_stages', 'pr_stages')
+for section in sections:
     for stage in wf.get(section, []) or []:
         if stage.get('trigger_label') == canonical:
             print(stage.get('handler', ''))

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -738,7 +738,7 @@ scan_project() {
     while IFS= read -r trigger_label; do
         [ -z "$trigger_label" ] && continue
         local handler event_type
-        handler=$(loop_handler_for_label "$slug" "$trigger_label" 2>/dev/null || true)
+        handler=$(loop_handler_for_label "$slug" "$trigger_label" issue 2>/dev/null || true)
         [ -z "$handler" ] && continue
         if $_slots_gate_active && [ "$trigger_label" = "$_first_issue_trigger" ]; then
             continue
@@ -754,7 +754,7 @@ scan_project() {
     while IFS= read -r trigger_label; do
         [ -z "$trigger_label" ] && continue
         local handler event_type
-        handler=$(loop_handler_for_label "$slug" "$trigger_label" 2>/dev/null || true)
+        handler=$(loop_handler_for_label "$slug" "$trigger_label" pr 2>/dev/null || true)
         [ -z "$handler" ] && continue
         event_type=$(_handler_to_event_type "$handler")
         _scan_pr_stage "$slug" "$repo" "$trigger_label" "$handler" "$event_type"

--- a/tests/workflow-handler-lookup-kind.bats
+++ b/tests/workflow-handler-lookup-kind.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+# tests/workflow-handler-lookup-kind.bats —
+# Regression coverage for issue #441: when a label triggers both an
+# issue_stage and a pr_stage, loop_handler_for_label must disambiguate
+# by kind. Previously returned the first match across both sections,
+# making the PR rework handler unreachable in the default workflow.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    # shellcheck source=../lib/workflow.sh
+    source "$REPO_ROOT/lib/workflow.sh"
+
+    TEST_TMP="$(mktemp -d)"
+    cat > "$TEST_TMP/dual.yaml" <<'YAML'
+version: 1
+name: dual
+description: shared-label test workflow
+issue_stages:
+  - id: dev
+    trigger_label: shared-label
+    handler: dev-handler
+    on_done: review-pending
+pr_stages:
+  - id: rework
+    trigger_label: shared-label
+    handler: dev-rework-handler
+    on_done: review-pending
+YAML
+    # Override workflow dir + slug-to-workflow mapping for the test.
+    _LOOP_WORKFLOW_DIR="$TEST_TMP"
+    loop_workflow_for_project() { echo "dual"; }
+    export LOOP_CONFIG="$TEST_TMP/projects.yaml"
+    : > "$LOOP_CONFIG"
+}
+
+teardown() {
+    rm -rf "$TEST_TMP"
+}
+
+@test "handler-lookup: kind=issue returns issue-stage handler for shared label" {
+    run loop_handler_for_label dummy shared-label issue
+    [ "$status" -eq 0 ]
+    [ "$output" = "dev-handler" ]
+}
+
+@test "handler-lookup: kind=pr returns pr-stage handler for shared label (the #441 fix)" {
+    run loop_handler_for_label dummy shared-label pr
+    [ "$status" -eq 0 ]
+    [ "$output" = "dev-rework-handler" ]
+}
+
+@test "handler-lookup: no kind preserves legacy behaviour (first match wins)" {
+    run loop_handler_for_label dummy shared-label
+    [ "$status" -eq 0 ]
+    [ "$output" = "dev-handler" ]
+}
+
+@test "handler-lookup: kind=pr returns nothing when label only in issue_stages" {
+    cat > "$TEST_TMP/issue-only.yaml" <<'YAML'
+version: 1
+name: issue-only
+description: issue-only stages
+issue_stages:
+  - id: dev
+    trigger_label: only-issue
+    handler: dev-handler
+    on_done: done
+YAML
+    loop_workflow_for_project() { echo "issue-only"; }
+    run loop_handler_for_label dummy only-issue pr
+    [ "$status" -ne 0 ]
+}
+
+@test "handler-lookup: default workflow resolves loop:action:dev to dev-rework-handler when kind=pr" {
+    _LOOP_WORKFLOW_DIR="$REPO_ROOT/config/workflows"
+    loop_workflow_for_project() { echo "default"; }
+    run loop_handler_for_label loop "loop:action:dev" pr
+    [ "$status" -eq 0 ]
+    [ "$output" = "dev-rework-handler" ]
+}


### PR DESCRIPTION
Closes #441

## Summary

`loop_handler_for_label` previously iterated `issue_stages` before `pr_stages` and returned the first match — so when a label triggers both kinds of stage (e.g. `loop:action:dev` in `default.yaml`: issue dev + PR rework), the PR path always resolved to `dev-handler` and the rework handler was unreachable.

Effect in the wild: every PR labeled `loop:action:dev` (review-rejected, conflict-needing-rebase) dispatched the wrong handler — masked further by the LOOP-418 stage-age guard, which then silently skipped the broken PRs after 1h.

## Changes

- **`lib/workflow.sh`** — `loop_handler_for_label` accepts an optional third `kind` arg (`issue`|`pr`). When provided, only the matching `<kind>_stages` section is searched. Omitting `kind` preserves legacy first-match behaviour for any external callers.
- **`scanner/scanner.sh`** — the two call sites now pass `issue` / `pr` explicitly (lines 741, 757).
- **`tests/workflow-handler-lookup-kind.bats`** — 5 new tests covering both kinds, legacy fallback, missing-stage failure, and the real-world `default.yaml` regression.

## Test Plan

- [x] `bash -n` clean on `lib/*.sh scripts/*.sh scanner/*.sh install.sh`
- [x] `shellcheck -S warning lib/workflow.sh scanner/scanner.sh` clean
- [x] `bats tests/workflow-handler-lookup-kind.bats` — 5/5 pass
- [x] Live verification against `config/workflows/default.yaml`:
  - `loop_handler_for_label loop "loop:action:dev" issue` → `dev-handler`
  - `loop_handler_for_label loop "loop:action:dev" pr` → `dev-rework-handler`

After this lands, conflicting PRs like #390/#402/#412/#417 should be picked up by `dev-rework-handler` on the next scanner tick (assuming their stage-age cache entry is cleared; see also #439 for the durable fix to that).