### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,6 +338,26 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    # Scanner liveness watchdog — kills the scanner if its heartbeat file goes
+    # stale (default 2 × poll interval), so launchd restarts it. Runs every
+    # 5 min independently of the scanner cadence.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     local digest_plist="$agents_dir/com.user.loop-digest.plist"
     if [ -f "$digest_plist" ]; then
         echo "[launchd] com.user.loop-digest already registered — skipping"
@@ -361,8 +381,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +404,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — kill a wedged scanner so launchd/cron restarts it.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat. If the file is absent or its mtime
+# is older than STALE_THRESHOLD_SECONDS (default: 2 × LOOP_SCANNER_INTERVAL,
+# i.e. 2 × 300 = 600 s), the scanner is considered wedged.
+#
+# On macOS:  sends SIGTERM to the PID in /tmp/loop-scanner.lock, then waits
+#            up to 10 s for it to die; falls back to SIGKILL.
+#            launchd (KeepAlive=true) restarts the scanner automatically.
+#
+# On Linux:  same PID-kill logic; cron or a separate restart daemon handles
+#            re-launch.
+#
+# Run every 5 min via launchd StartInterval or cron */5.
+#
+# Usage:
+#   scanner-watchdog.sh [--dry-run]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+LOCK_FILE="${LOOP_SCANNER_LOCK:-/tmp/loop-scanner.lock}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_WATCHDOG_STALE_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _file_age_seconds <path>
+# Returns the age of <path> in seconds, or a very large number if absent.
+_file_age_seconds() {
+    local path="$1"
+    if [ ! -f "$path" ]; then
+        echo "999999"
+        return 0
+    fi
+    local mtime now
+    mtime=$(stat -f%m "$path" 2>/dev/null || stat -c%Y "$path" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+age=$(_file_age_seconds "$HEARTBEAT_FILE")
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is alive (heartbeat age=${age}s, threshold=${STALE_THRESHOLD}s)"
+    exit 0
+fi
+
+log "WARN: heartbeat stale for ${age}s (threshold=${STALE_THRESHOLD}s) — scanner appears wedged"
+
+# Read scanner PID from lock file.
+pid=""
+if [ -f "$LOCK_FILE" ]; then
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+fi
+
+if [ -z "$pid" ]; then
+    log "no lock file / empty PID — scanner is not running; launchd will restart it"
+    exit 0
+fi
+
+if ! kill -0 "$pid" 2>/dev/null; then
+    log "PID $pid is already dead — launchd will restart scanner"
+    exit 0
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would send SIGTERM to scanner PID $pid"
+    exit 0
+fi
+
+log "sending SIGTERM to scanner PID $pid"
+kill -TERM "$pid" 2>/dev/null || true
+
+# Wait up to 10 s for graceful exit, then SIGKILL.
+local_wait=0
+while kill -0 "$pid" 2>/dev/null && [ "$local_wait" -lt 10 ]; do
+    sleep 1
+    local_wait=$(( local_wait + 1 ))
+done
+
+if kill -0 "$pid" 2>/dev/null; then
+    log "WARN: PID $pid did not exit after ${local_wait}s; sending SIGKILL"
+    kill -KILL "$pid" 2>/dev/null || true
+fi
+
+log "scanner killed — launchd/cron will restart it"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -775,6 +776,22 @@ scan_project() {
 }
 
 run_once() {
+    # Stdout integrity: if the log file is no longer writable (e.g. after
+    # rotation that left a closed pipe or a deleted inode), exit so launchd
+    # restarts us against a fresh file descriptor. Don't apply in dry-run
+    # mode where LOG_FILE may be the terminal.
+    if ! $DRY_RUN && [ -n "${LOG_FILE:-}" ] && [ ! -w "$LOG_FILE" ]; then
+        # Attempt one re-open before giving up; handles the common case where
+        # the file was just created by logrotate and is now writable again.
+        exec 1>>"$LOG_FILE" 2>&1 || true
+        if [ ! -w "$LOG_FILE" ]; then
+            exit 1
+        fi
+    fi
+
+    # Heartbeat: update mtime so scanner-watchdog can detect a wedged process.
+    $DRY_RUN || touch "$HEARTBEAT_FILE"
+
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <!-- Fire every 5 minutes to check scanner heartbeat -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — heartbeat file written on every tick.
+#
+# Sources scanner.sh function definitions (same awk-strip strategy as
+# tests/scanner.bats). Verifies that run_once() touches HEARTBEAT_FILE on
+# each call when not in dry-run mode, and skips the touch in dry-run mode.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+    touch "$LOG_FILE"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    # Stub out everything run_once calls so the test stays unit-level.
+    log()              { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs()  { echo ""; }
+    LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/scanner-src.sh" "$BATS_TMPDIR/scanner-test.log" 2>/dev/null || true
+}
+
+@test "run_once: creates heartbeat file on first tick" {
+    [ ! -f "$HEARTBEAT_FILE" ]
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: updates heartbeat mtime on every tick" {
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE")
+    # Small sleep so mtime can advance (1-second resolution on most filesystems)
+    sleep 1
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE")
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once: skips heartbeat in dry-run mode" {
+    DRY_RUN=true
+    run_once
+    [ ! -f "$HEARTBEAT_FILE" ]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- Added `HEARTBEAT_FILE` variable pointing to `${LOOP_LOG_DIR}/scanner-heartbeat`.
- At the top of every `run_once()` tick, `touch "$HEARTBEAT_FILE"` updates its mtime (skipped in `--dry-run` mode).
- Added stdout integrity check: if `$LOG_FILE` is not writable at tick start, attempts one `exec` re-open; exits (triggering launchd restart) if still not writable.

### `scanner/scanner-watchdog.sh` (new)
- Reads the heartbeat file mtime; if age > `LOOP_WATCHDOG_STALE_THRESHOLD` (default `2 × LOOP_SCANNER_INTERVAL = 600 s`), the scanner is considered wedged.
- Sends SIGTERM to the PID from `/tmp/loop-scanner.lock`; waits up to 10 s, then SIGKILL if needed.
- launchd (KeepAlive) auto-restarts the scanner after the kill.
- Supports `--dry-run` mode for safe manual testing.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- Runs `scanner-watchdog.sh` every 5 min via `StartInterval=300`.

### `install.sh`
- `bootstrap_register_launchd`: installs `com.user.loop-scanner-watchdog.plist` alongside the existing plists.
- `bootstrap_register_cron`: adds a `*/5` cron entry for `scanner-watchdog.sh` on Linux.

### `tests/scanner-heartbeat.bats` (new)
- 3 bats tests: heartbeat file is created on first tick, mtime updated on each tick, and skipped in dry-run mode.

## Test Plan

- All 3 `tests/scanner-heartbeat.bats` tests pass locally.
- `bash -n` and `shellcheck -S warning` pass on all `lib/*.sh scripts/*.sh scanner/*.sh install.sh`.
- Existing `tests/scanner.bats` and `tests/scanner-log-sighup.bats` pass without regression.
- Manual verify: `kill -STOP $SCANNER_PID` → within 10 min watchdog detects stale heartbeat, kills, launchd restarts.