### PR TITLE
[LOOP-413] scanner: heartbeat file + scanner-watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -316,6 +316,25 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    # Scanner liveness watchdog — restarts the scanner if its heartbeat file
+    # hasn't been updated in 2× the poll interval. Fires every 5 min.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     # PR auto-rework watchdog — labels stale loop-authored PRs needs-rework so
     # the dev-rework handler picks them up. Independent of scanner; runs every
     # 15 min on its own cadence. Only acts on PRs whose author is in the
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local scanner_watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local scanner_watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $scanner_watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$scanner_watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$scanner_watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -774,8 +774,16 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+_write_heartbeat() {
+    # Write current timestamp to heartbeat file so the scanner-watchdog can
+    # detect a silently-wedged process (alive PID but no tick activity).
+    local hb_file="${LOOP_LOG_DIR}/scanner-heartbeat"
+    date +%s > "$hb_file" 2>/dev/null || true
+}
+
 run_once() {
     log "=== scan tick start ==="
+    $DRY_RUN || _write_heartbeat
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart a silently-wedged scanner process.
+#
+# The scanner can become wedged: alive PID, sleep loop intact, but emits no
+# events. This script reads the heartbeat file written every tick and kills
+# the scanner if it hasn't updated in STALE_THRESHOLD seconds (default:
+# 2 × LOOP_SCANNER_INTERVAL, or 900s). launchd KeepAlive then restarts it.
+#
+# Usage:
+#   scanner-watchdog.sh            # check and restart if stale
+#   scanner-watchdog.sh --dry-run  # log what would happen without killing
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+LOCK_FILE="/tmp/loop-scanner.lock"
+HB_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_SCANNER_WATCHDOG_THRESHOLD:-$(( POLL_INTERVAL * 2 + 60 ))}"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -15
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# Compute age of the heartbeat file in seconds, or a large sentinel if absent.
+_heartbeat_age() {
+    if [ ! -f "$HB_FILE" ]; then
+        echo 999999
+        return
+    fi
+    local mtime now
+    mtime=$(stat -f%m "$HB_FILE" 2>/dev/null || stat -c%Y "$HB_FILE" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+age=$(_heartbeat_age)
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is alive — no action needed"
+    exit 0
+fi
+
+# Heartbeat is stale. Read scanner PID from lock file.
+pid=""
+if [ -f "$LOCK_FILE" ]; then
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+fi
+
+if [ -z "$pid" ]; then
+    log "WARN: heartbeat stale but no lock file found — scanner may not be running"
+    exit 0
+fi
+
+if ! kill -0 "$pid" 2>/dev/null; then
+    log "WARN: heartbeat stale but PID $pid is already dead — launchd should restart scanner"
+    exit 0
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID $pid (stale for ${age}s)"
+    exit 0
+fi
+
+log "killing stale scanner PID $pid (no heartbeat for ${age}s) — launchd will restart"
+kill "$pid" 2>/dev/null || true

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <!-- Check every 5 minutes; threshold defaults to 2*poll+60=660s so two
+         missed ticks trigger a restart. -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`** — writes `${LOOP_LOG_DIR}/scanner-heartbeat` (Unix timestamp) at the start of every `run_once()` tick. Skipped in dry-run mode.

**`scripts/scanner-watchdog.sh`** — new script that reads the heartbeat file mtime. If the age exceeds `LOOP_SCANNER_WATCHDOG_THRESHOLD` (default: `2 × LOOP_SCANNER_INTERVAL + 60`, i.e. ~660 s for the default 5-min poll) it reads the scanner PID from the lock file and sends SIGTERM. launchd KeepAlive restarts the scanner within seconds. Supports `--dry-run`.

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** — launchd plist that fires the watchdog every 5 minutes. Uses the same `__LOOP_ROOT__` / `__LOG_DIR__` / `__HOME__` / `__EXTRA_PATH__` placeholders as other templates.

**`install.sh`** — registers the scanner-watchdog in both paths:
- macOS: installs `com.user.loop-scanner-watchdog.plist` via `bootstrap_register_launchd` (idempotent, same pattern as pr-watchdog)
- Linux: adds a `*/5 * * * *` cron entry in `bootstrap_register_cron` (idempotent, marker-guarded)

## Test Plan

- Verify heartbeat file is written on every scanner tick: `watch -n5 stat ~/.loop/logs/scanner-heartbeat`
- Simulate a wedge: `kill -STOP $(cat /tmp/loop-scanner.lock)` → watchdog should log and kill within ≤10 min (two watchdog ticks)
- `scripts/scanner-watchdog.sh --dry-run` should log "would kill" without touching the process
- `./install.sh --bootstrap` on macOS: confirm `com.user.loop-scanner-watchdog.plist` appears in `~/Library/LaunchAgents/` and is loaded