### PR TITLE
[LOOP-413] scanner: write heartbeat file each tick + watchdog restart script

### DIFF
--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -774,7 +775,26 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+# _scanner_write_heartbeat — update the heartbeat file so the watchdog can
+# confirm the scanner is still making forward progress on every tick.
+_scanner_write_heartbeat() {
+    $DRY_RUN && return 0
+    date '+%Y-%m-%dT%H:%M:%SZ' > "$HEARTBEAT_FILE" 2>/dev/null || true
+}
+
+# _scanner_check_log_fd — if the log file is no longer writable (e.g. the
+# inode was rotated away), exit so launchd can restart with a fresh fd.
+_scanner_check_log_fd() {
+    [ -z "${LOG_FILE:-}" ] && return 0
+    if [ ! -w "$LOG_FILE" ]; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] FATAL: log file not writable — exiting for restart" >&2
+        exit 1
+    fi
+}
+
 run_once() {
+    _scanner_check_log_fd
+    _scanner_write_heartbeat
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/scripts/restart-scanner-if-stale.sh
+++ b/scripts/restart-scanner-if-stale.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# restart-scanner-if-stale.sh — kill and restart the scanner if its heartbeat is stale.
+#
+# Checks ${LOOP_LOG_DIR}/scanner-heartbeat. If the file's mtime is older than
+# LOOP_SCANNER_STALE_THRESHOLD seconds (default: 900 / 15 min), the scanner is
+# considered wedged. The lock file at /tmp/loop-scanner.lock is read for the PID;
+# if alive it is sent SIGTERM (then SIGKILL if needed) so launchd (KeepAlive=true
+# on com.user.loop-scanner) auto-restarts the process.
+#
+# Falls back to checking the scanner log mtime when the heartbeat file is absent.
+#
+# Designed to run every 5 minutes via launchd / cron.
+#
+# Usage:
+#   restart-scanner-if-stale.sh [--dry-run]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+SCANNER_LOG="${LOOP_LOG_DIR}/loop-scanner.log"
+LOCK_FILE="/tmp/loop-scanner.lock"
+WATCHDOG_LOG="${LOOP_LOG_DIR}/loop-scanner-watchdog.log"
+STALE_THRESHOLD="${LOOP_SCANNER_STALE_THRESHOLD:-900}"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*" | tee -a "$WATCHDOG_LOG"; }
+
+# _file_age_seconds <path>
+# Prints seconds since the file was last modified; prints -1 if absent.
+_file_age_seconds() {
+    local path="$1"
+    [ -f "$path" ] || { echo -1; return; }
+    local mtime now
+    mtime=$(stat -f%m "$path" 2>/dev/null || stat -c%Y "$path" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+# Determine liveness from the heartbeat file; fall back to the scanner log.
+probe_file="$HEARTBEAT_FILE"
+probe_label="heartbeat"
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    probe_file="$SCANNER_LOG"
+    probe_label="scanner-log"
+fi
+
+age=$(_file_age_seconds "$probe_file")
+
+if [ "$age" -lt 0 ]; then
+    log "${probe_label} file missing — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+log "${probe_label} age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is healthy"
+    exit 0
+fi
+
+log "STALE: ${probe_label} is ${age}s old (threshold=${STALE_THRESHOLD}s)"
+
+if $DRY_RUN; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    log "DRY-RUN: would kill scanner PID ${scanner_pid:-<unknown>} and trigger launchd restart"
+    exit 0
+fi
+
+if [ ! -f "$LOCK_FILE" ]; then
+    log "no lock file — scanner not running; launchd will restart it automatically"
+    exit 0
+fi
+
+scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+if [ -z "$scanner_pid" ]; then
+    log "lock file is empty — removing and allowing launchd to restart"
+    rm -f "$LOCK_FILE"
+    exit 0
+fi
+
+if ! kill -0 "$scanner_pid" 2>/dev/null; then
+    log "scanner PID $scanner_pid is already dead — removing stale lock; launchd will restart"
+    rm -f "$LOCK_FILE"
+    exit 0
+fi
+
+log "killing wedged scanner PID $scanner_pid (SIGTERM) — launchd KeepAlive will restart"
+kill "$scanner_pid" || true
+sleep 2
+if kill -0 "$scanner_pid" 2>/dev/null; then
+    log "WARN: PID $scanner_pid still alive after SIGTERM — sending SIGKILL"
+    kill -9 "$scanner_pid" || true
+fi
+
+# Belt-and-suspenders: kickstart via launchctl for macOS environments.
+if command -v launchctl >/dev/null 2>&1; then
+    launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null \
+        && log "launchctl kickstart succeeded" \
+        || log "launchctl kickstart not available or failed (expected on Linux/cron installs)"
+fi
+
+log "done — scanner will be restarted by launchd / cron"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+  Fires every 5 minutes to check the scanner heartbeat and restart if stale.
+
+  Install (LOOP_LOG_DIR must be set, e.g. via your loop.env):
+    sed "s|@LOOP_ROOT@|$(cd "$(dirname "$0")/.." && pwd)|g; \
+         s|@LOG_DIR@|$LOOP_LOG_DIR|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>@LOOP_ROOT@/scripts/restart-scanner-if-stale.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>@LOG_DIR@/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>@LOG_DIR@/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for scanner liveness heartbeat (#413).
+#
+# Tests:
+#  - _scanner_write_heartbeat creates the heartbeat file on the first tick.
+#  - _scanner_write_heartbeat updates the file mtime on subsequent ticks.
+#  - _scanner_check_log_fd exits when the log file is not writable.
+#  - restart-scanner-if-stale.sh reports "healthy" when heartbeat is fresh.
+#  - restart-scanner-if-stale.sh reports "STALE" when heartbeat is old.
+#  - restart-scanner-if-stale.sh --dry-run does not kill any process.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+
+    # Source just the helper functions from scanner.sh into current shell.
+    local _src="$BATS_TMPDIR/heartbeat-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        printf "LOOP_LOG_DIR='%s'\n" "$LOOP_LOG_DIR"
+        printf "HEARTBEAT_FILE='%s/scanner-heartbeat'\n" "$LOOP_LOG_DIR"
+        printf "LOG_FILE='%s/scanner-test.log'\n" "$BATS_TMPDIR"
+        printf "DRY_RUN=false\n"
+        awk '/^_scanner_write_heartbeat\(\)/,/^\}/' "$REPO_ROOT/scanner/scanner.sh"
+        awk '/^_scanner_check_log_fd\(\)/,/^\}/' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    touch "$BATS_TMPDIR/scanner-test.log"
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/heartbeat-src.sh" \
+           "$BATS_TMPDIR/scanner-test.log" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# _scanner_write_heartbeat
+# ---------------------------------------------------------------------------
+
+@test "_scanner_write_heartbeat: creates heartbeat file on first call" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    rm -f "$hb"
+    _scanner_write_heartbeat
+    [ -f "$hb" ]
+}
+
+@test "_scanner_write_heartbeat: file contains an ISO timestamp" {
+    _scanner_write_heartbeat
+    local content
+    content=$(cat "$LOOP_LOG_DIR/scanner-heartbeat")
+    [[ "$content" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
+}
+
+@test "_scanner_write_heartbeat: updates mtime on repeated calls" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    _scanner_write_heartbeat
+    local mtime1
+    mtime1=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb")
+    sleep 1
+    _scanner_write_heartbeat
+    local mtime2
+    mtime2=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb")
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "_scanner_write_heartbeat: no-op when DRY_RUN=true" {
+    DRY_RUN=true
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    rm -f "$hb"
+    _scanner_write_heartbeat
+    [ ! -f "$hb" ]
+}
+
+# ---------------------------------------------------------------------------
+# _scanner_check_log_fd
+# ---------------------------------------------------------------------------
+
+@test "_scanner_check_log_fd: passes when log file is writable" {
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    _scanner_check_log_fd
+}
+
+@test "_scanner_check_log_fd: exits non-zero when log file is missing" {
+    LOG_FILE="$BATS_TMPDIR/no-such-log.log"
+    run _scanner_check_log_fd
+    [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# restart-scanner-if-stale.sh
+# ---------------------------------------------------------------------------
+
+@test "watchdog: reports healthy when heartbeat is fresh" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    date '+%Y-%m-%dT%H:%M:%SZ' > "$hb"
+    run bash "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"healthy"* ]]
+}
+
+@test "watchdog: reports STALE when heartbeat is old" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    date '+%Y-%m-%dT%H:%M:%SZ' > "$hb"
+    # Back-date the file mtime to 20 minutes ago
+    touch -t "$(date -v-20M '+%Y%m%d%H%M' 2>/dev/null || date -d '20 minutes ago' '+%Y%m%d%H%M')" "$hb"
+    run bash "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+}
+
+@test "watchdog --dry-run: does not kill any process" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    date '+%Y-%m-%dT%H:%M:%SZ' > "$hb"
+    touch -t "$(date -v-20M '+%Y%m%d%H%M' 2>/dev/null || date -d '20 minutes ago' '+%Y%m%d%H%M')" "$hb"
+    # Write a fake lock with our own PID — watchdog must not kill us
+    echo $$ > /tmp/loop-scanner.lock
+    run bash "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+    rm -f /tmp/loop-scanner.lock
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DRY-RUN"* ]]
+    # Verify we are still alive
+    kill -0 $$ 2>/dev/null
+}
+
+@test "watchdog: skips gracefully when heartbeat is absent and scanner log is missing" {
+    # Neither heartbeat nor scanner log exist
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat" "$LOOP_LOG_DIR/loop-scanner.log"
+    run bash "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"missing"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

- **scanner/scanner.sh**: Added `_scanner_write_heartbeat()` which writes the current UTC timestamp to `${LOOP_LOG_DIR}/scanner-heartbeat` at the start of every tick (skipped in dry-run). Added `_scanner_check_log_fd()` which exits with status 1 when the log file is no longer writable, allowing launchd to restart the process with a fresh file descriptor.

- **scripts/restart-scanner-if-stale.sh**: New watchdog script that reads the heartbeat file mtime. If older than `LOOP_SCANNER_STALE_THRESHOLD` seconds (default 900 / 15 min), it sends SIGTERM to the scanner PID (from the lock file), then SIGKILL if needed, and calls `launchctl kickstart` as a belt-and-suspenders fallback. Falls back to checking the scanner log when the heartbeat file doesn't exist yet. Supports `--dry-run`.

- **templates/launchd/com.user.loop-scanner-watchdog.plist.template**: launchd plist template that fires `restart-scanner-if-stale.sh` every 5 minutes (StartInterval=300). Follows the same `@LOOP_ROOT@`/`@LOG_DIR@` substitution pattern as other plist templates.

- **tests/scanner-heartbeat.bats**: bats test suite covering: heartbeat file creation on first tick, ISO timestamp format validation, mtime update on repeat, dry-run no-op, log fd check pass/fail, watchdog healthy path, watchdog stale path (backdated mtime), dry-run no-kill, and absent-file graceful skip.

## Test Plan

- Run `bats tests/scanner-heartbeat.bats` — all tests should pass
- Manual: start scanner, verify `${LOOP_LOG_DIR}/scanner-heartbeat` is updated each tick
- Manual: install watchdog plist, then `kill -STOP $SCANNER_PID` — watchdog should detect stale heartbeat within 10 min and restart scanner
- Verify `--dry-run` mode prints action without killing anything