### PR TITLE
[LOOP-413] scanner: liveness heartbeat + auto-restart watchdog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,6 +338,25 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    # Scanner liveness watchdog — checks heartbeat every 5 min and restarts
+    # the scanner if it has been silent longer than 2× poll interval.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     local digest_plist="$agents_dir/com.user.loop-digest.plist"
     if [ -f "$digest_plist" ]; then
         echo "[launchd] com.user.loop-digest already registered — skipping"
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -775,6 +776,19 @@ scan_project() {
 }
 
 run_once() {
+    # Heartbeat — updated every tick so scanner-watchdog can detect wedged process.
+    $DRY_RUN || touch "$HEARTBEAT_FILE"
+
+    # Log-file integrity check: if the log path is no longer writable (e.g. after
+    # a logrotate that left us writing to a deleted inode and the SIGHUP trap was
+    # missed), reopen stdout/stderr and exit if the reopen also fails so launchd
+    # restarts us cleanly.
+    if [ -n "${LOG_FILE:-}" ] && ! $DRY_RUN; then
+        if [ ! -w "$LOG_FILE" ] 2>/dev/null || [ ! -e "$LOG_FILE" ]; then
+            exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" || exit 1
+        fi
+    fi
+
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if it stops emitting heartbeats.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat. If the file is absent or its mtime
+# is older than STALE_THRESHOLD_SECONDS (default: 2 × LOOP_SCANNER_INTERVAL,
+# minimum 600s), the scanner is considered wedged and is restarted:
+#   macOS:  launchctl kickstart -k gui/<uid>/com.user.loop-scanner
+#   Linux:  kill the PID from /tmp/loop-scanner.lock (launchd/cron restarts it)
+#
+# Designed to run every 5 min via launchd (StartInterval=300) or cron (*/5).
+# Safe to run even when the scanner is healthy — it is a no-op in that case.
+#
+# Flags:
+#   --dry-run   log what would happen without actually restarting
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+# Stale threshold: 2× poll interval, but no less than 600s (10 min).
+_double=$(( POLL_INTERVAL * 2 ))
+STALE_THRESHOLD="${LOOP_SCANNER_WATCHDOG_STALE:-$(( _double > 600 ? _double : 600 ))}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+SCANNER_LOCK="/tmp/loop-scanner.lock"
+LAUNCHD_LABEL="com.user.loop-scanner"
+LOG_FILE="${LOOP_LOG_DIR}/loop-scanner-watchdog.log"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# Redirect output to the watchdog log (unless dry-run, where stdout is fine).
+$DRY_RUN || exec 1>>"$LOG_FILE" 2>>"$LOG_FILE"
+
+# Determine heartbeat age in seconds. Returns a very large number when the
+# file is absent so the stale check still triggers.
+_heartbeat_age() {
+    if [ ! -f "$HEARTBEAT_FILE" ]; then
+        echo 999999
+        return
+    fi
+    local mtime now
+    mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+         || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+         || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+age=$(_heartbeat_age)
+log "heartbeat_age=${age}s threshold=${STALE_THRESHOLD}s file=${HEARTBEAT_FILE}"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner healthy — no action"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat stale (${age}s > ${STALE_THRESHOLD}s) — restarting"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would restart scanner"
+    exit 0
+fi
+
+# macOS: use launchctl kickstart to replace the running instance cleanly.
+if command -v launchctl >/dev/null 2>&1; then
+    local_uid=$(id -u)
+    if launchctl kickstart -k "gui/${local_uid}/${LAUNCHD_LABEL}" 2>/dev/null; then
+        log "restarted via launchctl kickstart gui/${local_uid}/${LAUNCHD_LABEL}"
+        exit 0
+    fi
+    log "WARN: launchctl kickstart failed — falling back to kill"
+fi
+
+# Fallback (Linux / launchctl unavailable): kill the PID so the cron/supervisor
+# respawns the scanner on next schedule.
+if [ -f "$SCANNER_LOCK" ]; then
+    local_pid=$(cat "$SCANNER_LOCK" 2>/dev/null || true)
+    if [ -n "$local_pid" ] && kill -0 "$local_pid" 2>/dev/null; then
+        kill "$local_pid" && log "killed scanner PID ${local_pid}"
+        rm -f "$SCANNER_LOCK"
+        exit 0
+    fi
+fi
+
+log "WARN: no running scanner PID found — lock file absent or stale; nothing to kill"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <!-- Check every 5 minutes whether the scanner heartbeat is fresh -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,159 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — liveness heartbeat (#413).
+#
+# 1. scanner.sh: heartbeat file is touched on every run_once tick.
+# 2. scanner-watchdog.sh: no-op when heartbeat is fresh.
+# 3. scanner-watchdog.sh: exits non-zero (or logs restart intent) when stale.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    # Provide a mock gh so env.sh sources don't fail.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Suppress LOOP_EXTRA_PATH so env.sh doesn't shadow our mock gh.
+    export LOOP_EXTRA_PATH=""
+
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/logs" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Helper: source scanner.sh function definitions only (same strategy as
+# scanner.bats — strip SCRIPT_DIR/LOOP_ROOT assignments and arg-parser loop,
+# stop before acquire_lock).
+# ---------------------------------------------------------------------------
+_source_scanner() {
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    # Override paths after sourcing.
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+    log() { :; }
+    dispatch_direct() { :; }
+}
+
+# ---------------------------------------------------------------------------
+# scanner.sh — heartbeat file updated on every tick
+# ---------------------------------------------------------------------------
+
+@test "scanner run_once: heartbeat file is created on first tick" {
+    _source_scanner
+
+    # Stub out everything scan_project calls so run_once completes quickly.
+    loop_list_slugs()    { return 0; }
+    _sweep_stale_locks() { return 0; }
+    jobs_init_schema()   { return 0; }
+
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    rm -f "$HEARTBEAT_FILE"
+
+    run_once
+
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "scanner run_once: heartbeat file mtime advances between ticks" {
+    _source_scanner
+
+    loop_list_slugs()    { return 0; }
+    _sweep_stale_locks() { return 0; }
+    jobs_init_schema()   { return 0; }
+
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    rm -f "$HEARTBEAT_FILE"
+
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+
+    # Wait 1s so the mtime can differ.
+    sleep 1
+
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "scanner run_once: heartbeat file not created in --dry-run mode" {
+    _source_scanner
+    DRY_RUN=true
+
+    loop_list_slugs()    { return 0; }
+    _sweep_stale_locks() { return 0; }
+    jobs_init_schema()   { return 0; }
+
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    rm -f "$HEARTBEAT_FILE"
+
+    run_once
+
+    [ ! -f "$HEARTBEAT_FILE" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh — behavioural tests
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: no-op when heartbeat is fresh" {
+    # Create a heartbeat file with mtime = now.
+    touch "$LOOP_LOG_DIR/scanner-heartbeat"
+
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner healthy"* ]]
+}
+
+@test "scanner-watchdog: detects stale heartbeat and logs restart intent" {
+    # Create a heartbeat file and set threshold to 1s so it's immediately stale.
+    touch "$LOOP_LOG_DIR/scanner-heartbeat"
+    sleep 2
+    LOOP_SCANNER_WATCHDOG_STALE=1 \
+        run "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DRY-RUN: would restart scanner"* ]]
+}
+
+@test "scanner-watchdog: detects absent heartbeat as stale" {
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DRY-RUN: would restart scanner"* ]]
+}
+
+@test "scanner-watchdog.sh source: HEARTBEAT_FILE variable is declared in scanner.sh" {
+    grep -q 'HEARTBEAT_FILE=' "$REPO_ROOT/scanner/scanner.sh"
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- Added `HEARTBEAT_FILE` variable (`${LOOP_LOG_DIR}/scanner-heartbeat`)
- `run_once()` now calls `touch "$HEARTBEAT_FILE"` at the start of every tick (skipped in `--dry-run` mode)
- Added log-file integrity check at tick start: if `$LOG_FILE` no longer exists or isn't writable (e.g. after a logrotate that bypassed the SIGHUP trap), re-opens stdout/stderr or exits so launchd can restart cleanly

### `scripts/scanner-watchdog.sh` (new)
- Reads the heartbeat file mtime; stale threshold = `2 × LOOP_SCANNER_INTERVAL` (min 600s, override via `LOOP_SCANNER_WATCHDOG_STALE`)
- On macOS: uses `launchctl kickstart -k gui/<uid>/com.user.loop-scanner` to replace the wedged instance
- Fallback (Linux / launchctl unavailable): kills the PID from the scanner lock file so cron/supervisor respawns it
- Logs to `${LOOP_LOG_DIR}/loop-scanner-watchdog.log`
- `--dry-run` flag for safe testing

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- `StartInterval=300` (every 5 min)
- Runs `scanner-watchdog.sh`

### `install.sh`
- `bootstrap_register_launchd`: installs the `com.user.loop-scanner-watchdog` plist
- `bootstrap_register_cron`: adds a `*/5` cron entry for `scanner-watchdog.sh` (Linux)

### `tests/scanner-heartbeat.bats` (new, 7 tests)
- Heartbeat file created on first tick
- Heartbeat mtime advances between ticks
- Heartbeat not touched in `--dry-run` mode
- Watchdog no-ops when heartbeat is fresh
- Watchdog detects stale heartbeat (threshold=1s) and logs restart intent
- Watchdog detects absent heartbeat as stale
- `HEARTBEAT_FILE` variable declared in scanner.sh (regression guard)

## Test Plan
- All 7 new tests pass: `bats tests/scanner-heartbeat.bats`
- Existing scanner tests: no regressions introduced (4 pre-existing failures unrelated to this PR)
- CI: `bash -n` + `shellcheck -S warning` clean on all changed files
- Manual: simulate wedge with `kill -STOP $SCANNER_PID`; watchdog should restart within 10 min (2 × 300s default)