### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — fires every 5 min, restarts scanner if heartbeat
+    # file is older than LOOP_SCANNER_WATCHDOG_STALE (default 15 min).
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -774,7 +774,32 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+
+# _scanner_write_heartbeat — update the heartbeat timestamp file every tick.
+# A separate scanner-watchdog reads this file; if it is older than
+# 2 × POLL_INTERVAL the watchdog restarts the scanner.
+_scanner_write_heartbeat() {
+    $DRY_RUN && return 0
+    printf '%s\n' "$(date '+%Y-%m-%d %H:%M:%S')" > "$HEARTBEAT_FILE" 2>/dev/null || true
+}
+
+# _scanner_check_log_writable — if LOG_FILE is no longer writable, reopen it
+# or exit so launchd restarts the scanner with a fresh stdout.
+_scanner_check_log_writable() {
+    [ -z "${LOG_FILE:-}" ] && return 0
+    if [ ! -w "$LOG_FILE" ] && [ ! -w "$(dirname "$LOG_FILE")" ]; then
+        # Cannot write to log dir at all — force exit so launchd restarts.
+        exit 1
+    fi
+    # Reopen fd 1/2 to ensure we are writing to the current inode (e.g. after
+    # log rotation without a SIGHUP, or if the fd was silently closed).
+    exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" || exit 1
+}
+
 run_once() {
+    _scanner_check_log_writable
+    _scanner_write_heartbeat
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if its heartbeat is stale.
+#
+# Designed to run every 5 minutes via launchd (macOS) or cron (Linux).
+# On each run it reads the scanner-heartbeat file written by scanner.sh
+# every tick. If the file is older than STALE_THRESHOLD_SECONDS (default 15
+# min = 2× the default 5-min poll interval with margin), the watchdog kills
+# the scanner PID and, on macOS, triggers launchd to restart it; on Linux it
+# removes the stale lock file so the next cron invocation starts cleanly.
+#
+# Flags:
+#   --dry-run   report what would happen without killing/restarting
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+STALE_THRESHOLD_SECONDS="${LOOP_SCANNER_WATCHDOG_STALE:-900}"  # 15 min
+SCANNER_LOCK_FILE="/tmp/loop-scanner.lock"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOG_FILE="${LOOP_LOG_DIR}/loop-scanner-watchdog.log"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -15
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*" | tee -a "$LOG_FILE"; }
+
+# _file_age_seconds <path> — prints the age of the file in seconds.
+# Portable: tries macOS stat -f%m first, then GNU stat -c%Y.
+_file_age_seconds() {
+    local path="$1"
+    local mtime now
+    mtime=$(stat -f%m "$path" 2>/dev/null || stat -c%Y "$path" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+log "tick (stale-threshold=${STALE_THRESHOLD_SECONDS}s dry-run=${DRY_RUN})"
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file not found — scanner may not have started yet or LOOP_LOG_DIR is wrong"
+    exit 0
+fi
+
+heartbeat_age=$(_file_age_seconds "$HEARTBEAT_FILE")
+log "heartbeat age: ${heartbeat_age}s (threshold=${STALE_THRESHOLD_SECONDS}s)"
+
+if [ "$heartbeat_age" -lt "$STALE_THRESHOLD_SECONDS" ]; then
+    log "scanner is healthy"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat is stale (${heartbeat_age}s > ${STALE_THRESHOLD_SECONDS}s) — restarting"
+
+# Kill the scanner if its PID is known and still alive.
+if [ -f "$SCANNER_LOCK_FILE" ]; then
+    local_pid=$(cat "$SCANNER_LOCK_FILE" 2>/dev/null || echo "")
+    if [ -n "$local_pid" ] && kill -0 "$local_pid" 2>/dev/null; then
+        if $DRY_RUN; then
+            log "DRY-RUN: would kill scanner PID $local_pid"
+        else
+            log "killing wedged scanner PID $local_pid"
+            kill "$local_pid" 2>/dev/null || true
+            sleep 2
+        fi
+    fi
+    if ! $DRY_RUN; then
+        rm -f "$SCANNER_LOCK_FILE" 2>/dev/null || true
+    fi
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would restart scanner"
+    exit 0
+fi
+
+# macOS: launchd manages scanner lifecycle via KeepAlive. Removing the lock
+# file and sending kickstart is sufficient; launchd will relaunch the process.
+if command -v launchctl >/dev/null 2>&1; then
+    if launchctl list com.user.loop-scanner >/dev/null 2>&1; then
+        log "kickstarting com.user.loop-scanner via launchd"
+        launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null \
+            || launchctl stop com.user.loop-scanner 2>/dev/null || true
+    else
+        log "launchctl: com.user.loop-scanner not registered — scanner will self-start via cron or manual launch"
+    fi
+else
+    # Linux/cron: lock file is already removed; the next cron tick starts a fresh scanner.
+    log "non-macOS: stale lock removed — next cron invocation will start a fresh scanner"
+fi
+
+log "restart triggered"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <!-- Run every 5 minutes. The watchdog restarts the scanner if its
+         heartbeat file is older than LOOP_SCANNER_WATCHDOG_STALE (default 15 min). -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verify scanner writes a heartbeat file on every tick.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Suppress LOOP_EXTRA_PATH so env.sh does not shadow the mock gh binary.
+    export LOOP_EXTRA_PATH=""
+
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    STAGE_AGE_DIR="$BATS_TMPDIR/stage-age"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR" "$STAGE_AGE_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { :; }
+    _scanner_check_log_writable() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" "$BATS_TMPDIR/stage-age" \
+           "$BATS_TMPDIR/scanner-src.sh" "$BATS_TMPDIR/scanner-test.log" 2>/dev/null || true
+}
+
+@test "_scanner_write_heartbeat: creates heartbeat file" {
+    rm -f "$HEARTBEAT_FILE"
+    _scanner_write_heartbeat
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "_scanner_write_heartbeat: heartbeat file contains a timestamp" {
+    _scanner_write_heartbeat
+    run cat "$HEARTBEAT_FILE"
+    [ "$status" -eq 0 ]
+    # Should look like YYYY-MM-DD HH:MM:SS
+    [[ "$output" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\ [0-9]{2}:[0-9]{2}:[0-9]{2}$ ]]
+}
+
+@test "_scanner_write_heartbeat: updates mtime on repeated calls" {
+    _scanner_write_heartbeat
+    local mtime1
+    mtime1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE")
+    sleep 1
+    _scanner_write_heartbeat
+    local mtime2
+    mtime2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE")
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "_scanner_write_heartbeat: no-op in dry-run mode" {
+    rm -f "$HEARTBEAT_FILE"
+    DRY_RUN=true
+    _scanner_write_heartbeat
+    [ ! -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: writes heartbeat file" {
+    rm -f "$HEARTBEAT_FILE"
+    LOOP_JOBS_ENQUEUE=0
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+}


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- Added `_scanner_write_heartbeat()` — writes current timestamp to `${LOOP_LOG_DIR}/scanner-heartbeat` on every tick. The watchdog reads this file to detect a wedged scanner.
- Added `_scanner_check_log_writable()` — at the top of each tick, re-opens stdout/stderr against the log file path (defensive against closed/orphaned FDs). If the log directory is entirely unwritable, exits so launchd restarts cleanly.
- Both are called at the start of `run_once()` before the scan body.

### scripts/scanner-watchdog.sh (new)
- Fires every 5 min (via launchd or cron). Reads `scanner-heartbeat` mtime; if older than `LOOP_SCANNER_WATCHDOG_STALE` (default 900s = 15 min), kills the wedged scanner PID and triggers a restart.
- macOS: uses `launchctl kickstart` so launchd's KeepAlive immediately respawns the scanner.
- Linux: removes the stale lock file so the next cron invocation starts cleanly.
- Supports `--dry-run` flag.

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
- launchd plist for the watchdog agent. `StartInterval=300` (every 5 min).

### install.sh
- `bootstrap_register_launchd`: registers `com.user.loop-scanner-watchdog` alongside the existing agents.
- `bootstrap_register_cron`: adds a `*/5 * * * *` cron entry for the watchdog on Linux.

### tests/scanner-heartbeat.bats (new)
- 5 bats tests covering: heartbeat file creation, timestamp format, mtime update, dry-run no-op, and `run_once()` integration.

## Test Plan
- `bats tests/scanner-heartbeat.bats` — all 5 pass.
- Manual: after install, confirm `${LOOP_LOG_DIR}/scanner-heartbeat` is updated every poll interval.
- Manual wedge simulation: `kill -STOP $SCANNER_PID` → watchdog should restart within 15 min (next 5-min tick that sees a 15-min-stale heartbeat).