### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-stop detection

### DIFF
--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — detect a wedged scanner and restart it.
+#
+# The scanner writes a heartbeat timestamp to ${LOOP_LOG_DIR}/scanner-heartbeat
+# on every tick. This watchdog checks that file's mtime; if it is older than
+# STALE_THRESHOLD seconds (default 2× POLL_INTERVAL = 600s) the scanner is
+# considered wedged, its PID is killed, and launchd/cron restarts it.
+#
+# Designed to run every 5 minutes via launchd (macOS) or cron (Linux).
+#
+# Usage:
+#   scanner-watchdog.sh [--dry-run]
+#
+# Environment:
+#   LOOP_SCANNER_INTERVAL   poll cadence in seconds (default 300)
+#   LOOP_WATCHDOG_THRESHOLD override stale threshold in seconds
+#   LOOP_LOG_DIR            log directory (loaded from loop.env)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_WATCHDOG_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _file_age_seconds <path>
+# Returns how many seconds ago the file was last modified, or "" if not found.
+_file_age_seconds() {
+    local path="$1"
+    [ -f "$path" ] || { echo ""; return 0; }
+    local mtime now
+    mtime=$(stat -f%m "$path" 2>/dev/null || stat -c%Y "$path" 2>/dev/null || echo "")
+    [ -z "$mtime" ] && { echo ""; return 0; }
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+log "tick (threshold=${STALE_THRESHOLD}s dry=${DRY_RUN})"
+
+# If no heartbeat file exists yet, the scanner may never have started — skip.
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "no heartbeat file found — scanner may not have run yet; skipping"
+    exit 0
+fi
+
+age=$(_file_age_seconds "$HEARTBEAT_FILE")
+if [ -z "$age" ]; then
+    log "could not read heartbeat mtime — skipping"
+    exit 0
+fi
+
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is healthy"
+    exit 0
+fi
+
+log "WARN: scanner appears wedged (heartbeat ${age}s old, threshold ${STALE_THRESHOLD}s)"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would restart scanner"
+    exit 0
+fi
+
+# Kill the scanner PID recorded in the lock file so launchd/cron restarts it.
+if [ -f "$LOCK_FILE" ]; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+        log "killing wedged scanner PID $scanner_pid"
+        kill "$scanner_pid" 2>/dev/null || true
+        sleep 2
+        # Force-kill if still alive.
+        if kill -0 "$scanner_pid" 2>/dev/null; then
+            log "WARN: PID $scanner_pid still alive after SIGTERM — sending SIGKILL"
+            kill -9 "$scanner_pid" 2>/dev/null || true
+        fi
+    else
+        log "lock file exists but PID '${scanner_pid:-}' is not alive — removing stale lock"
+        rm -f "$LOCK_FILE"
+    fi
+else
+    log "no lock file found — scanner not running; nothing to kill"
+fi
+
+# On macOS with launchd KeepAlive=true the scanner restarts automatically after
+# the kill above. On Linux with cron the next cron tick launches a fresh scanner.
+log "scanner restart triggered"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -775,6 +776,17 @@ scan_project() {
 }
 
 run_once() {
+    # Liveness heartbeat — write current timestamp so scanner-watchdog can detect
+    # a wedged process (alive PID but no tick activity for 2× poll interval).
+    $DRY_RUN || date '+%Y-%m-%d %H:%M:%S' > "$HEARTBEAT_FILE" 2>/dev/null || true
+
+    # Stdout writability guard — if the log file has become unwritable (e.g.
+    # inode replaced after rotation without a SIGHUP), reopen it so writes
+    # resume to the current inode; if reopen also fails, exit so launchd restarts.
+    if [ -n "${LOG_FILE:-}" ] && ! $DRY_RUN && [ ! -w "$LOG_FILE" ]; then
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" || exit 1
+    fi
+
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes. Reads ${LOOP_LOG_DIR}/scanner-heartbeat; if the file
+  is older than LOOP_WATCHDOG_THRESHOLD seconds (default 2× poll interval),
+  kills the wedged scanner PID and lets launchd KeepAlive restart it.
+
+  Install (LOOP_ROOT and LOOP_LOG_DIR must be set, e.g. via your loop.env):
+    sed "s|__LOOP_ROOT__|$LOOP_ROOT|g; \
+         s|__LOG_DIR__|$LOOP_LOG_DIR|g; \
+         s|__HOME__|$HOME|g; \
+         s|__EXTRA_PATH__|${LOOP_EXTRA_PATH:-/opt/homebrew/bin:/usr/local/bin}|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <!-- Check every 5 minutes — well within the default 10-minute stale window -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,141 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 liveness heartbeat.
+#
+# Verifies that:
+#   1. run_once() writes a timestamp to HEARTBEAT_FILE on every tick.
+#   2. scanner-watchdog.sh exits 0 (healthy) when heartbeat is fresh.
+#   3. scanner-watchdog.sh kills the scanner PID when heartbeat is stale.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner.sh function definitions only (same pattern as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    touch "$LOG_FILE"
+
+    # Minimal stubs so run_once doesn't try to poll GitHub.
+    log()              { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { return 0; }
+    loop_list_slugs()  { return 0; }
+    LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-src.sh" \
+           "$BATS_TMPDIR/scanner-test.log" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat — run_once() writes the file
+# ---------------------------------------------------------------------------
+
+@test "run_once: creates heartbeat file on first tick" {
+    rm -f "$HEARTBEAT_FILE"
+    DRY_RUN=false
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: heartbeat file contains a timestamp" {
+    DRY_RUN=false
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+    local content
+    content=$(cat "$HEARTBEAT_FILE")
+    # Timestamp format: YYYY-MM-DD HH:MM:SS
+    [[ "$content" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\ [0-9]{2}:[0-9]{2}:[0-9]{2}$ ]]
+}
+
+@test "run_once: heartbeat mtime is updated on each tick" {
+    DRY_RUN=false
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+    sleep 1
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once: heartbeat is NOT written in dry-run mode" {
+    rm -f "$HEARTBEAT_FILE"
+    DRY_RUN=true
+    run_once
+    [ ! -f "$HEARTBEAT_FILE" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh — healthy scanner
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits 0 when heartbeat is fresh" {
+    # Write a heartbeat with current timestamp.
+    date '+%Y-%m-%d %H:%M:%S' > "$HEARTBEAT_FILE"
+
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        LOOP_WATCHDOG_THRESHOLD=600 \
+        LOOP_EXTRA_PATH="" \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner is healthy"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh — stale heartbeat triggers restart
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: detects stale heartbeat in dry-run" {
+    # Write a heartbeat with a mtime 700 seconds in the past.
+    date '+%Y-%m-%d %H:%M:%S' > "$HEARTBEAT_FILE"
+    # Back-date the file by 700s.  touch -t on macOS: [[CC]YY]MMDDhhmm[.SS]
+    # Use perl as a portable fallback for setting mtime.
+    if ! touch -A -0000700 "$HEARTBEAT_FILE" 2>/dev/null; then
+        perl -e 'utime(time()-700, time()-700, $ARGV[0])' "$HEARTBEAT_FILE"
+    fi
+
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        LOOP_WATCHDOG_THRESHOLD=600 \
+        LOOP_EXTRA_PATH="" \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"wedged"* ]]
+    [[ "$output" == *"DRY-RUN"* ]]
+}
+
+@test "scanner-watchdog: skips gracefully when no heartbeat file exists" {
+    rm -f "$HEARTBEAT_FILE"
+
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        LOOP_WATCHDOG_THRESHOLD=600 \
+        LOOP_EXTRA_PATH="" \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no heartbeat file"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- Added `HEARTBEAT_FILE` variable pointing to `${LOOP_LOG_DIR}/scanner-heartbeat`.
- At the top of every `run_once()` tick (skipped in `--dry-run` mode), writes the current timestamp to the heartbeat file. This gives the watchdog a reliable signal that the scanner is still executing tick bodies, not just sleeping.
- Added a stdout writability guard at the top of each tick: if `LOG_FILE` is not writable (e.g. inode replaced after log rotation without a SIGHUP), attempts to reopen FDs 1+2 against the path; exits so launchd can restart if reopen fails. Complements the existing SIGHUP reopen trap (#194).

### `scanner/scanner-watchdog.sh` (new)
- Reads the heartbeat file's mtime. If older than `LOOP_WATCHDOG_THRESHOLD` seconds (default `2 × LOOP_SCANNER_INTERVAL` = 600s), kills the scanner PID recorded in `/tmp/loop-scanner.lock` (SIGTERM → SIGKILL if needed). launchd's `KeepAlive=true` then restarts the scanner automatically; on Linux, the next cron tick does the same.
- Supports `--dry-run` to log what would happen without killing anything.
- Gracefully skips if the heartbeat file doesn't exist yet (scanner never ran).

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- Launchd plist that fires the watchdog every 5 minutes (`StartInterval=300`).
- Uses the same placeholder convention (`__LOOP_ROOT__`, `__LOG_DIR__`, `__HOME__`, `__EXTRA_PATH__`) as the existing scanner plist template.

### `tests/scanner-heartbeat.bats` (new)
- 7 tests covering: heartbeat file created on first tick, contains a timestamp, mtime updated on each tick, not written in dry-run mode, watchdog exits healthy on fresh heartbeat, watchdog detects stale heartbeat in dry-run, watchdog skips gracefully with no heartbeat file.

## Test Plan
- All 7 new bats tests pass.
- All pre-existing scanner tests pass (5 pre-existing failures in `scanner.bats` are unrelated to this PR and present on `main`).
- `bash -n` and `shellcheck -S warning` pass on all scripts.
- No personal identifiers found.
- Manual: simulate wedge with `kill -STOP $SCANNER_PID` → after `LOOP_WATCHDOG_THRESHOLD` seconds the watchdog should log "wedged" and kill it; launchd should restart within 60s.