### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,6 +338,23 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     local digest_plist="$agents_dir/com.user.loop-digest.plist"
     if [ -f "$digest_plist" ]; then
         echo "[launchd] com.user.loop-digest already registered — skipping"
@@ -361,8 +378,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +401,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — Liveness watchdog for scanner.sh.
+#
+# Reads the heartbeat file written by scanner.sh on every tick.
+# If the file is missing or stale (mtime older than LOOP_SCANNER_WATCHDOG_THRESHOLD
+# seconds, default 2 × LOOP_SCANNER_INTERVAL), the scanner PID is killed so
+# launchd (macOS) or cron (Linux) restarts it automatically.
+#
+# Usage:
+#   scanner-watchdog.sh            # normal (run via launchd StartInterval or cron)
+#   scanner-watchdog.sh --dry-run  # report status without killing
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -15
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+THRESHOLD="${LOOP_SCANNER_WATCHDOG_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+HB_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+
+log "threshold=${THRESHOLD}s heartbeat=${HB_FILE}"
+
+# Check heartbeat file age.
+if [ ! -f "$HB_FILE" ]; then
+    log "WARN: heartbeat file missing — scanner may never have started or is wedged"
+    hb_age=$((THRESHOLD + 1))
+else
+    now=$(date +%s)
+    hb_mtime=$(stat -f%m "$HB_FILE" 2>/dev/null || stat -c%Y "$HB_FILE" 2>/dev/null || echo 0)
+    hb_age=$(( now - hb_mtime ))
+    log "heartbeat age=${hb_age}s"
+fi
+
+if [ "$hb_age" -lt "$THRESHOLD" ]; then
+    log "OK — scanner is alive (heartbeat ${hb_age}s < threshold ${THRESHOLD}s)"
+    exit 0
+fi
+
+log "STALE: heartbeat is ${hb_age}s old (threshold ${THRESHOLD}s) — scanner appears wedged"
+
+# Read the scanner PID from the lock file.
+scanner_pid=""
+if [ -f "$LOCK_FILE" ]; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+fi
+
+if $DRY_RUN; then
+    if [ -n "$scanner_pid" ]; then
+        log "DRY-RUN: would kill scanner PID $scanner_pid"
+    else
+        log "DRY-RUN: no PID in lock file — launchd/cron would restart on next check"
+    fi
+    exit 0
+fi
+
+if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+    log "killing wedged scanner PID $scanner_pid"
+    kill "$scanner_pid" 2>/dev/null || true
+    sleep 2
+    # SIGKILL if still alive.
+    if kill -0 "$scanner_pid" 2>/dev/null; then
+        log "SIGKILL scanner PID $scanner_pid"
+        kill -9 "$scanner_pid" 2>/dev/null || true
+    fi
+    rm -f "$LOCK_FILE"
+    log "scanner killed — launchd/cron will restart it"
+else
+    log "scanner PID not alive (pid='$scanner_pid') — removing stale lock if present"
+    rm -f "$LOCK_FILE"
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -774,8 +774,17 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+# _scanner_write_heartbeat — record the current timestamp so the watchdog
+# can detect a wedged scanner (alive PID, no tick activity).
+_scanner_write_heartbeat() {
+    $DRY_RUN && return 0
+    local hb_file="${LOOP_LOG_DIR}/scanner-heartbeat"
+    printf '%s\n' "$(date '+%Y-%m-%d %H:%M:%S')" > "$hb_file" 2>/dev/null || true
+}
+
 run_once() {
     log "=== scan tick start ==="
+    _scanner_write_heartbeat
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes. Checks the scanner heartbeat file; if stale
+  (default: older than 2 × LOOP_SCANNER_INTERVAL = 10 min), kills the
+  scanner PID so launchd restarts it via the KeepAlive scanner plist.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,117 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 scanner liveness heartbeat.
+#
+# Verifies that _scanner_write_heartbeat writes a file to LOOP_LOG_DIR on
+# every real (non-dry-run) tick, and that the watchdog script correctly
+# classifies fresh vs. stale heartbeats.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Source scanner function definitions only (same awk filter as scanner.bats).
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    log() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# _scanner_write_heartbeat
+# ---------------------------------------------------------------------------
+
+@test "_scanner_write_heartbeat: creates heartbeat file" {
+    DRY_RUN=false
+    _scanner_write_heartbeat
+    [ -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+@test "_scanner_write_heartbeat: heartbeat file is non-empty" {
+    DRY_RUN=false
+    _scanner_write_heartbeat
+    [ -s "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+@test "_scanner_write_heartbeat: updates mtime on repeated calls" {
+    DRY_RUN=false
+    _scanner_write_heartbeat
+    local mtime1
+    mtime1=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+             || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null)
+    sleep 1
+    _scanner_write_heartbeat
+    local mtime2
+    mtime2=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+             || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null)
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "_scanner_write_heartbeat: no-op in dry-run mode" {
+    DRY_RUN=true
+    _scanner_write_heartbeat
+    [ ! -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh
+# ---------------------------------------------------------------------------
+
+@test "scanner.sh contains _scanner_write_heartbeat function" {
+    grep -q "_scanner_write_heartbeat()" "$REPO_ROOT/scanner/scanner.sh"
+}
+
+@test "scanner.sh calls _scanner_write_heartbeat in run_once" {
+    grep -q "_scanner_write_heartbeat" "$REPO_ROOT/scanner/scanner.sh"
+    # Verify the call appears inside run_once (between run_once() and the next top-level function).
+    awk '/^run_once\(\)/{found=1} found && /_scanner_write_heartbeat/{print; exit}' \
+        "$REPO_ROOT/scanner/scanner.sh" | grep -q "_scanner_write_heartbeat"
+}
+
+@test "scanner-watchdog.sh exits 0 when heartbeat is fresh" {
+    # Write a fresh heartbeat.
+    printf '%s\n' "$(date '+%Y-%m-%d %H:%M:%S')" > "${LOOP_LOG_DIR}/scanner-heartbeat"
+    # Watchdog should report OK and exit 0.
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" LOOP_SCANNER_INTERVAL=300 \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -qi "OK"
+}
+
+@test "scanner-watchdog.sh reports stale when heartbeat is old" {
+    # Write a heartbeat with an old mtime (touch -t in the past).
+    touch -t "$(date -v-1H '+%Y%m%d%H%M' 2>/dev/null || date -d '-1 hour' '+%Y%m%d%H%M' 2>/dev/null)" \
+        "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || \
+        touch "${LOOP_LOG_DIR}/scanner-heartbeat"
+    # Force threshold to 60s so even a 1-minute-old file triggers.
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" LOOP_SCANNER_WATCHDOG_THRESHOLD=60 \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -qi "STALE\|stale"
+}
+
+@test "scanner-watchdog.sh reports stale when heartbeat file is missing" {
+    rm -f "${LOOP_LOG_DIR}/scanner-heartbeat"
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" LOOP_SCANNER_WATCHDOG_THRESHOLD=60 \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -qi "missing\|STALE\|stale"
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- Added `_scanner_write_heartbeat()` — writes the current timestamp to `${LOOP_LOG_DIR}/scanner-heartbeat` on every real tick (no-op in dry-run). The file mtime is the liveness signal.
- Called at the top of `run_once()` so a wedged main-loop body (stuck in a `gh` call etc.) will cause the file to go stale and the watchdog to trigger.

### `scanner/scanner-watchdog.sh` (new)
- Standalone script that reads the heartbeat file mtime.
- If `now - mtime > LOOP_SCANNER_WATCHDOG_THRESHOLD` (default: `2 × LOOP_SCANNER_INTERVAL` = 600s), kills the scanner PID from `/tmp/loop-scanner.lock` and lets launchd/cron restart it automatically.
- Supports `--dry-run` for safe inspection without killing.
- Threshold is tunable via `LOOP_SCANNER_WATCHDOG_THRESHOLD` env var.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- Fires the watchdog every 5 minutes (`StartInterval=300`).
- Follows the same `__LOOP_ROOT__` / `__LOG_DIR__` / `__HOME__` / `__EXTRA_PATH__` substitution pattern as other Loop plists.

### `install.sh`
- `bootstrap_register_launchd`: registers and loads `com.user.loop-scanner-watchdog` alongside the existing scanner/reconciler/pr-watchdog plists.
- `bootstrap_register_cron` (Linux): adds a `*/5 * * * *` watchdog cron entry with `# loop-scanner-watchdog` marker for idempotency.

### `tests/scanner-heartbeat.bats` (new)
9 bats tests covering:
- `_scanner_write_heartbeat` creates / updates the heartbeat file on each real tick
- `_scanner_write_heartbeat` is a no-op in dry-run mode
- `scanner-watchdog.sh --dry-run` reports OK for a fresh heartbeat
- `scanner-watchdog.sh --dry-run` reports STALE for an old heartbeat
- `scanner-watchdog.sh --dry-run` reports stale when the heartbeat file is missing

## Test Plan

**Automated (bats):**
- `bats tests/scanner-heartbeat.bats` — all 9 tests pass

**Manual (simulated wedge):**
1. Confirm `${LOOP_LOG_DIR}/scanner-heartbeat` is updated every poll interval.
2. `kill -STOP $SCANNER_PID` to freeze the scanner.
3. Wait until `stat -f%m ${LOOP_LOG_DIR}/scanner-heartbeat` is > 600s in the past.
4. Run `scanner/scanner-watchdog.sh --dry-run` — should report STALE.
5. Run `scanner/scanner-watchdog.sh` (live) — watchdog kills the frozen PID; launchd restarts scanner within seconds.
6. Confirm new scanner begins writing heartbeat immediately.