### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-wedge detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,6 +338,26 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    # Scanner liveness watchdog — fires every 5 min; kills a wedged scanner
+    # PID so launchd can auto-restart it (KeepAlive). Complements SIGHUP log
+    # reopen (#194) by catching the case where the process is alive but silent.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     local digest_plist="$agents_dir/com.user.loop-digest.plist"
     if [ -f "$digest_plist" ]; then
         echo "[launchd] com.user.loop-digest already registered — skipping"
@@ -361,8 +381,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +404,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -775,6 +775,20 @@ scan_project() {
 }
 
 run_once() {
+    # Liveness heartbeat — write current timestamp so the watchdog can detect a
+    # silent wedge (alive PID but no emit activity). Skip in dry-run to avoid
+    # side-effects during testing.
+    if ! $DRY_RUN && ! $ONCE; then
+        printf '%s\n' "$(date +%s)" > "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+    fi
+
+    # Stdout integrity check: if the log file has become non-writable (e.g., a
+    # closed pipe upstream), exit so launchd can restart with a fresh fd.
+    if [ -n "${LOG_FILE:-}" ] && [ ! -w "$LOG_FILE" ]; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] WARN: log file not writable — exiting for restart" >&2
+        exit 1
+    fi
+
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/scanner/watchdog.sh
+++ b/scanner/watchdog.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# scanner/watchdog.sh — Scanner liveness watchdog.
+# Fires every 5 minutes (launchd StartInterval=300 or cron */5).
+# If the scanner heartbeat file is older than LOOP_SCANNER_STALE_THRESHOLD
+# seconds (default 900 = 15 min), kills the scanner PID so launchd or the
+# next cron tick can start a fresh instance.
+#
+# Usage: watchdog.sh [--dry-run]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -10; exit 0 ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [watchdog] $*"; }
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+SCANNER_LOG="${LOOP_LOG_DIR}/loop-scanner.log"
+SCANNER_LOCK="/tmp/loop-scanner.lock"
+STALE_THRESHOLD="${LOOP_SCANNER_STALE_THRESHOLD:-900}"
+
+# _mtime_age <file>
+# Returns seconds since the file was last modified, or a large number if absent.
+_mtime_age() {
+    local f="$1"
+    if [ ! -f "$f" ]; then
+        echo "999999"
+        return
+    fi
+    local mtime now
+    mtime=$(stat -f%m "$f" 2>/dev/null || stat -c%Y "$f" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+heartbeat_age=$(_mtime_age "$HEARTBEAT_FILE")
+log_age=$(_mtime_age "$SCANNER_LOG")
+
+log "heartbeat_age=${heartbeat_age}s  log_age=${log_age}s  threshold=${STALE_THRESHOLD}s"
+
+if [ "$heartbeat_age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is alive — no action needed"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat is ${heartbeat_age}s old (> ${STALE_THRESHOLD}s) — scanner may be wedged"
+
+# Read the scanner PID from the lock file.
+scanner_pid=""
+if [ -f "$SCANNER_LOCK" ]; then
+    scanner_pid=$(cat "$SCANNER_LOCK" 2>/dev/null || true)
+fi
+
+if $DRY_RUN; then
+    if [ -n "$scanner_pid" ]; then
+        log "DRY-RUN: would kill scanner PID $scanner_pid"
+    else
+        log "DRY-RUN: no scanner lock found — nothing to kill"
+    fi
+    exit 0
+fi
+
+if [ -z "$scanner_pid" ]; then
+    log "no scanner lock file found — scanner is not running; launchd/cron will start it"
+    exit 0
+fi
+
+if ! kill -0 "$scanner_pid" 2>/dev/null; then
+    log "scanner PID $scanner_pid is already gone — removing stale lock"
+    rm -f "$SCANNER_LOCK"
+    exit 0
+fi
+
+log "killing wedged scanner PID $scanner_pid"
+kill "$scanner_pid" 2>/dev/null || true
+
+# On macOS with KeepAlive=true, launchd restarts the scanner automatically.
+# On Linux (cron every 5 min), clearing the lock unblocks the next cron tick.
+log "scanner killed — launchd/cron will restart it"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/watchdog.sh</string>
+    </array>
+    <!-- Run every 5 minutes to check scanner liveness -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,126 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — heartbeat file is written on every scanner tick.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner functions (same awk extraction as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+    touch "$LOG_FILE"
+
+    DRY_RUN=false
+    ONCE=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    # Stub out everything that does real work in run_once.
+    log() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+@test "heartbeat file is created on first tick" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    [ ! -f "$hb" ]
+    run_once
+    [ -f "$hb" ]
+}
+
+@test "heartbeat file contains a unix timestamp" {
+    run_once
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    local ts
+    ts=$(cat "$hb")
+    # timestamp must be numeric and recent (within the last 60 seconds)
+    [[ "$ts" =~ ^[0-9]+$ ]]
+    local now
+    now=$(date +%s)
+    local age=$(( now - ts ))
+    [ "$age" -ge 0 ]
+    [ "$age" -lt 60 ]
+}
+
+@test "heartbeat file is updated on subsequent ticks" {
+    run_once
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    local ts1
+    ts1=$(cat "$hb")
+    sleep 1
+    run_once
+    local ts2
+    ts2=$(cat "$hb")
+    # second tick must be >= first (clock monotonically increases)
+    [ "$ts2" -ge "$ts1" ]
+}
+
+@test "heartbeat is NOT written in dry-run mode" {
+    DRY_RUN=true
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    [ ! -f "$hb" ]
+    run_once
+    [ ! -f "$hb" ]
+}
+
+@test "watchdog.sh script exists and passes bash -n" {
+    bash -n "$REPO_ROOT/scanner/watchdog.sh"
+}
+
+@test "watchdog.sh --dry-run prints no-action message when heartbeat is fresh" {
+    # Write a fresh heartbeat.
+    printf '%s\n' "$(date +%s)" > "$LOOP_LOG_DIR/scanner-heartbeat"
+    # Very high threshold ensures fresh heartbeat is never stale.
+    export LOOP_SCANNER_STALE_THRESHOLD=99999
+    run "$REPO_ROOT/scanner/watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner is alive"* ]]
+}
+
+@test "watchdog.sh --dry-run reports stale heartbeat and would-kill message" {
+    # Write a heartbeat with a timestamp 2000 seconds in the past.
+    local past=$(( $(date +%s) - 2000 ))
+    printf '%s\n' "$past" > "$LOOP_LOG_DIR/scanner-heartbeat"
+    # Write a fake lock file with a PID that does not exist.
+    printf '99999999\n' > /tmp/loop-scanner.lock
+    export LOOP_SCANNER_STALE_THRESHOLD=900
+    run "$REPO_ROOT/scanner/watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"wedged"* ]]
+    [[ "$output" == *"DRY-RUN"* ]]
+    rm -f /tmp/loop-scanner.lock
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- At the top of each `run_once()` tick, writes the current Unix timestamp to `${LOOP_LOG_DIR}/scanner-heartbeat`. Skipped in `--dry-run` and `--once` modes to avoid side-effects.
- Adds a stdout integrity check: if `LOG_FILE` is non-writable at tick start, logs a warning to stderr and exits so launchd can restart with a fresh fd. This catches the closed-pipe failure mode described in the issue.

### `scanner/watchdog.sh` (new)
- Fires every 5 minutes (via launchd `StartInterval` or cron `*/5`).
- Reads the heartbeat file mtime. If older than `LOOP_SCANNER_STALE_THRESHOLD` seconds (default 900 = 15 min), reads the scanner PID from the lock file and kills it.
- On macOS with `KeepAlive=true`, launchd auto-restarts the scanner within seconds. On Linux, clearing the lock lets the next cron tick start fresh.
- Supports `--dry-run` for testing without actually killing the scanner.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- LaunchAgent plist template; `StartInterval=300` (every 5 minutes).
- Logs to `loop-scanner-watchdog.log`.

### `install.sh`
- `bootstrap_register_launchd`: installs and loads the watchdog plist alongside the scanner and reconciler plists (idempotent).
- `bootstrap_register_cron`: adds a `*/5 * * * *` cron entry for the watchdog on Linux (idempotent, marker-guarded).

### `tests/scanner-heartbeat.bats` (new)
7 tests covering:
- Heartbeat file created on first tick
- Heartbeat file contains a valid, recent Unix timestamp
- Heartbeat file updated on subsequent ticks
- Heartbeat NOT written in dry-run mode
- `watchdog.sh` passes `bash -n`
- Watchdog `--dry-run` reports "alive" when heartbeat is fresh
- Watchdog `--dry-run` reports "wedged" and would-kill message when heartbeat is stale

## Test Plan
- All 7 new bats tests pass locally
- `bash -n` and `shellcheck -S warning` pass on all scripts
- No personal identifiers detected
- Manual verification: `kill -STOP $SCANNER_PID` → watchdog kills it within 15 min; launchd restarts automatically