### PR TITLE
[LOOP-413] scanner: liveness heartbeat + watchdog auto-restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — fires every 5 min, kills a wedged scanner so
+    # launchd auto-restarts it. Installed after scanner so it has something to watch.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — detect and restart a wedged scanner process.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written by scanner.sh on every tick).
+# If the file is absent or its mtime exceeds STALE_THRESHOLD_SECONDS (default
+# 2 × LOOP_SCANNER_INTERVAL = 10 min at default settings), the scanner is
+# considered wedged and its PID is killed; launchd (macOS) or cron (Linux) then
+# restarts it automatically.
+#
+# Usage:
+#   scanner-watchdog.sh             # one-shot check (for launchd StartInterval / cron)
+#   scanner-watchdog.sh --dry-run   # print verdict without killing
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_SCANNER_WATCHDOG_STALE_SECONDS:-$(( POLL_INTERVAL * 2 ))}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _heartbeat_age_seconds — prints seconds since heartbeat file was last modified.
+# Returns 1 (prints nothing) if the file does not exist.
+_heartbeat_age_seconds() {
+    [ -f "$HEARTBEAT_FILE" ] || return 1
+    local mtime now
+    mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+        || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+        || return 1)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+# _scanner_pid — read PID from lock file if the process is still alive.
+# Prints the PID or prints nothing.
+_scanner_pid() {
+    [ -f "$LOCK_FILE" ] || return 0
+    local pid
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    [ -n "$pid" ] || return 0
+    kill -0 "$pid" 2>/dev/null && echo "$pid" || true
+}
+
+main() {
+    local age pid verdict="ok"
+
+    if ! age=$(_heartbeat_age_seconds); then
+        pid=$(_scanner_pid)
+        if [ -n "$pid" ]; then
+            log "WARN: scanner PID $pid running but no heartbeat file — pre-first-tick or heartbeat disabled"
+        else
+            log "heartbeat file absent and no scanner lock — nothing to watch"
+        fi
+        log "verdict=ok"
+        return 0
+    fi
+
+    log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+    if [ "$age" -ge "$STALE_THRESHOLD" ]; then
+        verdict="stale"
+        pid=$(_scanner_pid)
+        if [ -n "$pid" ]; then
+            if $DRY_RUN; then
+                log "DRY-RUN: would kill wedged scanner PID $pid (heartbeat age=${age}s >= threshold=${STALE_THRESHOLD}s)"
+            else
+                log "WARN: scanner wedged — killing PID $pid (heartbeat age=${age}s >= threshold=${STALE_THRESHOLD}s)"
+                kill "$pid" 2>/dev/null || log "WARN: kill $pid failed (already gone?)"
+                log "scanner killed — launchd/cron will restart it"
+            fi
+        else
+            log "WARN: stale heartbeat (age=${age}s) but no live scanner PID — scanner may have already exited"
+        fi
+    fi
+
+    log "verdict=${verdict}"
+}
+
+main

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -63,6 +64,23 @@ for arg in "$@"; do
 done
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] $*"; }
+
+# _write_heartbeat — touch HEARTBEAT_FILE with current epoch so the watchdog
+# can detect a wedged scanner by comparing mtime to now.
+_write_heartbeat() {
+    printf '%s\n' "$(date +%s)" > "$HEARTBEAT_FILE" 2>/dev/null || true
+}
+
+# _check_stdout_health — if the log file is no longer writable (e.g. rotated
+# away with our FD pointing at a deleted inode), reopen it. If reopening also
+# fails, exit so launchd/cron restarts us with clean FDs.
+_check_stdout_health() {
+    [ -n "${LOG_FILE:-}" ] || return 0
+    if ! echo "" >> "$LOG_FILE" 2>/dev/null; then
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" \
+            || { echo "$(date '+%Y-%m-%d %H:%M:%S') [scanner] FATAL: cannot reopen log — exiting for restart" >&2; exit 1; }
+    fi
+}
 
 # _scanner_jobs_enqueue <slug> <stage> <num>
 # Best-effort dual-write to the jobs table alongside the legacy label-event path.
