### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,6 +338,26 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    # Scanner liveness watchdog — restarts a wedged scanner (alive PID but stale
+    # heartbeat) by killing the PID so launchd KeepAlive triggers a fresh start.
+    # Runs every 5 min on its own cadence, independent of the scanner interval.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     local digest_plist="$agents_dir/com.user.loop-digest.plist"
     if [ -f "$digest_plist" ]; then
         echo "[launchd] com.user.loop-digest already registered — skipping"
@@ -361,8 +381,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local scanner_watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local scanner_watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $scanner_watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +404,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$scanner_watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$scanner_watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -761,7 +761,32 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+# _write_heartbeat — update ${LOOP_LOG_DIR}/scanner-heartbeat with the current
+# timestamp and scanner PID. Called at the top of every tick so an external
+# watchdog can detect a wedged scanner by comparing the file mtime against now.
+_write_heartbeat() {
+    $DRY_RUN && return 0
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    printf '%s pid=%s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$$" > "$hb" || true
+}
+
+# _check_log_fd — if LOG_FILE is no longer writable (e.g. logrotate deleted the
+# inode), reopen stdout/stderr against the path so writes resume to a live file.
+# Exits the scanner if the reopen fails so launchd/cron can restart cleanly.
+_check_log_fd() {
+    [ -n "${LOG_FILE:-}" ] || return 0
+    if [ ! -w "$LOG_FILE" ] 2>/dev/null; then
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" || {
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] FATAL: cannot reopen $LOG_FILE — exiting for restart" >&2
+            exit 1
+        }
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] log FD reopened (file was unwritable)"
+    fi
+}
+
 run_once() {
+    _check_log_fd
+    _write_heartbeat
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if its heartbeat file goes stale.
+#
+# Designed to run every 5 minutes via launchd (macOS) or cron (Linux).
+# On macOS the scanner is a KeepAlive launchd agent — killing its PID causes
+# launchd to auto-restart it. On Linux the scanner runs via cron (--once),
+# so stale heartbeat = something wedged in the current invocation; killing it
+# lets cron start a fresh one on the next tick.
+#
+# Environment (read from loop.env if present):
+#   LOOP_SCANNER_INTERVAL   — expected tick interval in seconds (default 300)
+#   LOOP_SCANNER_STALE_MULT — heartbeat age multiplier before declaring stale (default 2)
+#   LOOP_LOG_DIR            — where scanner-heartbeat lives
+#
+# Flags:
+#   --dry-run   report staleness without killing the scanner
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_MULT="${LOOP_SCANNER_STALE_MULT:-2}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * STALE_MULT ))
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+
+log "tick (stale-threshold=${STALE_THRESHOLD}s, dry-run=${DRY_RUN})"
+
+# --- check heartbeat freshness ---
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "INFO: heartbeat file not found — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+heartbeat_age=$(( $(date +%s) - $(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0) ))
+
+if [ "$heartbeat_age" -lt "$STALE_THRESHOLD" ]; then
+    log "OK: heartbeat age=${heartbeat_age}s < threshold=${STALE_THRESHOLD}s"
+    exit 0
+fi
+
+log "WARN: heartbeat stale (age=${heartbeat_age}s >= threshold=${STALE_THRESHOLD}s)"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner and let launchd/cron restart it"
+    exit 0
+fi
+
+# --- kill the wedged scanner ---
+scanner_pid=""
+if [ -f "$LOCK_FILE" ]; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+fi
+
+if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+    log "killing scanner PID $scanner_pid"
+    kill "$scanner_pid" 2>/dev/null || true
+    sleep 2
+    # Force if still alive
+    if kill -0 "$scanner_pid" 2>/dev/null; then
+        log "scanner still alive after SIGTERM — sending SIGKILL"
+        kill -9 "$scanner_pid" 2>/dev/null || true
+    fi
+    rm -f "$LOCK_FILE"
+    log "scanner killed; launchd/cron will restart on next interval"
+else
+    log "WARN: no live scanner PID found (lock=${LOCK_FILE}, pid=${scanner_pid:-none}) — removing stale heartbeat"
+    rm -f "$HEARTBEAT_FILE"
+fi

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+  Runs every 5 minutes. If the scanner heartbeat file is older than
+  2 * LOOP_SCANNER_INTERVAL (default 600s), kills the scanner PID so
+  launchd auto-restarts it via the scanner's KeepAlive plist.
+
+  Installed automatically by: install.sh --bootstrap
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,150 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verify scanner heartbeat and watchdog behaviour.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    log() { :; }
+    dispatch_direct() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# _write_heartbeat
+# ---------------------------------------------------------------------------
+
+@test "_write_heartbeat: creates heartbeat file in LOOP_LOG_DIR" {
+    _write_heartbeat
+    [ -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+@test "_write_heartbeat: heartbeat file contains a timestamp" {
+    _write_heartbeat
+    local content
+    content=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+    [[ "$content" == *"20"* ]]
+}
+
+@test "_write_heartbeat: heartbeat file contains scanner PID" {
+    _write_heartbeat
+    local content
+    content=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+    [[ "$content" == *"pid=$$"* ]]
+}
+
+@test "_write_heartbeat: updates mtime on each call" {
+    # stat -f%m is macOS-specific; skip on platforms where it is unavailable.
+    _write_heartbeat
+    local mtime1
+    mtime1=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null) || skip "stat -f%m unavailable"
+    sleep 1
+    _write_heartbeat
+    local mtime2
+    mtime2=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null)
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "_write_heartbeat: no-op in dry-run mode" {
+    DRY_RUN=true
+    _write_heartbeat
+    [ ! -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+# ---------------------------------------------------------------------------
+# run_once writes heartbeat
+# ---------------------------------------------------------------------------
+
+@test "run_once: writes heartbeat file on every tick" {
+    # Stub out all project scanning so run_once completes quickly.
+    loop_list_slugs()    { return 0; }
+    _sweep_stale_locks() { return 0; }
+    jobs_init_schema()   { return 0; }
+    LOOP_JOBS_ENQUEUE=0
+
+    run_once
+
+    [ -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh — basic behaviour
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits 0 with INFO when heartbeat file is absent" {
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"not found"* ]]
+}
+
+@test "scanner-watchdog: reports OK when heartbeat is fresh" {
+    touch "${LOOP_LOG_DIR}/scanner-heartbeat"
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"OK"* ]]
+}
+
+@test "scanner-watchdog --dry-run: reports stale but does not kill when heartbeat is old" {
+    # Create a heartbeat file with an old mtime (touch -t sets mtime).
+    touch "${LOOP_LOG_DIR}/scanner-heartbeat"
+    # Back-date it 60 seconds. Use a very short interval (5s) + mult=2 so
+    # threshold is 10s — well below 60s regardless of operator's loop.env.
+    local old_time
+    old_time=$(date -v -60S '+%Y%m%d%H%M.%S' 2>/dev/null \
+               || date -d '60 seconds ago' '+%Y%m%d%H%M.%S' 2>/dev/null \
+               || { skip "date -v/-d unavailable on this platform"; return; })
+    touch -t "$old_time" "${LOOP_LOG_DIR}/scanner-heartbeat"
+
+    # Write a dummy lock file pointing at a non-existent PID.
+    echo "999999" > /tmp/loop-scanner.lock
+
+    # Force a known-short interval so the stale threshold is 10s (5*2),
+    # well below the 60s back-dated mtime — independent of operator loop.env.
+    run env LOOP_SCANNER_INTERVAL=5 LOOP_SCANNER_STALE_MULT=2 \
+        "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    rm -f /tmp/loop-scanner.lock
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"stale"* ]]
+    [[ "$output" == *"DRY-RUN"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`**
- `_write_heartbeat()` — writes `${LOOP_LOG_DIR}/scanner-heartbeat` (timestamp + PID) at the top of every tick. No-op in `--dry-run` mode.
- `_check_log_fd()` — proactive stdout FD integrity check: if `LOG_FILE` is no longer writable (e.g. logrotate deleted the inode), reopen FDs 1+2 against the path. Exit cleanly if reopen fails so launchd/cron can restart.
- Both functions called at the start of `run_once()`.

**`scripts/scanner-watchdog.sh`** (new)
- Runs every 5 minutes via launchd (macOS) or cron (Linux).
- Reads `scanner-heartbeat` mtime; if older than `LOOP_SCANNER_INTERVAL * LOOP_SCANNER_STALE_MULT` (default 600s), kills the scanner PID. launchd `KeepAlive=true` auto-restarts it within seconds.
- Supports `--dry-run` for safe operator testing.

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new)
- `StartInterval=300` (5 min cadence).
- Uses `__LOOP_ROOT__` / `__LOG_DIR__` / `__HOME__` / `__EXTRA_PATH__` tokens, consistent with all other templates.

**`install.sh`**
- `bootstrap_register_launchd`: registers `com.user.loop-scanner-watchdog.plist` alongside scanner.
- `bootstrap_register_cron`: adds `*/5 * * * *` watchdog entry for Linux.

**`tests/scanner-heartbeat.bats`** (new, 9 tests)
- `_write_heartbeat` creates file, contains timestamp and PID, is a no-op in dry-run.
- `run_once` writes heartbeat on every tick.
- `scanner-watchdog.sh`: missing heartbeat → INFO; fresh heartbeat → OK; stale heartbeat + `--dry-run` → WARN + dry-run message.

## Test Plan
- CI: `bash -n`, `shellcheck`, personal-identifiers grep — all pass locally.
- 9 new bats tests all green.
- Manual: `kill -STOP $SCANNER_PID` → watchdog should restart within 10 min (2 × 5 min interval).