### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,15 +354,36 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — restarts a silently wedged scanner.
+    # Fires every 5 min; checks heartbeat mtime; kills+kickstarts if stale.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
-# Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
+# Register scanner + reconciler + watchdog via crontab (Linux). Idempotent: skips if marker present.
 bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — Restart the scanner if its heartbeat is stale.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written by scanner at each tick start).
+# If the file's mtime is older than LOOP_SCANNER_WATCHDOG_THRESHOLD seconds
+# (default: 2 × LOOP_SCANNER_INTERVAL = 600s), kills the scanner PID (read from
+# /tmp/loop-scanner.lock) and lets launchd (KeepAlive) or cron restart it.
+#
+# Run every 5 minutes via launchd (macOS) or cron (Linux).
+# Safe to run while the scanner is healthy — does nothing when heartbeat is fresh.
+#
+# Simulate a wedge for manual testing:
+#   kill -STOP $SCANNER_PID   # pause scanner without killing it
+#   # wait > THRESHOLD seconds, watchdog should kill+restart
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+THRESHOLD="${LOOP_SCANNER_WATCHDOG_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+log "tick (threshold=${THRESHOLD}s)"
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "no heartbeat file found — scanner may not have started yet"
+    exit 0
+fi
+
+heartbeat_mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+    || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+    || echo 0)
+age=$(( $(date +%s) - heartbeat_mtime ))
+
+if [ "$age" -lt "$THRESHOLD" ]; then
+    log "heartbeat ok (age=${age}s, threshold=${THRESHOLD}s)"
+    exit 0
+fi
+
+log "STALE heartbeat (age=${age}s >= threshold=${THRESHOLD}s) — restarting scanner"
+
+# Kill the scanner if the lock file records a live PID.
+if [ -f "$LOCK_FILE" ]; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || echo "")
+    if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+        log "sending SIGTERM to scanner PID ${scanner_pid}"
+        kill "$scanner_pid" 2>/dev/null || true
+        sleep 2
+    fi
+fi
+
+# On macOS with launchd: kickstart so the scanner restarts immediately via
+# KeepAlive rather than waiting for the next ThrottleInterval window.
+# On Linux: killing the cron-started process is sufficient; cron restarts on
+# the next */5 tick.
+if command -v launchctl >/dev/null 2>&1; then
+    if launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null; then
+        log "launchctl kickstart: scanner restarted"
+    else
+        log "launchctl kickstart failed — scanner will restart via KeepAlive or next cron tick"
+    fi
+fi
+
+log "watchdog done"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -64,6 +64,12 @@ done
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] $*"; }
 
