### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-stop recovery

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,6 +338,25 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    # Scanner liveness watchdog — fires every 5 min, kills wedged scanner PID so
+    # launchd can restart it automatically.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     local digest_plist="$agents_dir/com.user.loop-digest.plist"
     if [ -f "$digest_plist" ]; then
         echo "[launchd] com.user.loop-digest already registered — skipping"
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local scanner_watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local scanner_watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $scanner_watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$scanner_watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$scanner_watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -776,6 +776,10 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Liveness heartbeat — written every tick so a watchdog can detect wedged scanners.
+    # A separate scanner-watchdog process compares this file's mtime against now;
+    # if stale by > 2× poll_interval it kills the scanner PID and lets launchd restart.
+    $DRY_RUN || printf '%s\n' "$(date '+%Y-%m-%d %H:%M:%S')" > "${LOOP_LOG_DIR}/scanner-heartbeat"
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — detect and recover a wedged scanner process.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat; if its mtime is older than
+# LOOP_SCANNER_WATCHDOG_THRESHOLD seconds (default: 2 × poll interval = 10 min)
+# the scanner is considered wedged. The watchdog kills the PID recorded in
+# /tmp/loop-scanner.lock and exits, allowing launchd (KeepAlive=true) to
+# restart the scanner automatically.
+#
+# Designed to run every 5 min via launchd / cron. Safe to run concurrently
+# with the scanner — it only signals a process, never modifies shared state.
+#
+# Flags:
+#   --dry-run   report what would be done, do not kill anything
+#   --once      single check (default; reserved for future loop mode)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+THRESHOLD="${LOOP_SCANNER_WATCHDOG_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+LOCK_FILE="${LOOP_SCANNER_LOCK_FILE:-/tmp/loop-scanner.lock}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        --once)    : ;;  # default; reserved
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _file_age_seconds <path>
+# Returns the number of seconds since the file was last modified.
+# Falls back to a very large number (effectively infinite age) if the
+# file does not exist or stat is unavailable.
+_file_age_seconds() {
+    local path="$1"
+    [ -f "$path" ] || { echo 999999; return; }
+    local mtime now
+    mtime=$(stat -f%m "$path" 2>/dev/null || stat -c%Y "$path" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+log "check (threshold=${THRESHOLD}s dry-run=${DRY_RUN})"
+
+age=$(_file_age_seconds "$HEARTBEAT_FILE")
+log "heartbeat age=${age}s (file: ${HEARTBEAT_FILE})"
+
+if [ "$age" -lt "$THRESHOLD" ]; then
+    log "scanner is alive — nothing to do"
+    exit 0
+fi
+
+# Heartbeat is stale — scanner is wedged or has never started.
+log "WARN: heartbeat stale for ${age}s (threshold=${THRESHOLD}s) — scanner may be wedged"
+
+if [ ! -f "$LOCK_FILE" ]; then
+    log "no lock file at ${LOCK_FILE} — scanner not running; nothing to kill"
+    exit 0
+fi
+
+scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+if [ -z "$scanner_pid" ]; then
+    log "lock file empty — removing stale lock"
+    $DRY_RUN || rm -f "$LOCK_FILE"
+    exit 0
+fi
+
+if ! kill -0 "$scanner_pid" 2>/dev/null; then
+    log "scanner PID ${scanner_pid} is already dead — removing stale lock"
+    $DRY_RUN || rm -f "$LOCK_FILE"
+    exit 0
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID ${scanner_pid}"
+    exit 0
+fi
+
+log "killing wedged scanner PID ${scanner_pid} — launchd will restart"
+kill "$scanner_pid" 2>/dev/null || true
+
+log "done"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes and checks whether the scanner heartbeat file is
+  fresh. If the heartbeat is older than 2 × LOOP_SCANNER_INTERVAL (default
+  10 min) the watchdog kills the wedged scanner PID and launchd auto-restarts
+  it (KeepAlive=true on the scanner plist).
+
+  Install via:
+    ./install.sh --bootstrap
+  or manually:
+    sed -e "s|__LOOP_ROOT__|$(pwd)|g" \
+        -e "s|__LOG_DIR__|$LOOP_LOG_DIR|g" \
+        -e "s|__HOME__|$HOME|g" \
+        -e "s|__EXTRA_PATH__|/opt/homebrew/bin:/usr/local/bin|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <!-- Check every 5 minutes -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,185 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 scanner liveness heartbeat.
+#
+# Verifies:
+#   1. run_once() writes the heartbeat file on every real tick.
+#   2. run_once() skips heartbeat write in --dry-run mode.
+#   3. scanner-watchdog.sh exits cleanly when heartbeat is fresh.
+#   4. scanner-watchdog.sh kills a wedged scanner PID when heartbeat is stale.
+#   5. scanner-watchdog.sh --dry-run reports but does not kill.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner.sh function definitions (same awk-strip strategy as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    # Silence helpers; no-op scan so run_once() completes without real GitHub calls.
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    loop_list_slugs() { :; }
+    jobs_init_schema() { :; }
+    LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat file written by run_once
+# ---------------------------------------------------------------------------
+
+@test "run_once: writes heartbeat file on each tick" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    [ ! -f "$hb" ]
+
+    run_once
+
+    [ -f "$hb" ]
+    [ -s "$hb" ]
+}
+
+@test "run_once: heartbeat file mtime is updated on second tick" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb" 2>/dev/null || echo 0)
+
+    sleep 1
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb" 2>/dev/null || echo 0)
+
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once: heartbeat file NOT written when DRY_RUN=true" {
+    DRY_RUN=true
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    [ ! -f "$hb" ]
+
+    run_once
+
+    [ ! -f "$hb" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh behaviour
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits 0 (alive) when heartbeat is fresh" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    printf '%s\n' "$(date '+%Y-%m-%d %H:%M:%S')" > "$hb"
+
+    # Threshold = 600s; freshly-written file is 0s old.
+    LOOP_SCANNER_WATCHDOG_THRESHOLD=600 \
+    LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner is alive"* ]]
+}
+
+@test "scanner-watchdog: --dry-run reports stale heartbeat without killing" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    # Create a heartbeat file with an ancient mtime by touching it and
+    # setting mtime to 1 hour ago via a temp file approach.
+    printf '%s\n' "old" > "$hb"
+    touch -t "$(date -v-1H '+%Y%m%d%H%M.%S' 2>/dev/null || date --date='1 hour ago' '+%Y%m%d%H%M.%S' 2>/dev/null || echo '202001010000.00')" "$hb" 2>/dev/null || true
+
+    # Spawn a short-lived sleep as a fake scanner PID.
+    sleep 60 &
+    local fake_pid=$!
+    local lock_file="$BATS_TMPDIR/fake-scanner.lock"
+    echo "$fake_pid" > "$lock_file"
+
+    LOOP_SCANNER_WATCHDOG_THRESHOLD=1 \
+    LOOP_SCANNER_LOCK_FILE="$lock_file" \
+    LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+
+    # Clean up the sleep process.
+    kill "$fake_pid" 2>/dev/null || true
+    wait "$fake_pid" 2>/dev/null || true
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DRY-RUN"* ]]
+    # Process must still be alive after --dry-run (we kill it ourselves above).
+}
+
+@test "scanner-watchdog: kills wedged scanner when heartbeat is stale" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    printf '%s\n' "old" > "$hb"
+    touch -t "$(date -v-1H '+%Y%m%d%H%M.%S' 2>/dev/null || date --date='1 hour ago' '+%Y%m%d%H%M.%S' 2>/dev/null || echo '202001010000.00')" "$hb" 2>/dev/null || true
+
+    # Spawn a short-lived sleep as a fake scanner PID.
+    sleep 60 &
+    local fake_pid=$!
+    local lock_file="$BATS_TMPDIR/fake-scanner2.lock"
+    echo "$fake_pid" > "$lock_file"
+
+    # Confirm process is alive before the watchdog runs.
+    kill -0 "$fake_pid"
+
+    LOOP_SCANNER_WATCHDOG_THRESHOLD=1 \
+    LOOP_SCANNER_LOCK_FILE="$lock_file" \
+    LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh"
+
+    wait "$fake_pid" 2>/dev/null || true
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"killing wedged scanner"* ]]
+    # Process should be gone.
+    ! kill -0 "$fake_pid" 2>/dev/null
+}
+
+@test "scanner-watchdog: exits cleanly when no lock file exists" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    printf '%s\n' "old" > "$hb"
+    touch -t "$(date -v-1H '+%Y%m%d%H%M.%S' 2>/dev/null || date --date='1 hour ago' '+%Y%m%d%H%M.%S' 2>/dev/null || echo '202001010000.00')" "$hb" 2>/dev/null || true
+
+    LOOP_SCANNER_WATCHDOG_THRESHOLD=1 \
+    LOOP_SCANNER_LOCK_FILE="$BATS_TMPDIR/no-such-lock.lock" \
+    LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no lock file"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- Added a heartbeat write at the start of every `run_once()` tick: `printf %sn "$(date ...)" > ${LOOP_LOG_DIR}/scanner-heartbeat`
- Write is skipped in `--dry-run` mode
- No change to scan logic or lock behavior

