### PR TITLE
[LOOP-413] scanner: liveness heartbeat + watchdog + stdout integrity check

### DIFF
--- a/scanner/restart-scanner-if-stale.sh
+++ b/scanner/restart-scanner-if-stale.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# restart-scanner-if-stale.sh — scanner liveness watchdog.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written every tick by scanner.sh).
+# If the file is missing or older than LOOP_SCANNER_WATCHDOG_STALE_SECONDS
+# (default: 2 × LOOP_SCANNER_INTERVAL = 10 min), the scanner is considered
+# wedged: kill the lock-file PID and let launchd auto-restart it.
+#
+# Install as a launchd agent (macOS) or cron job (Linux) firing every 5 min.
+# Template: templates/launchd/com.user.loop-scanner-watchdog.plist.template
+#
+# Usage: restart-scanner-if-stale.sh  (no args — reads LOOP_LOG_DIR from loop.env)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+MAX_STALE="${LOOP_SCANNER_WATCHDOG_STALE_SECONDS:-$(( ${LOOP_SCANNER_INTERVAL:-300} * 2 ))}"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file absent — scanner may not have started yet; no action"
+    exit 0
+fi
+
+now=$(date +%s)
+last=$(cat "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+age=$(( now - last ))
+
+if [ "$age" -lt "$MAX_STALE" ]; then
+    log "OK: heartbeat age=${age}s (max=${MAX_STALE}s)"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat stale — age=${age}s > max_stale=${MAX_STALE}s"
+
+# Kill the running scanner; launchd (KeepAlive=true) will restart it.
+if [ -f "$LOCK_FILE" ]; then
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || echo "")
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "killing wedged scanner PID $pid"
+        kill "$pid" 2>/dev/null || true
+    else
+        log "lock file present but PID '$pid' is already dead — removing stale lock"
+        rm -f "$LOCK_FILE"
+    fi
+else
+    log "no lock file — scanner may have already restarted; no action"
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -775,6 +776,17 @@ scan_project() {
 }
 
 run_once() {
+    # Stdout integrity check: if the log file has become unwritable (closed fd
+    # due to dead tee child, EPIPE, or log rotation without SIGHUP), try to
+    # reopen it. Bail out on failure so launchd restarts with fresh fds.
+    if [ -n "${LOG_FILE:-}" ] && ! { : >> "$LOG_FILE"; } 2>/dev/null; then
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" \
+            || { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] ERROR: cannot reopen LOG_FILE — exiting for launchd restart" >&2; exit 1; }
+    fi
+    # Heartbeat: stamp liveness for the external watchdog.
+    if ! $DRY_RUN; then
+        printf '%s\n' "$(date +%s)" > "${HEARTBEAT_FILE}" 2>/dev/null || true
+    fi
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
@@ -785,6 +797,11 @@ run_once() {
         [ -z "$slug" ] && continue
         scan_project "$slug" || log "scan_project $slug failed (continuing)"
     done < <(loop_list_slugs)
+    # Tick-counter: count dedup entries for observability (scanner_tick event).
+    local _dedup_count=0
+    local _f
+    for _f in "$DEDUP_DIR"/*; do [ -f "$_f" ] && _dedup_count=$(( _dedup_count + 1 )); done
+    log "scanner_tick: ts=$(date +%s) dedup_count=${_dedup_count}"
     log "=== scan tick done ==="
 }
 

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 300 s (5 min). Reads scanner-heartbeat written by scanner.sh
+  each tick; if the file is older than LOOP_SCANNER_WATCHDOG_STALE_SECONDS
+  (default 2 × poll interval = 10 min) the watchdog kills the wedged scanner
+  PID so launchd's KeepAlive restarts it.
+
+  Install:
+    sed "s|__LOOP_ROOT__|$(cd "$(dirname "$0")/.." && pwd)|g; \
+         s|__LOG_DIR__|$LOOP_LOG_DIR|g; \
+         s|__HOME__|$HOME|g; \
+         s|__EXTRA_PATH__|${LOOP_EXTRA_PATH:-/opt/homebrew/bin:/usr/local/bin}|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/restart-scanner-if-stale.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,143 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — liveness heartbeat written by scanner.sh (#413).
+#
+# Verifies:
+#   1. run_once() writes HEARTBEAT_FILE on every tick (non-dry-run mode).
+#   2. The heartbeat file contains a recent Unix timestamp.
+#   3. run_once() does NOT write HEARTBEAT_FILE in dry-run mode.
+#   4. restart-scanner-if-stale.sh exits 0 when heartbeat is fresh.
+#   5. restart-scanner-if-stale.sh kills a stale scanner PID when wedged.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export LOOP_EXTRA_PATH=""
+
+    # Override paths that scanner.sh hard-codes after sourcing.
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    STAGE_AGE_DIR="$BATS_TMPDIR/stage-age"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR" "$STAGE_AGE_DIR"
+
+    # Source scanner.sh function definitions only (same technique as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    # Override dynamic paths to use test-local dirs.
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    STAGE_AGE_DIR="$BATS_TMPDIR/stage-age"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    # Silence log output and stub out functions that would make real API calls.
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { :; }
+    _budget_exceeded() { return 1; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" "$BATS_TMPDIR/stage-age" \
+           "$BATS_TMPDIR/scanner-test.log" "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat file written by run_once()
+# ---------------------------------------------------------------------------
+
+@test "run_once: writes HEARTBEAT_FILE on every tick" {
+    [ ! -f "$HEARTBEAT_FILE" ]  # precondition: file does not yet exist
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: HEARTBEAT_FILE contains a numeric Unix timestamp" {
+    run_once
+    local ts
+    ts=$(cat "$HEARTBEAT_FILE")
+    # Must be all digits and roughly match now (within 60s).
+    [[ "$ts" =~ ^[0-9]+$ ]]
+    local now delta
+    now=$(date +%s)
+    delta=$(( now - ts ))
+    [ "$delta" -ge 0 ]
+    [ "$delta" -lt 60 ]
+}
+
+@test "run_once: HEARTBEAT_FILE timestamp advances between ticks" {
+    run_once
+    local ts1
+    ts1=$(cat "$HEARTBEAT_FILE")
+    sleep 1
+    run_once
+    local ts2
+    ts2=$(cat "$HEARTBEAT_FILE")
+    [ "$ts2" -ge "$ts1" ]
+}
+
+@test "run_once: does NOT write HEARTBEAT_FILE in dry-run mode" {
+    DRY_RUN=true
+    run_once
+    [ ! -f "$HEARTBEAT_FILE" ]
+}
+
+# ---------------------------------------------------------------------------
+# restart-scanner-if-stale.sh watchdog
+# ---------------------------------------------------------------------------
+
+@test "restart-scanner-if-stale.sh: exits 0 when heartbeat is fresh" {
+    # Write a fresh heartbeat (now).
+    printf '%s\n' "$(date +%s)" > "$HEARTBEAT_FILE"
+    export LOOP_LOG_DIR
+    export LOOP_EXTRA_PATH=""
+    run bash "$REPO_ROOT/scanner/restart-scanner-if-stale.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"OK:"* ]]
+}
+
+@test "restart-scanner-if-stale.sh: exits 0 when heartbeat file is absent" {
+    rm -f "$HEARTBEAT_FILE"
+    export LOOP_LOG_DIR
+    export LOOP_EXTRA_PATH=""
+    run bash "$REPO_ROOT/scanner/restart-scanner-if-stale.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"absent"* ]]
+}
+
+@test "restart-scanner-if-stale.sh: detects stale heartbeat and removes dead lock" {
+    # Write a stale heartbeat (far in the past).
+    printf '%s\n' "0" > "$HEARTBEAT_FILE"
+    # Write a lock file pointing to a non-existent PID.
+    local fake_lock="/tmp/loop-scanner.lock"
+    printf '999999\n' > "$fake_lock"
+    export LOOP_LOG_DIR
+    export LOOP_EXTRA_PATH=""
+    export LOOP_SCANNER_WATCHDOG_STALE_SECONDS=1
+    run bash "$REPO_ROOT/scanner/restart-scanner-if-stale.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"WARN:"* ]]
+    # Stale lock file should have been removed.
+    [ ! -f "$fake_lock" ]
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`**
- Added `HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"` variable.
- At the top of every `run_once()` tick: stdout integrity check — if the log file becomes unwritable (dead `tee` child, closed fd, EPIPE), attempts to reopen it; exits on failure so launchd auto-restarts with fresh file descriptors.
- Writes a Unix timestamp to `scanner-heartbeat` at the start of each tick (skipped in `--dry-run` mode).
- Emits a `scanner_tick: ts=<epoch> dedup_count=<N>` log line at the end of each tick for observability.

**`scanner/restart-scanner-if-stale.sh`** (new)
- External watchdog script: reads `scanner-heartbeat` mtime; if age exceeds `LOOP_SCANNER_WATCHDOG_STALE_SECONDS` (default: `2 × LOOP_SCANNER_INTERVAL` = 10 min), kills the scanner PID from the lock file so launchd `KeepAlive` restarts it.
- Tunable via `LOOP_SCANNER_WATCHDOG_STALE_SECONDS` env var.

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new)
- launchd plist template for the watchdog; fires every 300 s (5 min) via `StartInterval`.

**`tests/scanner-heartbeat.bats`** (new)
- 7 bats tests covering: heartbeat written on each tick, valid timestamp, advances between ticks, not written in dry-run, watchdog exits OK on fresh heartbeat, exits OK on absent heartbeat, removes stale lock when heartbeat is old.

## Test Plan
- `bats tests/scanner-heartbeat.bats` — all 7 tests pass.
- `bash -n` syntax check passes on all shell scripts.
- `shellcheck -S warning` passes on all shell scripts.
- No personal identifiers introduced.
- Simulate wedge: `kill -STOP $SCANNER_PID` → watchdog should kill and launchd restarts within 10 min.