### PR TITLE
[LOOP-413] scanner: liveness heartbeat + watchdog auto-restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — kills and restarts the scanner if its heartbeat
+    # file goes stale, protecting against the silent-wedge failure mode.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if it stops emitting heartbeats.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written by scanner.sh every tick).
+# If the file is absent or older than LOOP_WATCHDOG_STALE_SECS (default 900s),
+# the scanner is considered wedged: kill it and let launchd/cron restart it.
+#
+# Usage (run every 5 min via launchd/cron — see install.sh):
+#   scanner-watchdog.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+STALE_SECS="${LOOP_WATCHDOG_STALE_SECS:-900}"
+LOCK_FILE="/tmp/loop-scanner.lock"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+_scanner_pid() {
+    local pid=""
+    if [ -f "$LOCK_FILE" ]; then
+        pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    fi
+    printf '%s' "$pid"
+}
+
+_heartbeat_age() {
+    if [ ! -f "$HEARTBEAT_FILE" ]; then
+        printf '%s' "999999"
+        return
+    fi
+    local mtime now age
+    mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+        || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+        || echo 0)
+    now=$(date +%s)
+    age=$(( now - mtime ))
+    printf '%s' "$age"
+}
+
+_restart_scanner() {
+    # Try launchctl kickstart (macOS) first; fall back to direct exec (Linux/cron).
+    if command -v launchctl >/dev/null 2>&1 && launchctl list com.user.loop-scanner >/dev/null 2>&1; then
+        launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null \
+            || launchctl stop com.user.loop-scanner 2>/dev/null \
+            || true
+        log "restarted via launchctl kickstart"
+    else
+        # Linux / non-launchd: launch scanner in the background.
+        # cron will restart it on the next tick regardless; this gives faster recovery.
+        nohup "$LOOP_ROOT/scanner/scanner.sh" >> "${LOOP_LOG_DIR}/loop-scanner.log" 2>&1 &
+        log "launched scanner directly (PID $!)"
+    fi
+}
+
+age=$(_heartbeat_age)
+log "heartbeat age=${age}s threshold=${STALE_SECS}s"
+
+if [ "$age" -lt "$STALE_SECS" ]; then
+    log "scanner healthy — nothing to do"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat stale (${age}s > ${STALE_SECS}s) — restarting"
+
+pid=$(_scanner_pid)
+if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    log "killing wedged scanner PID $pid"
+    kill "$pid" 2>/dev/null || true
+    sleep 2
+fi
+
+# Remove stale lock so the restarted process can acquire it.
+rm -f "$LOCK_FILE"
+
+_restart_scanner

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -32,6 +32,7 @@ LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 
 # SIGHUP-reopen contract (#194): logrotate-style tools truncate or rename
 # the on-disk log file. The launchd plist redirects stdout/stderr to a
@@ -775,6 +776,18 @@ scan_project() {
 }
 
 run_once() {
+    # Heartbeat: write timestamp so the watchdog can detect a wedged scanner.
+    if ! $DRY_RUN; then
+        printf '%s\n' "$(date '+%Y-%m-%d %H:%M:%S')" > "$HEARTBEAT_FILE" 2>/dev/null || true
+    fi
+
+    # Stdout integrity check: if the log file is no longer writable (e.g. deleted
+    # or inode swapped by logrotate without a SIGHUP), reopen FDs and continue;
+    # if reopen fails, exit so launchd restarts the process with a fresh FD.
+    if [ -n "${LOG_FILE:-}" ] && [ ! -w "$LOG_FILE" ]; then
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" || exit 1
+    fi
+
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
@@ -785,7 +798,9 @@ run_once() {
         [ -z "$slug" ] && continue
         scan_project "$slug" || log "scan_project $slug failed (continuing)"
     done < <(loop_list_slugs)
-    log "=== scan tick done ==="
+    local _dedup_count=0
+    _dedup_count=$(ls -1 "$DEDUP_DIR" 2>/dev/null | wc -l | tr -d ' ') || true
+    log "=== scan tick done (dedup_count=${_dedup_count}) ==="
 }
 
 acquire_lock

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <!-- Check scanner liveness every 5 minutes -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- Write `${LOOP_LOG_DIR}/scanner-heartbeat` (ISO timestamp) at the top of every `run_once()` tick — skipped in `--dry-run` mode.
- Stdout integrity check at tick start: if `$LOG_FILE` is not writable (e.g. inode swapped by logrotate without a SIGHUP), reopen FDs 1/2 against the path; exit with code 1 on failure so launchd immediately restarts the process.
- Appended `dedup_count` to the tick-done log line so silent-stop is visible at a glance.

### `scanner/scanner-watchdog.sh` (new)
- Reads `scanner-heartbeat` mtime. If file is absent or older than `LOOP_WATCHDOG_STALE_SECS` (default 900 s / 15 min), the scanner is considered wedged.
- Kills the PID recorded in the scanner lock file, removes the stale lock, then restarts the scanner: `launchctl kickstart` on macOS (so launchd owns the lifecycle), direct `nohup` exec on Linux.
- Designed to run every 5 min from launchd/cron.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- `StartInterval` 300 s, logs to `loop-scanner-watchdog.log`.
- Uses the same `__LOOP_ROOT__` / `__LOG_DIR__` / `__HOME__` / `__EXTRA_PATH__` substitution tokens that `bootstrap_register_launchd` already handles.

### `install.sh`
- `bootstrap_register_launchd`: installs `com.user.loop-scanner-watchdog.plist` (idempotent, skips if already registered).
- `bootstrap_register_cron`: adds `*/5 * * * * scanner-watchdog.sh` crontab entry with the `# loop-scanner-watchdog` marker (idempotent).

## Test Plan

- **Heartbeat written every tick**: after one scanner sweep, `stat ${LOOP_LOG_DIR}/scanner-heartbeat` should show mtime ≤ `POLL_INTERVAL` seconds ago.
- **Watchdog healthy path**: with a fresh heartbeat, `scanner-watchdog.sh` logs "scanner healthy — nothing to do" and exits 0.
- **Simulated wedge (manual)**: `kill -STOP $SCANNER_PID` to pause the scanner; wait 15 min (or lower `LOOP_WATCHDOG_STALE_SECS=60` for a quick test); confirm watchdog log shows "scanner heartbeat stale" and scanner restarts.
- **Stdout integrity check**: after logrotate or `> loop-scanner.log`, verify scanner reopens FDs and resumes logging rather than silently blocking.
- **CI**: `bash -n` + `shellcheck -S warning` pass on all modified/new scripts (verified locally).