### PR TITLE
[LOOP-413] scanner: liveness heartbeat + auto-restart watchdog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,26 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog (#413) — kills and restarts the scanner if its
+    # heartbeat file is stale (2×poll_interval). Runs every 5 min on its own
+    # cadence so a wedged KeepAlive scanner is detected within 10 minutes.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +381,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +404,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -776,6 +777,22 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+
+    # Heartbeat (#413): write current timestamp so scanner-watchdog.sh can
+    # detect a wedged scanner (alive PID, silent main loop).
+    touch "$HEARTBEAT_FILE"
+
+    # Stdout integrity check (#413): if the log file path is no longer
+    # writable (e.g. deleted after rotation without SIGHUP), reopen or exit
+    # so launchd restarts with fresh file descriptors.
+    if [ -n "${LOG_FILE:-}" ] && [ ! -w "$LOG_FILE" ]; then
+        _scanner_reopen_log
+        if [ ! -w "$LOG_FILE" ]; then
+            echo "[scanner] FATAL: cannot write to $LOG_FILE — exiting for restart" >&2
+            exit 1
+        fi
+    fi
+
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if its heartbeat file is stale.
+#
+# Runs every 5 min via launchd (macOS) or cron (Linux).
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat; if mtime > 2×POLL_INTERVAL seconds
+# ago, kills the scanner process (from /tmp/loop-scanner.lock) and triggers
+# a restart: launchd KeepAlive restarts automatically on kill; on Linux the
+# stale lock is removed so the next cron tick starts a fresh instance.
+#
+# Flags:
+#   --dry-run   print what would happen without killing anything
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 ))
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -15
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# If the heartbeat file does not exist yet the scanner may be starting up.
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "no heartbeat file — scanner may be starting"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+    || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+    || echo "$now")
+age=$(( now - mtime ))
+
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    exit 0
+fi
+
+log "STALE: scanner heartbeat is ${age}s old — restarting"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID and remove lock"
+    exit 0
+fi
+
+# Kill the scanner process so launchd KeepAlive restarts it immediately.
+pid=""
+if [ -f "$LOCK_FILE" ]; then
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+fi
+if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    log "killing scanner PID $pid"
+    kill "$pid" 2>/dev/null || true
+    sleep 1
+fi
+
+# Remove stale lock so the new instance can acquire it cleanly.
+rm -f "$LOCK_FILE"
+
+# On macOS, kickstart the launchd job immediately instead of waiting for
+# launchd's ThrottleInterval. Fall back silently on older launchctl.
+if command -v launchctl >/dev/null 2>&1; then
+    launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null \
+        || launchctl start com.user.loop-scanner 2>/dev/null \
+        || true
+fi
+
+log "restart triggered"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <!-- Check for a stale scanner every 5 minutes -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 scanner liveness heartbeat.
+#
+# Verifies that:
+#   1. run_once() writes/touches HEARTBEAT_FILE on every tick.
+#   2. scanner-watchdog.sh exits 0 when heartbeat is fresh.
+#   3. scanner-watchdog.sh logs STALE and removes the lock when heartbeat is old.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Suppress /opt/homebrew/bin prepend so mock binaries take precedence.
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner.sh function definitions (same awk extraction as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    # Override scanner-internal path variables.
+    HEARTBEAT_FILE="$BATS_TMPDIR/logs/scanner-heartbeat"
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/logs/loop-scanner.log"
+    mkdir -p "$DEDUP_DIR"
+    touch "$LOG_FILE"
+
+    # Silence log() and no-op heavy helpers so run_once() completes quickly.
+    log() { :; }
+    dispatch_direct() { :; }
+    loop_list_slugs() { printf ''; }
+    scan_project() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat — written on every tick
+# ---------------------------------------------------------------------------
+
+@test "run_once: creates heartbeat file on first tick" {
+    rm -f "$HEARTBEAT_FILE"
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: heartbeat file mtime is updated on subsequent ticks" {
+    rm -f "$HEARTBEAT_FILE"
+    run_once
+
+    # Record the mtime after the first tick.
+    local mtime1
+    mtime1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+        || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+
+    # Wait one second so the filesystem mtime can advance.
+    sleep 1
+    run_once
+
+    local mtime2
+    mtime2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+        || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh — fresh heartbeat → no kill
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits 0 with no-op when heartbeat is fresh" {
+    touch "$HEARTBEAT_FILE"
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"STALE"* ]]
+}
+
+@test "scanner-watchdog: exits 0 with informational message when heartbeat file absent" {
+    rm -f "$HEARTBEAT_FILE"
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no heartbeat"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh — stale heartbeat → dry-run logs STALE
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog --dry-run: logs STALE when heartbeat is old" {
+    # Create a heartbeat file with mtime well in the past (>600s ago).
+    touch -t 200001010000 "$HEARTBEAT_FILE" 2>/dev/null \
+        || touch -d "1970-01-01 00:00:00" "$HEARTBEAT_FILE" 2>/dev/null \
+        || : # if neither works the stat-based age will be very large
+
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+    [[ "$output" == *"DRY-RUN"* ]]
+}
+
+@test "scanner-watchdog --dry-run: does not remove lock file" {
+    touch -t 200001010000 "$HEARTBEAT_FILE" 2>/dev/null || true
+
+    local lock_file="/tmp/loop-scanner.lock"
+    echo "99999" > "$lock_file"
+
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+
+    # Lock must survive a dry-run.
+    [ -f "$lock_file" ]
+    rm -f "$lock_file"
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- Added `HEARTBEAT_FILE` variable (`${LOOP_LOG_DIR}/scanner-heartbeat`).
- `run_once()` now `touch`es the heartbeat file at the start of every tick — even a wedged tick (where `scan_project` hangs) won't update it, so the watchdog can distinguish a live-but-silent scanner from a running one.
- Added a log-file writable check at the top of each tick: if `$LOG_FILE` is not writable (deleted inode after rotation without SIGHUP), `_scanner_reopen_log` is called; if still unwritable, the scanner exits so launchd restarts it with fresh FDs.

### `scripts/scanner-watchdog.sh` (new)
- Reads `scanner-heartbeat` mtime; if older than `2 × LOOP_SCANNER_INTERVAL` (default 600 s) logs STALE, kills the scanner PID (from `/tmp/loop-scanner.lock`), removes the stale lock, and on macOS `launchctl kickstart`s the scanner job immediately.
- Under launchd `KeepAlive=true` the kill alone is sufficient — `kickstart -k` just makes it faster.
- `--dry-run` flag prints what would happen without touching anything.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- Runs `scanner-watchdog.sh` every 5 minutes (`StartInterval=300`) via launchd.
- Uses the same `__LOOP_ROOT__` / `__LOG_DIR__` / `__HOME__` / `__EXTRA_PATH__` substitution tokens as the scanner plist so `bootstrap_register_launchd` can install it with one `sed` pass.

### `install.sh`
- `bootstrap_register_launchd()` registers `com.user.loop-scanner-watchdog` after the other plists.
- `bootstrap_register_cron()` adds a `*/5 * * * *` watchdog cron entry (Linux path) alongside the scanner entry.

### `tests/scanner-heartbeat.bats` (new)
Six bats tests covering:
- `run_once()` creates heartbeat file on first tick.
- `run_once()` updates heartbeat mtime on subsequent ticks.
- Watchdog exits 0 and is silent when heartbeat is fresh.
- Watchdog exits 0 with informational message when heartbeat file is absent.
- Watchdog logs STALE + DRY-RUN when heartbeat is artificially old.
- Watchdog does not remove the lock file in dry-run mode.

## Test Plan
- `bash -n` and `shellcheck -S warning` — both clean.
- `bats tests/scanner-heartbeat.bats` — 6/6 pass.
- Existing `tests/scanner.bats` — same 5 pre-existing failures, no regressions.
- Manual: `kill -STOP $SCANNER_PID` → within 10 min the watchdog detects stale heartbeat and `kill`s it → launchd restarts.