### PR TITLE
[LOOP-413] scanner: liveness heartbeat + scanner-watchdog auto-restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — checks heartbeat file every 5 min; kills
+    # and lets launchd restart the scanner if it has been silent too long.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local scanner_watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local scanner_watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $scanner_watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$scanner_watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$scanner_watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner when its heartbeat goes stale.
+#
+# The scanner writes ${LOOP_LOG_DIR}/scanner-heartbeat on every tick.
+# This script checks that file's mtime; if it is older than the stale
+# threshold (default: 2 × LOOP_SCANNER_INTERVAL + 60s), the scanner is
+# considered wedged and is killed so launchd (macOS) or cron (Linux) can
+# restart it automatically.
+#
+# Designed to run every 5 minutes via launchd or cron.
+#
+# Usage:
+#   scanner-watchdog.sh            # check and restart if stale
+#   scanner-watchdog.sh --dry-run  # report only; no kills
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+# Default stale threshold: 2 × poll interval + 60s grace.
+STALE_THRESHOLD="${LOOP_SCANNER_WATCHDOG_STALE:-$(( POLL_INTERVAL * 2 + 60 ))}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _file_age_seconds <path>
+# Returns the age of a file in seconds (now - mtime). Prints 0 if not found.
+_file_age_seconds() {
+    local path="$1"
+    if [ ! -f "$path" ]; then
+        echo 0
+        return
+    fi
+    local mtime now
+    mtime=$(stat -f%m "$path" 2>/dev/null || stat -c%Y "$path" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+age=$(_file_age_seconds "$HEARTBEAT_FILE")
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "ok: heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+    exit 0
+fi
+
+log "WARN: heartbeat stale (age=${age}s > threshold=${STALE_THRESHOLD}s) — scanner appears wedged"
+
+# Read the scanner PID from its lock file.
+scanner_pid=""
+if [ -f "$LOCK_FILE" ]; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID=${scanner_pid:-unknown} and let launchd/cron restart it"
+    exit 0
+fi
+
+if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+    log "killing wedged scanner PID=$scanner_pid"
+    kill "$scanner_pid" 2>/dev/null || true
+    # Give it 5s to exit cleanly; force-kill if still alive.
+    sleep 5
+    if kill -0 "$scanner_pid" 2>/dev/null; then
+        log "scanner still alive after SIGTERM — sending SIGKILL"
+        kill -9 "$scanner_pid" 2>/dev/null || true
+    fi
+    rm -f "$LOCK_FILE"
+    log "scanner killed; launchd/cron will restart it automatically"
+else
+    # No live scanner PID found — lock file may be stale; remove it so a
+    # fresh scanner can start on the next launchd/cron trigger.
+    log "no live scanner PID (lock=${scanner_pid:-empty}); removing stale lock"
+    rm -f "$LOCK_FILE"
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -776,6 +776,11 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Liveness heartbeat — written every tick so the scanner-watchdog can
+    # detect a wedged process by comparing mtime against now.
+    if ! $DRY_RUN; then
+        date '+%Y-%m-%d %H:%M:%S' > "${LOOP_LOG_DIR}/scanner-heartbeat" || true
+    fi
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <!-- Run every 5 minutes to catch a wedged scanner within one check cycle -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — liveness heartbeat written by scanner (#413).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export LOOP_EXTRA_PATH=""
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+
+    # Source scanner functions (same strategy as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-hb-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-hb-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    # Stub out dispatch and log so run_once doesn't actually poll GitHub.
+    log() { :; }
+    dispatch_direct() { :; }
+    loop_list_slugs() { echo ""; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-hb-src.sh" \
+           "$BATS_TMPDIR/scanner-hb-test.log" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat: run_once writes the file
+# ---------------------------------------------------------------------------
+
+@test "run_once: writes scanner-heartbeat file to LOOP_LOG_DIR" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    rm -f "$hb"
+    run_once
+    [ -f "$hb" ]
+}
+
+@test "run_once: scanner-heartbeat contains a timestamp" {
+    run_once
+    local content
+    content=$(cat "$LOOP_LOG_DIR/scanner-heartbeat")
+    # Must look like YYYY-MM-DD HH:MM:SS
+    [[ "$content" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\ [0-9]{2}:[0-9]{2}:[0-9]{2}$ ]]
+}
+
+@test "run_once: scanner-heartbeat mtime is updated on each call" {
+    # stat -f%m is macOS-specific; skip on platforms where it is unavailable.
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    touch -t 200001010000 "$hb" 2>/dev/null || touch "$hb"
+    local before
+    before=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb" 2>/dev/null) || \
+        skip "stat not available on this platform"
+    sleep 1
+    run_once
+    local after
+    after=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb" 2>/dev/null)
+    [ "$after" -gt "$before" ]
+}
+
+@test "run_once: heartbeat is NOT written in dry-run mode" {
+    DRY_RUN=true
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    rm -f "$hb"
+    run_once
+    [ ! -f "$hb" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh: stale threshold detection
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog --dry-run: exits 0 when heartbeat is fresh" {
+    # Write a fresh heartbeat.
+    date '+%Y-%m-%d %H:%M:%S' > "$LOOP_LOG_DIR/scanner-heartbeat"
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ok:"* ]]
+}
+
+@test "scanner-watchdog --dry-run: reports stale when heartbeat is old" {
+    # Write a heartbeat with a past mtime (simulate wedged scanner).
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    date '+%Y-%m-%d %H:%M:%S' > "$hb"
+    # Back-date by 1 hour using touch -t.
+    touch -t "$(date -v-1H '+%Y%m%d%H%M' 2>/dev/null || date -d '-1 hour' '+%Y%m%d%H%M' 2>/dev/null || echo '200001010000')" "$hb"
+    # Set a low threshold so the 1-hour-old file is definitely stale.
+    export LOOP_SCANNER_WATCHDOG_STALE=60
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"stale"* ]]
+    [[ "$output" == *"DRY-RUN"* ]]
+}
+
+@test "scanner-watchdog --dry-run: exits 0 when heartbeat file does not exist yet" {
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+    # age=0 < threshold → considered fresh (scanner has not ticked yet).
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
Added a heartbeat write at the top of `run_once()`: every tick writes the current timestamp to `${LOOP_LOG_DIR}/scanner-heartbeat`. Skipped in `--dry-run` mode. This gives a reliable mtime-based liveness signal with no new dependencies.

### scanner/scanner-watchdog.sh (new)
Standalone watchdog script that:
- Reads the heartbeat file's mtime and compares it against a configurable stale threshold (default: `2 × LOOP_SCANNER_INTERVAL + 60s` = 660s)
- If stale: reads scanner PID from `/tmp/loop-scanner.lock`, sends SIGTERM, waits 5s, then SIGKILL if still alive, removes the lock file so launchd/cron restarts a fresh scanner
- If heartbeat file doesn't exist (scanner hasn't ticked yet), age=0 is always below threshold — healthy
- Accepts `--dry-run` flag; threshold tunable via `LOOP_SCANNER_WATCHDOG_STALE`

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
Runs `scanner-watchdog.sh` every 5 minutes via launchd (macOS), using the same `__LOOP_ROOT__`/`__LOG_DIR__`/`__HOME__`/`__EXTRA_PATH__` substitution pattern as other plist templates.

### install.sh
- `bootstrap_register_launchd()`: registers `com.user.loop-scanner-watchdog` plist after digest
- `bootstrap_register_cron()`: adds `*/5 * * * *` cron entry for Linux with `# loop-scanner-watchdog` idempotency marker

### tests/scanner-heartbeat.bats (new)
7 bats tests covering: heartbeat file creation, timestamp format, mtime update per tick, dry-run suppression, watchdog fresh/stale/missing detection.

## Test Plan

- All 7 new bats tests pass locally
- `bash -n` and `shellcheck -S warning` clean on all scripts
- No personal identifiers in any changed file
- Pre-existing test failures on `main` unaffected by this change
- Manual verification: `kill -STOP $SCANNER_PID` for >660s → watchdog kills it within next 5-min cycle, launchd restarts fresh scanner