### PR TITLE
[LOOP-413] scanner: heartbeat file + liveness watchdog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — fires every 5 min, restarts scanner if
+    # heartbeat file is stale (default threshold: 15 min / 900 s).
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart a silently-wedged scanner.
+#
+# Reads the heartbeat file written by scanner.sh every tick.
+# If the file is missing or its mtime is older than LOOP_SCANNER_STALE_THRESHOLD
+# seconds (default 900 = 15 min), the scanner is considered wedged and is
+# restarted via launchctl kickstart (macOS) or by killing the PID (Linux).
+#
+# Usage (run every 5 min via launchd StartInterval or cron):
+#   scanner-watchdog.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+LOG_FILE="${LOOP_LOG_DIR}/loop-scanner-watchdog.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="${LOOP_LOG_DIR}/loop-scanner.lock"
+STALE_THRESHOLD="${LOOP_SCANNER_STALE_THRESHOLD:-900}"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*" | tee -a "$LOG_FILE"; }
+
+_scanner_pid() {
+    cat "$LOCK_FILE" 2>/dev/null || true
+}
+
+_heartbeat_age() {
+    if [ ! -f "$HEARTBEAT_FILE" ]; then
+        echo 99999
+        return
+    fi
+    local mtime now
+    mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+         || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+         || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+_restart_scanner() {
+    local pid="$1"
+    log "Restarting wedged scanner (PID=${pid:-unknown})"
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        kill "$pid" 2>/dev/null || true
+        sleep 2
+    fi
+    if command -v launchctl >/dev/null 2>&1; then
+        launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null \
+            || log "WARN: launchctl kickstart failed — scanner will restart on next KeepAlive cycle"
+    else
+        log "INFO: no launchctl; scanner will be re-spawned by cron on next tick"
+    fi
+}
+
+age=$(_heartbeat_age)
+pid=$(_scanner_pid)
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "OK: heartbeat age=${age}s (threshold=${STALE_THRESHOLD}s)"
+    exit 0
+fi
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "WARN: heartbeat file missing — scanner may not have started yet (threshold=${STALE_THRESHOLD}s)"
+else
+    log "STALE: heartbeat age=${age}s >= threshold=${STALE_THRESHOLD}s — scanner appears wedged"
+fi
+
+_restart_scanner "$pid"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -775,6 +775,20 @@ scan_project() {
 }
 
 run_once() {
+    # Log-file integrity guard: if the log file path exists but is not writable,
+    # exit so launchd/cron restarts the scanner with a fresh log FD.
+    if [ -n "${LOG_FILE:-}" ] && [ -e "$LOG_FILE" ] && [ ! -w "$LOG_FILE" ]; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] FATAL: log file not writable — exiting for restart" >&2
+        exit 1
+    fi
+
+    # Heartbeat: write current epoch to a file so an external watchdog can
+    # detect a silently-wedged scanner (alive PID, no tick activity).
+    if ! $DRY_RUN; then
+        local _hb_file="${LOOP_LOG_DIR}/scanner-heartbeat"
+        date +%s > "$_hb_file" 2>/dev/null || true
+    fi
+
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes, reads the scanner heartbeat file, and restarts
+  the scanner if the heartbeat is older than LOOP_SCANNER_STALE_THRESHOLD
+  seconds (default 900 s = 15 min).
+
+  Installed automatically by: ./install.sh --bootstrap
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verify scanner writes heartbeat file every tick.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { :; }
+    LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+@test "run_once: heartbeat file is created on first tick" {
+    local hb_file="${LOOP_LOG_DIR}/scanner-heartbeat"
+    [ ! -f "$hb_file" ]
+    run_once
+    [ -f "$hb_file" ]
+}
+
+@test "run_once: heartbeat file contains a unix timestamp" {
+    run_once
+    local hb_file="${LOOP_LOG_DIR}/scanner-heartbeat"
+    local ts
+    ts=$(cat "$hb_file")
+    # Timestamp should be a number and > 1000000000 (year 2001)
+    [[ "$ts" =~ ^[0-9]+$ ]]
+    [ "$ts" -gt 1000000000 ]
+}
+
+@test "run_once: heartbeat file mtime is updated on each tick" {
+    run_once
+    local hb_file="${LOOP_LOG_DIR}/scanner-heartbeat"
+    local mtime1
+    mtime1=$(stat -f%m "$hb_file" 2>/dev/null || stat -c%Y "$hb_file" 2>/dev/null)
+
+    sleep 1
+    run_once
+
+    local mtime2
+    mtime2=$(stat -f%m "$hb_file" 2>/dev/null || stat -c%Y "$hb_file" 2>/dev/null)
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once: heartbeat file is NOT written in dry-run mode" {
+    DRY_RUN=true
+    local hb_file="${LOOP_LOG_DIR}/scanner-heartbeat"
+    run_once
+    [ ! -f "$hb_file" ]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- Added log-file integrity guard at the top of `run_once`: if `LOG_FILE` exists but is not writable, the scanner exits immediately so launchd/cron can restart it with a fresh FD.
- Added heartbeat write at the top of `run_once`: each tick writes the current epoch to `${LOOP_LOG_DIR}/scanner-heartbeat`. Skipped in `--dry-run` mode. This gives an external watchdog a monotonically-updated mtime to check.

### `scanner/scanner-watchdog.sh` (new)
- Reads the heartbeat file mtime. If age >= `LOOP_SCANNER_STALE_THRESHOLD` (default 900 s / 15 min), kills the scanner PID (from the lock file) and uses `launchctl kickstart` on macOS (or relies on cron re-invocation on Linux) to restart it.
- Logs to `${LOOP_LOG_DIR}/loop-scanner-watchdog.log`.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- launchd plist that fires every 5 minutes (`StartInterval=300`).
- Installed by `./install.sh --bootstrap`.

### `install.sh`
- `bootstrap_register_launchd`: registers `com.user.loop-scanner-watchdog` plist (idempotent).
- `bootstrap_register_cron`: adds `*/5 * * * *` cron entry for `scanner-watchdog.sh` (idempotent, marker-guarded).

### `tests/scanner-heartbeat.bats` (new)
- Tests that `run_once` creates the heartbeat file, writes a valid epoch timestamp, updates mtime on each call, and skips the write in dry-run mode.

## Test Plan
- All CI checks pass locally: `bash -n`, `shellcheck -S warning`, no-personal-identifiers grep.
- New bats tests in `tests/scanner-heartbeat.bats` cover heartbeat creation, content, mtime update, and dry-run suppression.
- Manual: `kill -STOP $SCANNER_PID` → watchdog restarts within 15 min.