@@ -775,6 +793,8 @@ scan_project() {
 }
 
 run_once() {
+    $DRY_RUN || _check_stdout_health
+    $DRY_RUN || _write_heartbeat
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+  Fires every 5 minutes; kills a wedged scanner so launchd auto-restarts it.
+
+  Installed automatically by install.sh --bootstrap.
+  Manual install:
+    sed "s|__LOOP_ROOT__|$(pwd)|g; s|__LOG_DIR__|$LOOP_LOG_DIR|g; \
+         s|__HOME__|$HOME|g; s|__EXTRA_PATH__|/opt/homebrew/bin:/usr/local/bin|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,110 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 scanner liveness heartbeat.
+#
+# Verifies:
+#   1. _write_heartbeat creates / updates HEARTBEAT_FILE on every tick.
+#   2. scanner-watchdog.sh reports verdict=ok when heartbeat is fresh.
+#   3. scanner-watchdog.sh reports verdict=stale when heartbeat is old.
+#   4. scanner-watchdog.sh handles absent heartbeat + no lock gracefully.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Source scanner.sh function definitions only (same pattern as scanner.bats).
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    STAGE_AGE_DIR="$BATS_TMPDIR/stage-age"
+    mkdir -p "$DEDUP_DIR" "$STAGE_AGE_DIR"
+
+    log() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/stage-age" "$BATS_TMPDIR/scanner-src.sh" \
+           "$BATS_TMPDIR/scanner-test.log" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# _write_heartbeat
+# ---------------------------------------------------------------------------
+
+@test "_write_heartbeat: creates HEARTBEAT_FILE" {
+    rm -f "$HEARTBEAT_FILE"
+    _write_heartbeat
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "_write_heartbeat: file contains a numeric epoch" {
+    _write_heartbeat
+    local ts
+    ts=$(cat "$HEARTBEAT_FILE")
+    [[ "$ts" =~ ^[0-9]+$ ]]
+}
+
+@test "_write_heartbeat: mtime advances on second call" {
+    _write_heartbeat
+    local t1
+    t1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE")
+    sleep 1
+    _write_heartbeat
+    local t2
+    t2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE")
+    [ "$t2" -ge "$t1" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: verdict=ok when heartbeat is fresh" {
+    printf '%s\n' "$(date +%s)" > "$LOOP_LOG_DIR/scanner-heartbeat"
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        LOOP_SCANNER_INTERVAL=300 \
+        LOOP_SCANNER_WATCHDOG_STALE_SECONDS=600 \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"verdict=ok"* ]]
+}
+
+@test "scanner-watchdog: verdict=stale when heartbeat is old" {
+    # Write a timestamp 20 minutes in the past and backdate the file.
+    printf '%s\n' "$(( $(date +%s) - 1200 ))" > "$LOOP_LOG_DIR/scanner-heartbeat"
+    touch -t "$(date -d '20 minutes ago' '+%Y%m%d%H%M' 2>/dev/null \
+        || date -v-20M '+%Y%m%d%H%M')" "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null || true
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        LOOP_SCANNER_INTERVAL=300 \
+        LOOP_SCANNER_WATCHDOG_STALE_SECONDS=600 \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"stale"* ]]
+}
+
+@test "scanner-watchdog: absent heartbeat with no lock exits 0" {
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        LOOP_SCANNER_INTERVAL=300 \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- Added `HEARTBEAT_FILE` variable (`${LOOP_LOG_DIR}/scanner-heartbeat`)
- Added `_write_heartbeat()`: writes current epoch to the heartbeat file at the top of every tick
- Added `_check_stdout_health()`: verifies the log file is writable before each tick; reopens FDs if needed, exits if reopen fails (triggering launchd/cron restart)
- Both called from `run_once()` before the tick body; skipped in `--dry-run` mode

### `scanner/scanner-watchdog.sh` (new)
- Reads heartbeat mtime; if age ≥ `LOOP_SCANNER_WATCHDOG_STALE_SECONDS` (default `2 × LOOP_SCANNER_INTERVAL` = 10 min), kills the wedged scanner PID so launchd/cron restarts it
- `--dry-run` flag: prints verdict without killing any PID
- Safe when heartbeat file is absent and no lock exists (scanner not yet started)
- Logs `verdict=ok` or `verdict=stale` for easy grep/monitoring

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- `StartInterval=300` (every 5 min), `RunAtLoad=false` — intentionally one-shot, not KeepAlive
- Same `__LOOP_ROOT__` / `__LOG_DIR__` / `__HOME__` / `__EXTRA_PATH__` substitution tokens

### `install.sh`
- `bootstrap_register_launchd`: registers `com.user.loop-scanner-watchdog` plist (idempotent — skips if already present)
- `bootstrap_register_cron`: adds `*/5 * * * *` watchdog cron entry (idempotent)

### `tests/scanner-heartbeat.bats` (new)
- 6 bats tests: heartbeat file creation, epoch content, mtime advance; watchdog ok/stale/absent verdicts

## Test Plan
- `bats tests/scanner-heartbeat.bats` — all 6 tests pass
- `bash -n` syntax check passes on all scripts
- `shellcheck -S warning` passes on all scripts
- No personal identifiers introduced
- Manual: `kill -STOP $SCANNER_PID` → watchdog kills it within 10 min, launchd restarts