### PR TITLE
[LOOP-413] scanner: liveness heartbeat + watchdog auto-restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,24 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — kills a wedged scanner so launchd auto-restarts it.
+    local watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$watchdog_plist"
+        if launchctl load "$watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +379,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +402,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -776,6 +776,8 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Heartbeat: update mtime so scanner-watchdog can detect a wedged process.
+    touch "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — detect a wedged scanner and trigger a restart.
+#
+# Runs every 5 minutes (via launchd StartInterval or cron). Checks the
+# scanner-heartbeat file; if its mtime is older than 2 × LOOP_SCANNER_INTERVAL
+# (default 10 min) the scanner is considered wedged: its PID is killed so
+# launchd (KeepAlive=true) or cron restarts it automatically.
+#
+# On macOS with launchd, launchctl kickstart is attempted for an immediate
+# restart rather than waiting out the ThrottleInterval.
+#
+# Usage:
+#   scanner-watchdog.sh [--dry-run]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+# Stale = 2× poll interval + 60s grace for scheduler jitter.
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 + 60 ))
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat absent — scanner may not have ticked yet; skipping"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+age=$(( now - mtime ))
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s — scanner healthy"
+    exit 0
+fi
+
+log "WARN: heartbeat stale (age=${age}s > threshold=${STALE_THRESHOLD}s) — triggering restart"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner and trigger restart"
+    exit 0
+fi
+
+# Kill the scanner PID so launchd/cron restarts it.
+if [ -f "$LOCK_FILE" ]; then
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || echo "")
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "killing scanner PID $pid"
+        kill "$pid" || true
+    else
+        log "lock PID '${pid}' not alive — removing stale lock"
+        rm -f "$LOCK_FILE"
+    fi
+else
+    log "no lock file — scanner not running; nothing to kill"
+fi
+
+# macOS: kickstart immediately rather than waiting out ThrottleInterval.
+if [ "$(uname -s)" = "Darwin" ] && command -v launchctl >/dev/null 2>&1; then
+    if launchctl list com.user.loop-scanner >/dev/null 2>&1; then
+        launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null \
+            || log "WARN: launchctl kickstart failed — launchd will auto-restart after ThrottleInterval"
+    fi
+fi
+
+log "restart triggered"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <!-- Check every 5 minutes whether the scanner heartbeat is stale -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,110 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verify scanner heartbeat and watchdog behaviour.
+#
+# Heartbeat: run_once() must touch ${LOOP_LOG_DIR}/scanner-heartbeat on each tick.
+# Watchdog: scanner-watchdog.sh must report healthy/stale based on heartbeat mtime.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Expose a no-op mock gh so env.sh sources cleanly.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+    export LOOP_EXTRA_PATH=""
+
+    # Extract run_once + its helpers from scanner.sh (stop before acquire_lock).
+    local _src="$BATS_TMPDIR/scanner-hb-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    # Override dirs and helpers so run_once does not do real work.
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+    log()            { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema()   { :; }
+    loop_list_slugs()    { printf ''; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-hb-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat
+# ---------------------------------------------------------------------------
+
+@test "run_once: creates scanner-heartbeat on first tick" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    [ ! -f "$hb" ]
+    run_once
+    [ -f "$hb" ]
+}
+
+@test "run_once: updates scanner-heartbeat mtime on each tick" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    touch -t 202001010000 "$hb"
+    local before
+    before=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb" 2>/dev/null)
+    sleep 1
+    run_once
+    local after
+    after=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb" 2>/dev/null)
+    [ "$after" -gt "$before" ]
+}
+
+# ---------------------------------------------------------------------------
+# Watchdog: healthy case
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits 0 and reports healthy when heartbeat is fresh" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    touch "$hb"   # mtime = now
+    export LOOP_SCANNER_INTERVAL=300
+    run bash "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner healthy"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Watchdog: stale case (dry-run so no kill/launchctl side-effects)
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: reports stale when heartbeat is old" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    touch -t 202001010000 "$hb"   # epoch-like ancient mtime
+    export LOOP_SCANNER_INTERVAL=300
+    run bash "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"heartbeat stale"* ]]
+    [[ "$output" == *"DRY-RUN"* ]]
+}
+
+@test "scanner-watchdog: exits 0 and skips when heartbeat absent" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    rm -f "$hb"
+    run bash "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"heartbeat absent"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`** — touch `${LOOP_LOG_DIR}/scanner-heartbeat` at the start of every `run_once()` tick. This gives an always-current mtime signal that reflects whether the scan loop is alive.

**`scripts/scanner-watchdog.sh`** (new) — runs every 5 minutes. Reads the heartbeat file mtime; if age > `2 × LOOP_SCANNER_INTERVAL + 60s` (default 660s ≈ 11 min), the scanner is considered wedged: its PID (from the lock file) is killed so launchd (KeepAlive=true) auto-restarts it. On macOS, `launchctl kickstart` is attempted for an immediate restart rather than waiting out the 60s ThrottleInterval.

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new) — launchd plist for the watchdog; `StartInterval=300` (5 min), no `KeepAlive`.

**`install.sh`** — registers the watchdog plist in `bootstrap_register_launchd()` and adds a `*/5` cron entry in `bootstrap_register_cron()` for Linux.

**`tests/scanner-heartbeat.bats`** (new) — 5 bats tests covering:
- `run_once` creates heartbeat on first tick
- `run_once` updates heartbeat mtime on subsequent ticks
- watchdog reports healthy when heartbeat is fresh
- watchdog reports stale (dry-run) when heartbeat is old
- watchdog exits cleanly when heartbeat file is absent

## Test Plan

- All 846 existing bats tests pass
- New `tests/scanner-heartbeat.bats` (5 tests) all pass
- Manual: `kill -STOP $SCANNER_PID` → watchdog kills it within 11 min → launchd restarts
- `scanner-watchdog.sh --dry-run` shows healthy/stale without side effects