### PR TITLE
[LOOP-413] scanner: liveness heartbeat + watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,23 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +378,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +401,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# scanner/scanner-watchdog.sh — Scanner liveness watchdog.
+#
+# Reads the heartbeat file written by scanner.sh on every tick.
+# If the file is missing or older than LOOP_SCANNER_WATCHDOG_STALE_SECS (default: 900s),
+# the scanner is considered wedged: its PID is killed so launchd (KeepAlive) or
+# cron restarts it automatically.
+#
+# Designed to run every 5 minutes via launchd (macOS) or cron (Linux).
+#
+# Usage:
+#   scanner-watchdog.sh           # normal operation
+#   scanner-watchdog.sh --dry-run # report staleness, do not kill
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -15
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+# Stale threshold: 2 × default poll interval (300s), minimum 900s.
+STALE_SECS="${LOOP_SCANNER_WATCHDOG_STALE_SECS:-900}"
+
+# _file_age_secs <path>
+# Prints the age of a file in seconds, or empty string on error.
+_file_age_secs() {
+    local path="$1"
+    local mtime now
+    mtime=$(stat -f%m "$path" 2>/dev/null || stat -c%Y "$path" 2>/dev/null) || return 1
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file absent: $HEARTBEAT_FILE — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+age=$(_file_age_secs "$HEARTBEAT_FILE" || echo "$STALE_SECS")
+
+if [ "$age" -lt "$STALE_SECS" ]; then
+    log "ok: heartbeat age=${age}s (threshold=${STALE_SECS}s)"
+    exit 0
+fi
+
+log "STALE: heartbeat age=${age}s >= ${STALE_SECS}s — scanner appears wedged"
+
+if $DRY_RUN; then
+    log "dry-run: would kill scanner and let launchd/cron restart it"
+    exit 0
+fi
+
+# Read the scanner PID from the lock file. Kill it so launchd (KeepAlive=true)
+# or cron restarts a fresh instance. Fall back to pkill if the lock is missing.
+if [ -f "$LOCK_FILE" ]; then
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "killing scanner PID $pid"
+        kill "$pid" || true
+        # Remove stale heartbeat so the next watchdog run doesn't immediately re-kill.
+        rm -f "$HEARTBEAT_FILE"
+        log "done: scanner killed; launchd/cron will restart it"
+        exit 0
+    fi
+    log "lock file exists but PID ${pid:-<empty>} is not alive — removing stale lock"
+    rm -f "$LOCK_FILE"
+fi
+
+# No live PID found in lock. Use pkill as best-effort fallback.
+if pkill -f "scanner/scanner.sh" 2>/dev/null; then
+    rm -f "$HEARTBEAT_FILE"
+    log "killed scanner via pkill; launchd/cron will restart it"
+else
+    log "no scanner process found to kill (may have already exited)"
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -776,6 +776,8 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Heartbeat: updated every tick so the scanner watchdog can detect a wedged process.
+    $DRY_RUN || touch "${LOOP_LOG_DIR}/scanner-heartbeat"
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <!-- Run every 5 minutes; kills a wedged scanner so KeepAlive restarts it. -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — heartbeat file is written every tick (#413).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_EXTRA_PATH=""
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+
+    # Source scanner.sh definitions only (stop before acquire_lock).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    # Stub out log and run_once side-effects not under test.
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { :; }
+    scan_project() { :; }
+    LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+@test "run_once: writes heartbeat file to LOOP_LOG_DIR" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    [ ! -f "$hb" ]
+    run_once
+    [ -f "$hb" ]
+}
+
+@test "run_once: updates heartbeat mtime on successive calls" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb")
+    sleep 1
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb")
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once: does NOT write heartbeat in dry-run mode" {
+    DRY_RUN=true
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    run_once
+    [ ! -f "$hb" ]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- `run_once()` now calls `touch "${LOOP_LOG_DIR}/scanner-heartbeat"` at the start of every tick (skipped in `--dry-run` mode). This gives the watchdog a reliable mtime to monitor without adding any external dependencies.

### `scanner/scanner-watchdog.sh` (new)
- Reads `${LOOP_LOG_DIR}/scanner-heartbeat` mtime.
- If the file is absent or older than `LOOP_SCANNER_WATCHDOG_STALE_SECS` (default: 900s = 3× the 300s poll interval), the scanner is considered wedged.
- Reads the scanner PID from `/tmp/loop-scanner.lock` and kills it; falls back to `pkill` if the lock is missing.
- launchd `KeepAlive=true` / cron restarts a fresh instance automatically after the kill.
- Supports `--dry-run` for observability without action.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- Runs `scanner-watchdog.sh` every 5 minutes (`StartInterval 300`).

### `install.sh`
- `bootstrap_register_launchd`: registers `com.user.loop-scanner-watchdog` alongside the other agents.
- `bootstrap_register_cron` (Linux): adds a `*/5 * * * *` watchdog cron entry.

### `tests/scanner-heartbeat.bats` (new)
- 3 bats tests: heartbeat file is created, mtime updated on successive `run_once` calls, and *not* written in dry-run mode.

## Test Plan
- `bats tests/scanner-heartbeat.bats` — all 3 pass locally.
- Manual wedge simulation: `kill -STOP $SCANNER_PID` → after ≤ 15 min the watchdog detects stale heartbeat and kills the paused process; launchd restarts the scanner.
- `scanner-watchdog.sh --dry-run` reports staleness without killing.