### PR TITLE
[LOOP-413] scanner: liveness heartbeat + watchdog for silent-wedge detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,6 +338,23 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    local watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$watchdog_plist"
+        if launchctl load "$watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     local digest_plist="$agents_dir/com.user.loop-digest.plist"
     if [ -f "$digest_plist" ]; then
         echo "[launchd] com.user.loop-digest already registered — skipping"
@@ -361,8 +378,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +401,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — Liveness watchdog for the Loop scanner.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written every tick by scanner.sh).
+# If the heartbeat is older than LOOP_SCANNER_WATCHDOG_STALE seconds (default:
+# 2× poll interval = 600s), the scanner is considered silently wedged. The
+# watchdog kills the scanner PID (from /tmp/loop-scanner.lock) so that launchd
+# (macOS, KeepAlive=true) or the next cron invocation restarts it.
+#
+# Run every 5 minutes via launchd (macOS) or cron (Linux).
+#
+# Flags:
+#   --dry-run   print what would happen, do not kill anything
+#   --once      no-op alias (all invocations are single-sweep)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+# Default stale threshold: 2× poll interval (10 min for the default 5-min poll).
+STALE_SECONDS="${LOOP_SCANNER_WATCHDOG_STALE:-$(( POLL_INTERVAL * 2 ))}"
+LOCK_FILE="/tmp/loop-scanner.lock"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        --once)    : ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _file_age_seconds <path>
+# Returns the number of seconds since <path> was last modified.
+# Falls back to a very large value (9999999) if the file is missing or
+# stat is unavailable, so the watchdog treats a missing heartbeat as stale.
+_file_age_seconds() {
+    local path="$1"
+    local mtime now
+    if [ ! -f "$path" ]; then
+        echo 9999999
+        return 0
+    fi
+    mtime=$(stat -f%m "$path" 2>/dev/null || stat -c%Y "$path" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+age=$(_file_age_seconds "$HEARTBEAT_FILE")
+log "heartbeat age=${age}s stale_threshold=${STALE_SECONDS}s"
+
+if [ "$age" -lt "$STALE_SECONDS" ]; then
+    log "scanner is live — nothing to do"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat stale (age=${age}s >= ${STALE_SECONDS}s) — triggering restart"
+
+# Read scanner PID from lock file.
+scanner_pid=""
+if [ -f "$LOCK_FILE" ]; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+fi
+
+if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+    if $DRY_RUN; then
+        log "DRY-RUN: would kill scanner PID $scanner_pid"
+    else
+        log "killing wedged scanner PID $scanner_pid"
+        kill "$scanner_pid" 2>/dev/null || true
+        # Give the process a moment to exit, then force-kill if still alive.
+        sleep 2
+        if kill -0 "$scanner_pid" 2>/dev/null; then
+            log "scanner PID $scanner_pid still alive — sending SIGKILL"
+            kill -9 "$scanner_pid" 2>/dev/null || true
+        fi
+        # Remove stale lock so the next scanner invocation does not self-exit.
+        rm -f "$LOCK_FILE"
+        log "scanner killed; launchd/cron will restart it"
+    fi
+else
+    # Scanner is not running (PID dead or lock absent). Remove stale lock if
+    # present so the next invocation can acquire it cleanly.
+    if [ -f "$LOCK_FILE" ]; then
+        if $DRY_RUN; then
+            log "DRY-RUN: would remove stale lock $LOCK_FILE (PID ${scanner_pid:-unknown} not alive)"
+        else
+            log "removing stale lock $LOCK_FILE (PID ${scanner_pid:-unknown} not alive)"
+            rm -f "$LOCK_FILE"
+        fi
+    else
+        log "scanner not running and no lock file — launchd/cron will start it on next tick"
+    fi
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -774,7 +774,28 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+# _write_heartbeat — record the current epoch to the liveness file.
+# The scanner-watchdog reads this to detect a silently-wedged scanner.
+_write_heartbeat() {
+    if ! $DRY_RUN && [ -n "${LOOP_LOG_DIR:-}" ]; then
+        printf '%s\n' "$(date +%s)" > "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+    fi
+}
+
+# _check_log_fd — re-attach stdout/stderr to LOG_FILE if the file is no longer
+# writable (e.g. after log rotation removed the inode). Exits with status 1 so
+# launchd/cron can restart the scanner when the reopen itself fails.
+_check_log_fd() {
+    [ -z "${LOG_FILE:-}" ] && return 0
+    [ -w "${LOG_FILE}" ] && return 0
+    # File is gone or unwritable — try to reopen stdout then stderr.
+    exec 1>>"${LOG_FILE}" || exit 1
+    exec 2>>"${LOG_FILE}" || exit 1
+}
+
 run_once() {
+    _check_log_fd
+    _write_heartbeat
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <!-- Run every 5 minutes to detect a silently-wedged scanner. -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — liveness heartbeat written every scanner tick.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    log() { :; }
+    dispatch_direct() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# _write_heartbeat
+# ---------------------------------------------------------------------------
+
+@test "_write_heartbeat: creates heartbeat file in LOOP_LOG_DIR" {
+    rm -f "${LOOP_LOG_DIR}/scanner-heartbeat"
+    _write_heartbeat
+    [ -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+@test "_write_heartbeat: heartbeat file contains a unix epoch timestamp" {
+    _write_heartbeat
+    local ts
+    ts=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+    # Epoch seconds since 2020-01-01 — just a sanity bound.
+    [ "$ts" -gt 1577836800 ] 2>/dev/null
+}
+
+@test "_write_heartbeat: updates mtime on every call" {
+    _write_heartbeat
+    local mtime1
+    mtime1=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+             || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null)
+    sleep 1
+    _write_heartbeat
+    local mtime2
+    mtime2=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+             || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null)
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "_write_heartbeat: is no-op in dry-run mode" {
+    DRY_RUN=true
+    rm -f "${LOOP_LOG_DIR}/scanner-heartbeat"
+    _write_heartbeat
+    [ ! -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+@test "run_once: heartbeat file exists after a tick" {
+    rm -f "${LOOP_LOG_DIR}/scanner-heartbeat"
+
+    # Stub everything run_once calls so the tick completes without real I/O.
+    loop_list_slugs()    { return 0; }
+    jobs_init_schema()   { return 0; }
+    _sweep_stale_locks() { return 0; }
+    LOOP_JOBS_ENQUEUE=0
+
+    run_once
+
+    [ -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh — basic liveness checks
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog.sh: exits 0 and logs 'scanner is live' when heartbeat is fresh" {
+    printf '%s\n' "$(date +%s)" > "${LOOP_LOG_DIR}/scanner-heartbeat"
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+            LOOP_SCANNER_WATCHDOG_STALE=600 \
+            LOOP_EXTRA_PATH="" \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner is live"* ]]
+}
+
+@test "scanner-watchdog.sh: detects stale heartbeat and reports in dry-run" {
+    # Write a heartbeat that is 700 seconds old.
+    local old_time=$(( $(date +%s) - 700 ))
+    printf '%s\n' "$old_time" > "${LOOP_LOG_DIR}/scanner-heartbeat"
+    # Also set the file mtime to match so stat-based age check is consistent.
+    touch -t "$(date -r "$old_time" '+%Y%m%d%H%M.%S' 2>/dev/null || \
+                date -d "@$old_time" '+%Y%m%d%H%M.%S' 2>/dev/null || \
+                echo "202001010000.00")" \
+        "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+            LOOP_SCANNER_WATCHDOG_STALE=600 \
+            LOOP_EXTRA_PATH="" \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"stale"* ]]
+}
+
+@test "scanner-watchdog.sh: exits 0 when heartbeat file is missing (treated as stale)" {
+    rm -f "${LOOP_LOG_DIR}/scanner-heartbeat"
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+            LOOP_SCANNER_WATCHDOG_STALE=600 \
+            LOOP_EXTRA_PATH="" \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"stale"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- Added `_write_heartbeat()`: writes the current epoch timestamp to `${LOOP_LOG_DIR}/scanner-heartbeat` at the start of every tick. This gives external observers a clock they can check without reading process internals.
- Added `_check_log_fd()`: at the top of each tick, checks whether `LOG_FILE` is writable. If not (e.g. after log rotation), re-attaches stdout/stderr to the log path. If that fails, exits cleanly so launchd/cron restarts the scanner. Both helpers are called by `run_once()` before any scan logic runs.

### `scanner/scanner-watchdog.sh` (new)
- Standalone watchdog script that reads the heartbeat file mtime and compares it to `LOOP_SCANNER_WATCHDOG_STALE` (default: `2 × LOOP_SCANNER_INTERVAL`, i.e. 600s).
- If stale: reads the scanner PID from `/tmp/loop-scanner.lock`, sends `SIGTERM`, waits 2s, then `SIGKILL` if still alive, and removes the lock file so launchd/cron can restart cleanly.
- `--dry-run` flag for manual verification without killing anything.
- On Linux (cron mode), killing is sufficient — cron fires `scanner.sh --once` on the next tick.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- `StartInterval=300` (every 5 minutes). Worst-case detection latency: 5 min (watchdog period) + 10 min (stale threshold) = 15 min, consistent with the issue's target.

### `install.sh`
- `bootstrap_register_launchd`: installs `com.user.loop-scanner-watchdog.plist` alongside the scanner plist.
- `bootstrap_register_cron` (Linux): adds `*/5 * * * * scanner-watchdog.sh` cron entry.

### `tests/scanner-heartbeat.bats` (new)
- 8 tests covering: heartbeat creation, timestamp sanity, mtime update on each call, dry-run no-op, presence after `run_once()`, and watchdog dry-run paths (fresh, stale, missing heartbeat).

## Test Plan
- All 8 new tests pass (`bats tests/scanner-heartbeat.bats`).
- `bash -n` and `shellcheck -S warning` pass on all shell files.
- No personal identifiers in committed files.
- Pre-existing test failures in `scanner.bats` (tests 15, 16, 20, 21, 28) and `scanner-jobs-enqueue.bats` (53, 54) are unrelated to this change and present on `main` before this branch.
- Manual simulation: `kill -STOP $SCANNER_PID` then run watchdog with `LOOP_SCANNER_WATCHDOG_STALE=60 --dry-run` to verify stale detection. Remove `--dry-run` and let launchd restart.