+# _scanner_write_heartbeat — update ${LOOP_LOG_DIR}/scanner-heartbeat with the
+# current epoch so scanner-watchdog can detect a silently wedged process.
+_scanner_write_heartbeat() {
+    printf '%s\n' "$(date +%s)" > "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+}
+
 # _scanner_jobs_enqueue <slug> <stage> <num>
 # Best-effort dual-write to the jobs table alongside the legacy label-event path.
 # Skipped when LOOP_JOBS_ENQUEUE=0 or --dry-run.
@@ -775,6 +781,7 @@ scan_project() {
 }
 
 run_once() {
+    $DRY_RUN || _scanner_write_heartbeat
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Runs scanner-watchdog.sh every 5 minutes. The watchdog reads the scanner
+  heartbeat file (written at each tick by scanner.sh) and restarts the scanner
+  via launchctl kickstart if the heartbeat is stale (> 2× poll interval).
+
+  Install via ./install.sh --bootstrap  (macOS only; Linux uses crontab).
+
+  Manual install:
+    sed "s|__LOOP_ROOT__|$(cd "$(dirname "$0")/.." && pwd)|g; \
+         s|__LOG_DIR__|$LOOP_LOG_DIR|g; \
+         s|__HOME__|$HOME|g; \
+         s|__EXTRA_PATH__|/opt/homebrew/bin:/usr/local/bin|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,197 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — liveness heartbeat written by scanner each tick
+# and checked by scanner-watchdog.sh.
+#
+# Part 1: heartbeat file tests — source scanner.sh the same way scanner.bats does,
+# override LOOP_LOG_DIR, and verify _scanner_write_heartbeat + run_once behaviour.
+#
+# Part 2: watchdog logic tests — source scanner-watchdog.sh logic directly via
+# a trimmed copy that replaces the live launchctl/kill calls with stubs, so the
+# staleness-detection and age-calculation paths can be exercised without root.
+
+# ---------------------------------------------------------------------------
+# Part 1 — heartbeat written by scanner
+# ---------------------------------------------------------------------------
+
+setup_heartbeat() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs-hb"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src-hb.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup-hb"
+    LOG_FILE="$BATS_TMPDIR/scanner-hb.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    log() { :; }
+    dispatch_direct() { :; }
+}
+
+setup() { setup_heartbeat; }
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup-hb" \
+           "$BATS_TMPDIR/logs-hb" "$BATS_TMPDIR/scanner-hb.log" \
+           "$BATS_TMPDIR/scanner-src-hb.sh" 2>/dev/null || true
+}
+
+@test "heartbeat: _scanner_write_heartbeat creates file in LOOP_LOG_DIR" {
+    rm -f "${LOOP_LOG_DIR}/scanner-heartbeat"
+    _scanner_write_heartbeat
+    [ -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+@test "heartbeat: _scanner_write_heartbeat writes a numeric epoch value" {
+    _scanner_write_heartbeat
+    local val
+    val=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+    # Must be a number and reasonably close to now (within 60s).
+    [[ "$val" =~ ^[0-9]+$ ]]
+    local now
+    now=$(date +%s)
+    local delta=$(( now - val ))
+    [ "$delta" -ge 0 ] && [ "$delta" -lt 60 ]
+}
+
+@test "heartbeat: _scanner_write_heartbeat updates mtime on each call" {
+    _scanner_write_heartbeat
+    local first
+    first=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+    sleep 1
+    _scanner_write_heartbeat
+    local second
+    second=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+    # Epoch values must differ (second is later).
+    [ "$second" -gt "$first" ] || [ "$second" -eq "$first" ]
+    # File must exist.
+    [ -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+@test "heartbeat: run_once writes heartbeat file (not dry-run)" {
+    rm -f "${LOOP_LOG_DIR}/scanner-heartbeat"
+
+    # Stub out everything scan_project needs so run_once completes quickly.
+    loop_list_slugs()   { echo ""; }
+    scan_project()      { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema()  { :; }
+    LOOP_JOBS_ENQUEUE=0
+
+    run_once
+
+    [ -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+@test "heartbeat: run_once does NOT write heartbeat file in dry-run mode" {
+    rm -f "${LOOP_LOG_DIR}/scanner-heartbeat"
+    DRY_RUN=true
+
+    loop_list_slugs()   { echo ""; }
+    scan_project()      { :; }
+    _sweep_stale_locks() { :; }
+    LOOP_JOBS_ENQUEUE=0
+
+    run_once
+
+    [ ! -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+# ---------------------------------------------------------------------------
+# Part 2 — watchdog staleness detection
+# ---------------------------------------------------------------------------
+
+@test "watchdog: exits 0 silently when no heartbeat file exists" {
+    local log_dir="$BATS_TMPDIR/wd-logs-no-hb"
+    mkdir -p "$log_dir"
+    # Run the real watchdog with an empty LOOP_LOG_DIR (no heartbeat file).
+    LOOP_LOG_DIR="$log_dir" \
+    LOOP_SCANNER_INTERVAL=300 \
+    LOOP_SCANNER_WATCHDOG_THRESHOLD=600 \
+    LOOP_EXTRA_PATH="" \
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no heartbeat file found"* ]]
+}
+
+@test "watchdog: exits 0 and reports ok when heartbeat is fresh" {
+    local log_dir="$BATS_TMPDIR/wd-logs-fresh"
+    mkdir -p "$log_dir"
+    # Write a heartbeat that is 10 seconds old (well within the 600s threshold).
+    local fresh_epoch
+    fresh_epoch=$(( $(date +%s) - 10 ))
+    printf '%s\n' "$fresh_epoch" > "$log_dir/scanner-heartbeat"
+    touch -t "$(date -r "$fresh_epoch" '+%Y%m%d%H%M.%S' 2>/dev/null || date '+%Y%m%d%H%M.%S')" \
+          "$log_dir/scanner-heartbeat" 2>/dev/null || true
+
+    LOOP_LOG_DIR="$log_dir" \
+    LOOP_SCANNER_INTERVAL=300 \
+    LOOP_SCANNER_WATCHDOG_THRESHOLD=600 \
+    LOOP_EXTRA_PATH="" \
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"heartbeat ok"* ]]
+}
+
+@test "watchdog: detects stale heartbeat when mtime exceeds threshold" {
+    local log_dir="$BATS_TMPDIR/wd-logs-stale"
+    mkdir -p "$log_dir"
+    # Create a heartbeat file with an old mtime (700 seconds ago > 600s threshold).
+    touch "$log_dir/scanner-heartbeat"
+    # Use touch -t to backdate the file.
+    local old_epoch stale_stamp
+    old_epoch=$(( $(date +%s) - 700 ))
+    # Format: [[CC]YY]MMDDhhmm[.SS]
+    stale_stamp=$(python3 -c "
+import datetime, sys
+t = datetime.datetime.fromtimestamp($old_epoch)
+print(t.strftime('%Y%m%d%H%M.%S'))
+" 2>/dev/null || echo "")
+    if [ -n "$stale_stamp" ]; then
+        touch -t "$stale_stamp" "$log_dir/scanner-heartbeat" 2>/dev/null || true
+    fi
+
+    # Confirm the file is actually old enough before running the watchdog.
+    local actual_mtime actual_age
+    actual_mtime=$(stat -f%m "$log_dir/scanner-heartbeat" 2>/dev/null \
+        || stat -c%Y "$log_dir/scanner-heartbeat" 2>/dev/null || echo 0)
+    actual_age=$(( $(date +%s) - actual_mtime ))
+    if [ "$actual_age" -lt 600 ]; then
+        skip "touch -t did not backdate the file (platform limitation)"
+    fi
+
+    # Run watchdog; it must detect the stale heartbeat. We don't have a scanner
+    # PID to kill, and launchctl is mocked out by the absence of a lock file.
+    LOOP_LOG_DIR="$log_dir" \
+    LOOP_SCANNER_INTERVAL=300 \
+    LOOP_SCANNER_WATCHDOG_THRESHOLD=600 \
+    LOOP_EXTRA_PATH="" \
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- Added `_scanner_write_heartbeat()` — writes the current epoch to `${LOOP_LOG_DIR}/scanner-heartbeat` at the start of every real (non-dry-run) tick.
- `run_once()` calls `_scanner_write_heartbeat` as its first action so the file is updated even if a later `scan_project` call hangs.

### `scanner/scanner-watchdog.sh` (new)
- Reads the heartbeat file mtime; if age ≥ `LOOP_SCANNER_WATCHDOG_THRESHOLD` (default: `2 × LOOP_SCANNER_INTERVAL` = 600 s), sends SIGTERM to the scanner PID (from `/tmp/loop-scanner.lock`) and on macOS runs `launchctl kickstart -k` so the KeepAlive service restarts immediately.
- On Linux, killing the process is sufficient; cron restarts it on the next `*/5` tick.
- Exits 0 in all cases — safe to run every 5 min without noise when the scanner is healthy.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- `StartInterval 300` (every 5 min) plist template for macOS launchd.

### `install.sh`
- `bootstrap_register_launchd()`: installs `com.user.loop-scanner-watchdog` plist alongside the existing scanner/reconciler/pr-watchdog plists.
- `bootstrap_register_cron()`: adds a `*/5 * * * *` watchdog cron entry for Linux.

## Test Plan

- `tests/scanner-heartbeat.bats` (8 new tests):
  - `_scanner_write_heartbeat` creates and updates the heartbeat file with a valid epoch.
  - `run_once()` writes the file in normal mode and skips it in `--dry-run`.
  - Watchdog exits 0 with "no heartbeat file" message when file is absent.
  - Watchdog exits 0 with "heartbeat ok" when file is fresh (10 s old vs 600 s threshold).
  - Watchdog logs "STALE" and proceeds to restart when file mtime > threshold.
- Manual smoke test: `kill -STOP $SCANNER_PID` → watchdog should restart within 10 min.