### PR TITLE
[LOOP-413] scanner: liveness heartbeat + auto-restart watchdog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — detects a wedged scanner (alive PID, no emits)
+    # and kills it so launchd KeepAlive restarts it. Runs every 5 min.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — detect and restart a wedged scanner process.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written by scanner.sh on every tick).
+# If the heartbeat mtime is older than LOOP_SCANNER_WATCHDOG_STALE_SECONDS
+# (default: 2 × LOOP_SCANNER_INTERVAL = 600s), kills the scanner PID and lets
+# launchd (macOS) or cron (Linux) restart it.
+#
+# Designed to run every 5 min via launchd StartInterval or cron */5.
+#
+# Flags:
+#   --dry-run   log what would be done without killing anything
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_SCANNER_WATCHDOG_STALE_SECONDS:-$(( 2 * POLL_INTERVAL ))}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -15
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file absent — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+age=$(( now - mtime ))
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner healthy (heartbeat_age=${age}s threshold=${STALE_THRESHOLD}s)"
+    exit 0
+fi
+
+log "WARN: heartbeat stale (age=${age}s >= threshold=${STALE_THRESHOLD}s) — restarting scanner"
+
+pid=$(head -1 "$HEARTBEAT_FILE" 2>/dev/null | tr -d '[:space:]' || true)
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill PID ${pid:-unknown} and rely on launchd/cron to restart"
+    exit 0
+fi
+
+if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    log "sending SIGTERM to scanner PID $pid"
+    kill "$pid" 2>/dev/null || true
+    sleep 2
+    if kill -0 "$pid" 2>/dev/null; then
+        log "WARN: scanner PID $pid still alive after SIGTERM — sending SIGKILL"
+        kill -9 "$pid" 2>/dev/null || true
+    fi
+else
+    log "scanner PID ${pid:-unknown} already gone — launchd/cron will restart on next cycle"
+fi
+
+# On macOS, launchd KeepAlive=true restarts the scanner automatically after the kill.
+# On Linux (cron --once mode), the next cron tick starts a fresh scanner run.
+log "restart delegated to launchd (macOS) or next cron tick (Linux)"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -64,6 +64,23 @@ done
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] $*"; }
 
+# _scanner_heartbeat — write current PID to the heartbeat file so the
+# scanner-watchdog can detect a wedged process and restart it.
+# Skipped in dry-run mode to keep that path side-effect-free.
+_scanner_heartbeat() {
+    $DRY_RUN && return 0
+    printf '%s\n' "$$" > "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+}
+
+# _scanner_check_log — verify LOG_FILE is still writable at the top of each
+# tick. If not, try to reopen stdout/stderr; if that also fails, exit so that
+# launchd/cron can restart the process with clean file descriptors.
+_scanner_check_log() {
+    [ -n "${LOG_FILE:-}" ] || return 0
+    [ -w "${LOG_FILE}" ] && return 0
+    exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" || exit 1
+}
+
 # _scanner_jobs_enqueue <slug> <stage> <num>
 # Best-effort dual-write to the jobs table alongside the legacy label-event path.
 # Skipped when LOOP_JOBS_ENQUEUE=0 or --dry-run.
@@ -775,6 +792,8 @@ scan_project() {
 }
 
 run_once() {
+    _scanner_heartbeat
+    _scanner_check_log
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <!-- Fire every 5 minutes; detects a wedged scanner within 2× poll interval -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — heartbeat file is updated on every tick (#413).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    LOOP_LOG_DIR="$(mktemp -d)"
+    export LOOP_LOG_DIR
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    # Extract both helper functions from scanner.sh without sourcing the whole file.
+    eval "$(awk '/^_scanner_heartbeat\(\)/{p=1} p{print} p && /^\}$/{exit}' \
+        "$REPO_ROOT/scanner/scanner.sh")"
+    eval "$(awk '/^_scanner_check_log\(\)/{p=1} p{print} p && /^\}$/{exit}' \
+        "$REPO_ROOT/scanner/scanner.sh")"
+}
+
+teardown() {
+    rm -rf "$LOOP_LOG_DIR"
+}
+
+@test "_scanner_heartbeat: writes PID to heartbeat file" {
+    DRY_RUN=false
+    _scanner_heartbeat
+    [ -f "$HEARTBEAT_FILE" ]
+    content=$(cat "$HEARTBEAT_FILE")
+    # Must be a positive integer (the PID)
+    [[ "$content" =~ ^[0-9]+$ ]]
+}
+
+@test "_scanner_heartbeat: skipped in dry-run mode" {
+    DRY_RUN=true
+    _scanner_heartbeat
+    [ ! -f "$HEARTBEAT_FILE" ]
+}
+
+@test "_scanner_heartbeat: updates mtime on every call" {
+    DRY_RUN=false
+    _scanner_heartbeat
+    mtime1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE")
+    sleep 1
+    _scanner_heartbeat
+    mtime2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE")
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "_scanner_check_log: no-op when LOG_FILE is writable" {
+    LOG_FILE="$LOOP_LOG_DIR/loop-scanner.log"
+    touch "$LOG_FILE"
+    # Should succeed without side effects
+    _scanner_check_log
+}
+
+@test "_scanner_check_log: no-op when LOG_FILE is unset" {
+    LOG_FILE=""
+    _scanner_check_log
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`**
- Added `_scanner_heartbeat()`: writes the scanner PID to `${LOOP_LOG_DIR}/scanner-heartbeat` at the top of every `run_once()` tick. Skipped in `--dry-run` mode.
- Added `_scanner_check_log()`: verifies `$LOG_FILE` is writable at the top of each tick; attempts to reopen stdout/stderr against the file if not, exits so launchd/cron restarts with clean FDs if recovery fails.
- Both helpers are called at the start of `run_once()`.

**`scanner/scanner-watchdog.sh`** (new)
- Reads `${LOOP_LOG_DIR}/scanner-heartbeat` mtime.
- If `age >= LOOP_SCANNER_WATCHDOG_STALE_SECONDS` (default: `2 × LOOP_SCANNER_INTERVAL = 600s`), sends SIGTERM to the scanner PID (SIGKILL after 2s if still alive).
- On macOS: launchd `KeepAlive=true` restarts the scanner automatically. On Linux: next cron tick starts a fresh `--once` run.
- Supports `--dry-run` flag.

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new)
- Runs `scanner-watchdog.sh` every 300s (5 min) via launchd `StartInterval`.

**`install.sh`**
- `bootstrap_register_launchd`: installs and loads `com.user.loop-scanner-watchdog` plist.
- `bootstrap_register_cron`: adds a `*/5` cron entry for `scanner-watchdog.sh` on Linux.

**`tests/scanner-heartbeat.bats`** (new)
- 5 bats tests: heartbeat writes PID, skipped in dry-run, updates mtime on repeated calls, `_scanner_check_log` no-ops on writable file and on unset `LOG_FILE`.

## Test Plan

- `bash -n` syntax check: all pass
- `shellcheck -S warning`: no warnings
- Personal identifiers grep: clean
- `bats tests/scanner-heartbeat.bats`: 5/5 pass
- Manual: `kill -STOP $SCANNER_PID` → watchdog should log "heartbeat stale" and send SIGTERM within 10 min (2 × 300s); launchd restarts the scanner.