### PR TITLE
[LOOP-439] scanner: auto-expire stage-age quarantine after cooloff window

### DIFF
--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -182,16 +182,21 @@ _dedup_key() {
 
 # Stage-age cache — tracks when a PR first appeared at a given stage.
 # Prevents a stuck PR from winning the per-tick cap slot indefinitely.
-# Key: "stage-age:<event_type>:<slug>:<num>". Never auto-expires; clear
-# /tmp/loop-stage-age/ manually (or delete a specific entry) to reset.
+# Key: "stage-age:<event_type>:<slug>:<num>". Auto-expires after the cooloff
+# window (LOOP_STAGE_AGE_COOLOFF_MULTIPLIER × LOOP_MAX_AGE_IN_STAGE_SECONDS,
+# default 6h) so a quarantined PR gets one more dispatch attempt. Clear
+# /tmp/loop-stage-age/ manually to force immediate retry.
 STAGE_AGE_DIR="/tmp/loop-stage-age"
 mkdir -p "$STAGE_AGE_DIR"
 
-# _stage_age_exceeded <key> <max_seconds>
-# Returns 0 (true) if this key was first recorded more than max_seconds ago.
+# _stage_age_exceeded <key> <max_seconds> <cooloff_seconds>
+# Returns 0 (true) if this key was recorded more than max_seconds ago AND the
+# cooloff window has not yet elapsed (i.e., the PR is quarantined).
+# Once age >= cooloff_seconds the tracking file is deleted so the PR gets one
+# more dispatch attempt; if it stalls again a fresh quarantine begins.
 # Side-effect: creates the tracking file on first call for a new key.
 _stage_age_exceeded() {
-    local key="$1" max_age="$2"
+    local key="$1" max_age="$2" cooloff="$3"
     local key_file
     key_file="$STAGE_AGE_DIR/$(_dedup_key "$key")"
     if [ ! -f "$key_file" ]; then
@@ -200,6 +205,10 @@ _stage_age_exceeded() {
     fi
     local age
     age=$(( $(date +%s) - $(stat -f%m "$key_file" 2>/dev/null || stat -c%Y "$key_file" 2>/dev/null || echo 0) ))
+    if [ "$age" -ge "$cooloff" ]; then
+        rm -f "$key_file"
+        return 1
+    fi
     [ "$age" -ge "$max_age" ]
 }
 
@@ -648,11 +657,15 @@ _scan_pr_stage() {
 
         # Skip PRs stuck at this stage longer than LOOP_MAX_AGE_IN_STAGE_SECONDS (default 1h).
         # Prevents a zombie PR from consuming the per-tick cap slot indefinitely and
-        # starving all other PRs at this stage. Operator must clear /tmp/loop-stage-age/
-        # (or the specific entry) to re-enable dispatch for the affected PR.
+        # starving all other PRs at this stage. After the cooloff window the tracking
+        # entry is deleted and the PR gets one more auto-dispatch attempt; if it stalls
+        # again a fresh quarantine begins. Set LOOP_STAGE_AGE_COOLOFF_MULTIPLIER to
+        # tune the cooloff (default 6× max_age).
         local _max_stage_age="${LOOP_MAX_AGE_IN_STAGE_SECONDS:-3600}"
-        if _stage_age_exceeded "${event_type}:${slug}:${num}" "$_max_stage_age"; then
-            log "skip ${event_type} #${num}: stuck at ${trigger_label} for >${_max_stage_age}s — round-robin skip; operator action needed"
+        local _cooloff_mult="${LOOP_STAGE_AGE_COOLOFF_MULTIPLIER:-6}"
+        local _cooloff=$(( _max_stage_age * _cooloff_mult ))
+        if _stage_age_exceeded "${event_type}:${slug}:${num}" "$_max_stage_age" "$_cooloff"; then
+            log "skip ${event_type} #${num}: stuck at ${trigger_label} for >${_max_stage_age}s — quarantined for ${_cooloff}s then auto-retry"
             continue
         fi
 


### PR DESCRIPTION
Closes #439

## Changes

**Root cause:** `_stage_age_exceeded` created a tracking file on first sight of a stuck PR but never deleted it. Once a PR spent >1h at a stage the quarantine became permanent — requiring operator to manually `rm` the file.

**Fix:** Added a cooloff window (default 6× `LOOP_MAX_AGE_IN_STAGE_SECONDS` = 6h) after which the tracking file is automatically deleted. On the next scanner tick the PR is treated as fresh and gets one more dispatch attempt. If it stalls again, a new quarantine begins — this is a self-healing retry loop instead of a permanent gag.

**Changes to `scanner/scanner.sh`:**
- `_stage_age_exceeded`: accepts a third `<cooloff_seconds>` arg; deletes the tracking file and returns 1 (allow dispatch) when `age >= cooloff`
- `_scan_pr_stage`: computes `_cooloff = _max_stage_age × LOOP_STAGE_AGE_COOLOFF_MULTIPLIER` (default 6) and passes it through; updated log message to say "quarantined for Ns then auto-retry" so operators know recovery is automatic
- Updated comments to reflect the new self-expiring behavior

**New env var:** `LOOP_STAGE_AGE_COOLOFF_MULTIPLIER` (integer, default `6`) — controls how many max-age windows elapse before a quarantined PR gets another attempt. Operators can lower it (e.g. `2` = 2h cooloff) for faster retries or raise it for more conservative backoff.

## Test Plan

- Manually create a tracking file in `/tmp/loop-stage-age/` for an existing PR key and set its mtime to >6h ago; run `scanner.sh --once --dry-run` and confirm the PR is dispatched (not skipped) and the tracking file is gone
- Set its mtime to 2h ago; confirm the PR is still skipped with the "quarantined … then auto-retry" message
- Set `LOOP_STAGE_AGE_COOLOFF_MULTIPLIER=2` and verify the cooloff window scales correctly
- Confirm the 8+ blocked PRs from the issue (#402, #412, #417, #41, #58, #297, …) resume dispatch after the 6h window without operator intervention