### PR TITLE
[LOOP-413] scanner: add liveness heartbeat + watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,6 +338,23 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    local watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$watchdog_plist"
+        if launchctl load "$watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     local digest_plist="$agents_dir/com.user.loop-digest.plist"
     if [ -f "$digest_plist" ]; then
         echo "[launchd] com.user.loop-digest already registered — skipping"
@@ -361,8 +378,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +401,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the Loop scanner if its heartbeat file is stale.
+#
+# scanner.sh writes ${LOOP_LOG_DIR}/scanner-heartbeat on every tick. This
+# watchdog reads the file's mtime; if older than LOOP_WATCHDOG_STALE_SECONDS
+# (default 600 = 2× the default 5-min poll interval), it kills the stale
+# process and triggers a restart.
+#
+# Designed to run every 5 min via launchd (macOS) or cron (Linux).
+#
+# Flags:
+#   --dry-run   print what would be done without acting
+#   --once      single check (default; alias for clarity)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+STALE_SECONDS="${LOOP_WATCHDOG_STALE_SECONDS:-600}"
+SCANNER_LOCK="/tmp/loop-scanner.lock"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        --once)    : ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+log "check (stale_threshold=${STALE_SECONDS}s dry_run=${DRY_RUN})"
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat absent — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+    || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+    || echo 0)
+age=$(( now - mtime ))
+
+log "heartbeat age=${age}s"
+
+if [ "$age" -lt "$STALE_SECONDS" ]; then
+    log "scanner alive (heartbeat age=${age}s < ${STALE_SECONDS}s)"
+    exit 0
+fi
+
+log "WARN: heartbeat stale (${age}s >= ${STALE_SECONDS}s) — restarting scanner"
+
+scanner_pid=""
+if [ -f "$SCANNER_LOCK" ]; then
+    scanner_pid=$(cat "$SCANNER_LOCK" 2>/dev/null || true)
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill PID ${scanner_pid:-unknown} and trigger restart"
+    exit 0
+fi
+
+if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+    log "killing stale scanner PID $scanner_pid"
+    kill "$scanner_pid" 2>/dev/null || true
+    sleep 2
+fi
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    local_uid=$(id -u)
+    log "kickstart via launchctl (uid=$local_uid)"
+    launchctl kickstart -k "gui/${local_uid}/com.user.loop-scanner" 2>/dev/null \
+        || log "WARN: launchctl kickstart failed — launchd KeepAlive will restart on next cycle"
+else
+    log "Linux: scanner killed; cron will restart it on the next */5 interval"
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -775,6 +775,17 @@ scan_project() {
 }
 
 run_once() {
+    # Liveness heartbeat — watchdog reads mtime; kills + restarts if stale.
+    $DRY_RUN || touch "${LOOP_LOG_DIR}/scanner-heartbeat"
+
+    # Log-FD integrity check: if the log file went unwritable (e.g. log rotation
+    # without SIGHUP), reopen FDs so log() calls continue working. If reopen
+    # fails, exit so launchd/cron restarts a clean process.
+    if [ -n "${LOG_FILE:-}" ] && [ ! -w "${LOG_FILE}" ]; then
+        exec 1>>"${LOG_FILE}" 2>>"${LOG_FILE}" \
+            || { echo "FATAL: cannot reopen log ${LOG_FILE} — exiting for restart" >&2; exit 1; }
+    fi
+
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Runs every 5 minutes and restarts the scanner if its heartbeat file is stale
+  (older than LOOP_WATCHDOG_STALE_SECONDS, default 600s). Installed alongside
+  the scanner by ./install.sh --bootstrap.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verify scanner liveness heartbeat (#413).
+#
+# run_once() must touch ${LOOP_LOG_DIR}/scanner-heartbeat on every tick so
+# the scanner-watchdog can detect a wedged process by mtime.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    # Minimal mock-gh so env.sh / config.sh do not fail.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+
+    # Extract function definitions from scanner.sh up to (but not including)
+    # the bare acquire_lock call. Same awk pattern as tests/scanner.bats.
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    # Override dirs so the test is fully isolated.
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    STAGE_AGE_DIR="$BATS_TMPDIR/stage-age"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR" "$STAGE_AGE_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    # Stub out everything that would hit GitHub or run handlers.
+    log()             { :; }
+    dispatch_direct() { :; }
+    loop_list_slugs() { printf ''; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" "$BATS_TMPDIR/stage-age" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+@test "run_once: creates heartbeat file on first tick" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    [ ! -f "$hb" ]
+    run_once
+    [ -f "$hb" ]
+}
+
+@test "run_once: updates heartbeat mtime on each call" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb" 2>/dev/null)
+    sleep 1
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb" 2>/dev/null)
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once: heartbeat not written in dry-run mode" {
+    DRY_RUN=true
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    run_once
+    [ ! -f "$hb" ]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- `run_once()` now calls `touch "${LOOP_LOG_DIR}/scanner-heartbeat"` at the start of every tick (skipped in `--dry-run` mode). The watchdog reads this file's mtime to determine if the scanner is alive.
- Added a log-FD integrity check at the top of each tick: if `LOG_FILE` exists but is no longer writable (e.g. log rotation without SIGHUP), the FDs are reopened. If reopening fails, the process exits so launchd/cron restarts a fresh one. This complements the existing SIGHUP handler which handles the signal-based rotation path.

### `scanner/scanner-watchdog.sh` (new)
- Reads `${LOOP_LOG_DIR}/scanner-heartbeat` mtime.
- If the file is older than `LOOP_WATCHDOG_STALE_SECONDS` (default 600 s = 2× the 5-min poll interval), kills the stale scanner PID (read from the lock file) and:
  - macOS: calls `launchctl kickstart -k gui/<uid>/com.user.loop-scanner`
  - Linux: kills the PID; cron restarts it on the next `*/5` interval.
- Supports `--dry-run`.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- Runs `scanner-watchdog.sh` every 5 minutes (`StartInterval=300`).
- Same placeholder scheme as other launchd templates (`__LOOP_ROOT__`, `__LOG_DIR__`, `__HOME__`, `__EXTRA_PATH__`).

### `install.sh`
- `bootstrap_register_launchd()`: registers `com.user.loop-scanner-watchdog` alongside the existing scanner/reconciler/pr-watchdog plists.
- `bootstrap_register_cron()`: adds a `*/5` cron entry for `scanner-watchdog.sh` alongside the scanner entry (Linux path).

### `tests/scanner-heartbeat.bats` (new)
Three bats tests:
1. `run_once` creates the heartbeat file on first tick.
2. `run_once` updates the heartbeat mtime on each subsequent call.
3. Heartbeat is **not** written in `--dry-run` mode.

## Test Plan
- All three new bats tests pass (`bats tests/scanner-heartbeat.bats`).
- Existing scanner tests pass with no new failures.
- `bash -n` and `shellcheck -S warning` clean on all shell files.
- Manual simulation: `kill -STOP $SCANNER_PID` → watchdog kills and restarts within 10 min (2× poll interval watchdog window).
