### PR TITLE
[LOOP-413] scanner: liveness heartbeat + auto-restart watchdog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — kills + restarts the scanner if its heartbeat
+    # file goes stale (> 2 × poll interval). Runs every 5 min.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local scanner_watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local scanner_watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $scanner_watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$scanner_watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$scanner_watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -775,6 +776,20 @@ scan_project() {
 }
 
 run_once() {
+    # Stdout integrity check: if the log file is not writable, exit so launchd
+    # restarts the scanner. This catches the case where the file descriptor was
+    # lost (closed pipe, deleted inode after rotation without SIGHUP).
+    if [ -n "${LOG_FILE:-}" ] && [ ! -w "$LOG_FILE" ] 2>/dev/null; then
+        _scanner_reopen_log
+        if [ -n "${LOG_FILE:-}" ] && [ ! -w "$LOG_FILE" ] 2>/dev/null; then
+            exit 1
+        fi
+    fi
+
+    # Heartbeat: record the last-seen time so the external watchdog can detect
+    # a wedged scanner (alive PID, sleep loop intact, but no tick activity).
+    $DRY_RUN || date +%s > "$HEARTBEAT_FILE"
+
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if it stops emitting heartbeats.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written by scanner.sh every tick).
+# If the file is absent or its mtime is older than 2 × LOOP_SCANNER_INTERVAL
+# (default 10 min), the scanner is considered wedged: kill its PID (from the
+# lock file) and, on macOS, use launchctl kickstart to bring it back; on Linux
+# the scanner's cron entry will relaunch it on the next tick.
+#
+# Run every 5 min via launchd StartInterval (macOS) or cron (Linux).
+# Flags:
+#   --dry-run   report stale state but do not kill or restart
+#   --once      no-op alias (default behaviour is already single-sweep)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 ))
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        --once)    : ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+log "tick start (threshold=${STALE_THRESHOLD}s dry=${DRY_RUN})"
+
+now=$(date +%s)
+
+# Determine heartbeat age.
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "WARN: heartbeat file absent — scanner may not have started yet"
+    exit 0
+fi
+
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+    || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+    || echo 0)
+age=$(( now - mtime ))
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "ok: heartbeat age=${age}s < threshold=${STALE_THRESHOLD}s"
+    exit 0
+fi
+
+log "STALE: heartbeat age=${age}s >= threshold=${STALE_THRESHOLD}s — scanner appears wedged"
+
+# Read the scanner's PID from the lock file and kill it so launchd/cron restarts it.
+scanner_pid=""
+if [ -f "$LOCK_FILE" ]; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+fi
+
+if $DRY_RUN; then
+    log "DRY: would kill scanner PID=${scanner_pid:-unknown} and trigger restart"
+    exit 0
+fi
+
+if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+    log "killing wedged scanner PID=$scanner_pid"
+    kill "$scanner_pid" 2>/dev/null || true
+    sleep 2
+fi
+
+# On macOS, use launchctl kickstart so the scanner is restarted immediately
+# rather than waiting for launchd's ThrottleInterval.
+if [ "$(uname -s)" = "Darwin" ]; then
+    # Derive the launchd service domain from the current UID.
+    local_uid=$(id -u)
+    if launchctl kickstart -k "gui/${local_uid}/com.user.loop-scanner" 2>/dev/null; then
+        log "kickstarted com.user.loop-scanner via launchctl"
+    else
+        log "WARN: launchctl kickstart failed — launchd will auto-restart on ThrottleInterval"
+    fi
+else
+    log "Linux: scanner will be restarted by the next cron tick"
+fi
+
+log "tick done"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+  Fires every 5 min. Kills and restarts the scanner if its heartbeat file is
+  older than 2 × LOOP_SCANNER_INTERVAL (default 10 min).
+
+  Installed automatically by install.sh --bootstrap.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — heartbeat file updated every scanner tick (#413).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_EXTRA_PATH=""
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Expose a stub gh that returns empty lists so run_once completes quickly.
+    mkdir -p "$BATS_TMPDIR/bin"
+    cat > "$BATS_TMPDIR/bin/gh" <<'GH'
+#!/usr/bin/env bash
+# Return empty arrays for any list call; exit 0 for everything else.
+case "$*" in
+    *"pr list"*|*"issue list"*|*"api"*)
+        echo "[]" ;;
+esac
+exit 0
+GH
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    # Stub python3 to avoid real YAML parsing.
+    cat > "$BATS_TMPDIR/bin/python3" <<'PY'
+#!/usr/bin/env bash
+# Return empty for slugs, passthrough otherwise.
+cat /dev/stdin 2>/dev/null || true
+exit 0
+PY
+    chmod +x "$BATS_TMPDIR/bin/python3"
+
+    export HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    export DEDUP_DIR="$BATS_TMPDIR/dedup"
+    export STAGE_AGE_DIR="$BATS_TMPDIR/stage-age"
+    mkdir -p "$DEDUP_DIR" "$STAGE_AGE_DIR"
+
+    # Source only the function definitions from scanner.sh (stop before acquire_lock).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        printf "HEARTBEAT_FILE='%s'\n" "$HEARTBEAT_FILE"
+        printf "DEDUP_DIR='%s'\n" "$DEDUP_DIR"
+        printf "STAGE_AGE_DIR='%s'\n" "$STAGE_AGE_DIR"
+        printf "LOG_FILE='%s/loop-scanner.log'\n" "$LOOP_LOG_DIR"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^HEARTBEAT_FILE=/       { next }
+            /^DEDUP_DIR=/            { next }
+            /^STAGE_AGE_DIR=/        { next }
+            /^LOG_FILE=/             { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    # Stub loop_list_slugs to return empty (no projects to scan).
+    loop_list_slugs() { echo ""; }
+    # Stub jobs_init_schema to be a no-op.
+    jobs_init_schema() { return 0; }
+    # Stub _sweep_stale_locks.
+    _sweep_stale_locks() { return 0; }
+}
+
+teardown() {
+    rm -f "$HEARTBEAT_FILE"
+}
+
+@test "run_once writes heartbeat file" {
+    [ ! -f "$HEARTBEAT_FILE" ]
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once updates heartbeat timestamp on each call" {
+    run_once
+    local ts1
+    ts1=$(cat "$HEARTBEAT_FILE")
+
+    sleep 1
+    run_once
+    local ts2
+    ts2=$(cat "$HEARTBEAT_FILE")
+
+    [ "$ts2" -gt "$ts1" ]
+}
+
+@test "scanner.sh declares HEARTBEAT_FILE variable" {
+    grep -q "HEARTBEAT_FILE=" "$REPO_ROOT/scanner/scanner.sh"
+}
+
+@test "run_once writes epoch seconds to heartbeat file" {
+    run_once
+    local ts now
+    ts=$(cat "$HEARTBEAT_FILE")
+    now=$(date +%s)
+    # Timestamp must be recent (within 5s).
+    [ $(( now - ts )) -lt 5 ]
+}


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- Added `HEARTBEAT_FILE` variable pointing to `${LOOP_LOG_DIR}/scanner-heartbeat`
- At the top of every `run_once()` tick: writes the current epoch timestamp to the heartbeat file (skipped in `--dry-run` mode)
- Added stdout integrity check: if `$LOG_FILE` is not writable, attempts to reopen via `_scanner_reopen_log` and exits if that fails, letting launchd restart the process

