### PR TITLE
[LOOP-413] scanner: liveness heartbeat + auto-restart watchdog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — checks heartbeat file every 5 min; restarts
+    # the scanner via launchctl kickstart if it has been silent too long.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/restart-scanner-if-stale.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/restart-scanner-if-stale.sh
+++ b/scanner/restart-scanner-if-stale.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# restart-scanner-if-stale.sh — Scanner liveness watchdog.
+#
+# Reads the heartbeat file written by scanner.sh on every tick.
+# If the file is absent or its mtime is older than LOOP_HEARTBEAT_STALE_SECONDS
+# (default: 2× poll interval = 600s), the scanner is considered wedged and is
+# forcibly restarted via launchctl (macOS) or by killing the lock-file PID (Linux).
+#
+# Designed to run every 5 minutes via launchd (macOS) or cron (Linux).
+# On macOS: launchctl kickstart -k re-creates the process with KeepAlive in place.
+# On Linux: kill the PID from the lock file; cron will spawn a fresh --once run
+#           on the next tick (the continuous daemonised form is macOS-only).
+#
+# Usage (invoked by scheduler — no args needed):
+#   scanner/restart-scanner-if-stale.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+# Two poll intervals before declaring the scanner wedged.
+STALE_THRESHOLD="${LOOP_HEARTBEAT_STALE_SECONDS:-600}"
+LOG_FILE="${LOOP_LOG_DIR}/loop-scanner-watchdog.log"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*" | tee -a "$LOG_FILE"; }
+
+# _heartbeat_age — prints age in seconds of the heartbeat file, or a very large
+# number if the file is absent (treat missing file as maximally stale).
+_heartbeat_age() {
+    if [ ! -f "$HEARTBEAT_FILE" ]; then
+        echo 999999
+        return 0
+    fi
+    local mtime now
+    mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+         || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+         || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+age=$(_heartbeat_age)
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is healthy — no action needed"
+    exit 0
+fi
+
+log "WARN: scanner appears wedged (heartbeat ${age}s old) — restarting"
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    # macOS: kickstart respects KeepAlive and replaces any running instance.
+    local_uid=$(id -u)
+    if launchctl kickstart -k "gui/${local_uid}/com.user.loop-scanner" 2>/dev/null; then
+        log "launchctl kickstart succeeded"
+    else
+        # Fallback: kill PID from lock file; launchd KeepAlive will relaunch.
+        if [ -f "$LOCK_FILE" ]; then
+            old_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+            if [ -n "$old_pid" ] && kill -0 "$old_pid" 2>/dev/null; then
+                kill "$old_pid" && log "killed scanner PID $old_pid; launchd will restart"
+            else
+                log "lock file stale or empty — removing"
+                rm -f "$LOCK_FILE"
+            fi
+        else
+            log "no lock file found; scanner may have already exited"
+        fi
+    fi
+else
+    # Linux: kill PID from lock file; cron will spawn a fresh run on next tick.
+    if [ -f "$LOCK_FILE" ]; then
+        old_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+        if [ -n "$old_pid" ] && kill -0 "$old_pid" 2>/dev/null; then
+            kill "$old_pid" && log "killed scanner PID $old_pid"
+        else
+            log "lock file stale or empty — removing"
+            rm -f "$LOCK_FILE"
+        fi
+    else
+        log "no lock file found; scanner may have already exited"
+    fi
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -776,6 +777,9 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Liveness heartbeat — updated every tick so the watchdog can detect a
+    # wedged scanner (alive PID, loop intact, but emitting nothing).
+    $DRY_RUN || date +%s > "$HEARTBEAT_FILE"
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/restart-scanner-if-stale.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <!-- Check every 5 minutes (same cadence as the scanner poll interval) -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,133 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 scanner liveness heartbeat.
+#
+# Verifies:
+#  1. scanner.sh writes the heartbeat file on every run_once() tick.
+#  2. restart-scanner-if-stale.sh exits 0 (no restart) when heartbeat is fresh.
+#  3. restart-scanner-if-stale.sh detects a stale heartbeat and kills the PID.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Suppress LOOP_EXTRA_PATH so env.sh does not prepend /opt/homebrew/bin
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner.sh function definitions only (same technique as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    # Override paths set after sourcing.
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+
+    # Stub out functions that require a real environment.
+    log() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { :; }
+    LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/scanner-test.log" "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat file written on every tick
+# ---------------------------------------------------------------------------
+
+@test "run_once: writes heartbeat file on each tick" {
+    rm -f "$HEARTBEAT_FILE"
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: heartbeat file contains a unix timestamp" {
+    run_once
+    local ts
+    ts=$(cat "$HEARTBEAT_FILE")
+    # Must be a non-empty integer greater than a plausible epoch floor (2020-01-01).
+    [[ "$ts" =~ ^[0-9]+$ ]]
+    [ "$ts" -gt 1577836800 ]
+}
+
+@test "run_once: heartbeat mtime is updated on second tick" {
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE")
+    sleep 1
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE")
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once: does NOT write heartbeat file in dry-run mode" {
+    DRY_RUN=true
+    rm -f "$HEARTBEAT_FILE"
+    run_once
+    [ ! -f "$HEARTBEAT_FILE" ]
+}
+
+# ---------------------------------------------------------------------------
+# Watchdog script behaviour
+# ---------------------------------------------------------------------------
+
+@test "restart-scanner-if-stale: exits 0 when heartbeat is fresh" {
+    # Write a fresh heartbeat.
+    date +%s > "$HEARTBEAT_FILE"
+
+    # Run watchdog with a very generous threshold so fresh file is always fine.
+    LOOP_HEARTBEAT_STALE_SECONDS=9999 \
+    LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+    run "$REPO_ROOT/scanner/restart-scanner-if-stale.sh"
+    [ "$status" -eq 0 ]
+}
+
+@test "restart-scanner-if-stale: detects missing heartbeat as stale and logs warning" {
+    rm -f "$HEARTBEAT_FILE"
+
+    # Stub launchctl so we don't touch any real system state.
+    local stub_bin="$BATS_TMPDIR/stub-bin"
+    mkdir -p "$stub_bin"
+    printf '#!/usr/bin/env bash\nexit 1\n' > "$stub_bin/launchctl"
+    chmod +x "$stub_bin/launchctl"
+
+    # Use a lock file with a dead PID so the kill path hits the stale-lock
+    # branch (remove file) instead of actually sending a signal.
+    echo "999999999" > /tmp/loop-scanner.lock
+
+    PATH="$stub_bin:$PATH" \
+    LOOP_HEARTBEAT_STALE_SECONDS=1 \
+    LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+    run "$REPO_ROOT/scanner/restart-scanner-if-stale.sh"
+
+    # Watchdog must exit 0.
+    [ "$status" -eq 0 ]
+
+    # Log must contain the stale-scanner warning.
+    grep -q "wedged" "$LOOP_LOG_DIR/loop-scanner-watchdog.log"
+
+    rm -f /tmp/loop-scanner.lock
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`** — writes a unix timestamp to `${LOOP_LOG_DIR}/scanner-heartbeat` at the start of every `run_once()` tick (skipped in `--dry-run` mode). This is the observable liveness signal: if the file stops being updated, the scanner is wedged.

**`scanner/restart-scanner-if-stale.sh`** — new watchdog script:
- Reads the heartbeat file mtime; if absent or older than `LOOP_HEARTBEAT_STALE_SECONDS` (default 600 s = 2× poll interval), the scanner is declared wedged.
- macOS path: `launchctl kickstart -k gui/<uid>/com.user.loop-scanner` (respects KeepAlive), falling back to kill-PID-from-lockfile.
- Linux path: kill PID from lock file; cron will respawn `scanner.sh --once` on the next tick.
- Logs all decisions to `loop-scanner-watchdog.log` for auditability.

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** — new launchd template that runs the watchdog every 5 minutes (`StartInterval=300`). Uses the same `__PLACEHOLDER__` convention as all other Loop plist templates.

**`install.sh`** — `bootstrap_register_launchd` registers the watchdog plist on macOS; `bootstrap_register_cron` adds a `*/5 * * * *` cron entry on Linux. Both are idempotent (skip-if-exists).

**`tests/scanner-heartbeat.bats`** — 6 new bats tests:
1. `run_once()` creates the heartbeat file
2. Heartbeat file contains a valid unix timestamp
3. Heartbeat mtime is updated on each tick
4. Dry-run mode does NOT write the heartbeat file
5. Watchdog exits 0 when heartbeat is fresh
6. Watchdog detects a missing heartbeat and logs a stale-scanner warning

## Test Plan

- All 6 new tests pass: `bats tests/scanner-heartbeat.bats`
- No regressions in existing scanner tests (failures in tests/scanner.bats and tests/scanner-jobs-enqueue.bats are pre-existing, confirmed against `main`)
- `bash -n` and `shellcheck -S warning` clean on all modified files
- No personal identifiers in committed files

**Manual simulation of wedge detection:**
1. Start scanner; confirm `scanner-heartbeat` is written each tick.
2. `kill -STOP $SCANNER_PID` to freeze the process.
3. Wait > 10 min; run `scanner/restart-scanner-if-stale.sh` manually — should log "wedged" and restart.