### PR TITLE
[LOOP-413] scanner: heartbeat file + log-writability check + auto-restart watchdog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -316,6 +316,25 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    # Scanner liveness watchdog — checks heartbeat mtime every 5 min and
+    # restarts the scanner if it has been silent for >2× POLL_INTERVAL.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     # PR auto-rework watchdog — labels stale loop-authored PRs needs-rework so
     # the dev-rework handler picks them up. Independent of scanner; runs every
     # 15 min on its own cadence. Only acts on PRs whose author is in the
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/restart-scanner-if-stale.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/restart-scanner-if-stale.sh
+++ b/scanner/restart-scanner-if-stale.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# restart-scanner-if-stale.sh — liveness watchdog for the Loop scanner.
+#
+# Reads the scanner heartbeat file written on every tick. If the file is
+# older than LOOP_HEARTBEAT_STALE_SECONDS (default: 600 = 2 × 300s poll
+# interval), the scanner is presumed wedged and is restarted:
+#   macOS  — launchctl kickstart -k (launchd respects KeepAlive)
+#   Linux  — kill the scanner PID so cron re-spawns it on the next minute
+#
+# Designed to run every 5 minutes via launchd (StartInterval=300) or cron.
+# Does nothing if the heartbeat is fresh or the scanner is not running.
+#
+# Usage:
+#   restart-scanner-if-stale.sh [--dry-run]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+STALE_THRESHOLD="${LOOP_HEARTBEAT_STALE_SECONDS:-600}"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _file_age_seconds <path>
+# Prints the age of the file in seconds, or a very large number if it
+# does not exist (treating "never written" as infinitely stale).
+_file_age_seconds() {
+    local path="$1"
+    if [ ! -f "$path" ]; then
+        echo 999999
+        return
+    fi
+    local mtime now
+    mtime=$(stat -f%m "$path" 2>/dev/null || stat -c%Y "$path" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+age=$(_file_age_seconds "$HEARTBEAT_FILE")
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is healthy — nothing to do"
+    exit 0
+fi
+
+log "WARN: heartbeat stale (${age}s > ${STALE_THRESHOLD}s) — restarting scanner"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would restart scanner"
+    exit 0
+fi
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    # launchd — kickstart kills the running instance (if any) and starts a
+    # fresh one. -k = kill existing before starting. KeepAlive ensures it
+    # stays up after future exits too.
+    if launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null; then
+        log "restarted via launchctl kickstart"
+    else
+        # Fallback: kill the PID directly; launchd KeepAlive will revive it.
+        if [ -f "$LOCK_FILE" ]; then
+            local_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+            if [ -n "$local_pid" ] && kill -0 "$local_pid" 2>/dev/null; then
+                kill "$local_pid" 2>/dev/null && log "killed scanner PID $local_pid (launchd will restart)" || true
+            else
+                log "WARN: lock file stale or empty — scanner may already be down"
+            fi
+        else
+            log "WARN: no lock file found; scanner may not be running"
+        fi
+    fi
+else
+    # Linux — kill the PID so cron re-spawns it on the next minute.
+    if [ -f "$LOCK_FILE" ]; then
+        local_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+        if [ -n "$local_pid" ] && kill -0 "$local_pid" 2>/dev/null; then
+            kill "$local_pid" 2>/dev/null && log "killed scanner PID $local_pid (cron will restart)" || true
+        else
+            log "WARN: lock file stale or empty — scanner may already be down"
+        fi
+    else
+        log "WARN: no lock file found; scanner may not be running"
+    fi
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -46,6 +47,27 @@ _scanner_reopen_log() {
     fi
 }
 trap '_scanner_reopen_log; echo "[$(date "+%Y-%m-%d %H:%M:%S")] [scanner] SIGHUP — log fds reopened"' HUP
+
+# _scanner_write_heartbeat — update the heartbeat file on every tick.
+# The watchdog (restart-scanner-if-stale.sh) reads the mtime of this file;
+# if it is older than 2 × POLL_INTERVAL the scanner is presumed wedged and
+# gets restarted automatically.
+_scanner_write_heartbeat() {
+    $DRY_RUN && return 0
+    date '+%Y-%m-%d %H:%M:%S' > "$HEARTBEAT_FILE" || true
+}
+
+# _scanner_check_log_writability — if the log file is no longer writable,
+# attempt to reopen it (same mechanism as SIGHUP). If reopening fails, exit
+# so launchd/cron restarts the scanner with clean file descriptors.
+_scanner_check_log_writability() {
+    $DRY_RUN && return 0
+    [ -n "${LOG_FILE:-}" ] || return 0
+    if [ ! -w "$LOG_FILE" ] && ! exec 1>>"$LOG_FILE" 2>>"$LOG_FILE"; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] FATAL: cannot write to $LOG_FILE — exiting for restart" >&2
+        exit 1
+    fi
+}
 
 DRY_RUN=false
 ONCE=false
@@ -775,7 +797,16 @@ scan_project() {
 }
 
 run_once() {
+    _scanner_check_log_writability
+    _scanner_write_heartbeat
     log "=== scan tick start ==="
+    # Emit a scanner_tick event so the dashboard can detect silent-stop.
+    if ! $DRY_RUN; then
+        local _dedup_count _tick_ts
+        _tick_ts=$(date '+%Y-%m-%d %H:%M:%S')
+        _dedup_count=$(find "$DEDUP_DIR" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
+        log "scanner_tick: ts=${_tick_ts} dedup_count=${_dedup_count}"
+    fi
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+  Runs every 5 minutes. Restarts the scanner if its heartbeat file is stale.
+
+  Install:
+    sed -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+        -e "s|__LOG_DIR__|$LOOP_LOG_DIR|g" \
+        -e "s|__HOME__|$HOME|g" \
+        -e "s|__EXTRA_PATH__|/opt/homebrew/bin:/usr/local/bin|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/restart-scanner-if-stale.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verify scanner writes heartbeat on every tick.
+#
+# Sourcing strategy: same awk extraction as scanner.bats — pulls all function
+# definitions from scanner.sh, stops before the bare "acquire_lock" call that
+# starts the daemon loop.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Suppress LOOP_EXTRA_PATH so env.sh does not shadow the mock gh binary.
+    export LOOP_EXTRA_PATH=""
+
+    # Expose mock-gh.sh as the gh binary.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    # Source scanner.sh function definitions only.
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    # Override paths set after sourcing.
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    HEARTBEAT_FILE="$BATS_TMPDIR/logs/scanner-heartbeat"
+    mkdir -p "$DEDUP_DIR"
+    touch "$LOG_FILE"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    # Silence log output and no-op heavy operations so we can test heartbeat in isolation.
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { printf ''; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+@test "_scanner_write_heartbeat: creates heartbeat file" {
+    rm -f "$HEARTBEAT_FILE"
+    _scanner_write_heartbeat
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "_scanner_write_heartbeat: updates mtime on each call" {
+    _scanner_write_heartbeat
+    local mtime1
+    mtime1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE")
+    sleep 1
+    _scanner_write_heartbeat
+    local mtime2
+    mtime2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE")
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "_scanner_write_heartbeat: skipped in dry-run mode" {
+    DRY_RUN=true
+    rm -f "$HEARTBEAT_FILE"
+    _scanner_write_heartbeat
+    [ ! -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: heartbeat file is written" {
+    LOOP_JOBS_ENQUEUE=0
+    rm -f "$HEARTBEAT_FILE"
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: heartbeat content is a timestamp" {
+    LOOP_JOBS_ENQUEUE=0
+    run_once
+    local content
+    content=$(cat "$HEARTBEAT_FILE")
+    # Expect YYYY-MM-DD HH:MM:SS format
+    [[ "$content" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\ [0-9]{2}:[0-9]{2}:[0-9]{2}$ ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- Added `HEARTBEAT_FILE` var pointing to `${LOOP_LOG_DIR}/scanner-heartbeat`
- Added `_scanner_write_heartbeat()`: writes current timestamp to the heartbeat file on every tick; skipped in dry-run mode
- Added `_scanner_check_log_writability()`: at top of each tick, attempts to reopen log FDs if the file is not writable; exits (triggering launchd/cron restart) if reopen fails
- `run_once()` now calls both functions at the start and logs a `scanner_tick` line with timestamp and current dedup count for dashboard visibility

### scanner/restart-scanner-if-stale.sh (new)
- Watchdog script: reads `scanner-heartbeat` mtime; if older than `LOOP_HEARTBEAT_STALE_SECONDS` (default 600 = 2×poll), restarts the scanner
- macOS: uses `launchctl kickstart -k` with PID-kill fallback
- Linux: kills the scanner PID so cron re-spawns it on the next minute

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
- launchd plist that runs `restart-scanner-if-stale.sh` every 5 min (StartInterval=300)

### install.sh
- macOS bootstrap now registers `com.user.loop-scanner-watchdog` alongside scanner + reconciler
- Linux cron bootstrap adds `restart-scanner-if-stale.sh` as a `*/5` cron entry

### tests/scanner-heartbeat.bats (new)
- 5 bats tests covering: file creation, mtime updates, dry-run skip, `run_once` integration, and timestamp format

## Test Plan
- All 5 new heartbeat tests pass locally
- All existing scanner.bats / scanner-log-sighup.bats / scanner-stage-age.bats tests unchanged (pre-existing failures unrelated to this PR)
- Manual: `bash -n` and `shellcheck -S warning` pass on all scripts
- Manual simulation: `kill -STOP $SCANNER_PID` → heartbeat goes stale → watchdog kills PID → launchd auto-restarts