### PR TITLE
[LOOP-413] scanner: liveness heartbeat + watchdog auto-restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — checks heartbeat file every 5 min and
+    # kills/restarts the scanner if it has been silent for > 2× poll interval.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/check-scanner-liveness.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -775,6 +775,17 @@ scan_project() {
 }
 
 run_once() {
+    # Liveness heartbeat — written at the start of every tick so the external
+    # watchdog (check-scanner-liveness.sh) can detect a wedged scanner.
+    $DRY_RUN || touch "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+
+    # Log file integrity check — recover a broken/unwritable log FD so launchd
+    # sees output and the on-disk file reflects actual scanner activity.
+    if ! $DRY_RUN && [ -n "${LOG_FILE:-}" ] && [ ! -w "$LOG_FILE" ]; then
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" \
+            || { printf '[scanner] FATAL: log unwritable, exiting for launchd restart\n' >&2; exit 1; }
+    fi
+
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/scripts/check-scanner-liveness.sh
+++ b/scripts/check-scanner-liveness.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# check-scanner-liveness.sh — watchdog for the Loop scanner liveness heartbeat.
+#
+# Runs every 5 minutes via launchd (macOS) or cron (Linux).
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat; if the file's mtime is older than
+# LOOP_SCANNER_STALE_THRESHOLD seconds (default: 600 = 2× the 300s poll
+# interval), the scanner is considered wedged and is killed so that launchd
+# (KeepAlive=true) or the cron entry restarts it automatically.
+#
+# Exit codes: always 0 (launchd must not penalise the watchdog).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+STALE_THRESHOLD="${LOOP_SCANNER_STALE_THRESHOLD:-600}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+SCANNER_LOCK="/tmp/loop-scanner.lock"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _file_age_seconds <path>
+# Prints seconds since the file's last modification. Returns 1 if the file
+# does not exist (treat missing heartbeat as infinitely stale).
+_file_age_seconds() {
+    local path="$1"
+    [ -f "$path" ] || { echo "999999"; return 0; }
+    local mtime now
+    mtime=$(stat -f%m "$path" 2>/dev/null) \
+        || mtime=$(stat -c%Y "$path" 2>/dev/null) \
+        || { echo "999999"; return 0; }
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+main() {
+    local age
+    age=$(_file_age_seconds "$HEARTBEAT_FILE")
+
+    log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+    if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+        log "scanner is live — nothing to do"
+        return 0
+    fi
+
+    log "WARN: scanner heartbeat stale (${age}s > ${STALE_THRESHOLD}s) — restarting"
+
+    # Read the scanner PID from the advisory lock file.
+    local pid=""
+    if [ -f "$SCANNER_LOCK" ]; then
+        pid=$(cat "$SCANNER_LOCK" 2>/dev/null || true)
+    fi
+
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "killing wedged scanner PID $pid"
+        kill -TERM "$pid" 2>/dev/null || true
+        sleep 2
+        # Force-kill if still alive after SIGTERM.
+        kill -0 "$pid" 2>/dev/null && kill -KILL "$pid" 2>/dev/null || true
+    else
+        log "no live scanner PID found in $SCANNER_LOCK — lock may already be stale"
+        rm -f "$SCANNER_LOCK"
+    fi
+
+    # On macOS, kickstart the launchd agent so it restarts immediately rather
+    # than waiting for the next ThrottleInterval window.
+    if command -v launchctl >/dev/null 2>&1; then
+        log "kickstarting com.user.loop-scanner via launchctl"
+        launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null \
+            || launchctl start com.user.loop-scanner 2>/dev/null \
+            || log "WARN: launchctl kickstart failed — launchd KeepAlive will restart on next check"
+    fi
+
+    return 0
+}
+
+main "$@"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Loop scanner-liveness watchdog — fires every 5 minutes.
+  Checks scanner-heartbeat mtime; kills and kickstarts the scanner if stale.
+
+  Installed automatically by: ./install.sh --bootstrap
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/check-scanner-liveness.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 scanner liveness heartbeat.
+#
+# Verifies that:
+#   1. scanner.sh writes scanner-heartbeat at the start of every tick.
+#   2. check-scanner-liveness.sh exits quietly when heartbeat is fresh.
+#   3. check-scanner-liveness.sh kills a wedged PID when heartbeat is stale.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    # Fake log dir so env.sh doesn't touch ~/.loop/logs.
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Source scanner.sh function definitions only (same awk strip as scanner.bats).
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    # Silence log() and disable dispatch so run_once doesn't call gh.
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { echo ""; }
+    LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/scanner-src.sh" "$BATS_TMPDIR/scanner-test.log" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat: written on every tick
+# ---------------------------------------------------------------------------
+
+@test "run_once: creates scanner-heartbeat file on first tick" {
+    rm -f "${LOOP_LOG_DIR}/scanner-heartbeat"
+    run_once
+    [ -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+@test "run_once: updates scanner-heartbeat mtime on subsequent ticks" {
+    touch -t 200001010000 "${LOOP_LOG_DIR}/scanner-heartbeat"
+    local before
+    before=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+             || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat")
+    sleep 1
+    run_once
+    local after
+    after=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+            || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat")
+    [ "$after" -gt "$before" ]
+}
+
+@test "run_once: does NOT write heartbeat in dry-run mode" {
+    DRY_RUN=true
+    rm -f "${LOOP_LOG_DIR}/scanner-heartbeat"
+    run_once
+    [ ! -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+# ---------------------------------------------------------------------------
+# check-scanner-liveness.sh: fresh heartbeat → no action
+# ---------------------------------------------------------------------------
+
+@test "check-scanner-liveness: exits 0 with fresh heartbeat" {
+    touch "${LOOP_LOG_DIR}/scanner-heartbeat"
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+            LOOP_SCANNER_STALE_THRESHOLD=600 \
+            "$REPO_ROOT/scripts/check-scanner-liveness.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner is live"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# check-scanner-liveness.sh: stale heartbeat → kill wedged PID
+# ---------------------------------------------------------------------------
+
+@test "check-scanner-liveness: exits 0 even when heartbeat is stale (no live PID)" {
+    # Simulate stale heartbeat by backdating the file.
+    touch -t 200001010000 "${LOOP_LOG_DIR}/scanner-heartbeat"
+    # No lock file → watchdog should still exit cleanly.
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+            LOOP_SCANNER_STALE_THRESHOLD=1 \
+            "$REPO_ROOT/scripts/check-scanner-liveness.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"stale"* ]]
+}
+
+@test "check-scanner-liveness: kills wedged PID when heartbeat is stale" {
+    # Spawn a long-running background process to act as the fake wedged scanner.
+    sleep 60 &
+    local fake_pid=$!
+
+    # Write its PID to the scanner lock file.
+    echo "$fake_pid" > /tmp/loop-scanner.lock
+
+    # Back-date the heartbeat to simulate a stale scanner.
+    touch -t 200001010000 "${LOOP_LOG_DIR}/scanner-heartbeat"
+
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+            LOOP_SCANNER_STALE_THRESHOLD=1 \
+            "$REPO_ROOT/scripts/check-scanner-liveness.sh"
+    [ "$status" -eq 0 ]
+
+    # Give SIGTERM a moment to land.
+    sleep 1
+
+    # The fake process should no longer be alive.
+    ! kill -0 "$fake_pid" 2>/dev/null
+
+    rm -f /tmp/loop-scanner.lock
+}


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- Added `touch ${LOOP_LOG_DIR}/scanner-heartbeat` at the start of every `run_once()` tick (skipped in dry-run mode).
- Added a log-file writability check at the start of each tick: if the log FD is broken, re-exec FDs 1+2 against the log path or exit so launchd can restart cleanly.

### scripts/check-scanner-liveness.sh (new)
- Watchdog script run every 5 minutes (via launchd or cron).
- Reads `${LOOP_LOG_DIR}/scanner-heartbeat` mtime. If age > `LOOP_SCANNER_STALE_THRESHOLD` seconds (default 600 = 2× default poll interval), the scanner is considered wedged.
- Reads PID from `/tmp/loop-scanner.lock`, sends SIGTERM (then SIGKILL after 2s), then calls `launchctl kickstart` on macOS so the scanner restarts immediately rather than waiting for the next ThrottleInterval.
- Always exits 0 so launchd does not penalise the watchdog itself.

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
- `StartInterval=300` (every 5 min). `RunAtLoad=false` to avoid a spurious kill before the first scanner tick writes the heartbeat.

### install.sh
- `bootstrap_register_launchd()`: registers `com.user.loop-scanner-watchdog` plist (idempotent).
- `bootstrap_register_cron()`: adds `*/5 * * * *` cron entry for `check-scanner-liveness.sh` on Linux.

### tests/scanner-heartbeat.bats (new)
6 bats tests covering:
1. `run_once` creates heartbeat on first tick.
2. `run_once` updates heartbeat mtime on subsequent ticks.
3. `run_once` does NOT write heartbeat in dry-run mode.
4. Watchdog exits 0 and reports "live" when heartbeat is fresh.
5. Watchdog exits 0 even when heartbeat is stale and no scanner PID is found.
6. Watchdog kills the wedged PID when heartbeat is stale and a live PID exists.

## Test Plan
- All 6 new bats tests pass (`bats tests/scanner-heartbeat.bats`).
- `bash -n` and `shellcheck -S warning` pass on all scripts.
- No personal identifiers introduced.
- Manual simulation: `kill -STOP $SCANNER_PID` → heartbeat goes stale → watchdog (next 5-min tick) kills and kickstarts the scanner.