### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-wedge detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — kills a silently-wedged scanner every 5 min
+    # so launchd (KeepAlive) can restart it. Independent of the scanner itself.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — detect a silently-wedged scanner and force a restart.
+#
+# The scanner can appear alive (KeepAlive PID, sleep loop running) but emit
+# no events for hours. The heartbeat file written at the top of each scan tick
+# is the only signal external to the scanner process that it is doing useful
+# work. This watchdog reads that file and kills the scanner if the heartbeat
+# is stale, relying on launchd (KeepAlive) or cron to restart it.
+#
+# Stale threshold: 2 × LOOP_SCANNER_INTERVAL (default 300s → 600s).
+# Runs every 5 min via launchd StartInterval / cron */5.
+#
+# Usage:
+#   scanner-watchdog.sh [--dry-run]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+# Kill after 2 missed ticks to tolerate transient slowness.
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 ))
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _file_age_seconds <path>
+# Returns the age of the file in seconds, or a large sentinel (9999999) if missing.
+_file_age_seconds() {
+    local path="$1"
+    if [ ! -f "$path" ]; then
+        echo 9999999
+        return 0
+    fi
+    local mtime now
+    mtime=$(stat -f%m "$path" 2>/dev/null || stat -c%Y "$path" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+age=$(_file_age_seconds "$HEARTBEAT_FILE")
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is healthy — no action needed"
+    exit 0
+fi
+
+# Heartbeat is stale. Read the scanner PID from its lock file.
+scanner_pid=""
+if [ -f "$LOCK_FILE" ]; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+fi
+
+if [ -z "$scanner_pid" ]; then
+    log "WARN: heartbeat stale (${age}s) but no lock file found — scanner may already be stopped"
+    exit 0
+fi
+
+if ! kill -0 "$scanner_pid" 2>/dev/null; then
+    log "WARN: heartbeat stale (${age}s), lock PID ${scanner_pid} is already dead"
+    exit 0
+fi
+
+log "ALERT: scanner PID ${scanner_pid} heartbeat stale for ${age}s — killing for launchd restart"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill -TERM $scanner_pid"
+    exit 0
+fi
+
+kill -TERM "$scanner_pid" 2>/dev/null || kill -KILL "$scanner_pid" 2>/dev/null || true
+log "sent SIGTERM to scanner PID ${scanner_pid} — launchd will restart it"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -776,6 +777,9 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Heartbeat: every tick we stamp this file so the scanner watchdog can
+    # detect a silently-wedged process (alive PID, no scan activity).
+    $DRY_RUN || touch "$HEARTBEAT_FILE"
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <!-- Run every 5 minutes to catch a silently-wedged scanner within 2 ticks. -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — scanner heartbeat file is updated on every tick.
+#
+# Verifies that scanner.sh writes HEARTBEAT_FILE at the top of each run_once()
+# call, and that scanner-watchdog.sh correctly identifies stale heartbeats.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    # Pre-set log dir so env.sh does not create ~/.loop/logs during tests.
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Expose mock-gh.sh as the gh binary via a per-test temp bin directory.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+
+    # Source scanner.sh function definitions only (same pattern as scanner.bats).
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    HEARTBEAT_FILE="$BATS_TMPDIR/logs/scanner-heartbeat"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    # Silence log() and skip real scan work.
+    log() { :; }
+    loop_list_slugs() { echo ""; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat written by run_once
+# ---------------------------------------------------------------------------
+
+@test "run_once: heartbeat file is created on first tick" {
+    [ ! -f "$HEARTBEAT_FILE" ]
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: heartbeat file mtime is updated on each tick" {
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE")
+
+    # Small sleep so the mtime can advance even on a 1-second filesystem.
+    sleep 1.1
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE")
+
+    [ "$mtime2" -gt "$mtime1" ]
+}
+
+@test "run_once: heartbeat file is NOT written in dry-run mode" {
+    DRY_RUN=true
+    run_once
+    [ ! -f "$HEARTBEAT_FILE" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh logic
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits 0 when heartbeat is fresh" {
+    touch "$BATS_TMPDIR/logs/scanner-heartbeat"
+
+    # Run watchdog with a very high stale threshold so a just-touched file passes.
+    run env \
+        LOOP_LOG_DIR="$BATS_TMPDIR/logs" \
+        LOOP_SCANNER_INTERVAL=9999 \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner is healthy"* ]]
+}
+
+@test "scanner-watchdog: detects stale heartbeat when threshold is very small" {
+    touch "$BATS_TMPDIR/logs/scanner-heartbeat"
+    # Force stale by setting threshold to 0 seconds (any age is stale).
+    # We use a subshell override: scanner-watchdog reads LOOP_SCANNER_INTERVAL.
+    # Threshold = 2 * LOOP_SCANNER_INTERVAL; interval=0 → 0s threshold.
+    # Use interval=1 so threshold=2s; then age of a just-touched file (0s) < 2s.
+    # Instead, back-date the heartbeat file.
+
+    # Back-date to 1 hour ago so it is definitely stale.
+    touch -t "$(date -v-1H '+%Y%m%d%H%M.%S' 2>/dev/null || date -d '-1 hour' '+%Y%m%d%H%M.%S')" \
+        "$BATS_TMPDIR/logs/scanner-heartbeat" 2>/dev/null \
+        || touch -d "1970-01-01 00:00:00" "$BATS_TMPDIR/logs/scanner-heartbeat" 2>/dev/null \
+        || true
+
+    run env \
+        LOOP_LOG_DIR="$BATS_TMPDIR/logs" \
+        LOOP_SCANNER_INTERVAL=300 \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+
+    [ "$status" -eq 0 ]
+    # Should report stale — either "ALERT" or "WARN: heartbeat stale"
+    [[ "$output" == *"stale"* ]] || [[ "$output" == *"ALERT"* ]]
+}
+
+@test "scanner-watchdog: no-op when heartbeat file is missing and no lock file" {
+    rm -f "$BATS_TMPDIR/logs/scanner-heartbeat"
+
+    run env \
+        LOOP_LOG_DIR="$BATS_TMPDIR/logs" \
+        LOOP_SCANNER_INTERVAL=300 \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+
+    [ "$status" -eq 0 ]
+    # Either "WARN: heartbeat stale ... no lock file" or similar
+    [[ "$output" == *"stale"* ]] || [[ "$output" == *"WARN"* ]] || [[ "$output" == *"ALERT"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- Added `HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"` variable
- `run_once()` now calls `touch "$HEARTBEAT_FILE"` at the top of every tick (skipped in `--dry-run` mode)
- This gives an external observer a reliable signal that the scanner is actively executing scan logic, not just sleeping

### `scanner/scanner-watchdog.sh` (new)
- Standalone script that reads the heartbeat file mtime and computes its age
- Stale threshold: `2 × LOOP_SCANNER_INTERVAL` (default 600s — 2 missed ticks)
- If stale and a live scanner PID is found in `/tmp/loop-scanner.lock`, sends `SIGTERM` so launchd (KeepAlive=true) restarts it
- Handles edge cases: missing heartbeat, missing lock file, dead PID
- Supports `--dry-run` for safe testing

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- launchd agent that runs `scanner-watchdog.sh` every 5 minutes (`StartInterval=300`)
- Follows the same `__LOOP_ROOT__` / `__LOG_DIR__` / `__HOME__` substitution pattern as other plists

### `install.sh`
- `bootstrap_register_launchd()`: registers `com.user.loop-scanner-watchdog` plist (idempotent)
- `bootstrap_register_cron()`: adds `*/5 * * * *` cron entry for the watchdog on Linux (idempotent, marker-guarded)

### `tests/scanner-heartbeat.bats` (new)
- 6 tests covering: heartbeat file created on first tick, mtime advances each tick, not written in dry-run, watchdog healthy/stale/missing-file paths

## Test Plan
- `bats tests/scanner-heartbeat.bats` → 6/6 pass
- `bash -n` + `shellcheck -S warning` on all scripts → clean
- Personal identifiers grep → clean
- Manual: kill -STOP $SCANNER_PID → watchdog should restart within 10 min (2 × 300s interval)