### PR TITLE
[LOOP-413] scanner: add liveness heartbeat + auto-restart watchdog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,26 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — kills and lets launchd restart the scanner
+    # when the heartbeat file is stale (>= 2× poll interval, default 10 min).
+    # Runs every 5 min so a wedged scanner is detected within one check window.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +381,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +404,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — Restart a silently-wedged scanner.
+#
+# Checks the mtime of ${LOOP_LOG_DIR}/scanner-heartbeat. If the file is older
+# than LOOP_SCANNER_STALE_THRESHOLD seconds (default: 2 × poll interval = 600s)
+# the scanner is considered wedged: its PID is killed and launchd/cron will
+# restart it. If no heartbeat file exists yet the watchdog exits quietly so it
+# does not fire before the first scanner tick completes.
+#
+# Usage (called by launchd StartInterval or cron every 5 min):
+#   scanner-watchdog.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+LOCK_FILE="/tmp/loop-scanner.lock"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_SCANNER_STALE_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# No heartbeat file → scanner never started or just restarted; nothing to do.
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "no heartbeat file — scanner not yet started, exiting"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+age=$(( now - mtime ))
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s — scanner alive"
+    exit 0
+fi
+
+log "WARN: heartbeat stale (age=${age}s > threshold=${STALE_THRESHOLD}s) — scanner appears wedged"
+
+# Read the scanner PID from its lock file and kill it.
+if [ ! -f "$LOCK_FILE" ]; then
+    log "no lock file found — scanner may have already exited; removing stale heartbeat"
+    rm -f "$HEARTBEAT_FILE"
+    exit 0
+fi
+
+pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+if [ -z "$pid" ]; then
+    log "lock file empty — removing and clearing heartbeat"
+    rm -f "$LOCK_FILE" "$HEARTBEAT_FILE"
+    exit 0
+fi
+
+if ! kill -0 "$pid" 2>/dev/null; then
+    log "scanner PID $pid is already dead — removing stale lock and heartbeat"
+    rm -f "$LOCK_FILE" "$HEARTBEAT_FILE"
+    exit 0
+fi
+
+log "killing wedged scanner PID $pid (launchd/cron will restart it)"
+kill "$pid" 2>/dev/null || true
+# Remove the heartbeat so the next scanner tick writes a fresh one; if the
+# watchdog fires again before the scanner has done its first tick the missing-
+# file guard above will suppress a second kill attempt.
+rm -f "$HEARTBEAT_FILE"
+log "done — scanner PID $pid signalled"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -776,6 +776,9 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Liveness heartbeat — overwrite with current epoch so scanner-watchdog
+    # can detect a silently-wedged process (alive PID, no tick progress).
+    date +%s > "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes. Checks scanner-heartbeat mtime; kills and lets
+  launchd restart the scanner if it has been silent longer than
+  LOOP_SCANNER_STALE_THRESHOLD seconds (default: 2 × poll interval).
+
+  Installed automatically by install.sh --bootstrap alongside the scanner plist.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,95 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — liveness heartbeat written on every tick (#413).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner functions (same strategy as tests/scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    # Silence noisy helpers; prevent real dispatches.
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { :; }
+    LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+@test "run_once writes scanner-heartbeat file" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    [ ! -f "$hb" ]   # not present before first tick
+    run_once
+    [ -f "$hb" ]
+}
+
+@test "run_once updates heartbeat on each call" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    run_once
+    local ts1
+    ts1=$(cat "$hb")
+    sleep 1
+    run_once
+    local ts2
+    ts2=$(cat "$hb")
+    # Timestamps must be numeric and non-decreasing.
+    [[ "$ts1" =~ ^[0-9]+$ ]]
+    [[ "$ts2" =~ ^[0-9]+$ ]]
+    [ "$ts2" -ge "$ts1" ]
+}
+
+@test "scanner-watchdog.sh exits 0 when heartbeat is fresh" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    date +%s > "$hb"
+    run bash "$REPO_ROOT/scanner/scanner-watchdog.sh"
+    [ "$status" -eq 0 ]
+}
+
+@test "scanner-watchdog.sh exits 0 quietly when no heartbeat file" {
+    run bash "$REPO_ROOT/scanner/scanner-watchdog.sh"
+    [ "$status" -eq 0 ]
+}
+
+@test "scanner-watchdog.sh kills wedged scanner PID when heartbeat is stale" {
+    # Spawn a long-lived background process to act as the mock scanner.
+    sleep 60 &
+    local mock_pid=$!
+
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    # Write a stale timestamp (far in the past).
+    echo "1" > "$hb"   # epoch 1 is always stale
+
+    # Point lock file at our mock PID.
+    echo "$mock_pid" > /tmp/loop-scanner.lock
+
+    run bash -c "LOOP_LOG_DIR='$LOOP_LOG_DIR' LOOP_SCANNER_STALE_THRESHOLD=5 '$REPO_ROOT/scanner/scanner-watchdog.sh'"
+    [ "$status" -eq 0 ]
+
+    # Mock process should have been killed.
+    sleep 0.2
+    ! kill -0 "$mock_pid" 2>/dev/null
+
+    rm -f /tmp/loop-scanner.lock
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`**
- At the top of `run_once()`, writes `date +%s` to `${LOOP_LOG_DIR}/scanner-heartbeat`. This gives the watchdog a per-tick liveness signal without touching the existing log path.

**`scanner/scanner-watchdog.sh`** (new)
- Runs every 5 min (launchd `StartInterval` / cron `*/5`).
- Reads the heartbeat file mtime; if age ≥ `LOOP_SCANNER_STALE_THRESHOLD` (default `2 × LOOP_SCANNER_INTERVAL = 600s`) the scanner is considered wedged.
- Reads the PID from `/tmp/loop-scanner.lock`, sends `SIGTERM`, and removes the heartbeat file. launchd (`KeepAlive=true`) or cron restarts the scanner within seconds.
- Exits quietly if no heartbeat file exists (scanner not yet started or just restarted).

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new)
- Standard plist template following the same `__LOOP_ROOT__` / `__LOG_DIR__` / `__HOME__` / `__EXTRA_PATH__` substitution pattern. `StartInterval=300` (every 5 min).

**`install.sh`**
- `bootstrap_register_launchd`: installs `com.user.loop-scanner-watchdog.plist` alongside the scanner plist (idempotent).
- `bootstrap_register_cron`: adds a `*/5` cron entry for the watchdog on Linux (idempotent).

**`tests/scanner-heartbeat.bats`** (new)
- 5 tests: heartbeat file created on first tick, updated on each tick, watchdog exits cleanly when heartbeat is fresh, exits cleanly when no heartbeat, and kills the mock scanner PID when heartbeat is stale.

## Test Plan

- All 5 new bats tests pass (`bats tests/scanner-heartbeat.bats`).
- `bash -n` and `shellcheck -S warning` pass on all scripts.
- No personal identifiers introduced.
- Existing scanner test failures (tests 15, 16, 20, 21, 28) are pre-existing on `main` — not introduced by this PR.
- Manual simulation: `kill -STOP $SCANNER_PID` → watchdog detects stale heartbeat within one 5-min check interval and restarts.