### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,6 +338,26 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    # Scanner liveness watchdog — kills + lets launchd restart a wedged scanner.
+    # Fires every 5 min; compares scanner-heartbeat mtime against the stale
+    # threshold (2 × poll interval). Companion to the KeepAlive scanner plist.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     local digest_plist="$agents_dir/com.user.loop-digest.plist"
     if [ -f "$digest_plist" ]; then
         echo "[launchd] com.user.loop-digest already registered — skipping"
@@ -361,8 +381,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +404,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -776,6 +777,8 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Heartbeat: update mtime so scanner-watchdog can detect a wedged process.
+    $DRY_RUN || printf '%s %s\n' "$(date +%s)" "$$" > "$HEARTBEAT_FILE"
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if its heartbeat goes stale.
+#
+# Runs every 5 min via launchd StartInterval=300 (macOS) or cron (Linux).
+# Checks ${LOOP_LOG_DIR}/scanner-heartbeat mtime. If older than
+# LOOP_WATCHDOG_STALE_SECONDS (default: 2 × LOOP_SCANNER_INTERVAL = 600s),
+# kills the scanner PID from /tmp/loop-scanner.lock so launchd KeepAlive
+# can restart it.
+#
+# Flags:
+#   --dry-run   log what would be killed, don't send SIGTERM
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+STALE_THRESHOLD="${LOOP_WATCHDOG_STALE_SECONDS:-$(( ${LOOP_SCANNER_INTERVAL:-300} * 2 ))}"
+LOCK_FILE="/tmp/loop-scanner.lock"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -15
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# Heartbeat file must exist and be recent; absence is also treated as stale.
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file missing: $HEARTBEAT_FILE"
+else
+    heartbeat_age=$(( $(date +%s) - $(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+                        || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+                        || echo 0) ))
+    if [ "$heartbeat_age" -lt "$STALE_THRESHOLD" ]; then
+        log "heartbeat ok (age=${heartbeat_age}s < threshold=${STALE_THRESHOLD}s)"
+        exit 0
+    fi
+    log "STALE heartbeat: age=${heartbeat_age}s >= threshold=${STALE_THRESHOLD}s"
+fi
+
+# Read the scanner PID from the lock file.
+if [ ! -f "$LOCK_FILE" ]; then
+    log "lock file missing ($LOCK_FILE) — scanner may not be running; nothing to kill"
+    exit 0
+fi
+
+scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+if [ -z "$scanner_pid" ]; then
+    log "lock file empty — nothing to kill"
+    exit 0
+fi
+
+if ! kill -0 "$scanner_pid" 2>/dev/null; then
+    log "scanner PID $scanner_pid is already gone — launchd should restart it"
+    exit 0
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID $scanner_pid"
+    exit 0
+fi
+
+log "killing stale scanner PID $scanner_pid (SIGTERM)"
+kill "$scanner_pid" 2>/dev/null || true
+# Give it 5 s to exit cleanly, then SIGKILL.
+sleep 5
+if kill -0 "$scanner_pid" 2>/dev/null; then
+    log "scanner PID $scanner_pid still alive — sending SIGKILL"
+    kill -9 "$scanner_pid" 2>/dev/null || true
+fi
+log "done — launchd KeepAlive will restart the scanner"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 min. Checks scanner-heartbeat mtime; if older than
+  LOOP_WATCHDOG_STALE_SECONDS (default 600s = 2 × poll interval),
+  kills the scanner PID so launchd KeepAlive restarts it.
+
+  Install:
+    ./install.sh --bootstrap   # registers automatically
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,124 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verify scanner writes heartbeat on every tick.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Expose mock-gh.sh as gh.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+    export LOOP_EXTRA_PATH=""
+
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+
+    # Source scanner.sh definitions, same approach as scanner.bats.
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    log() { :; }
+    dispatch_direct() { :; }
+
+    # Stub out project scanning so run_once completes quickly.
+    loop_list_slugs() { return 0; }
+    _sweep_stale_locks() { return 0; }
+    jobs_init_schema() { return 0; }
+    LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+@test "run_once: creates heartbeat file on first tick" {
+    rm -f "$HEARTBEAT_FILE"
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: heartbeat file contains unix timestamp and PID" {
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+    local ts pid
+    read -r ts pid < "$HEARTBEAT_FILE"
+    # Timestamp must be a plausible unix epoch (> 2020-01-01 = 1577836800).
+    [ "$ts" -gt 1577836800 ]
+    # PID must be a positive integer.
+    [ "$pid" -gt 0 ]
+}
+
+@test "run_once: heartbeat mtime is updated on second tick" {
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+             || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+    # Ensure at least 1 second passes so mtime changes.
+    sleep 1
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+             || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once: heartbeat not written when DRY_RUN=true" {
+    DRY_RUN=true
+    rm -f "$HEARTBEAT_FILE"
+    run_once
+    [ ! -f "$HEARTBEAT_FILE" ]
+}
+
+@test "scanner-watchdog.sh: exits 0 and logs ok when heartbeat is fresh" {
+    # Write a current heartbeat.
+    printf '%s %s\n' "$(date +%s)" "$$" > "$HEARTBEAT_FILE"
+
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"heartbeat ok"* ]]
+}
+
+@test "scanner-watchdog.sh: dry-run reports stale when heartbeat is old" {
+    # Write a heartbeat with mtime 1 hour ago by using touch -t.
+    local old_time
+    old_time=$(date -v-1H '+%Y%m%d%H%M' 2>/dev/null \
+               || date -d '1 hour ago' '+%Y%m%d%H%M' 2>/dev/null \
+               || echo "")
+    if [ -z "$old_time" ]; then
+        skip "cannot set old mtime on this platform"
+    fi
+    printf '%s %s\n' "0" "$$" > "$HEARTBEAT_FILE"
+    touch -t "$old_time" "$HEARTBEAT_FILE"
+
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### Problem addressed
The scanner process could become silently wedged — alive PID, sleep loop intact, but emitting no events for hours. No alert, no telemetry. The only way to detect it was to compare `loop-scanner.log` mtime against now.

### Implementation

**Heartbeat write (scanner.sh)**
At the top of every `run_once()` tick, the scanner writes `${LOOP_LOG_DIR}/scanner-heartbeat` with the current unix timestamp and PID. This file is not written in `--dry-run` mode.

**Watchdog script (scripts/scanner-watchdog.sh)**
New script intended to run every 5 min. Reads the heartbeat file mtime; if older than `LOOP_WATCHDOG_STALE_SECONDS` (default: `2 × LOOP_SCANNER_INTERVAL = 600 s`), it kills the scanner PID from `/tmp/loop-scanner.lock` (SIGTERM, then SIGKILL after 5 s). launchd `KeepAlive=true` restarts the scanner automatically within seconds.

Supports `--dry-run` for safe inspection.

**launchd plist template (macOS)**
`templates/launchd/com.user.loop-scanner-watchdog.plist.template` — `StartInterval=300`, registered by `install.sh --bootstrap`.

**cron entry (Linux)**
`bootstrap_register_cron()` in `install.sh` now also adds a `*/5` cron entry for `scanner-watchdog.sh`.

**Tests**
`tests/scanner-heartbeat.bats` — 6 tests:
- Heartbeat file created on first tick
- File contains valid unix timestamp and PID
- Mtime advances on second tick
- File NOT written in dry-run mode
- Watchdog exits 0 with "ok" message when heartbeat is fresh
- Watchdog reports STALE when heartbeat is old (dry-run mode)

## Test Plan

- [ ] `bash -n` syntax check passes on all scripts
- [ ] `shellcheck -S warning` passes
- [ ] No personal identifiers in committed files
- [ ] All 6 new bats tests pass (`bats tests/scanner-heartbeat.bats`)
- [ ] Manual: after `install.sh --bootstrap`, confirm `com.user.loop-scanner-watchdog` appears in `launchctl list`
- [ ] Manual: simulate wedge with `kill -STOP $SCANNER_PID`; within 10 min watchdog should kill and launchd should restart