### PR TITLE
[LOOP-413] scanner: liveness heartbeat + watchdog auto-restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — fires every 5 min and kills a wedged scanner
+    # (heartbeat file older than 2 × poll interval) so launchd KeepAlive restarts it.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -776,6 +776,16 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Liveness heartbeat: update mtime so scanner-watchdog can detect silent stops.
+    if ! $DRY_RUN; then
+        printf '%s\n' "$(date '+%Y-%m-%d %H:%M:%S')" > "${LOOP_LOG_DIR}/scanner-heartbeat" || true
+    fi
+    # Stdout integrity: if the log file exists but is no longer writable, exit so
+    # launchd restarts the scanner and reopens a fresh fd.
+    if ! $DRY_RUN && [ -n "${LOG_FILE:-}" ] && [ -e "$LOG_FILE" ] && [ ! -w "$LOG_FILE" ]; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] FATAL: log file not writable — exiting for restart" >&2
+        exit 1
+    fi
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — detect a silently-wedged scanner and kill it so launchd restarts it.
+#
+# Runs every 5 minutes (via launchd StartInterval). Reads the heartbeat file written by
+# scanner.sh on every tick. If the file is older than 2 × POLL_INTERVAL (default 10 min),
+# the scanner is considered wedged and its PID is sent SIGTERM so launchd KeepAlive fires.
+#
+# Usage: called by launchd; can also be run manually for diagnostics.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 ))
+HEARTBEAT="${LOOP_LOG_DIR}/scanner-heartbeat"
+SCANNER_LOCK="/tmp/loop-scanner.lock"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+if [ ! -f "$HEARTBEAT" ]; then
+    log "heartbeat file absent — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+# Portable mtime: try macOS stat first, fall back to GNU stat.
+_mtime() { stat -f%m "$1" 2>/dev/null || stat -c%Y "$1" 2>/dev/null || echo 0; }
+
+age=$(( $(date +%s) - $(_mtime "$HEARTBEAT") ))
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner heartbeat ok (age=${age}s threshold=${STALE_THRESHOLD}s)"
+    exit 0
+fi
+
+log "WARN: heartbeat is ${age}s old (threshold=${STALE_THRESHOLD}s) — scanner appears wedged"
+
+if [ -f "$SCANNER_LOCK" ]; then
+    pid=$(cat "$SCANNER_LOCK" 2>/dev/null || true)
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "sending SIGTERM to scanner PID $pid"
+        kill "$pid" 2>/dev/null || true
+        log "done — launchd KeepAlive will restart the scanner"
+    else
+        log "lock file present but PID ${pid:-<empty>} is not alive — removing stale lock"
+        rm -f "$SCANNER_LOCK"
+    fi
+else
+    log "no scanner lock file found; scanner is not running — nothing to kill"
+fi

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <!-- Check every 5 minutes; threshold is 2 × scanner poll interval (default 10 min) -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verify scanner writes heartbeat on every tick (#413).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    log() { :; }
+    dispatch_direct() { :; }
+
+    # Minimal stubs so run_once does not attempt real GitHub calls.
+    loop_list_slugs()  { echo "test-slug"; }
+    scan_project()     { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+@test "run_once: heartbeat file is created on first tick" {
+    run_once
+    [ -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+@test "run_once: heartbeat file mtime is updated on each tick" {
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+        || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null)
+
+    # Ensure at least one second elapses so mtime changes.
+    sleep 1.1
+
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+        || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null)
+
+    [ "$mtime2" -gt "$mtime1" ]
+}
+
+@test "run_once: heartbeat file contains a timestamp line" {
+    run_once
+    local content
+    content=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+    # Matches YYYY-MM-DD HH:MM:SS
+    [[ "$content" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\ [0-9]{2}:[0-9]{2}:[0-9]{2}$ ]]
+}
+
+@test "run_once: heartbeat file is NOT written in dry-run mode" {
+    DRY_RUN=true
+    run_once
+    [ ! -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- At the start of every `run_once()` tick, writes the current timestamp to `${LOOP_LOG_DIR}/scanner-heartbeat`. This file's mtime is the liveness signal.
- Skipped in `--dry-run` mode (matches existing dedup/lock behaviour).
- Stdout integrity check: if `$LOG_FILE` exists but is no longer writable, exits with code 1 so launchd KeepAlive triggers an immediate restart.

### scripts/scanner-watchdog.sh (new)
- Reads `scanner-heartbeat` mtime. If age ≥ `2 × POLL_INTERVAL` (default 10 min), sends SIGTERM to the scanner PID recorded in `/tmp/loop-scanner.lock`.
- launchd KeepAlive then restarts the scanner within `ThrottleInterval` (60 s).
- Handles stale lock file (dead PID) by removing it cleanly.
- Designed to be called every 5 min from launchd or cron.

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
- `StartInterval 300` (every 5 min). `RunAtLoad false` — first check after first interval.
- Uses the same `__X__` placeholder convention as other loop plists.

### install.sh
- `bootstrap_register_launchd` registers `com.user.loop-scanner-watchdog` alongside the scanner plist. Idempotent (skips if already present).

### tests/scanner-heartbeat.bats (new, 4 tests)
- Heartbeat file is created on first `run_once()` call.
- Heartbeat mtime advances on subsequent calls (sleep 1s between calls).
- Heartbeat file content matches `YYYY-MM-DD HH:MM:SS` pattern.
- Heartbeat file is NOT written in dry-run mode.

## Test Plan
- [x] `bash -n` syntax check on all scripts — passes
- [x] `shellcheck -S warning` — passes
- [x] Personal-identifiers grep — clean
- [x] `bats tests/scanner-heartbeat.bats` — 4/4 pass
- [x] `bats tests/scanner.bats` — no regressions introduced (4 pre-existing failures unchanged)
- Manual simulation: `kill -STOP $SCANNER_PID` then wait >10 min → watchdog should SIGTERM and launchd restarts within 60 s