### PR TITLE
[LOOP-413] scanner: liveness heartbeat + watchdog auto-restart

### DIFF
--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — detect and restart a silently-wedged scanner.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written by scanner.sh every tick).
+# If the heartbeat file is older than STALE_THRESHOLD seconds, the scanner is
+# considered stuck: it is killed and launchd/cron restarts it automatically.
+#
+# Designed to run every 5 minutes via launchd (StartInterval=300) or cron.
+#
+# Env / config:
+#   LOOP_SCANNER_INTERVAL  — poll interval in seconds (default 300).
+#                            STALE_THRESHOLD defaults to 2× this value.
+#   LOOP_WATCHDOG_STALE_THRESHOLD — override stale threshold directly (seconds).
+#   LOOP_SCANNER_LOCK      — path to scanner singleton lock (default /tmp/loop-scanner.lock)
+#
+# Flags:
+#   --dry-run   report what would happen; do not kill/restart anything
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_WATCHDOG_STALE_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+LOCK_FILE="${LOOP_SCANNER_LOCK:-/tmp/loop-scanner.lock}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _file_age_seconds <path>
+# Prints the age of the file in seconds. Returns 1 if the file does not exist.
+_file_age_seconds() {
+    local f="$1"
+    [ -f "$f" ] || return 1
+    local mtime now
+    mtime=$(stat -f%m "$f" 2>/dev/null || stat -c%Y "$f" 2>/dev/null) || return 1
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+# _scanner_pid — read the PID from the lock file if the process is alive.
+_scanner_pid() {
+    [ -f "$LOCK_FILE" ] || return 1
+    local pid
+    pid=$(cat "$LOCK_FILE" 2>/dev/null) || return 1
+    [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && echo "$pid"
+}
+
+log "tick (stale-threshold=${STALE_THRESHOLD}s heartbeat=${HEARTBEAT_FILE})"
+
+# 1. If the heartbeat file does not exist at all, the scanner has never started
+#    (or LOOP_LOG_DIR changed). Nothing to do — launchd will start it.
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file absent — scanner not yet started or first run; skipping"
+    exit 0
+fi
+
+heartbeat_age=$(_file_age_seconds "$HEARTBEAT_FILE")
+
+if [ "$heartbeat_age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner healthy (heartbeat age=${heartbeat_age}s < threshold=${STALE_THRESHOLD}s)"
+    exit 0
+fi
+
+log "STALE: heartbeat age=${heartbeat_age}s >= ${STALE_THRESHOLD}s — scanner appears wedged"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner and trigger restart"
+    exit 0
+fi
+
+# 2. Kill the stuck scanner process so launchd (KeepAlive=true) restarts it.
+pid=$(_scanner_pid 2>/dev/null || true)
+if [ -n "$pid" ]; then
+    log "killing scanner PID $pid"
+    kill "$pid" 2>/dev/null || true
+    # Give it a moment to exit, then SIGKILL if still alive.
+    sleep 2
+    if kill -0 "$pid" 2>/dev/null; then
+        log "SIGKILL scanner PID $pid (did not exit after SIGTERM)"
+        kill -9 "$pid" 2>/dev/null || true
+    fi
+    # Remove stale lock so the launchd-restarted scanner can acquire it.
+    rm -f "$LOCK_FILE"
+    log "scanner PID $pid killed; launchd will restart it"
+else
+    log "no live scanner PID in $LOCK_FILE — removing stale lock if present"
+    rm -f "$LOCK_FILE"
+    # On macOS, request launchd to start the scanner label immediately.
+    if command -v launchctl >/dev/null 2>&1; then
+        launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null \
+            || log "WARN: launchctl kickstart failed (scanner may not be loaded as a LaunchAgent)"
+    fi
+fi
+
+log "tick done"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -775,6 +775,20 @@ scan_project() {
 }
 
 run_once() {
+    # Stdout/log file integrity check: if the log file has become unwritable
+    # (e.g. rotated away while FDs were still open), reopen it; if that fails,
+    # exit so launchd restarts the process with fresh file descriptors.
+    if [ -n "${LOG_FILE:-}" ] && ! true >> "$LOG_FILE" 2>/dev/null; then
+        exec 1>/dev/null 2>/dev/null
+        exit 1
+    fi
+
+    # Heartbeat: write current epoch to allow an external watchdog to detect
+    # a silent-stop (alive PID but no scan activity).
+    if ! $DRY_RUN; then
+        printf '%s\n' "$(date +%s)" > "${LOOP_LOG_DIR}/scanner-heartbeat" || true
+    fi
+
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Runs scanner-watchdog.sh every 5 minutes. The watchdog checks whether the
+  scanner heartbeat file (written every tick) is fresh. If the scanner appears
+  wedged (heartbeat older than 2× poll interval), it kills the process and
+  launchd restarts the scanner automatically (KeepAlive=true on the scanner
+  plist).
+
+  Install (requires LOOP_ROOT and LOG_DIR):
+    sed "s|__LOOP_ROOT__|$LOOP_ROOT|g; \
+         s|__LOG_DIR__|$LOOP_LOG_DIR|g; \
+         s|__HOME__|$HOME|g; \
+         s|__EXTRA_PATH__|${LOOP_EXTRA_PATH:-/opt/homebrew/bin:/usr/local/bin}|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <!-- Run every 5 minutes -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,138 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — scanner liveness heartbeat and watchdog tests.
+# Covers:
+#   1. scanner.sh writes the heartbeat file on every tick (run_once).
+#   2. scanner-watchdog.sh exits cleanly when the heartbeat is fresh.
+#   3. scanner-watchdog.sh detects a stale heartbeat and kills the locked PID.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    # Expose mock-gh.sh as the gh binary.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner.sh functions only (stop before acquire_lock).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    STAGE_AGE_DIR="$BATS_TMPDIR/stage-age"
+    mkdir -p "$DEDUP_DIR" "$STAGE_AGE_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    # Silence log/dispatch so run_once doesn't attempt real gh calls.
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { echo ""; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" "$BATS_TMPDIR/logs" \
+           "$BATS_TMPDIR/stage-age" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat written by run_once
+# ---------------------------------------------------------------------------
+
+@test "run_once writes heartbeat file to LOOP_LOG_DIR" {
+    run_once
+    [ -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+@test "run_once heartbeat file contains a numeric epoch timestamp" {
+    run_once
+    local ts
+    ts=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+    [[ "$ts" =~ ^[0-9]+$ ]]
+}
+
+@test "run_once updates heartbeat mtime on each call" {
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+             || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat")
+    # Backdate the file so any new write produces a measurably different mtime.
+    touch -t "$(date -v-1M +%Y%m%d%H%M.%S 2>/dev/null \
+               || date -d '1 minute ago' +%Y%m%d%H%M.%S)" \
+          "${LOOP_LOG_DIR}/scanner-heartbeat"
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+             || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat")
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once does NOT write heartbeat in dry-run mode" {
+    DRY_RUN=true
+    run_once
+    [ ! -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh behaviour
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits 0 with no message when heartbeat is fresh" {
+    # Write a brand-new heartbeat.
+    printf '%s\n' "$(date +%s)" > "${LOOP_LOG_DIR}/scanner-heartbeat"
+    # Low threshold so even a fresh file triggers "healthy" path.
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+            LOOP_WATCHDOG_STALE_THRESHOLD=600 \
+            LOOP_EXTRA_PATH="" \
+            "$REPO_ROOT/scanner/scanner-watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"healthy"* ]]
+}
+
+@test "scanner-watchdog: exits 0 when heartbeat file is absent (first start)" {
+    rm -f "${LOOP_LOG_DIR}/scanner-heartbeat"
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+            LOOP_EXTRA_PATH="" \
+            "$REPO_ROOT/scanner/scanner-watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"absent"* ]] || [[ "$output" == *"not yet started"* ]]
+}
+
+@test "scanner-watchdog --dry-run: reports stale but does not kill any PID" {
+    # Write a backdated heartbeat.
+    printf '%s\n' "$(date +%s)" > "${LOOP_LOG_DIR}/scanner-heartbeat"
+    touch -t "$(date -v-1H +%Y%m%d%H%M.%S 2>/dev/null \
+               || date -d '1 hour ago' +%Y%m%d%H%M.%S)" \
+          "${LOOP_LOG_DIR}/scanner-heartbeat"
+
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+            LOOP_WATCHDOG_STALE_THRESHOLD=60 \
+            LOOP_EXTRA_PATH="" \
+            "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DRY-RUN"* ]] || [[ "$output" == *"STALE"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- **Heartbeat file**: `run_once()` writes the current epoch to `${LOOP_LOG_DIR}/scanner-heartbeat` at the top of every tick. Skipped in `--dry-run` mode.
- **Log-writability check**: at the top of each tick, if `LOG_FILE` is no longer appendable (e.g. rotated/deleted), the scanner exits immediately so launchd restarts it with fresh FDs.

### scanner/scanner-watchdog.sh (new)
Companion watchdog script that:
1. Reads `${LOOP_LOG_DIR}/scanner-heartbeat` and computes its age.
2. If age >= `LOOP_WATCHDOG_STALE_THRESHOLD` (default 2× `LOOP_SCANNER_INTERVAL` = 600 s), kills the scanner PID so launchd (KeepAlive=true) auto-restarts it.
3. Supports `--dry-run` — reports staleness without killing anything.
4. Handles the "no heartbeat file yet" case gracefully (first start).

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
LaunchAgent plist that runs scanner-watchdog.sh every 5 minutes (StartInterval=300).

### tests/scanner-heartbeat.bats (new)
7 bats tests:
- `run_once` writes and updates heartbeat file each call
- `run_once` skips heartbeat in dry-run mode
- watchdog exits 0 and logs "healthy" when heartbeat is fresh
- watchdog exits 0 gracefully when heartbeat file is absent (first start)
- watchdog `--dry-run` reports STALE without killing any process

## Test Plan
- [ ] Run `bats tests/scanner-heartbeat.bats` — all 7 tests pass
- [ ] Verify `${LOOP_LOG_DIR}/scanner-heartbeat` is written after each scanner tick
- [ ] Manual wedge test: `kill -STOP $SCANNER_PID` → wait 10 min → `scanner-watchdog.sh` should log STALE and kill it; launchd restarts within 60 s (ThrottleInterval)
- [ ] Verify `--dry-run` mode does not create the heartbeat file