### PR TITLE
[LOOP-413] scanner: liveness heartbeat + watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — checks heartbeat file every 5 min and kills
+    # a wedged scanner so launchd KeepAlive restarts it automatically.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the Loop scanner when its heartbeat goes stale.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat written by scanner.sh on every tick.
+# If the file is older than LOOP_SCANNER_WATCHDOG_THRESHOLD seconds (default:
+# 2 × LOOP_SCANNER_INTERVAL = 600s), the scanner is considered wedged: its PID
+# (read from /tmp/loop-scanner.lock) is killed so launchd KeepAlive restarts it.
+# On Linux (no launchd) the kill alone suffices; cron re-invokes scanner.sh
+# --once on the next 5-minute tick.
+#
+# Usage:
+#   scanner-watchdog.sh          # single check (designed for launchd / cron)
+#   scanner-watchdog.sh --dry-run  # report state without killing
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+THRESHOLD="${LOOP_SCANNER_WATCHDOG_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _file_age_seconds <path>
+# Print seconds since last modification. Supports macOS (BSD) and Linux (GNU) stat.
+_file_age_seconds() {
+    local path="$1"
+    local mtime
+    if mtime=$(stat -f%m "$path" 2>/dev/null); then
+        echo $(( $(date +%s) - mtime ))
+    elif mtime=$(stat -c%Y "$path" 2>/dev/null); then
+        echo $(( $(date +%s) - mtime ))
+    fi
+}
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file absent ($HEARTBEAT_FILE) — scanner may not be running yet; skipping"
+    exit 0
+fi
+
+age=$(_file_age_seconds "$HEARTBEAT_FILE")
+if [ -z "$age" ]; then
+    log "WARN: could not stat heartbeat file — skipping"
+    exit 0
+fi
+
+log "heartbeat age=${age}s threshold=${THRESHOLD}s"
+
+if [ "$age" -lt "$THRESHOLD" ]; then
+    log "scanner is healthy"
+    exit 0
+fi
+
+# Scanner is wedged — kill it so launchd KeepAlive (macOS) or the next cron
+# invocation (Linux) restarts it.
+log "ALERT: heartbeat stale (${age}s >= ${THRESHOLD}s) — initiating restart"
+
+scanner_pid=""
+if [ -f "$LOCK_FILE" ]; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+fi
+
+if $DRY_RUN; then
+    if [ -n "$scanner_pid" ]; then
+        log "DRY-RUN: would kill scanner PID $scanner_pid and remove lock"
+    else
+        log "DRY-RUN: no scanner PID found; would remove stale lock if present"
+    fi
+    exit 0
+fi
+
+if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+    log "killing scanner PID $scanner_pid"
+    kill "$scanner_pid" 2>/dev/null || true
+else
+    log "scanner PID ${scanner_pid:-<none>} not alive — clearing stale lock"
+fi
+# Remove the lock file so the restarted scanner can acquire it immediately.
+rm -f "$LOCK_FILE" 2>/dev/null || true
+
+log "done — launchd KeepAlive will restart the scanner automatically"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -46,6 +47,18 @@ _scanner_reopen_log() {
     fi
 }
 trap '_scanner_reopen_log; echo "[$(date "+%Y-%m-%d %H:%M:%S")] [scanner] SIGHUP — log fds reopened"' HUP
+
+# _scanner_check_stdout — called at the start of each tick to verify the log
+# FD is still viable. If LOG_FILE no longer exists or is not writable (e.g.
+# deleted inode after rotation without SIGHUP, or broken pipe to a dead tee
+# child), attempt to reopen the FD; if that also fails, exit so launchd
+# KeepAlive restarts the scanner with fresh file descriptors.
+_scanner_check_stdout() {
+    [ -n "${LOG_FILE:-}" ] || return 0
+    if [ ! -e "$LOG_FILE" ] || [ ! -w "$LOG_FILE" ]; then
+        exec 1>>"$LOG_FILE" 2>&1 || exit 1
+    fi
+}
 
 DRY_RUN=false
 ONCE=false