### `scripts/scanner-watchdog.sh` (new)
- Reads `${LOOP_LOG_DIR}/scanner-heartbeat` mtime
- If stale by more than `LOOP_SCANNER_WATCHDOG_THRESHOLD` seconds (default: `2 × LOOP_SCANNER_INTERVAL` = 10 min), kills the PID from `/tmp/loop-scanner.lock`
- launchd `KeepAlive=true` on the scanner plist auto-restarts it within `ThrottleInterval`
- Supports `--dry-run` (reports without killing)
- `LOOP_SCANNER_LOCK_FILE` env var overrides lock path (used by tests)

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- Runs `scanner-watchdog.sh` every 5 minutes via `StartInterval=300`

### `install.sh`
- `bootstrap_register_launchd()`: registers `com.user.loop-scanner-watchdog.plist` (every 5 min)
- `bootstrap_register_cron()`: adds `*/5 * * * *` watchdog cron entry for Linux

### `tests/scanner-heartbeat.bats` (new)
7 bats tests:
1. `run_once` writes heartbeat file on tick
2. `run_once` updates heartbeat mtime on second tick
3. `run_once` skips write when `DRY_RUN=true`
4. Watchdog exits cleanly when heartbeat is fresh
5. `--dry-run` reports stale heartbeat without killing
6. Watchdog kills wedged scanner when heartbeat is stale
7. Watchdog exits cleanly when no lock file exists

## Test Plan
- All 7 new tests pass: `bats tests/scanner-heartbeat.bats`
- No regressions in existing scanner tests (`tests/scanner.bats`, etc.)
- Manual: `kill -STOP $SCANNER_PID` → heartbeat goes stale → watchdog kills PID within 5 min → launchd restarts
- CI: `bash -n` + `shellcheck -S warning` pass on all new/modified scripts