### PR TITLE
[LOOP-413] scanner: liveness heartbeat + auto-restart watchdog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — fires every 5 min; restarts the scanner if
+    # its heartbeat file is older than 2× the poll interval (default 600s).
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/restart-scanner-if-stale.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -776,6 +777,8 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Liveness heartbeat — updated every tick so the scanner-watchdog can detect a wedged process.
+    $DRY_RUN || date +%s > "$HEARTBEAT_FILE"
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scripts/restart-scanner-if-stale.sh
+++ b/scripts/restart-scanner-if-stale.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# restart-scanner-if-stale.sh — scanner liveness watchdog.
+#
+# Reads the heartbeat file written by scanner.sh on every tick.
+# If the heartbeat is absent or older than STALE_THRESHOLD_SECONDS (default:
+# 2 × poll interval = 600s), the scanner is considered wedged and restarted:
+#   macOS (launchd): launchctl kickstart the scanner service.
+#   Linux (cron):    pkill the scanner process; cron re-invokes on next tick.
+#
+# Designed to run every 5 min via launchd (StartInterval 300) or cron.
+#
+# Flags:
+#   --dry-run   log what would happen without taking action
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_SCANNER_STALE_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+_heartbeat_age() {
+    if [ ! -f "$HEARTBEAT_FILE" ]; then
+        echo "999999"
+        return
+    fi
+    local mtime now
+    mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+         || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+         || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+_restart_scanner_launchd() {
+    local label="com.user.loop-scanner"
+    local uid
+    uid=$(id -u)
+    if $DRY_RUN; then
+        log "DRY-RUN: would run: launchctl kickstart -k gui/${uid}/${label}"
+        return
+    fi
+    log "restarting scanner via launchctl kickstart -k gui/${uid}/${label}"
+    launchctl kickstart -k "gui/${uid}/${label}" 2>/dev/null \
+        || launchctl stop "$label" 2>/dev/null \
+        || true
+}
+
+_restart_scanner_linux() {
+    if $DRY_RUN; then
+        log "DRY-RUN: would run: pkill -f scanner.sh (cron re-invokes next tick)"
+        return
+    fi
+    log "restarting scanner via pkill (cron re-invokes on next tick)"
+    pkill -f "scanner.sh" 2>/dev/null || true
+}
+
+main() {
+    local age
+    age=$(_heartbeat_age)
+    log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s file=${HEARTBEAT_FILE}"
+
+    if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+        log "scanner is healthy — no action"
+        return 0
+    fi
+
+    log "WARN: scanner appears wedged (heartbeat ${age}s old, threshold ${STALE_THRESHOLD}s) — restarting"
+
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        _restart_scanner_launchd
+    else
+        _restart_scanner_linux
+    fi
+}
+
+main

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+  Fires every 5 minutes; kills and restarts the scanner if its heartbeat is stale.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/restart-scanner-if-stale.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 scanner liveness heartbeat.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+}
+
+teardown() {
+    rm -rf "$LOOP_LOG_DIR"
+}
+
+@test "scanner.sh defines HEARTBEAT_FILE variable" {
+    grep -q 'HEARTBEAT_FILE=' "$REPO_ROOT/scanner/scanner.sh"
+}
+
+@test "scanner.sh references scanner-heartbeat path" {
+    grep -q 'scanner-heartbeat' "$REPO_ROOT/scanner/scanner.sh"
+}
+
+@test "scanner.sh writes heartbeat before _sweep_stale_locks in run_once" {
+    local src="$REPO_ROOT/scanner/scanner.sh"
+    local hb_line sweep_line
+    hb_line=$(grep -n 'date +%s.*HEARTBEAT_FILE\|HEARTBEAT_FILE.*date +%s' "$src" | head -1 | cut -d: -f1)
+    sweep_line=$(grep -n '_sweep_stale_locks' "$src" | grep -v '^#' | tail -1 | cut -d: -f1)
+    [ -n "$hb_line" ]
+    [ -n "$sweep_line" ]
+    [ "$hb_line" -lt "$sweep_line" ]
+}
+
+@test "restart-scanner-if-stale.sh exists and is executable" {
+    [ -x "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" ]
+}
+
+@test "restart-scanner-if-stale.sh passes bash -n syntax check" {
+    bash -n "$REPO_ROOT/scripts/restart-scanner-if-stale.sh"
+}
+
+@test "restart-scanner-if-stale.sh dry-run: healthy heartbeat logs no restart" {
+    date +%s > "$HEARTBEAT_FILE"
+    LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+    LOOP_SCANNER_STALE_THRESHOLD=600 \
+        run "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner is healthy"* ]]
+}
+
+@test "restart-scanner-if-stale.sh dry-run: absent heartbeat triggers restart" {
+    rm -f "$HEARTBEAT_FILE"
+    LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+    LOOP_SCANNER_STALE_THRESHOLD=600 \
+        run "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"wedged"* ]] || [[ "$output" == *"DRY-RUN"* ]]
+}
+
+@test "restart-scanner-if-stale.sh dry-run: stale heartbeat triggers restart" {
+    touch -t 200001010000 "$HEARTBEAT_FILE"
+    LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+    LOOP_SCANNER_STALE_THRESHOLD=600 \
+        run "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"wedged"* ]] || [[ "$output" == *"DRY-RUN"* ]]
+}
+
+@test "scanner-watchdog launchd template exists" {
+    [ -f "$REPO_ROOT/templates/launchd/com.user.loop-scanner-watchdog.plist.template" ]
+}
+
+@test "scanner-watchdog launchd template has StartInterval 300" {
+    grep -q 'StartInterval' "$REPO_ROOT/templates/launchd/com.user.loop-scanner-watchdog.plist.template"
+    grep -A1 'StartInterval' "$REPO_ROOT/templates/launchd/com.user.loop-scanner-watchdog.plist.template" \
+        | grep -q '300'
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`**
- Defines `HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"` alongside other path vars.
- In `run_once()`, writes `date +%s` to `$HEARTBEAT_FILE` at the top of every tick (before `_sweep_stale_locks`). Skipped in `--dry-run` mode.

**`scripts/restart-scanner-if-stale.sh`** (new)
- Sources `lib/env.sh` for `LOOP_LOG_DIR` and `LOOP_SCANNER_INTERVAL`.
- Computes `STALE_THRESHOLD = 2 × POLL_INTERVAL` (default 600s), overridable via `LOOP_SCANNER_STALE_THRESHOLD`.
- Reads the heartbeat file mtime; if absent or older than threshold, restarts:
  - **macOS**: `launchctl kickstart -k gui/<uid>/com.user.loop-scanner`
  - **Linux**: `pkill -f scanner.sh` (cron re-invokes on next 5-min tick)
- `--dry-run` flag logs the action without executing it.

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new)
- Launchd agent plist. `StartInterval 300` (every 5 min). Standard `__LOOP_ROOT__` / `__LOG_DIR__` / `__HOME__` / `__EXTRA_PATH__` tokens. Logs to `loop-scanner-watchdog.log`.

**`install.sh`**
- `bootstrap_register_launchd`: registers `com.user.loop-scanner-watchdog` plist.
- `bootstrap_register_cron`: adds `*/5 * * * * restart-scanner-if-stale.sh` cron entry with `# loop-scanner-watchdog` idempotency marker.

**`tests/scanner-heartbeat.bats`** (new)
- 10 bats tests covering: heartbeat variable/path in scanner source, write-order relative to lock sweep, script existence + syntax, dry-run healthy/absent/stale heartbeat paths, launchd template presence + `StartInterval`.

## Test Plan
- `bash -n` and `shellcheck -S warning` — all pass.
- `bats tests/scanner-heartbeat.bats` — all 10 tests pass.
- Manual: `kill -STOP $SCANNER_PID` → `${LOOP_LOG_DIR}/scanner-heartbeat` stops updating → watchdog detects stale after 600s and restarts.
- Verify `${LOOP_LOG_DIR}/scanner-heartbeat` mtime updates every poll cycle.