### PR TITLE
[LOOP-413] scanner: liveness heartbeat + auto-restart watchdog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — checks scanner-heartbeat every 5 min;
+    # restarts the scanner if it has been silent for >2 poll intervals.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -775,6 +776,16 @@ scan_project() {
 }
 
 run_once() {
+    # Heartbeat: record epoch so the watchdog can detect a wedged scanner.
+    $DRY_RUN || date +%s > "$HEARTBEAT_FILE" 2>/dev/null || true
+
+    # Stdout integrity: if the log file is gone or not writable, reopen FDs
+    # (mirrors the SIGHUP reopen path) and continue; launchd will restart on
+    # any uncaught failure so we prefer recovery over exit here.
+    if [ -n "${LOG_FILE:-}" ] && [ ! -w "$LOG_FILE" ]; then
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" || true
+    fi
+
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if its heartbeat file goes stale.
+#
+# Designed to run every 5 min via launchd (macOS) or cron (Linux).
+# If the heartbeat file is older than LOOP_WATCHDOG_STALE_SECONDS (default
+# 2 × LOOP_SCANNER_INTERVAL = 10 min), the scanner PID is killed so launchd
+# (KeepAlive) or cron restarts it within one tick.
+#
+# macOS restart path: launchctl kickstart -k gui/$(id -u) com.user.loop-scanner
+# Linux restart path: kill <scanner PID from lock file>; cron respawns at next tick
+#
+# Flags:
+#   --dry-run   report stale status; do not kill or restart
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_SECONDS="${LOOP_WATCHDOG_STALE_SECONDS:-$(( POLL_INTERVAL * 2 ))}"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# Returns 0 (stale) if the heartbeat file is older than STALE_SECONDS,
+# or if it does not exist.
+_heartbeat_is_stale() {
+    [ -f "$HEARTBEAT_FILE" ] || return 0
+    local mtime now age
+    mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+         || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+         || echo 0)
+    now=$(date +%s)
+    age=$(( now - mtime ))
+    [ "$age" -ge "$STALE_SECONDS" ]
+}
+
+# _restart_scanner — kill the scanner PID so the OS supervisor restarts it.
+# On macOS with launchd we also call kickstart to make the restart immediate
+# rather than waiting for launchd's ThrottleInterval.
+_restart_scanner() {
+    local pid=""
+    if [ -f "$LOCK_FILE" ]; then
+        pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    fi
+
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "killing stale scanner PID $pid"
+        kill "$pid" 2>/dev/null || true
+        # Give the process a moment to clean up before kickstart.
+        sleep 2
+    else
+        log "no live scanner PID found (lock=${LOCK_FILE})"
+    fi
+
+    # macOS: launchctl kickstart schedules an immediate restart via KeepAlive.
+    if command -v launchctl >/dev/null 2>&1; then
+        local uid
+        uid=$(id -u)
+        if launchctl list com.user.loop-scanner >/dev/null 2>&1; then
+            log "launchctl kickstart gui/${uid}/com.user.loop-scanner"
+            launchctl kickstart -k "gui/${uid}/com.user.loop-scanner" 2>/dev/null \
+                || log "WARN: launchctl kickstart failed — launchd will auto-restart via KeepAlive"
+        fi
+    fi
+    # Linux: cron will re-invoke scanner.sh --once at the next */5 tick; no
+    # additional action needed beyond killing the PID above.
+}
+
+watchdog_run() {
+    log "check (stale_threshold=${STALE_SECONDS}s)"
+
+    if ! _heartbeat_is_stale; then
+        log "ok — heartbeat is fresh"
+        return 0
+    fi
+
+    log "STALE — heartbeat older than ${STALE_SECONDS}s (file=${HEARTBEAT_FILE})"
+
+    if $DRY_RUN; then
+        log "DRY-RUN: would restart scanner"
+        return 0
+    fi
+
+    _restart_scanner
+    log "restart triggered"
+}
+
+watchdog_run

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+  Runs every 5 min; restarts the scanner if its heartbeat file is stale.
+
+  Install (via ./install.sh --bootstrap, or manually):
+    sed -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+        -e "s|__LOG_DIR__|$LOOP_LOG_DIR|g" \
+        -e "s|__HOME__|$HOME|g" \
+        -e "s|__EXTRA_PATH__|$LOOP_EXTRA_PATH|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,159 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — scanner liveness heartbeat (#413).
+#
+# Verifies that scanner.sh writes HEARTBEAT_FILE at the start of every
+# run_once() call and that scanner-watchdog.sh correctly detects stale
+# and fresh heartbeat files.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    # Expose mock-gh.sh as the gh binary.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+
+    # Source scanner.sh definitions only (same awk pattern as scanner.bats).
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    # Stubs: silence log, no-op dispatch, no-op lock sweeps, empty project list.
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat — scanner.sh
+# ---------------------------------------------------------------------------
+
+@test "run_once: writes HEARTBEAT_FILE on each call" {
+    [ ! -f "$HEARTBEAT_FILE" ]
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: heartbeat file contains a recent unix timestamp" {
+    run_once
+    local ts
+    ts=$(cat "$HEARTBEAT_FILE")
+    local now
+    now=$(date +%s)
+    # Timestamp must be a number within the last 5 seconds.
+    [ "$ts" -gt 0 ]
+    [ $(( now - ts )) -lt 5 ]
+}
+
+@test "run_once: heartbeat updated on every call" {
+    run_once
+    local first
+    first=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+    sleep 1
+    run_once
+    local second
+    second=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+    [ "$second" -ge "$first" ]
+}
+
+@test "run_once: DRY_RUN skips heartbeat write" {
+    DRY_RUN=true
+    run_once
+    [ ! -f "$HEARTBEAT_FILE" ]
+}
+
+# ---------------------------------------------------------------------------
+# Watchdog — scripts/scanner-watchdog.sh
+# ---------------------------------------------------------------------------
+
+_source_watchdog() {
+    local _wsrc="$BATS_TMPDIR/watchdog-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        printf "LOOP_LOG_DIR='%s'\n" "$LOOP_LOG_DIR"
+        awk '
+            /^SCRIPT_DIR=/    { next }
+            /^LOOP_ROOT=/     { next }
+            /^source.*env\.sh/ { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; next }
+            skip && /^done$/  { skip=0; next }
+            skip              { next }
+            /^watchdog_run$/  { exit }
+            { print }
+        ' "$REPO_ROOT/scripts/scanner-watchdog.sh"
+        # Stub out log() and _restart_scanner() so tests don't trigger them.
+        printf "log() { :; }\n"
+        printf "_restart_scanner() { :; }\n"
+    } > "$_wsrc"
+    # shellcheck disable=SC1090
+    source "$_wsrc"
+}
+
+@test "watchdog: _heartbeat_is_stale returns 0 when file missing" {
+    _source_watchdog
+    HEARTBEAT_FILE="$BATS_TMPDIR/no-such-heartbeat"
+    STALE_SECONDS=600
+    run _heartbeat_is_stale
+    [ "$status" -eq 0 ]
+}
+
+@test "watchdog: _heartbeat_is_stale returns 1 for a fresh file" {
+    _source_watchdog
+    HEARTBEAT_FILE="$BATS_TMPDIR/fresh-heartbeat"
+    touch "$HEARTBEAT_FILE"
+    STALE_SECONDS=600
+    run _heartbeat_is_stale
+    [ "$status" -eq 1 ]
+}
+
+@test "watchdog: _heartbeat_is_stale returns 0 for a file older than threshold" {
+    _source_watchdog
+    HEARTBEAT_FILE="$BATS_TMPDIR/old-heartbeat"
+    # Create file and backdate its mtime by 700 seconds using touch -t.
+    touch "$HEARTBEAT_FILE"
+    local old_time
+    old_time=$(date -v -700S '+%Y%m%d%H%M.%S' 2>/dev/null \
+        || date -d '-700 seconds' '+%Y%m%d%H%M.%S' 2>/dev/null \
+        || true)
+    [ -n "$old_time" ] && touch -t "$old_time" "$HEARTBEAT_FILE"
+    STALE_SECONDS=600
+    run _heartbeat_is_stale
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #413

## Changes

**scanner/scanner.sh**
- Write epoch timestamp to `${LOOP_LOG_DIR}/scanner-heartbeat` at the start of every `run_once()` tick; skip in `--dry-run` mode.
- Add proactive stdout integrity check: if `LOG_FILE` is not writable at tick start, reopen FDs (mirrors the existing SIGHUP reopen path) to recover from log rotation without launchd restart.

**scripts/scanner-watchdog.sh** (new)
- Reads the heartbeat file; if mtime is older than `LOOP_WATCHDOG_STALE_SECONDS` (default: `2 × LOOP_SCANNER_INTERVAL` = 10 min), kills the scanner PID and triggers a restart.
- macOS: calls `launchctl kickstart -k gui/<uid>/com.user.loop-scanner` for an immediate KeepAlive restart.
- Linux: kills the PID from the lock file; cron respawns at the next `*/5` tick.
- Supports `--dry-run`.

**templates/launchd/com.user.loop-scanner-watchdog.plist.template** (new)
- Launchd plist running `scanner-watchdog.sh` every 5 min (`StartInterval 300`).

**install.sh**
- `bootstrap_register_launchd()`: register the watchdog plist alongside the existing scanner/reconciler/pr-watchdog plists.
- `bootstrap_register_cron()`: add a `*/5` cron entry for the watchdog on Linux.

**tests/scanner-heartbeat.bats** (new)
- 7 bats tests: heartbeat file created on each tick, contains a recent unix timestamp, updated on each call, skipped in dry-run mode, plus `_heartbeat_is_stale` returns correct results for missing/fresh/old heartbeat files.

## Test Plan

- [x] `bash -n` syntax check passes on all scripts
- [x] `shellcheck -S warning` passes on all scripts
- [x] No personal identifiers
- [x] `bats tests/scanner-heartbeat.bats` — 7/7 pass
- [ ] Manual: `kill -STOP $SCANNER_PID` → watchdog detects stale heartbeat within 10 min and restarts
- [ ] Manual: verify `${LOOP_LOG_DIR}/scanner-heartbeat` is touched on every scan tick