### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-stall detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner heartbeat watchdog — restarts the scanner if its heartbeat file
+    # goes stale (silent-wedge detection). Runs every 5 min.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the Loop scanner if its heartbeat goes stale.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written by scanner.sh on every tick).
+# If the file is missing or its mtime is older than LOOP_SCANNER_STALE_SECONDS
+# (default 600 = 2 × the default 300-s poll interval), the scanner is considered
+# wedged and is restarted.
+#
+# On macOS: restarts via launchctl kickstart -k (KeepAlive=true relaunches).
+# On Linux (or macOS launchctl failure): kills the PID in /tmp/loop-scanner.lock;
+# the process supervisor (cron/systemd) is expected to restart the scanner.
+#
+# Designed to run every 5 minutes via launchd StartInterval=300 or cron.
+#
+# Flags:
+#   --dry-run   report stale state without restarting
+#   --once      single sweep (default; reserved for future loop-mode)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+STALE_THRESHOLD="${LOOP_SCANNER_STALE_SECONDS:-600}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+LAUNCHD_LABEL="${LOOP_SCANNER_LAUNCHD_LABEL:-com.user.loop-scanner}"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        --once)    : ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _file_age_seconds <path> — prints seconds since file was last modified.
+# Returns 1 if the file does not exist.
+_file_age_seconds() {
+    local path="$1"
+    [ -f "$path" ] || return 1
+    local mtime now
+    mtime=$(stat -f%m "$path" 2>/dev/null || stat -c%Y "$path" 2>/dev/null || return 1)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+# _kill_scanner_pid — send SIGTERM to the scanner PID recorded in the lock file.
+_kill_scanner_pid() {
+    if [ ! -f "$LOCK_FILE" ]; then
+        log "WARN: lock file $LOCK_FILE not found — scanner may not be running"
+        return
+    fi
+    local pid
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "sending SIGTERM to scanner PID $pid"
+        kill "$pid" 2>/dev/null || true
+    else
+        log "WARN: no live scanner PID in $LOCK_FILE"
+    fi
+}
+
+# _restart_scanner — restart the scanner via launchctl (macOS) or PID kill (Linux).
+_restart_scanner() {
+    if [[ "$(uname)" == "Darwin" ]]; then
+        local uid
+        uid=$(id -u)
+        log "restarting via launchctl kickstart -k gui/${uid}/${LAUNCHD_LABEL}"
+        if launchctl kickstart -k "gui/${uid}/${LAUNCHD_LABEL}" 2>/dev/null; then
+            return 0
+        fi
+        log "WARN: launchctl kickstart failed — falling back to PID kill"
+    fi
+    _kill_scanner_pid
+}
+
+log "tick start (stale-threshold=${STALE_THRESHOLD}s dry-run=${DRY_RUN})"
+
+age=""
+if ! age=$(_file_age_seconds "$HEARTBEAT_FILE" 2>/dev/null); then
+    log "WARN: heartbeat file missing: ${HEARTBEAT_FILE} — scanner may never have started"
+    if $DRY_RUN; then
+        log "DRY-RUN: would restart scanner (no heartbeat file)"
+    else
+        _restart_scanner
+    fi
+    log "tick done"
+    exit 0
+fi
+
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -ge "$STALE_THRESHOLD" ]; then
+    log "WARN: scanner heartbeat is stale (${age}s >= ${STALE_THRESHOLD}s) — restarting"
+    if $DRY_RUN; then
+        log "DRY-RUN: would restart scanner"
+    else
+        _restart_scanner
+    fi
+else
+    log "scanner is alive (heartbeat age=${age}s)"
+fi
+
+log "tick done"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -64,6 +64,23 @@ done
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] $*"; }
 