@@ -775,6 +788,9 @@ scan_project() {
 }
 
 run_once() {
+    _scanner_check_stdout
+    # Write liveness heartbeat so scanner-watchdog can detect a wedged process.
+    $DRY_RUN || printf '%s\n' "$(date +%s)" > "${HEARTBEAT_FILE}" 2>/dev/null || true
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <!-- Check every 5 minutes; threshold is 2 × scanner poll interval (default 10 min) -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verify scanner liveness heartbeat (issue #413).
+#
+# scanner.sh must write ${LOOP_LOG_DIR}/scanner-heartbeat on every tick so the
+# external watchdog (scanner-watchdog.sh) can detect a wedged scanner without
+# parsing log files.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+    LOOP_JOBS_ENQUEUE=0
+
+    log() { :; }
+    dispatch_direct() { :; }
+    loop_list_slugs() { printf ''; }
+    scan_project() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+@test "run_once: creates heartbeat file on first tick" {
+    rm -f "$HEARTBEAT_FILE"
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: heartbeat file contains a unix timestamp" {
+    run_once
+    local ts
+    ts=$(cat "$HEARTBEAT_FILE")
+    [ -n "$ts" ]
+    # Must be a number greater than 2020-01-01 (1577836800)
+    [ "$ts" -gt 1577836800 ] 2>/dev/null
+}
+
+@test "run_once: heartbeat file is updated on subsequent ticks" {
+    run_once
+    local ts1
+    ts1=$(cat "$HEARTBEAT_FILE")
+    sleep 1
+    run_once
+    local ts2
+    ts2=$(cat "$HEARTBEAT_FILE")
+    # Second timestamp must be >= first
+    [ "$ts2" -ge "$ts1" ]
+}
+
+@test "run_once: DRY_RUN=true does not write heartbeat file" {
+    DRY_RUN=true
+    rm -f "$HEARTBEAT_FILE"
+    run_once
+    [ ! -f "$HEARTBEAT_FILE" ]
+}
+
+@test "scanner.sh: HEARTBEAT_FILE is defined as \${LOOP_LOG_DIR}/scanner-heartbeat" {
+    # Regression guard: ensure the variable assignment is present in the source.
+    grep -q 'HEARTBEAT_FILE=.*scanner-heartbeat' "$REPO_ROOT/scanner/scanner.sh"
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`**
- Added `HEARTBEAT_FILE` variable (`${LOOP_LOG_DIR}/scanner-heartbeat`)
- Added `_scanner_check_stdout()`: called at the start of each tick — if the log file is missing or not writable (deleted inode after rotation without SIGHUP, broken pipe to a dead tee child), reopens FD1/FD2 to the log path or exits so launchd KeepAlive restarts the scanner with fresh descriptors
- `run_once()` now writes the current unix timestamp to `HEARTBEAT_FILE` at tick start (skipped under `--dry-run`)

**`scanner/scanner-watchdog.sh`** (new)
- Single-shot script designed for launchd (StartInterval 300) or cron (*/5)
- Reads `LOOP_LOG_DIR/scanner-heartbeat`; if mtime > `LOOP_SCANNER_WATCHDOG_THRESHOLD` seconds (default: `2 × LOOP_SCANNER_INTERVAL = 600s`), kills the scanner PID from `/tmp/loop-scanner.lock` and removes the lock so launchd KeepAlive restarts cleanly
- Supports `--dry-run` for operator inspection without side effects
- Portable `stat` wrapper handles both BSD (macOS) and GNU (Linux) stat

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new)
- `StartInterval 300` (every 5 min) with standard `__LOOP_ROOT__`/`__LOG_DIR__`/`__HOME__`/`__EXTRA_PATH__` substitution placeholders

**`install.sh`**
- `bootstrap_register_launchd`: registers `com.user.loop-scanner-watchdog` plist (idempotent)
- `bootstrap_register_cron`: adds `*/5 * * * * scanner-watchdog.sh` cron entry for Linux (idempotent, marker-guarded)

**`tests/scanner-heartbeat.bats`** (new)
- 5 tests verifying: heartbeat created on first tick, contains a valid unix timestamp, updated on subsequent ticks, not written under `--dry-run`, and variable definition present in scanner source

## Test Plan
- `bash -n` + `shellcheck -S warning` pass on all scripts
- `bats tests/scanner-heartbeat.bats` → 5/5 pass
- Existing scanner test suites show no new failures
- Manual: `kill -STOP $SCANNER_PID` → heartbeat goes stale → watchdog kills and launchd restarts within 5 min
- `scanner-watchdog.sh --dry-run` reports state without side effects