### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,23 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    local watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$watchdog_plist"
+        if launchctl load "$watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +378,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +401,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -762,6 +763,15 @@ scan_project() {
 }
 
 run_once() {
+    # Heartbeat: updated every tick so the scanner-watchdog can detect a wedged process.
+    $DRY_RUN || touch "$HEARTBEAT_FILE"
+
+    # Stdout integrity check: if the log file is not writable, exit and let launchd/cron restart.
+    if ! $DRY_RUN && [ -n "${LOG_FILE:-}" ] && [ ! -w "$LOG_FILE" ]; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] FATAL: log file not writable ($LOG_FILE) — exiting for restart" >&2
+        exit 1
+    fi
+
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — Detect a wedged scanner and restart it.
+#
+# Runs every 5 minutes via launchd (macOS) or cron (Linux).
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat; if the file is older than
+# 2 × LOOP_SCANNER_INTERVAL + 60 s (grace), the scanner is considered
+# wedged and is restarted:
+#   macOS: launchctl kickstart -k gui/<uid>/com.user.loop-scanner
+#   Linux: kill the PID in /tmp/loop-scanner.lock (cron respawns it)
+#
+# Exits 0 in all cases — a non-zero exit from a launchd StartInterval job
+# would suppress subsequent runs.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 + 60 ))
+LOCK_FILE="/tmp/loop-scanner.lock"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file absent — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+_mtime() {
+    stat -f%m "$1" 2>/dev/null || stat -c%Y "$1" 2>/dev/null || echo 0
+}
+
+heartbeat_age=$(( $(date +%s) - $(_mtime "$HEARTBEAT_FILE") ))
+
+if [ "$heartbeat_age" -le "$STALE_THRESHOLD" ]; then
+    log "scanner healthy (heartbeat_age=${heartbeat_age}s threshold=${STALE_THRESHOLD}s)"
+    exit 0
+fi
+
+log "STALE: heartbeat is ${heartbeat_age}s old (threshold=${STALE_THRESHOLD}s) — restarting scanner"
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    if launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null; then
+        log "launchctl kickstart sent"
+    else
+        log "WARN: launchctl kickstart failed — scanner may need manual restart"
+    fi
+else
+    if [ -f "$LOCK_FILE" ]; then
+        local_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+        if [ -n "$local_pid" ] && kill -0 "$local_pid" 2>/dev/null; then
+            kill "$local_pid" 2>/dev/null && log "killed wedged scanner PID $local_pid — cron will restart"
+        else
+            rm -f "$LOCK_FILE"
+            log "stale lock removed — scanner will restart on next cron tick"
+        fi
+    else
+        log "WARN: no lock file found — scanner may not be running"
+    fi
+fi
+
+exit 0

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <!-- Check every 5 minutes; stale threshold = 2 × poll_interval + 60 s -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verify scanner writes heartbeat on every tick.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    mkdir -p "$DEDUP_DIR"
+    touch "$LOG_FILE"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    log()           { :; }
+    dispatch_direct() { :; }
+    scan_project()  { :; }
+    loop_list_slugs() { printf ''; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+@test "run_once: creates heartbeat file on first tick" {
+    rm -f "$HEARTBEAT_FILE"
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: updates heartbeat mtime on subsequent ticks" {
+    touch -t 200001010000 "$HEARTBEAT_FILE"
+    local before
+    before=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+    sleep 1
+    run_once
+    local after
+    after=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+    [ "$after" -gt "$before" ]
+}
+
+@test "run_once: skips heartbeat in dry-run mode" {
+    DRY_RUN=true
+    rm -f "$HEARTBEAT_FILE"
+    run_once
+    [ ! -f "$HEARTBEAT_FILE" ]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- Added `HEARTBEAT_FILE` variable (`${LOOP_LOG_DIR}/scanner-heartbeat`)
- At the start of every `run_once()` tick, `touch "$HEARTBEAT_FILE"` (skipped in `--dry-run` mode)
- Added stdout integrity check: if `LOG_FILE` exists but is not writable, exit with code 1 so launchd/cron restarts the process

### `scripts/scanner-watchdog.sh` (new)
- Reads the heartbeat file mtime; if older than `2 × LOOP_SCANNER_INTERVAL + 60 s` (stale threshold), considers the scanner wedged
- macOS: `launchctl kickstart -k gui/<uid>/com.user.loop-scanner` to force a clean restart
- Linux: kills the PID recorded in `/tmp/loop-scanner.lock`; cron respawns the scanner on the next tick
- Exits 0 in all cases (prevents launchd from suppressing subsequent runs on failure)

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- Runs `scanner-watchdog.sh` every 5 minutes via `StartInterval`
- Uses the same `__LOOP_ROOT__` / `__LOG_DIR__` / `__HOME__` / `__EXTRA_PATH__` substitution placeholders as the other plist templates

### `install.sh`
- `bootstrap_register_launchd`: registers `com.user.loop-scanner-watchdog` alongside the existing scanner/reconciler/watchdog plists
- `bootstrap_register_cron` (Linux): adds `*/5 * * * *` cron entry for `scanner-watchdog.sh`

### `tests/scanner-heartbeat.bats` (new)
- 3 bats tests: heartbeat file is created on first tick, mtime is updated on subsequent ticks, and heartbeat is skipped in `--dry-run` mode

## Test Plan
- Run `bats tests/scanner-heartbeat.bats` — all 3 tests pass
- Manual verification: after install, confirm `${LOOP_LOG_DIR}/scanner-heartbeat` is updated every poll interval
- Wedge simulation: `kill -STOP $SCANNER_PID`; after `STALE_THRESHOLD` seconds the watchdog should restart the scanner via launchctl/kill