### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog auto-restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — kills a wedged scanner (alive PID, no events)
+    # so launchd auto-restarts it. Runs every 5 min; harmless when scanner is healthy.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — Liveness watchdog for the scanner process.
+#
+# Checks scanner-heartbeat mtime each run. If the heartbeat file is older than
+# LOOP_SCANNER_WATCHDOG_THRESHOLD (default: 2 × poll interval + 60 s = 660 s),
+# the scanner is considered wedged: its PID is killed so launchd (macOS) or the
+# cron re-invocation restarts it automatically.
+#
+# Usage (macOS — managed by launchd, StartInterval=300):
+#   Installed automatically by install.sh --bootstrap as com.user.loop-scanner-watchdog
+#
+# Usage (Linux — cron):
+#   */5 * * * * /path/to/loop/scanner/scanner-watchdog.sh >> /path/to/logs/loop-scanner-watchdog.log 2>&1
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+# Default threshold: 2 poll cycles + 60 s grace.  Override via env for tests.
+THRESHOLD="${LOOP_SCANNER_WATCHDOG_THRESHOLD:-$(( POLL_INTERVAL * 2 + 60 ))}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "no heartbeat file found — scanner not yet started or running in dry-run mode; skipping"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+age=$(( now - mtime ))
+
+if [ "$age" -lt "$THRESHOLD" ]; then
+    log "heartbeat age=${age}s threshold=${THRESHOLD}s — scanner healthy"
+    exit 0
+fi
+
+log "ALERT: heartbeat stale (age=${age}s > threshold=${THRESHOLD}s) — scanner may be wedged"
+
+if [ ! -f "$LOCK_FILE" ]; then
+    log "no lock file found — scanner not running; nothing to kill"
+    exit 0
+fi
+
+pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+if [ -z "$pid" ]; then
+    log "lock file empty — skipping kill"
+    exit 0
+fi
+
+if ! kill -0 "$pid" 2>/dev/null; then
+    log "scanner PID $pid is already dead; launchd/cron will restart it"
+    exit 0
+fi
+
+log "sending SIGTERM to wedged scanner (PID $pid)"
+kill "$pid" || true
+
+# On Linux there is no launchd to auto-restart.  Spawn a fresh scanner in the
+# background so the pipeline resumes without waiting for the next cron tick.
+if [ "$(uname -s)" != "Darwin" ]; then
+    sleep 2
+    log "Linux mode — spawning replacement scanner"
+    nohup "$LOOP_ROOT/scanner/scanner.sh" >> "${LOOP_LOG_DIR}/loop-scanner.log" 2>&1 &
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -776,6 +776,10 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Write liveness heartbeat so scanner-watchdog can detect silent wedges.
+    if ! $DRY_RUN; then
+        touch "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+    fi
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <!-- Check scanner liveness every 5 minutes -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — heartbeat liveness mechanism tests.
+#
+# 1. Verifies scanner.sh touches ${LOOP_LOG_DIR}/scanner-heartbeat on each tick.
+# 2. Verifies scanner-watchdog.sh correctly classifies fresh vs stale heartbeats.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_EXTRA_PATH=""
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs"
+}
+
+# ---------------------------------------------------------------------------
+# scanner.sh — source-level guard
+# ---------------------------------------------------------------------------
+
+@test "scanner.sh touches scanner-heartbeat inside run_once" {
+    grep -q "scanner-heartbeat" "$REPO_ROOT/scanner/scanner.sh"
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh — fresh heartbeat
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits 0 and reports healthy when heartbeat is fresh" {
+    touch "$LOOP_LOG_DIR/scanner-heartbeat"
+    LOOP_SCANNER_WATCHDOG_THRESHOLD=600 \
+        run "$REPO_ROOT/scanner/scanner-watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "healthy" ]]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh — missing heartbeat
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits 0 when heartbeat file is absent" {
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "no heartbeat" ]]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh — stale heartbeat, no live scanner
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: reports ALERT when heartbeat is stale" {
+    touch "$LOOP_LOG_DIR/scanner-heartbeat"
+    # Backdate the heartbeat so it looks 30 min old.
+    touch -t "$(date -v-30M '+%Y%m%d%H%M.%S' 2>/dev/null \
+             || date -d '30 minutes ago' '+%Y%m%d%H%M.%S' 2>/dev/null \
+             || echo '197001010000.00')" \
+        "$LOOP_LOG_DIR/scanner-heartbeat"
+    # Use a 60 s threshold so any file older than 1 min triggers.
+    LOOP_SCANNER_WATCHDOG_THRESHOLD=60 \
+        run "$REPO_ROOT/scanner/scanner-watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "ALERT" ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

**Problem:** The scanner process could become silently wedged — alive PID, sleeping between ticks, but emitting zero events for hours. No alert, no telemetry. The only signal was comparing `loop-scanner.log` mtime to now.

**Solution:**

1. **Heartbeat file** (`scanner.sh`): `run_once()` now `touch`es `${LOOP_LOG_DIR}/scanner-heartbeat` at the start of every tick. This gives the watchdog a reliable, per-tick liveness signal without touching any external service.

2. **Watchdog script** (`scanner/scanner-watchdog.sh`): Runs independently every 5 min. Reads the heartbeat file's mtime; if age exceeds `LOOP_SCANNER_WATCHDOG_THRESHOLD` (default: `2 × POLL_INTERVAL + 60 s = 660 s`, configurable), it considers the scanner wedged, sends `SIGTERM` to the scanner PID from the lock file, and on Linux directly spawns a replacement (macOS relies on launchd `KeepAlive`).

3. **launchd template** (`templates/launchd/com.user.loop-scanner-watchdog.plist.template`): `StartInterval=300` (5 min), installed alongside the existing scanner plist.

4. **install.sh**: Registers `com.user.loop-scanner-watchdog` on macOS via `bootstrap_register_launchd` and adds a `*/5 * * * *` crontab entry on Linux via `bootstrap_register_cron`.

5. **Tests** (`tests/scanner-heartbeat.bats`): 4 bats tests — source guard that heartbeat write is present, healthy exit, missing-file exit, and stale-heartbeat ALERT path.

## Test Plan

- [ ] All 4 bats tests in `tests/scanner-heartbeat.bats` pass (`bats tests/scanner-heartbeat.bats`)
- [ ] `bash -n` and `shellcheck -S warning` pass on all scripts
- [ ] Manual: `kill -STOP $SCANNER_PID` → watchdog detects stale heartbeat within 10 min and kills the stopped PID → launchd restarts scanner
- [ ] After install, verify `~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist` exists and `launchctl list | grep loop-scanner-watchdog` shows it loaded