### PR TITLE
[LOOP-413] scanner: liveness heartbeat + watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — checks heartbeat file every 5 min and kills
+    # a wedged scanner so launchd KeepAlive restarts it automatically.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if its heartbeat goes stale.
+#
+# Run every 5 min via launchd (macOS) or cron (Linux). Reads
+# ${LOOP_LOG_DIR}/scanner-heartbeat; if its mtime is older than
+# 2 × LOOP_SCANNER_INTERVAL (default 600s), kills the scanner PID and logs.
+# launchd KeepAlive=true on the scanner plist auto-restarts it within seconds.
+#
+# Flags:
+#   --dry-run   report stale state without killing
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 ))
+HB_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+SCANNER_LOCK="/tmp/loop-scanner.lock"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -12
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+if [ ! -f "$HB_FILE" ]; then
+    log "heartbeat file absent — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+hb_mtime=$(stat -f%m "$HB_FILE" 2>/dev/null || stat -c%Y "$HB_FILE" 2>/dev/null || echo 0)
+age=$(( $(date +%s) - hb_mtime ))
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "ok: heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+    exit 0
+fi
+
+log "STALE: heartbeat age=${age}s > ${STALE_THRESHOLD}s — scanner appears wedged"
+
+pid=""
+if [ -f "$SCANNER_LOCK" ]; then
+    pid=$(cat "$SCANNER_LOCK" 2>/dev/null || true)
+fi
+
+if $DRY_RUN; then
+    log "dry-run: would kill scanner PID ${pid:-unknown}"
+    exit 0
+fi
+
+if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" && log "killed scanner PID $pid — launchd/cron will restart"
+else
+    log "scanner lock PID (${pid:-none}) not running — launchd/cron should restart automatically"
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -46,6 +47,25 @@ _scanner_reopen_log() {
     fi
 }
 trap '_scanner_reopen_log; echo "[$(date "+%Y-%m-%d %H:%M:%S")] [scanner] SIGHUP — log fds reopened"' HUP
+
+# _scanner_update_heartbeat — write current timestamp + PID to the heartbeat
+# file so the external watchdog knows the scanner is alive and active.
+# Called unconditionally at the top of every tick (including --dry-run).
+_scanner_update_heartbeat() {
+    printf '%s pid=%s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$$" > "$HEARTBEAT_FILE" || true
+}
+
+# _scanner_check_log_fd — if LOG_FILE is no longer writable (e.g. deleted or
+# permissions changed), attempt to reopen stdout/stderr against it. If the
+# reopen fails, exit so launchd/cron can restart the process with a fresh fd.
+_scanner_check_log_fd() {
+    [ -n "${LOG_FILE:-}" ] || return 0
+    if [ ! -w "$LOG_FILE" ] && [ ! -e "$LOG_FILE" ]; then
+        # Attempt recovery first; exit on failure so launchd restarts cleanly.
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" \
+            || { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] FATAL: log fd unrecoverable — exiting for restart" >&2; exit 1; }
+    fi
+}
 
 DRY_RUN=false
 ONCE=false
@@ -775,6 +795,8 @@ scan_project() {
 }
 
 run_once() {
+    _scanner_update_heartbeat
+    _scanner_check_log_fd
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <!-- Run every 5 minutes — catches a wedged scanner within one check cycle -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 scanner liveness heartbeat.
+#
+# Tests that:
+#   1. _scanner_update_heartbeat writes the heartbeat file on every tick.
+#   2. scanner-watchdog.sh exits cleanly when heartbeat is fresh.
+#   3. scanner-watchdog.sh kills a stale scanner lock PID.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Source scanner.sh function definitions only (same approach as scanner.bats).
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    log() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# _scanner_update_heartbeat
+# ---------------------------------------------------------------------------
+
+@test "_scanner_update_heartbeat: creates heartbeat file" {
+    rm -f "$HEARTBEAT_FILE"
+    _scanner_update_heartbeat
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "_scanner_update_heartbeat: heartbeat file contains current pid" {
+    _scanner_update_heartbeat
+    grep -q "pid=$$" "$HEARTBEAT_FILE"
+}
+
+@test "_scanner_update_heartbeat: updates mtime on repeated calls" {
+    _scanner_update_heartbeat
+    local t1
+    t1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+    sleep 1
+    _scanner_update_heartbeat
+    local t2
+    t2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+    [ "$t2" -gt "$t1" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits 0 silently when heartbeat is absent" {
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh"
+    [ "$status" -eq 0 ]
+}
+
+@test "scanner-watchdog: exits 0 when heartbeat is fresh" {
+    printf '%s pid=%s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$$" \
+        > "$LOOP_LOG_DIR/scanner-heartbeat"
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ok:"* ]]
+}
+
+@test "scanner-watchdog --dry-run: reports stale without killing" {
+    # Write a heartbeat file with an ancient mtime (touch -t sets to year 2000).
+    printf 'stale\n' > "$LOOP_LOG_DIR/scanner-heartbeat"
+    touch -t 200001010000 "$LOOP_LOG_DIR/scanner-heartbeat"
+
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"dry-run"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`**
- Added `HEARTBEAT_FILE` constant pointing to `${LOOP_LOG_DIR}/scanner-heartbeat`
- Added `_scanner_update_heartbeat()` — writes `now pid=$$` to the heartbeat file at the top of every tick (including `--dry-run` mode; liveness is independent of dispatch mode)
- Added `_scanner_check_log_fd()` — at the top of every tick, if `LOG_FILE` is absent/unwritable, attempts to reopen stdout/stderr against it; exits with code 1 on failure so launchd KeepAlive restarts with fresh file descriptors
- Both helpers called at the start of `run_once()`

**`scanner/scanner-watchdog.sh`** (new)
- Standalone script that checks the heartbeat file mtime
- If age > `2 × LOOP_SCANNER_INTERVAL` (default 600s), kills the scanner PID found in the lock file and logs; launchd KeepAlive on the scanner plist auto-restarts within seconds
- Supports `--dry-run` for safe testing
- Exits 0 (no-op) when heartbeat file is absent (scanner not yet started)

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new)
- Runs `scanner-watchdog.sh` every 5 minutes via `StartInterval`
- Follows the same `__LOOP_ROOT__` / `__LOG_DIR__` / `__HOME__` / `__EXTRA_PATH__` substitution pattern as other plists

**`install.sh`**
- `bootstrap_register_launchd`: registers `com.user.loop-scanner-watchdog` (idempotent, skips if plist exists)
- `bootstrap_register_cron`: adds `*/5` crontab entry with `# loop-scanner-watchdog` marker (idempotent)

**`tests/scanner-heartbeat.bats`** (new)
- 6 tests covering `_scanner_update_heartbeat` (creates file, contains pid, updates mtime) and `scanner-watchdog.sh` (absent heartbeat, fresh heartbeat, stale + dry-run)

## Test Plan

- [ ] `bash -n` + `shellcheck -S warning` pass on all scripts
- [ ] `bats tests/scanner-heartbeat.bats` — all 6 tests green
- [ ] No regressions in `bats tests/scanner.bats tests/scanner-log-sighup.bats tests/scanner-stage-age.bats`
- [ ] Manual: run scanner, inspect `${LOOP_LOG_DIR}/scanner-heartbeat` updates each tick
- [ ] Manual: run `scanner-watchdog.sh --dry-run` — confirms "ok:" when heartbeat is fresh
- [ ] Manual: `kill -STOP $SCANNER_PID` → after 10 min watchdog should kill+restart it