### PR TITLE
[LOOP-413] scanner: write heartbeat file each tick + watchdog restart script

### DIFF
--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if its heartbeat is stale.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat. If the file's mtime is older than
+# STALE_THRESHOLD seconds (default: 2 × POLL_INTERVAL = 600s), the scanner is
+# considered wedged. The lock file at /tmp/loop-scanner.lock is read for the
+# scanner PID; if that PID is alive it is killed so launchd (KeepAlive=true)
+# restarts the scanner automatically.
+#
+# Designed to run every 5 minutes via launchd StartInterval or cron.
+#
+# Usage:
+#   scanner-watchdog.sh [--dry-run]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 ))
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _file_age_seconds <path>
+# Prints seconds since the file was last modified. Prints -1 if the file does not exist.
+_file_age_seconds() {
+    local path="$1"
+    if [ ! -f "$path" ]; then
+        echo -1
+        return
+    fi
+    local mtime now
+    mtime=$(stat -f%m "$path" 2>/dev/null || stat -c%Y "$path" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+heartbeat_age=$(_file_age_seconds "$HEARTBEAT_FILE")
+
+if [ "$heartbeat_age" -lt 0 ]; then
+    log "heartbeat file missing — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+log "heartbeat age=${heartbeat_age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$heartbeat_age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is healthy"
+    exit 0
+fi
+
+log "STALE: scanner heartbeat is ${heartbeat_age}s old (threshold=${STALE_THRESHOLD}s)"
+
+if $DRY_RUN; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    log "DRY-RUN: would kill scanner PID ${scanner_pid:-<unknown>} and allow launchd to restart it"
+    exit 0
+fi
+
+if [ ! -f "$LOCK_FILE" ]; then
+    log "no lock file found — scanner is not running; launchd will restart it"
+    exit 0
+fi
+
+scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+if [ -z "$scanner_pid" ]; then
+    log "lock file is empty — removing and allowing launchd to restart"
+    rm -f "$LOCK_FILE"
+    exit 0
+fi
+
+if ! kill -0 "$scanner_pid" 2>/dev/null; then
+    log "scanner PID $scanner_pid is already dead — launchd will restart it"
+    rm -f "$LOCK_FILE"
+    exit 0
+fi
+
+log "killing wedged scanner PID $scanner_pid — launchd (KeepAlive=true) will restart it"
+kill "$scanner_pid" || true
+# Give launchd a moment to notice the exit; the watchdog itself does not restart
+# the scanner directly — that is launchd's job.
+sleep 2
+if kill -0 "$scanner_pid" 2>/dev/null; then
+    log "WARN: PID $scanner_pid still alive after SIGTERM — sending SIGKILL"
+    kill -9 "$scanner_pid" || true
+fi
+log "done — scanner will be restarted by launchd"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -774,7 +774,30 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+
+# _scanner_write_heartbeat — update mtime of the heartbeat file so the watchdog
+# can confirm the scanner is still making forward progress every tick.
+_scanner_write_heartbeat() {
+    $DRY_RUN && return 0
+    date '+%Y-%m-%dT%H:%M:%SZ' > "$HEARTBEAT_FILE" 2>/dev/null || true
+}
+
+# _scanner_check_log_fd — if the log file is no longer writable (e.g. the
+# inode was rotated away and LOG_FILE was redirected by launchd), exit so
+# launchd can restart with a fresh fd. The SIGHUP handler covers the log-
+# rotation case; this guard catches any other fd corruption.
+_scanner_check_log_fd() {
+    [ -z "${LOG_FILE:-}" ] && return 0
+    if [ ! -w "$LOG_FILE" ]; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] FATAL: log file not writable — exiting for restart" >&2
+        exit 1
+    fi
+}
+
 run_once() {
+    _scanner_check_log_fd
+    _scanner_write_heartbeat
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/scripts/restart-scanner-if-stale.sh
+++ b/scripts/restart-scanner-if-stale.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# restart-scanner-if-stale.sh — kill and restart the scanner if its heartbeat is stale.
+#
+# Checks ${LOOP_LOG_DIR}/scanner-heartbeat. If the file's mtime is older than
+# STALE_THRESHOLD seconds (default: 900 s / 15 min), the scanner is considered
+# wedged. The lock file at /tmp/loop-scanner.lock is read for the PID; if alive
+# it is sent SIGTERM (then SIGKILL if needed) so launchd (KeepAlive=true on
+# com.user.loop-scanner) auto-restarts the process.
+#
+# Falls back to checking the scanner log mtime when the heartbeat file is absent.
+#
+# Designed to run every 5 minutes via launchd / cron.
+#
+# Usage:
+#   restart-scanner-if-stale.sh [--dry-run]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+SCANNER_LOG="${LOOP_LOG_DIR}/loop-scanner.log"
+LOCK_FILE="/tmp/loop-scanner.lock"
+WATCHDOG_LOG="${LOOP_LOG_DIR}/loop-scanner-watchdog.log"
+STALE_THRESHOLD="${LOOP_SCANNER_STALE_THRESHOLD:-900}"   # 15 min default
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*" | tee -a "$WATCHDOG_LOG"; }
+
+# _file_age_seconds <path>
+# Prints seconds since the file was last modified.
+# Prints -1 if the file does not exist.
+_file_age_seconds() {
+    local path="$1"
+    if [ ! -f "$path" ]; then
+        echo -1
+        return
+    fi
+    local mtime now
+    mtime=$(stat -f%m "$path" 2>/dev/null || stat -c%Y "$path" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+# Determine liveness from the heartbeat file; fall back to the scanner log.
+probe_file="$HEARTBEAT_FILE"
+probe_label="heartbeat"
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    probe_file="$SCANNER_LOG"
+    probe_label="scanner-log"
+fi
+
+age=$(_file_age_seconds "$probe_file")
+
+if [ "$age" -lt 0 ]; then
+    log "${probe_label} file missing — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+log "${probe_label} age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is healthy"
+    exit 0
+fi
+
+log "STALE: ${probe_label} is ${age}s old (threshold=${STALE_THRESHOLD}s)"
+
+if $DRY_RUN; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    log "DRY-RUN: would kill scanner PID ${scanner_pid:-<unknown>} and trigger launchd restart"
+    exit 0
+fi
+
+if [ ! -f "$LOCK_FILE" ]; then
+    log "no lock file found — scanner is not running; launchd will restart it automatically"
+    exit 0
+fi
+
+scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+if [ -z "$scanner_pid" ]; then
+    log "lock file is empty — removing and allowing launchd to restart"
+    rm -f "$LOCK_FILE"
+    exit 0
+fi
+
+if ! kill -0 "$scanner_pid" 2>/dev/null; then
+    log "scanner PID $scanner_pid is already dead — removing stale lock; launchd will restart"
+    rm -f "$LOCK_FILE"
+    exit 0
+fi
+
+log "killing wedged scanner PID $scanner_pid (SIGTERM) — launchd KeepAlive will restart"
+kill "$scanner_pid" || true
+sleep 2
+if kill -0 "$scanner_pid" 2>/dev/null; then
+    log "WARN: PID $scanner_pid still alive after SIGTERM — sending SIGKILL"
+    kill -9 "$scanner_pid" || true
+fi
+
+# Attempt launchctl kickstart as a belt-and-suspenders fallback for environments
+# where KeepAlive may not be configured (Linux cron installs).
+if command -v launchctl >/dev/null 2>&1; then
+    launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null \
+        && log "launchctl kickstart succeeded" \
+        || log "launchctl kickstart not available or failed (expected on Linux/cron installs)"
+fi
+
+log "done — scanner will be restarted by launchd / cron"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes. If the scanner heartbeat file is stale (older than
+  2 × poll_interval, default 600 s) the watchdog kills the wedged scanner PID
+  so launchd (KeepAlive=true on com.user.loop-scanner) restarts it.
+
+  Install:
+    sed "s|__LOOP_ROOT__|$(cd "$(dirname "$0")/.." && pwd)|g; \
+         s|__LOG_DIR__|$LOOP_LOG_DIR|g; \
+         s|__HOME__|$HOME|g; \
+         s|__EXTRA_PATH__|${LOOP_EXTRA_PATH:-/opt/homebrew/bin:/usr/local/bin}|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/templates/launchd/loop-scanner-watchdog.plist.template
+++ b/templates/launchd/loop-scanner-watchdog.plist.template
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes. If the scanner heartbeat (or scanner log as fallback)
+  is older than LOOP_SCANNER_STALE_THRESHOLD seconds (default 900 s / 15 min)
+  the watchdog kills the wedged scanner PID so launchd (KeepAlive=true on
+  com.user.loop-scanner) restarts it automatically.
+
+  Install:
+    LOOP_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+    source "$LOOP_ROOT/loop.env"   # sets LOOP_LOG_DIR
+    sed "s|__LOOP_ROOT__|$LOOP_ROOT|g; \
+         s|__LOG_DIR__|$LOOP_LOG_DIR|g; \
+         s|__HOME__|$HOME|g; \
+         s|__EXTRA_PATH__|${LOOP_EXTRA_PATH:-/opt/homebrew/bin:/usr/local/bin}|g" \
+        templates/launchd/loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/restart-scanner-if-stale.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/test/scanner-heartbeat.bats
+++ b/test/scanner-heartbeat.bats
@@ -1,0 +1,133 @@
+#!/usr/bin/env bats
+# test/scanner-heartbeat.bats — bats coverage for scanner liveness heartbeat (#413).
+#
+# Tests:
+#  - heartbeat file is created on the first tick (_scanner_write_heartbeat)
+#  - heartbeat file mtime is updated on subsequent ticks
+#  - dry-run mode does not write the heartbeat file
+#  - restart-scanner-if-stale.sh reports "healthy" when heartbeat is fresh
+#  - restart-scanner-if-stale.sh reports "STALE" when heartbeat is old
+#  - restart-scanner-if-stale.sh --dry-run does not kill any PID
+#  - watchdog exits gracefully when heartbeat file is absent (falls back to log)
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/loop-logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+
+    # Build a minimal source file containing only the heartbeat helpers extracted
+    # from scanner.sh, so we can unit-test them without running the full scanner.
+    local _src="$BATS_TMPDIR/heartbeat-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        printf "LOOP_LOG_DIR='%s'\n" "$LOOP_LOG_DIR"
+        printf "HEARTBEAT_FILE='%s/scanner-heartbeat'\n" "$LOOP_LOG_DIR"
+        printf "DRY_RUN=false\n"
+        printf "LOG_FILE='%s/scanner-test.log'\n" "$BATS_TMPDIR"
+        # Pull _scanner_write_heartbeat from scanner.sh
+        awk '/^_scanner_write_heartbeat\(\)/{p=1} p; p && /^\}/{p=0; exit}' \
+            "$REPO_ROOT/scanner/scanner.sh"
+        # Pull _scanner_check_log_fd from scanner.sh
+        awk '/^_scanner_check_log_fd\(\)/{p=1} p; p && /^\}/{p=0; exit}' \
+            "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    touch "$BATS_TMPDIR/scanner-test.log"
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/loop-logs" "$BATS_TMPDIR/heartbeat-src.sh" \
+           "$BATS_TMPDIR/scanner-test.log" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# _scanner_write_heartbeat unit tests
+# ---------------------------------------------------------------------------
+
+@test "_scanner_write_heartbeat: creates heartbeat file on first call" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    rm -f "$hb"
+    _scanner_write_heartbeat
+    [ -f "$hb" ]
+}
+
+@test "_scanner_write_heartbeat: file contains a timestamp" {
+    _scanner_write_heartbeat
+    local content
+    content=$(cat "$LOOP_LOG_DIR/scanner-heartbeat")
+    # Should match ISO 8601 date pattern written by scanner.sh
+    [[ "$content" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
+}
+
+@test "_scanner_write_heartbeat: updates mtime on subsequent calls" {
+    _scanner_write_heartbeat
+    local mtime1
+    mtime1=$(stat -f%m "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null \
+             || stat -c%Y "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null)
+    sleep 1
+    _scanner_write_heartbeat
+    local mtime2
+    mtime2=$(stat -f%m "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null \
+             || stat -c%Y "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null)
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "_scanner_write_heartbeat: no-op in dry-run mode" {
+    DRY_RUN=true
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    rm -f "$hb"
+    _scanner_write_heartbeat
+    [ ! -f "$hb" ]
+    DRY_RUN=false
+}
+
+# ---------------------------------------------------------------------------
+# restart-scanner-if-stale.sh integration tests (no real kills)
+# ---------------------------------------------------------------------------
+
+@test "restart-scanner-if-stale.sh: reports healthy when heartbeat is fresh" {
+    date '+%Y-%m-%dT%H:%M:%SZ' > "$LOOP_LOG_DIR/scanner-heartbeat"
+
+    LOOP_SCANNER_STALE_THRESHOLD=900 \
+        run "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"healthy"* ]]
+}
+
+@test "restart-scanner-if-stale.sh: reports STALE when heartbeat is old" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    date '+%Y-%m-%dT%H:%M:%SZ' > "$hb"
+    # Backdate 30 minutes — well past the 15-min threshold
+    touch -t "$(date -v-30M +%Y%m%d%H%M.%S 2>/dev/null \
+               || date -d '30 minutes ago' +%Y%m%d%H%M.%S)" "$hb"
+
+    LOOP_SCANNER_STALE_THRESHOLD=900 \
+        run "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+    [[ "$output" == *"DRY-RUN"* ]]
+}
+
+@test "restart-scanner-if-stale.sh: skips gracefully when heartbeat file is absent" {
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+    # Also remove scanner log so both probes are absent
+    rm -f "$LOOP_LOG_DIR/loop-scanner.log"
+
+    run "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"missing"* ]]
+}
+
+@test "restart-scanner-if-stale.sh: falls back to scanner log when heartbeat is absent" {
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+    # Write a fresh scanner log
+    date '+%Y-%m-%dT%H:%M:%SZ' > "$LOOP_LOG_DIR/loop-scanner.log"
+
+    LOOP_SCANNER_STALE_THRESHOLD=900 \
+        run "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"healthy"* ]]
+}

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,140 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for scanner liveness heartbeat (#413).
+#
+# Tests:
+#  - _scanner_write_heartbeat creates the heartbeat file on the first tick.
+#  - _scanner_write_heartbeat updates the file on subsequent ticks.
+#  - scanner-watchdog.sh reports "healthy" when heartbeat is fresh.
+#  - scanner-watchdog.sh reports "STALE" when heartbeat is old.
+#  - scanner-watchdog.sh --dry-run does not kill any PID.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+
+    # Extract _scanner_write_heartbeat and _scanner_check_log_fd from scanner.sh.
+    local _src="$BATS_TMPDIR/heartbeat-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        printf "LOOP_LOG_DIR='%s'\n" "$LOOP_LOG_DIR"
+        printf "HEARTBEAT_FILE='%s/scanner-heartbeat'\n" "$LOOP_LOG_DIR"
+        printf "DRY_RUN=false\n"
+        printf "LOG_FILE='%s/scanner-test.log'\n" "$BATS_TMPDIR"
+        # Pull in _scanner_write_heartbeat
+        awk '/^_scanner_write_heartbeat\(\)/{p=1} p; p && /^\}/{p=0; exit}' \
+            "$REPO_ROOT/scanner/scanner.sh"
+        # Pull in _scanner_check_log_fd
+        awk '/^_scanner_check_log_fd\(\)/{p=1} p; p && /^\}/{p=0; exit}' \
+            "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    touch "$BATS_TMPDIR/scanner-test.log"
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/heartbeat-src.sh" \
+           "$BATS_TMPDIR/scanner-test.log" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# _scanner_write_heartbeat
+# ---------------------------------------------------------------------------
+
+@test "_scanner_write_heartbeat: creates heartbeat file on first call" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    rm -f "$hb"
+    _scanner_write_heartbeat
+    [ -f "$hb" ]
+}
+
+@test "_scanner_write_heartbeat: file contains a timestamp" {
+    _scanner_write_heartbeat
+    local content
+    content=$(cat "$LOOP_LOG_DIR/scanner-heartbeat")
+    # Should match ISO 8601 date pattern
+    [[ "$content" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
+}
+
+@test "_scanner_write_heartbeat: updates mtime on subsequent calls" {
+    _scanner_write_heartbeat
+    local mtime1
+    mtime1=$(stat -f%m "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null \
+             || stat -c%Y "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null)
+    sleep 1
+    _scanner_write_heartbeat
+    local mtime2
+    mtime2=$(stat -f%m "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null \
+             || stat -c%Y "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null)
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "_scanner_write_heartbeat: no-op in dry-run mode" {
+    DRY_RUN=true
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    rm -f "$hb"
+    _scanner_write_heartbeat
+    [ ! -f "$hb" ]
+    DRY_RUN=false
+}
+
+# ---------------------------------------------------------------------------
+# _scanner_check_log_fd
+# ---------------------------------------------------------------------------
+
+@test "_scanner_check_log_fd: does not exit when log file is writable" {
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    run _scanner_check_log_fd
+    [ "$status" -eq 0 ]
+}
+
+@test "_scanner_check_log_fd: exits 1 when log file path is a directory (not writable as file)" {
+    # Use a path that exists but is not writable as a regular file.
+    local ro_dir="$BATS_TMPDIR/ro-log-dir"
+    mkdir -p "$ro_dir"
+    chmod 444 "$ro_dir"
+    LOG_FILE="$ro_dir/scanner.log"
+    # File doesn't exist and parent dir is not writable — [ ! -w ] should be true.
+    run _scanner_check_log_fd
+    chmod 755 "$ro_dir"
+    [ "$status" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh (integration — no actual kill)
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog.sh: reports healthy when heartbeat is fresh" {
+    # Write a fresh heartbeat
+    date '+%Y-%m-%dT%H:%M:%SZ' > "$LOOP_LOG_DIR/scanner-heartbeat"
+
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"healthy"* ]]
+}
+
+@test "scanner-watchdog.sh: reports STALE when heartbeat is old" {
+    # Write a heartbeat and backdate it well past the default stale threshold.
+    # Unset LOOP_SCANNER_INTERVAL so the watchdog uses the built-in default
+    # (300 s) giving a threshold of 600 s; backdate by 30 minutes (1800 s).
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    date '+%Y-%m-%dT%H:%M:%SZ' > "$hb"
+    touch -t "$(date -v-30M +%Y%m%d%H%M.%S 2>/dev/null \
+               || date -d '30 minutes ago' +%Y%m%d%H%M.%S)" "$hb"
+
+    LOOP_SCANNER_INTERVAL=300 run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+    [[ "$output" == *"DRY-RUN"* ]]
+}
+
+@test "scanner-watchdog.sh: skips gracefully when heartbeat file is absent" {
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"missing"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes
- scanner/scanner.sh: write `${LOOP_LOG_DIR}/scanner-heartbeat` on every tick (via `_scanner_write_heartbeat`) so liveness is externally observable
- scanner/scanner-watchdog.sh: thin watchdog (fires every 5 min via launchd) that kills the scanner if heartbeat is stale >2× poll-interval; launchd KeepAlive restarts it
- scripts/restart-scanner-if-stale.sh: standalone watchdog script with 15-min stale threshold, scanner-log fallback, and `launchctl kickstart` belt-and-suspenders restart
- templates/launchd/com.user.loop-scanner-watchdog.plist.template: launchd plist for scanner-watchdog.sh (StartInterval=300)
- templates/launchd/loop-scanner-watchdog.plist.template: launchd plist wiring restart-scanner-if-stale.sh (StartInterval=300)
- tests/scanner-heartbeat.bats: bats tests for heartbeat write, check-log-fd, and watchdog healthy/stale/missing paths
- test/scanner-heartbeat.bats: bats tests for restart-scanner-if-stale.sh healthy/stale/absent/fallback paths

## Test Plan
- Verify heartbeat file is created and updated on each scanner tick
- Simulate wedge: `kill -STOP $SCANNER_PID` → watchdog should restart within 10 min (2 × 5 min interval)
- Run bats tests: `bats test/scanner-heartbeat.bats` and `bats tests/scanner-heartbeat.bats`
- Dry-run smoke test: `LOOP_LOG_DIR=/tmp/test-loop scripts/restart-scanner-if-stale.sh --dry-run`