### PR TITLE
[LOOP-413] scanner: liveness heartbeat + watchdog auto-restart

### DIFF
--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if it stops emitting heartbeats.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written every tick by scanner.sh).
+# If the file is missing or its mtime exceeds 2 × POLL_INTERVAL (default 10 min),
+# the scanner is considered wedged: kill the PID from /tmp/loop-scanner.lock so
+# launchd (KeepAlive=true) or cron restarts it.
+#
+# Designed to run every 5 min via launchd StartInterval or cron.
+# Linux fallback: if launchctl is absent, kill the PID and let cron or the
+# process supervisor restart it independently.
+#
+# Flags:
+#   --dry-run   print verdict without killing
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+LOCK_FILE="${LOOP_SCANNER_LOCK:-/tmp/loop-scanner.lock}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+MAX_SILENCE=$(( POLL_INTERVAL * 2 ))
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _file_age_seconds <path>
+# Returns seconds since the file was last modified, or a large number if absent.
+_file_age_seconds() {
+    local path="$1"
+    [ -f "$path" ] || { echo 999999; return 0; }
+    local mtime now
+    mtime=$(stat -f%m "$path" 2>/dev/null || stat -c%Y "$path" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+age=$(_file_age_seconds "$HEARTBEAT_FILE")
+log "heartbeat age=${age}s threshold=${MAX_SILENCE}s heartbeat=${HEARTBEAT_FILE}"
+
+if [ "$age" -lt "$MAX_SILENCE" ]; then
+    log "scanner is alive (age ${age}s < ${MAX_SILENCE}s) — nothing to do"
+    exit 0
+fi
+
+log "WARN: scanner appears wedged — heartbeat silent for ${age}s (threshold=${MAX_SILENCE}s)"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would restart scanner"
+    exit 0
+fi
+
+# Kill the recorded PID so launchd / the supervisor restarts it.
+if [ -f "$LOCK_FILE" ]; then
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "killing wedged scanner PID $pid"
+        kill "$pid" 2>/dev/null || true
+        sleep 2
+    else
+        log "lock file present but PID ${pid:-<empty>} not alive — removing stale lock"
+        rm -f "$LOCK_FILE"
+    fi
+else
+    log "no lock file at $LOCK_FILE — scanner may have already exited"
+fi
+
+# On macOS: kickstart via launchctl so launchd brings it back immediately
+# rather than waiting for ThrottleInterval.
+SCANNER_LABEL="${LOOP_SCANNER_LAUNCHD_LABEL:-com.user.loop-scanner}"
+if command -v launchctl >/dev/null 2>&1; then
+    if launchctl list "$SCANNER_LABEL" >/dev/null 2>&1; then
+        log "launchctl kickstart gui/$(id -u)/${SCANNER_LABEL}"
+        launchctl kickstart "gui/$(id -u)/${SCANNER_LABEL}" 2>/dev/null \
+            || launchctl start "$SCANNER_LABEL" 2>/dev/null \
+            || log "WARN: launchctl kickstart failed — launchd will retry via KeepAlive"
+    else
+        log "launchd service $SCANNER_LABEL not loaded — KeepAlive will restart on next tick"
+    fi
+else
+    log "launchctl not available — scanner will be restarted by its supervisor"
+fi
+
+log "watchdog done"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -774,8 +774,16 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+
+_write_heartbeat() {
+    $DRY_RUN && return 0
+    date '+%Y-%m-%d %H:%M:%S' > "$HEARTBEAT_FILE" 2>/dev/null || true
+}
+
 run_once() {
     log "=== scan tick start ==="
+    _write_heartbeat
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes; checks scanner-heartbeat mtime; if stale, kills
+  the wedged scanner so launchd (KeepAlive=true) restarts it immediately.
+
+  Install:
+    sed "s|__LOOP_ROOT__|$(cd "$(dirname "$0")/.." && pwd)|g; \
+         s|__LOG_DIR__|$LOOP_LOG_DIR|g; \
+         s|__HOME__|$HOME|g; \
+         s|__EXTRA_PATH__|${LOOP_EXTRA_PATH:-/opt/homebrew/bin:/usr/local/bin}|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,124 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — scanner liveness heartbeat (#413).
+#
+# Verifies that _write_heartbeat creates / updates the heartbeat file on every
+# tick, and that scanner-watchdog.sh exits cleanly when the file is fresh and
+# detects staleness when it is old.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Minimal mock-gh so env.sh can source workflow.sh without side effects.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner function definitions (same strategy as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+    DRY_RUN=false
+
+    log() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/bin" "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# _write_heartbeat
+# ---------------------------------------------------------------------------
+
+@test "_write_heartbeat: creates heartbeat file when absent" {
+    rm -f "$HEARTBEAT_FILE"
+    _write_heartbeat
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "_write_heartbeat: updates mtime on every call" {
+    _write_heartbeat
+    local t1
+    t1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+    # Wait at least 1 second so mtime resolution shows a difference.
+    sleep 1.1
+    _write_heartbeat
+    local t2
+    t2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+    [ "$t2" -gt "$t1" ]
+}
+
+@test "_write_heartbeat: writes current timestamp in readable form" {
+    _write_heartbeat
+    local content
+    content=$(cat "$HEARTBEAT_FILE")
+    # Matches YYYY-MM-DD HH:MM:SS
+    [[ "$content" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\ [0-9]{2}:[0-9]{2}:[0-9]{2}$ ]]
+}
+
+@test "_write_heartbeat: no-op in dry-run mode" {
+    DRY_RUN=true
+    rm -f "$HEARTBEAT_FILE"
+    _write_heartbeat
+    [ ! -f "$HEARTBEAT_FILE" ]
+    DRY_RUN=false
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh — integration tests
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits 0 when heartbeat is fresh" {
+    # Write a fresh heartbeat (age ≈ 0 s).
+    date '+%Y-%m-%d %H:%M:%S' > "$HEARTBEAT_FILE"
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner is alive"* ]]
+}
+
+@test "scanner-watchdog: detects stale heartbeat and reports wedge" {
+    # Set LOOP_SCANNER_INTERVAL=60 so threshold=120s; file is 300s old → stale.
+    export LOOP_SCANNER_INTERVAL=60
+
+    touch "$HEARTBEAT_FILE"
+    python3 -c "
+import os, time
+path = '$HEARTBEAT_FILE'
+old = time.time() - 300
+os.utime(path, (old, old))
+"
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"wedged"* ]]
+    [[ "$output" == *"DRY-RUN"* ]]
+    unset LOOP_SCANNER_INTERVAL
+}
+
+@test "scanner-watchdog: treats missing heartbeat as stale" {
+    export LOOP_SCANNER_INTERVAL=60
+    rm -f "$HEARTBEAT_FILE"
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"wedged"* ]]
+    unset LOOP_SCANNER_INTERVAL
+}


