### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — kills a wedged scanner process and lets launchd
+    # restart it. Fires every 5 min; acts only when heartbeat is stale (>900 s).
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -363,6 +382,9 @@ bootstrap_register_cron() {
     local reconciler_marker="# loop-reconciler"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+
+    local watchdog_marker="# loop-scanner-watchdog"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/restart-scanner-if-stale.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +404,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/restart-scanner-if-stale.sh
+++ b/scanner/restart-scanner-if-stale.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# restart-scanner-if-stale.sh — scanner liveness watchdog.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written by scanner.sh at the start
+# of every tick). If the file is older than LOOP_SCANNER_WATCHDOG_STALE_SECONDS
+# (default 900 = 3× the default 300 s poll interval) AND a scanner PID is alive
+# in the lock file (confirming a wedged rather than stopped process), kills the
+# PID and, on macOS, issues a launchctl kickstart so KeepAlive fires immediately.
+# On Linux, killing the PID is sufficient — cron re-launches the scanner within
+# the next 5-minute slot.
+#
+# Designed to run every 5 min via launchd (StartInterval 300) or cron (*/5).
+# Install via: ./install.sh --bootstrap  (adds the launchd plist / cron entry).
+#
+# Flags:
+#   --dry-run   report stale status without killing or restarting
+#   -h|--help   print this header
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+STALE_SECONDS="${LOOP_SCANNER_WATCHDOG_STALE_SECONDS:-900}"
+LOCK_FILE="/tmp/loop-scanner.lock"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _file_age_seconds <path>
+# Returns the number of seconds since the file was last modified.
+# Supports both macOS (stat -f%m) and Linux (stat -c%Y).
+_file_age_seconds() {
+    local path="$1"
+    local mtime
+    mtime=$(stat -f%m "$path" 2>/dev/null || stat -c%Y "$path" 2>/dev/null || echo 0)
+    echo $(( $(date +%s) - mtime ))
+}
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "no heartbeat file at $HEARTBEAT_FILE — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+age=$(_file_age_seconds "$HEARTBEAT_FILE")
+
+if [ "$age" -lt "$STALE_SECONDS" ]; then
+    log "heartbeat ok (age=${age}s < threshold=${STALE_SECONDS}s)"
+    exit 0
+fi
+
+log "STALE: heartbeat age=${age}s >= threshold=${STALE_SECONDS}s"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would restart scanner (heartbeat stale)"
+    exit 0
+fi
+
+# Kill the wedged scanner process so launchd/cron can restart it.
+if [ -f "$LOCK_FILE" ]; then
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "killing stale scanner PID $pid"
+        kill "$pid" 2>/dev/null || true
+    else
+        log "lock file present but PID ${pid:-unknown} is not alive — lock is already stale"
+    fi
+else
+    log "no lock file found at $LOCK_FILE"
+fi
+
+# On macOS, kickstart immediately rather than waiting for the next KeepAlive cycle.
+if command -v launchctl >/dev/null 2>&1; then
+    if launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null; then
+        log "launchctl kickstart issued for com.user.loop-scanner"
+    else
+        log "launchctl kickstart failed or service not loaded — scanner will restart via KeepAlive"
+    fi
+fi
+
+log "restart triggered"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -775,6 +775,8 @@ scan_project() {
 }
 
 run_once() {
+    # Heartbeat: update mtime so the scanner watchdog can detect a wedged process.
+    touch "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Runs restart-scanner-if-stale.sh every 5 minutes. The script reads
+  ${LOOP_LOG_DIR}/scanner-heartbeat (written by scanner.sh each tick).
+  If the heartbeat is older than LOOP_SCANNER_WATCHDOG_STALE_SECONDS
+  (default 900 s), it kills the wedged scanner PID and issues a
+  launchctl kickstart so the KeepAlive scanner restarts immediately.
+
+  Install (handled automatically by: ./install.sh --bootstrap):
+    sed -e "s|__LOOP_ROOT__|/path/to/loop|g" \
+        -e "s|__LOG_DIR__|$LOOP_LOG_DIR|g" \
+        -e "s|__HOME__|$HOME|g" \
+        -e "s|__EXTRA_PATH__|/opt/homebrew/bin:/usr/local/bin|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/restart-scanner-if-stale.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <!-- Fire every 5 minutes (300 s) -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- Write `touch ${LOOP_LOG_DIR}/scanner-heartbeat` at the start of every `run_once()` tick. This gives the watchdog a reliable mtime-based liveness signal — if the file goes stale, the scanner is either wedged in a tick or stuck in the sleep loop with a broken state.

### `scanner/restart-scanner-if-stale.sh` (new)
- Sources `lib/env.sh` for `LOOP_LOG_DIR` and env config.
- Reads mtime of `scanner-heartbeat`. If older than `LOOP_SCANNER_WATCHDOG_STALE_SECONDS` (default 900 s = 3× the default 300 s poll interval), kills the PID recorded in `/tmp/loop-scanner.lock`.
- On macOS, issues `launchctl kickstart -k gui/<uid>/com.user.loop-scanner` so KeepAlive fires immediately rather than waiting for the next restart cycle.
- On Linux, killing the PID is sufficient — cron relaunches within the next 5-minute slot.
- Supports `--dry-run` for manual inspection.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- `StartInterval 300` (every 5 min), `RunAtLoad false` (no false-positive on fresh install).
- Uses the same `__LOOP_ROOT__` / `__LOG_DIR__` / `__HOME__` / `__EXTRA_PATH__` substitution pattern as all other templates. Logs to `loop-scanner-watchdog.log`.

### `install.sh`
- `bootstrap_register_launchd()`: installs and loads `com.user.loop-scanner-watchdog.plist` after the digest agent.
- `bootstrap_register_cron()`: adds `*/5 * * * *` watchdog cron entry alongside the existing scanner and reconciler entries.

## Test Plan
- Simulate wedge on macOS: `kill -STOP $SCANNER_PID` → within 15 min the watchdog should log "STALE" and restart the scanner.
- Dry-run: `scanner/restart-scanner-if-stale.sh --dry-run` with a stale heartbeat should print "DRY-RUN: would restart" without touching the process.
- Fresh install: `./install.sh --bootstrap` should register four launchd agents including `com.user.loop-scanner-watchdog`.
- Heartbeat presence: after the scanner runs one tick, `${LOOP_LOG_DIR}/scanner-heartbeat` should exist and have a recent mtime.
- No false positives: during normal operation (heartbeat < 900 s old) the watchdog exits with "heartbeat ok".