### scripts/scanner-watchdog.sh (new)
- Standalone watchdog script that runs every 5 minutes
- Reads the heartbeat file mtime; if age > `2 × LOOP_SCANNER_INTERVAL` (default 10 min), the scanner is considered wedged
- Kills the scanner PID (from `/tmp/loop-scanner.lock`) and on macOS uses `launchctl kickstart` to restart immediately; on Linux the next cron tick restarts it
- Supports `--dry-run` flag

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
- launchd template for the scanner watchdog; fires every 5 minutes via `StartInterval`

### install.sh
- launchd path: registers `com.user.loop-scanner-watchdog` alongside the existing watchdogs
- cron path: adds a `*/5 * * * *` crontab entry for `scanner-watchdog.sh`

### tests/scanner-heartbeat.bats (new)
- 4 bats tests: heartbeat file is created by `run_once`, timestamp is updated on each call, file holds epoch seconds, `HEARTBEAT_FILE` variable is declared in scanner.sh

## Test Plan
- `bats tests/scanner-heartbeat.bats` passes (4/4)
- `bash -n` and `shellcheck -S warning` clean on all scripts
- No personal identifiers introduced
- Manual test: `kill -STOP $SCANNER_PID` → watchdog detects stale heartbeat within one 5-min interval and kicks the scanner