### PR DESCRIPTION
Closes #413

## Changes

- **`scanner/scanner.sh`**: `_write_heartbeat()` writes the current timestamp to `${LOOP_LOG_DIR}/scanner-heartbeat` at the start of every tick via `run_once()`. No-op in dry-run mode.

- **`scanner/scanner-watchdog.sh`** (new): Runs every 5 min via launchd. Reads `scanner-heartbeat` mtime; if silent for `> 2 × LOOP_SCANNER_INTERVAL` (default 10 min), kills the wedged scanner PID from the lock file so launchd (KeepAlive=true) auto-restarts it. On macOS, uses `launchctl kickstart` for immediate restart rather than waiting for ThrottleInterval.

- **`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new): Launchd plist template for the watchdog. StartInterval=300 (5 min). Follows the same `__LOOP_ROOT__` / `__LOG_DIR__` / `__HOME__` substitution pattern as existing plist templates.

- **`tests/scanner-heartbeat.bats`** (new): 7 tests — 4 for `_write_heartbeat` (creates file, updates mtime, correct timestamp format, no-op in dry-run) and 3 for `scanner-watchdog.sh` (fresh heartbeat → alive, stale heartbeat → wedge + DRY-RUN, missing heartbeat → wedge).

## Test Plan

- `bash -n` + `shellcheck -S warning` — both pass (all scripts)
- `bats tests/scanner-heartbeat.bats` — 7/7 pass
- Existing `bats tests/scanner.bats` failures are pre-existing (label renames) and unrelated to this change
- Manual: `kill -STOP $SCANNER_PID` for 10+ min → watchdog logs "wedged" and kills/restarts; `kill -CONT` before watchdog fires → watchdog logs "alive"