### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,26 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — fires every 5 min to check the heartbeat file
+    # written by scanner.sh. If the scanner is silently wedged, kills its PID so
+    # launchd (KeepAlive=true) restarts it automatically.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +381,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +404,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — detect and recover a silently-wedged scanner.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written by scanner.sh every tick).
+# If the file is older than STALE_THRESHOLD seconds (default: 2 × poll interval),
+# the scanner is considered wedged: its PID (from the lock file) is killed so
+# launchd (KeepAlive=true) or the cron entry restarts it automatically.
+#
+# Designed to run every 5 minutes via launchd (macOS) or cron (Linux).
+# It is intentionally single-shot and stateless.
+#
+# Flags:
+#   --dry-run  report what would be done without killing the scanner
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+LOCK_FILE="${LOOP_SCANNER_LOCK_FILE:-/tmp/loop-scanner.lock}"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_SCANNER_STALE_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _file_age_seconds <path>
+# Prints the age of the file in seconds, or a very large number if absent.
+_file_age_seconds() {
+    local path="$1"
+    if [ ! -f "$path" ]; then
+        echo 999999
+        return
+    fi
+    local mtime now
+    mtime=$(stat -f%m "$path" 2>/dev/null || stat -c%Y "$path" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+age=$(_file_age_seconds "$HEARTBEAT_FILE")
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s file=${HEARTBEAT_FILE}"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner healthy — no action needed"
+    exit 0
+fi
+
+# Scanner is stale. Read its PID from the lock file.
+scanner_pid=""
+if [ -f "$LOCK_FILE" ]; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID=${scanner_pid:-unknown} (stale for ${age}s)"
+    exit 0
+fi
+
+log "WARN: scanner stale for ${age}s — triggering restart"
+
+if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+    log "killing wedged scanner PID $scanner_pid"
+    kill "$scanner_pid" 2>/dev/null || true
+    # Give launchd a moment to observe the exit before we return.
+    sleep 2
+fi
+
+# On macOS, also kick launchd directly so the restart is immediate rather than
+# waiting for launchd's ThrottleInterval.
+if command -v launchctl >/dev/null 2>&1; then
+    launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null \
+        || log "launchctl kickstart failed (scanner may restart on its own via KeepAlive)"
+fi
+
+log "restart triggered"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -776,6 +776,16 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Heartbeat: touch the file every tick so the watchdog can detect silent-stop
+    # by comparing its mtime against now. Skipped in --dry-run to avoid side effects.
+    $DRY_RUN || touch "${LOOP_LOG_DIR}/scanner-heartbeat"
+    # Stdout integrity: if the log file has disappeared or become unwritable since
+    # launchd started us (e.g., after logrotate without SIGHUP), reopen it. If
+    # the reopen also fails, exit so launchd restarts us with a clean fd table.
+    if [ -n "${LOG_FILE:-}" ] && [ ! -w "${LOG_FILE}" ]; then
+        exec 1>>"${LOG_FILE}" 2>>"${LOG_FILE}" \
+            || { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] FATAL: cannot reopen LOG_FILE, exiting for restart" >&2; exit 1; }
+    fi
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <!-- Check every 5 minutes whether the scanner heartbeat is fresh -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,133 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — scanner liveness heartbeat (#413).
+#
+# Verifies that scanner.sh touches ${LOOP_LOG_DIR}/scanner-heartbeat on every
+# run_once() call (non-dry-run), and that scanner-watchdog.sh correctly detects
+# a stale heartbeat and reports it.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Suppress LOOP_EXTRA_PATH so env.sh does not prepend /opt/homebrew/bin
+    export LOOP_EXTRA_PATH=""
+
+    # Mock PATH so gh, launchctl, etc. don't run real binaries.
+    mkdir -p "$BATS_TMPDIR/bin"
+    # Stub gh — returns empty arrays for all list calls.
+    cat > "$BATS_TMPDIR/bin/gh" <<'SH'
+#!/usr/bin/env bash
+echo "[]"
+SH
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    # Stub launchctl — noop so watchdog's kickstart call doesn't fail the test.
+    cat > "$BATS_TMPDIR/bin/launchctl" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+    chmod +x "$BATS_TMPDIR/bin/launchctl"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    # Source scanner.sh function definitions only (same strategy as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    # Silence log() and no-op dispatch_direct / scan_project so run_once completes fast.
+    log() { :; }
+    dispatch_direct() { :; }
+    scan_project() { :; }
+    loop_list_slugs() { printf ''; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat file in scanner.sh
+# ---------------------------------------------------------------------------
+
+@test "run_once: heartbeat file is created on first tick" {
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+    run_once
+    [ -f "$LOOP_LOG_DIR/scanner-heartbeat" ]
+}
+
+@test "run_once: heartbeat file mtime is updated on every tick" {
+    touch -t "200001010000" "$LOOP_LOG_DIR/scanner-heartbeat"
+    local before
+    before=$(stat -f%m "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null \
+             || stat -c%Y "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null)
+    run_once
+    local after
+    after=$(stat -f%m "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null \
+            || stat -c%Y "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null)
+    [ "$after" -gt "$before" ]
+}
+
+@test "run_once --dry-run: heartbeat file is NOT written" {
+    DRY_RUN=true
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+    run_once
+    [ ! -f "$LOOP_LOG_DIR/scanner-heartbeat" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh logic
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits 0 when heartbeat is fresh" {
+    touch "$LOOP_LOG_DIR/scanner-heartbeat"
+    # LOOP_SCANNER_STALE_THRESHOLD=600 — fresh file is well within threshold.
+    run bash "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner healthy"* ]]
+}
+
+@test "scanner-watchdog: reports stale when heartbeat is old" {
+    # Make the heartbeat look old (year 2000).
+    touch -t "200001010000" "$LOOP_LOG_DIR/scanner-heartbeat"
+    # Use a tiny threshold so even a freshly-touched file would qualify — but
+    # here we set threshold=1 and an ancient mtime so it definitely fires.
+    LOOP_SCANNER_STALE_THRESHOLD=1 \
+    run bash "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"would kill"* ]] || [[ "$output" == *"stale"* ]]
+}
+
+@test "scanner-watchdog: exits 0 when heartbeat file is absent (treats as stale)" {
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+    LOOP_SCANNER_STALE_THRESHOLD=1 \
+    run bash "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"stale"* ]] || [[ "$output" == *"would kill"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- `run_once()` now calls `touch "${LOOP_LOG_DIR}/scanner-heartbeat"` at the start of every tick (skipped in `--dry-run` mode). Any external process can detect silent-stop by comparing the heartbeat file mtime against now.
- Added stdout integrity check: if `LOG_FILE` exists but is no longer writable (e.g., after logrotate without SIGHUP), the scanner attempts to reopen it; if that also fails it exits immediately so launchd restarts it with a clean fd table.

### `scanner/scanner-watchdog.sh` (new)
- Single-shot script designed to run every 5 minutes via launchd or cron.
- Reads `${LOOP_LOG_DIR}/scanner-heartbeat` mtime. If older than `LOOP_SCANNER_STALE_THRESHOLD` seconds (default: `2 × LOOP_SCANNER_INTERVAL` = 600 s), the scanner is considered wedged.
- Kills the scanner PID (from `/tmp/loop-scanner.lock`) and calls `launchctl kickstart` on macOS so the restart is immediate rather than waiting for `ThrottleInterval`.
- Safe `--dry-run` flag for testing without side effects.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- Runs `scanner-watchdog.sh` every 5 minutes (`StartInterval=300`).
- Logs to `loop-scanner-watchdog.log`.

### `install.sh`
- `bootstrap_register_launchd`: registers the scanner-watchdog plist alongside the existing scanner/reconciler plists.
- `bootstrap_register_cron`: adds a `*/5 * * * *` cron entry for `scanner-watchdog.sh` on Linux.

### `tests/scanner-heartbeat.bats` (new)
- 6 tests covering: heartbeat file created/updated on tick, skipped in dry-run, watchdog detects fresh/stale/absent heartbeat.

## Test Plan
- All 6 `scanner-heartbeat.bats` tests pass locally.
- `bash -n` and `shellcheck -S warning` pass on all scripts.
- No personal identifiers detected.
- Manual: simulate wedge via `kill -STOP $SCANNER_PID` → watchdog should log "WARN: scanner stale" and trigger restart within 10 minutes (2 × poll interval).