### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog auto-restart on silent stop

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -316,6 +316,25 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    # Scanner liveness watchdog — restarts scanner if heartbeat goes stale.
+    # Runs every 5 min; only kicks in if heartbeat age > 2× poll interval.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     # PR auto-rework watchdog — labels stale loop-authored PRs needs-rework so
     # the dev-rework handler picks them up. Independent of scanner; runs every
     # 15 min on its own cadence. Only acts on PRs whose author is in the
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local scanner_watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local scanner_watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $scanner_watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$scanner_watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$scanner_watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart scanner if its heartbeat goes stale.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written by scanner.sh every tick).
+# If the file is missing or older than STALE_THRESHOLD seconds, the scanner
+# is considered wedged and is killed + restarted.
+#
+# Designed to run every 5 min via launchd (macOS) or cron (Linux).
+#
+# Flags:
+#   --dry-run   print what would happen without killing/restarting anything
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+# Stale = 2× poll interval so one missed tick doesn't trigger a false restart.
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 ))
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -15
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+
+now=$(date +%s)
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file missing (${HEARTBEAT_FILE}) — scanner may not have started yet"
+    exit 0
+fi
+
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+age=$(( now - mtime ))
+
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is alive — no action needed"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat stale (age=${age}s > threshold=${STALE_THRESHOLD}s) — restarting"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would restart scanner now"
+    exit 0
+fi
+
+# macOS: launchd manages the scanner via KeepAlive; kickstart -k kills the
+# running instance and lets launchd relaunch it.
+if [ "$(uname -s)" = "Darwin" ] && command -v launchctl >/dev/null 2>&1; then
+    if launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null; then
+        log "restarted via launchctl kickstart"
+        exit 0
+    fi
+    log "launchctl kickstart failed — falling back to SIGTERM"
+fi
+
+# Linux / fallback: kill the running scanner PID so its supervisor (cron or
+# systemd) relaunches it on the next scheduled run.
+local_lock="/tmp/loop-scanner.lock"
+if [ -f "$local_lock" ]; then
+    old_pid=$(cat "$local_lock" 2>/dev/null || echo "")
+    if [ -n "$old_pid" ] && kill -0 "$old_pid" 2>/dev/null; then
+        log "sending SIGTERM to scanner PID ${old_pid}"
+        kill -TERM "$old_pid" 2>/dev/null || true
+    else
+        log "lock file present but PID ${old_pid} is not running — removing stale lock"
+        rm -f "$local_lock"
+    fi
+else
+    log "no lock file found — scanner is not running; nothing to kill"
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -776,6 +776,8 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Heartbeat: write current epoch so scanner-watchdog can detect silent stops.
+    $DRY_RUN || date +%s > "${LOOP_LOG_DIR}/scanner-heartbeat" || true
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <!-- Check every 5 minutes; stale threshold defaults to 2× poll interval -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — heartbeat file is written on every scanner tick.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner.sh function definitions only (same technique as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    # Override paths so scanner runs against test dirs.
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { return 0; }
+    loop_list_slugs() { echo ""; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/scanner-test.log" "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+@test "run_once: heartbeat file is created on first tick" {
+    LOOP_JOBS_ENQUEUE=0 run_once
+    [ -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+@test "run_once: heartbeat file contains a unix timestamp" {
+    LOOP_JOBS_ENQUEUE=0 run_once
+    local val
+    val=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+    # Timestamp should be a 10-digit number (valid through year 2286)
+    [[ "$val" =~ ^[0-9]{10}$ ]]
+}
+
+@test "run_once: heartbeat file mtime advances on consecutive ticks" {
+    LOOP_JOBS_ENQUEUE=0 run_once
+    local mtime1
+    mtime1=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+             || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null)
+    sleep 1
+    LOOP_JOBS_ENQUEUE=0 run_once
+    local mtime2
+    mtime2=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+             || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null)
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once: heartbeat file is NOT written in dry-run mode" {
+    DRY_RUN=true
+    LOOP_JOBS_ENQUEUE=0 run_once
+    [ ! -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- At the top of every `run_once()` tick, writes the current epoch (`date +%s`) to `${LOOP_LOG_DIR}/scanner-heartbeat`. Skipped in `--dry-run` mode.

### `scanner/scanner-watchdog.sh` (new)
- Reads the heartbeat file and computes its age (`now - mtime`).
- Stale threshold = `2 × LOOP_SCANNER_INTERVAL` (default 600 s).
- If stale on macOS: `launchctl kickstart -k gui/$(id -u)/com.user.loop-scanner` (kills + lets launchd relaunch via KeepAlive).
- If stale on Linux / fallback: sends SIGTERM to the PID recorded in `/tmp/loop-scanner.lock`.
- `--dry-run` flag logs what would happen without touching anything.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- Runs `scanner-watchdog.sh` every 5 minutes via `StartInterval=300`.

### `install.sh`
- Registers the watchdog plist in `bootstrap_register_launchd` (macOS).
- Adds a `*/5 * * * *` cron entry in `bootstrap_register_cron` (Linux).

### `tests/scanner-heartbeat.bats` (new)
- Heartbeat file created on first tick.
- File contains a valid unix timestamp.
- File mtime advances on consecutive ticks.
- File is NOT written in `--dry-run` mode.

## Test Plan
- [ ] `bats tests/scanner-heartbeat.bats` — all 4 tests pass
- [ ] `bash -n scanner/scanner-watchdog.sh` + `shellcheck -S warning scanner/scanner-watchdog.sh` — no errors
- [ ] Manual: run `scanner.sh --once`, confirm `${LOOP_LOG_DIR}/scanner-heartbeat` is written
- [ ] Manual: simulate wedge with `kill -STOP $SCANNER_PID`, wait >10 min, confirm watchdog restarts scanner