+# _scanner_write_heartbeat — write a liveness sentinel every tick.
+# The scanner-watchdog reads this file's mtime to detect silent stalls.
+_scanner_write_heartbeat() {
+    printf '%s\n' "$(date '+%Y-%m-%d %H:%M:%S')" \
+        > "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+}
+
+# _scanner_check_log_fd — verify the log file is writable; reopen if not.
+# Protects against the closed-pipe / rotated-file failure mode where the
+# script is alive but STDOUT writes block or go to a deleted inode.
+# Exits (triggering launchd restart) if the reopen also fails.
+_scanner_check_log_fd() {
+    [ -n "${LOG_FILE:-}" ] || return 0
+    [ -w "$LOG_FILE" ] && return 0
+    exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" || exit 1
+}
+
 # _scanner_jobs_enqueue <slug> <stage> <num>
 # Best-effort dual-write to the jobs table alongside the legacy label-event path.
 # Skipped when LOOP_JOBS_ENQUEUE=0 or --dry-run.
@@ -762,6 +779,8 @@ scan_project() {
 }
 
 run_once() {
+    _scanner_check_log_fd
+    _scanner_write_heartbeat
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <!-- Run every 5 minutes; restarts scanner if heartbeat is stale (>10 min) -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verify scanner heartbeat file is written on every tick.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-hb-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+    LOOP_JOBS_ENQUEUE=0
+
+    log() { :; }
+    dispatch_direct() { :; }
+    loop_list_slugs() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-hb-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# _scanner_write_heartbeat
+# ---------------------------------------------------------------------------
+
+@test "_scanner_write_heartbeat: creates heartbeat file in LOOP_LOG_DIR" {
+    rm -f "${LOOP_LOG_DIR}/scanner-heartbeat"
+    _scanner_write_heartbeat
+    [ -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+@test "_scanner_write_heartbeat: heartbeat file contains a date timestamp" {
+    _scanner_write_heartbeat
+    local content
+    content=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+    [[ "$content" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2} ]]
+}
+
+@test "_scanner_write_heartbeat: successive calls update the file" {
+    _scanner_write_heartbeat
+    local mtime1
+    mtime1=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+        || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null)
+    sleep 1
+    _scanner_write_heartbeat
+    local mtime2
+    mtime2=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+        || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null)
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+# ---------------------------------------------------------------------------
+# run_once — heartbeat integration
+# ---------------------------------------------------------------------------
+
+@test "run_once: heartbeat file is created on tick" {
+    rm -f "${LOOP_LOG_DIR}/scanner-heartbeat"
+    run_once
+    [ -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+@test "run_once: heartbeat file is newer after second tick" {
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+        || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null)
+    sleep 1
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+        || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null)
+    [ "$mtime2" -ge "$mtime1" ]
+}


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- Added `_scanner_write_heartbeat()` — writes current timestamp to `${LOOP_LOG_DIR}/scanner-heartbeat` on every tick. The scanner-watchdog reads this file's mtime to detect silent wedges.
- Added `_scanner_check_log_fd()` — verifies the log file is still writable at the top of each tick. Attempts to reopen stdout/stderr against the current path if not; exits for launchd restart if reopen fails.
- Both functions called at the start of `run_once()` before the scan body.

### scanner/scanner-watchdog.sh (new)
- Reads `${LOOP_LOG_DIR}/scanner-heartbeat` mtime each run.
- If the file is missing or older than `LOOP_SCANNER_STALE_SECONDS` (default 600s = 2× the default 300s poll interval), restarts the scanner.
- On macOS: `launchctl kickstart -k gui/<uid>/com.user.loop-scanner`; falls back to SIGTERM on lock-file PID if launchctl fails.
- On Linux: kills the PID from `/tmp/loop-scanner.lock`; cron/systemd expected to restart.
- Supports `--dry-run`. Configurable via `LOOP_SCANNER_STALE_SECONDS` and `LOOP_SCANNER_LAUNCHD_LABEL`.

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
- Runs `scanner-watchdog.sh` every 5 minutes (`StartInterval=300`).
- Follows existing plist template variable conventions (`__LOOP_ROOT__`, `__LOG_DIR__`, `__HOME__`, `__EXTRA_PATH__`).

### install.sh
- `bootstrap_register_launchd()`: registers the scanner-watchdog plist (idempotent, same pattern as pr-watchdog).
- `bootstrap_register_cron()`: adds `*/5 * * * *` cron entry for `scanner-watchdog.sh` on Linux.

### tests/scanner-heartbeat.bats (new)
- 5 tests: `_scanner_write_heartbeat` creates file, content has timestamp, updates mtime; `run_once` creates heartbeat on tick and updates it on the second tick.

## Test Plan
- `bash -n`: all pass
- `shellcheck -S warning`: no warnings
- Personal identifier grep: clean
- `bats tests/scanner-heartbeat.bats`: 5/5 pass
- Manual: simulate wedge with `kill -STOP $SCANNER_PID` → watchdog restarts within 10 min (2× 5-min run interval)