### PR TITLE
[LOOP-413] scanner: heartbeat file + external watchdog for silent-stop detection

### DIFF
--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if it stops emitting heartbeats.
+#
+# Run every 5 minutes by launchd (macOS) or cron (Linux).
+# If the scanner heartbeat file is older than 2×POLL_INTERVAL the scanner is
+# considered wedged: we kill the PID in the lock file and let launchd/cron
+# restart it via KeepAlive=true.
+#
+# Usage:
+#   scanner-watchdog.sh           # normal run
+#   scanner-watchdog.sh --dry-run # print verdict without killing
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+LOCK_FILE="/tmp/loop-scanner.lock"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD=$(( 2 * POLL_INTERVAL ))
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -15
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "no heartbeat file at $HEARTBEAT_FILE — scanner not yet started; skipping"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+    || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+    || echo 0)
+age=$(( now - mtime ))
+
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -le "$STALE_THRESHOLD" ]; then
+    log "ok — scanner is alive"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat is stale (${age}s > ${STALE_THRESHOLD}s) — triggering restart"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID and let launchd restart it"
+    exit 0
+fi
+
+# Kill the wedged scanner process so launchd/cron restarts it.
+if [ -f "$LOCK_FILE" ]; then
+    local_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    if [ -n "$local_pid" ] && kill -0 "$local_pid" 2>/dev/null; then
+        log "killing wedged scanner PID $local_pid"
+        kill "$local_pid" 2>/dev/null || true
+    else
+        log "lock file present but PID ${local_pid:-<empty>} is not alive — cleaning up"
+        rm -f "$LOCK_FILE"
+    fi
+fi
+
+# On macOS with launchd: kickstart the service so it restarts immediately
+# instead of waiting for the ThrottleInterval.
+if command -v launchctl >/dev/null 2>&1; then
+    local_label="gui/$(id -u)/com.user.loop-scanner"
+    if launchctl print "$local_label" >/dev/null 2>&1; then
+        log "kickstarting launchd service $local_label"
+        launchctl kickstart -k "$local_label" 2>/dev/null || true
+    fi
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -774,8 +774,30 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+# _scanner_write_heartbeat — update the liveness file every tick.
+# An external watchdog reads this file; if mtime is older than 2×POLL_INTERVAL
+# the scanner is considered wedged and the watchdog kills + restarts it.
+_scanner_write_heartbeat() {
+    $DRY_RUN && return 0
+    printf '%s\n' "$(date +%s)" > "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+}
+
+# _scanner_check_log_writable — if the log file exists but is no longer
+# writable (e.g. FD points at a deleted/rotated inode), reopen it.
+# Exit so launchd restarts cleanly if reopen fails.
+_scanner_check_log_writable() {
+    [ -n "${LOG_FILE:-}" ] || return 0
+    if [ -e "$LOG_FILE" ] && [ ! -w "$LOG_FILE" ]; then
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" || exit 1
+    fi
+}
+
 run_once() {
-    log "=== scan tick start ==="
+    _scanner_check_log_writable
+    _scanner_write_heartbeat
+    local _dedup_count
+    _dedup_count=$(find "$DEDUP_DIR" -type f 2>/dev/null | wc -l | tr -d ' ')
+    log "=== scan tick start === ts=$(date +%s) dedup_count=${_dedup_count}"
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+  Fires every 5 minutes. If the scanner heartbeat file is older than
+  2×LOOP_SCANNER_INTERVAL (default 10 min), kills the wedged scanner so
+  launchd restarts it via the scanner's own KeepAlive=true plist.
+
+  Install:
+    sed "s|__LOOP_ROOT__|$(cd "$(dirname "$0")/.." && pwd)|g; \
+         s|__LOG_DIR__|$LOOP_LOG_DIR|g; \
+         s|__HOME__|$HOME|g; \
+         s|__EXTRA_PATH__|${LOOP_EXTRA_PATH:-/opt/homebrew/bin:/usr/local/bin}|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <!-- Fire every 5 minutes. -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 liveness heartbeat.
+#
+# Verifies that:
+#   1. _scanner_write_heartbeat creates/updates ${LOOP_LOG_DIR}/scanner-heartbeat
+#   2. The heartbeat file is updated on every run_once() tick.
+#   3. scanner-watchdog.sh exits cleanly when heartbeat is fresh.
+#   4. scanner-watchdog.sh triggers kill logic when heartbeat is stale
+#      (dry-run mode — no actual kill).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Source scanner.sh function definitions only (same awk filter as scanner.bats).
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    log() { :; }
+    dispatch_direct() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/scanner-test.log" "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# _scanner_write_heartbeat
+# ---------------------------------------------------------------------------
+
+@test "_scanner_write_heartbeat: creates heartbeat file in LOOP_LOG_DIR" {
+    _scanner_write_heartbeat
+    [ -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+@test "_scanner_write_heartbeat: file contains a unix timestamp" {
+    _scanner_write_heartbeat
+    local content
+    content=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+    [ -n "$content" ]
+    [[ "$content" =~ ^[0-9]+$ ]]
+}
+
+@test "_scanner_write_heartbeat: updates mtime on second call" {
+    _scanner_write_heartbeat
+    local before_content
+    before_content=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+
+    # Ensure at least 1 second passes so timestamp changes.
+    sleep 1
+
+    _scanner_write_heartbeat
+    local after_content
+    after_content=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+
+    # Timestamp must be >= before (monotone).
+    [ "$after_content" -ge "$before_content" ]
+}
+
+@test "_scanner_write_heartbeat: skipped in dry-run mode" {
+    DRY_RUN=true
+    _scanner_write_heartbeat
+    [ ! -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+# ---------------------------------------------------------------------------
+# run_once writes heartbeat
+# ---------------------------------------------------------------------------
+
+@test "run_once: heartbeat file exists after one tick" {
+    # Stub out everything so run_once completes without hitting GitHub.
+    loop_list_slugs()      { return 0; }
+    jobs_init_schema()     { return 0; }
+    _sweep_stale_locks()   { return 0; }
+
+    run_once
+
+    [ -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh — behavioural tests
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog.sh: exits 0 without error when heartbeat file is fresh" {
+    # Create a fresh heartbeat file (mtime = now).
+    touch "${LOOP_LOG_DIR}/scanner-heartbeat"
+
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ok — scanner is alive"* ]]
+}
+
+@test "scanner-watchdog.sh: exits 0 when no heartbeat file exists yet" {
+    rm -f "${LOOP_LOG_DIR}/scanner-heartbeat"
+
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner not yet started"* ]]
+}
+
+@test "scanner-watchdog.sh: reports stale heartbeat in dry-run mode" {
+    # Write a heartbeat with a past timestamp (mtime set to epoch).
+    touch -t 197001010000 "${LOOP_LOG_DIR}/scanner-heartbeat"
+
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"stale"* ]]
+    [[ "$output" == *"DRY-RUN"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- Added `_scanner_write_heartbeat()` — writes current unix timestamp to `${LOOP_LOG_DIR}/scanner-heartbeat` at the start of every tick (skipped in `--dry-run` mode). An external watchdog reads this file; stale mtime means the scanner is wedged.
- Added `_scanner_check_log_writable()` — at the start of each tick, verifies the log file is still writable. If the inode has been rotated and is no longer writable, reopens FDs 1+2 against the path; exits so launchd restarts cleanly if reopen fails.
- Extended the `=== scan tick start ===` log line to include `ts=<epoch>` and `dedup_count=<n>` so silent-stop is visible in logs without a separate dashboard.

### scanner/scanner-watchdog.sh (new)
- Standalone watchdog script that fires every 5 minutes (via launchd or cron).
- Reads `scanner-heartbeat` mtime; if age > `2 × LOOP_SCANNER_INTERVAL` (default 600s) the scanner is considered wedged.
- Kills the PID recorded in the lock file; on macOS also calls `launchctl kickstart` on the scanner service so it restarts immediately rather than waiting for `ThrottleInterval`.
- Supports `--dry-run` for safe testing.

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
- launchd plist template for the watchdog, firing every 300s (`StartInterval`).
- Follows the same placeholder convention (`__LOOP_ROOT__`, `__LOG_DIR__`, `__HOME__`, `__EXTRA_PATH__`) as the existing scanner plist template.

### tests/scanner-heartbeat.bats (new)
- 8 bats tests covering: heartbeat file creation, timestamp content, mtime update, dry-run skip, heartbeat written by `run_once()`, and all three watchdog scenarios (fresh / missing / stale heartbeat).

## Test Plan
- `bats tests/scanner-heartbeat.bats` — all 8 tests pass.
- `bash -n` + `shellcheck -S warning` on all `lib/*.sh scripts/*.sh scanner/*.sh install.sh` — clean.
- No personal identifiers introduced.
- Manual: simulate wedge with `kill -STOP $SCANNER_PID`; watchdog should trigger restart within 10 min (2 × 300s threshold + up to 300s watchdog cadence).