### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-wedge detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,15 +354,37 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — detects a silently-wedged scanner by checking
+    # the heartbeat file mtime. Runs every 5 min; kills a stale scanner so
+    # launchd (KeepAlive=true) restarts it automatically.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
-# Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
+# Register scanner + reconciler + watchdog via crontab (Linux). Idempotent: skips if marker present.
 bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +404,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -776,6 +776,18 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+
+    # Heartbeat: write current epoch so scanner-watchdog.sh can detect silent
+    # wedges (alive PID but no events emitted for an extended period).
+    printf '%s\n' "$(date +%s)" > "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+
+    # Stdout integrity check: if LOG_FILE is no longer writable (e.g. deleted
+    # inode after log rotation with a dead tee child), reopen FDs. Exit on
+    # failure so launchd restarts us cleanly with fresh file descriptors.
+    if [ -n "${LOG_FILE:-}" ] && ! { true >> "$LOG_FILE"; } 2>/dev/null; then
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" || exit 1
+    fi
+
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — detect a silently-wedged scanner and kill it so launchd restarts it.
+#
+# The scanner writes ${LOOP_LOG_DIR}/scanner-heartbeat on every tick. If that
+# file's mtime is older than STALE_THRESHOLD (default 2 × POLL_INTERVAL = 600s),
+# the scanner is considered wedged; its PID is sent SIGTERM so launchd
+# (KeepAlive=true) or cron restarts it immediately.
+#
+# Run every 5 minutes via launchd (macOS) or cron (Linux):
+#   macOS: com.user.loop-scanner-watchdog.plist (StartInterval 300)
+#   Linux: */5 * * * * /path/to/scripts/scanner-watchdog.sh
+#
+# Flags:
+#   --dry-run   report stale state without sending SIGTERM
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+# Stale threshold: 2 × poll interval. Configurable via LOOP_WATCHDOG_STALE_THRESHOLD.
+STALE_THRESHOLD="${LOOP_WATCHDOG_STALE_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+log "tick (stale-threshold=${STALE_THRESHOLD}s dry-run=${DRY_RUN})"
+
+# No heartbeat file yet — scanner has never ticked or LOOP_LOG_DIR changed.
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "no heartbeat file at $HEARTBEAT_FILE — scanner not yet started or log dir changed"
+    exit 0
+fi
+
+# Compute heartbeat age in seconds.
+now=$(date +%s)
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+    || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+    || echo "$now")
+age=$(( now - mtime ))
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "heartbeat age=${age}s — scanner healthy"
+    exit 0
+fi
+
+log "WARN: heartbeat age=${age}s >= threshold=${STALE_THRESHOLD}s — scanner appears wedged"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID from $LOCK_FILE"
+    exit 0
+fi
+
+# Read the scanner PID from its lock file and send SIGTERM.
+# launchd (KeepAlive=true) will restart the scanner automatically.
+if [ ! -f "$LOCK_FILE" ]; then
+    log "WARN: no lock file at $LOCK_FILE — scanner may not be running"
+    exit 0
+fi
+
+scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+if [ -z "$scanner_pid" ]; then
+    log "WARN: lock file is empty — cannot determine scanner PID"
+    exit 0
+fi
+
+if ! kill -0 "$scanner_pid" 2>/dev/null; then
+    log "WARN: scanner PID $scanner_pid is not alive — lock is stale"
+    exit 0
+fi
+
+log "sending SIGTERM to scanner PID $scanner_pid (launchd will restart)"
+kill -TERM "$scanner_pid" 2>/dev/null || {
+    log "WARN: could not send SIGTERM to PID $scanner_pid"
+    exit 1
+}
+log "done — scanner PID $scanner_pid terminated"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <!-- Run every 5 minutes to detect a silently-wedged scanner -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,125 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verify heartbeat file is written on every scanner tick.
+#
+# Uses the same source-extraction strategy as scanner.bats: awk strips the
+# acquire_lock call and arg-parsing block so we can source scanner.sh functions
+# directly without starting the daemon loop.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export LOOP_EXTRA_PATH=""
+
+    local _src="$BATS_TMPDIR/scanner-src-hb.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-hb-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    log()           { :; }
+    dispatch_direct() { :; }
+    loop_list_slugs() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema()   { :; }
+    LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/scanner-hb-test.log" \
+           "$BATS_TMPDIR/scanner-src-hb.sh" 2>/dev/null || true
+}
+
+@test "run_once: writes scanner-heartbeat file to LOOP_LOG_DIR" {
+    run_once
+    [ -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+@test "run_once: heartbeat file contains a recent epoch timestamp" {
+    run_once
+    local ts
+    ts=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+    local now
+    now=$(date +%s)
+    # Timestamp must be numeric and within 10 seconds of now.
+    [[ "$ts" =~ ^[0-9]+$ ]]
+    local diff=$(( now - ts ))
+    [ "$diff" -ge 0 ]
+    [ "$diff" -lt 10 ]
+}
+
+@test "run_once: heartbeat file mtime is updated on repeated calls" {
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+        || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null)
+
+    # Brief sleep to ensure mtime can change (1-second resolution on most FS).
+    sleep 1
+    run_once
+
+    local mtime2
+    mtime2=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+        || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null)
+
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "scanner-watchdog.sh: exits 0 with healthy heartbeat" {
+    # Write a fresh heartbeat.
+    printf '%s\n' "$(date +%s)" > "${LOOP_LOG_DIR}/scanner-heartbeat"
+
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        LOOP_SCANNER_INTERVAL=300 \
+        LOOP_WATCHDOG_STALE_THRESHOLD=600 \
+        "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner healthy"* ]]
+}
+
+@test "scanner-watchdog.sh: reports stale when heartbeat is old" {
+    # Write a heartbeat with a timestamp 700 seconds in the past.
+    printf '%s\n' "$(( $(date +%s) - 700 ))" > "${LOOP_LOG_DIR}/scanner-heartbeat"
+    # Back-date the file mtime to match.
+    touch -t "$(date -v-700S '+%Y%m%d%H%M.%S' 2>/dev/null \
+                || date -d '700 seconds ago' '+%Y%m%d%H%M.%S' 2>/dev/null \
+                || date '+%Y%m%d%H%M.%S')" \
+        "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        LOOP_SCANNER_INTERVAL=300 \
+        LOOP_WATCHDOG_STALE_THRESHOLD=600 \
+        "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"appears wedged"* ]] || [[ "$output" == *"DRY-RUN"* ]]
+}
+
+@test "scanner-watchdog.sh: exits 0 when no heartbeat file exists" {
+    rm -f "${LOOP_LOG_DIR}/scanner-heartbeat"
+
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"not yet started"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- **Heartbeat file**: writes current epoch to `${LOOP_LOG_DIR}/scanner-heartbeat` at the start of every `run_once()` tick, giving the watchdog a reliable signal that the scanner is alive and processing.
- **Stdout integrity check**: at the top of each tick, verifies `LOG_FILE` is still writable. If not (e.g. after log rotation destroyed the inode), reopens FDs or exits so launchd restarts the process with fresh file descriptors.

### `scripts/scanner-watchdog.sh` (new)
Standalone watchdog script that:
1. Reads the `scanner-heartbeat` mtime.
2. If age ≥ `LOOP_WATCHDOG_STALE_THRESHOLD` (default: `2 × LOOP_SCANNER_INTERVAL` = 600s), sends SIGTERM to the scanner PID from the lock file — launchd (KeepAlive=true) or cron then restarts it automatically.
3. Supports `--dry-run` for safe testing.
4. Exits 0 if no heartbeat file exists yet (scanner not yet started).

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
LaunchAgent plist that runs `scanner-watchdog.sh` every 5 minutes (StartInterval 300).

### `install.sh`
- **macOS bootstrap**: registers `com.user.loop-scanner-watchdog` alongside scanner/reconciler.
- **Linux bootstrap**: adds a `*/5 * * * *` cron entry for `scanner-watchdog.sh`.

### `tests/scanner-heartbeat.bats` (new)
6 BATS tests covering:
- `run_once()` creates the heartbeat file in `LOOP_LOG_DIR`
- Heartbeat contains a recent epoch timestamp
- Heartbeat mtime is updated on repeated calls
- Watchdog exits 0 (healthy) when heartbeat is fresh
- Watchdog reports stale when heartbeat mtime is old
- Watchdog exits 0 gracefully when no heartbeat file exists

## Test Plan
- All 6 new tests pass (`bats tests/scanner-heartbeat.bats`)
- All pre-existing scanner tests unchanged (failures in tests 15/16/20/21/28 are pre-existing on `main`, unrelated to this PR)
- `bash -n` and `shellcheck -S warning` clean on all scripts
- No personal identifiers found
- Manual: simulate wedge with `kill -STOP $SCANNER_PID` → watchdog should terminate and launchd restart within 10 min (2 × 5-min interval)