### PR TITLE
[LOOP-413] scanner: add liveness heartbeat + watchdog auto-restart

### DIFF
--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -776,6 +776,8 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Write heartbeat so the watchdog can detect a silent-stop scanner.
+    $DRY_RUN || printf '%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "${LOOP_LOG_DIR}/scanner-heartbeat"
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scripts/restart-scanner-if-stale.sh
+++ b/scripts/restart-scanner-if-stale.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# restart-scanner-if-stale.sh — Watchdog for the Loop scanner process.
+#
+# Checks the mtime of ${LOOP_LOG_DIR}/scanner-heartbeat. If the file is older
+# than STALE_THRESHOLD seconds (default 900 = 15 min, which is 3× the default
+# 300 s poll interval) the scanner is considered silently wedged and is
+# restarted via launchctl kickstart (macOS) or kill + respawn (Linux).
+#
+# Intended to be run every 5 minutes by a launchd agent (macOS) or cron (Linux).
+# The launchd plist template is: templates/launchd/com.user.loop-scanner-watchdog.plist.template
+#
+# Usage:
+#   restart-scanner-if-stale.sh [--dry-run]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+STALE_THRESHOLD="${LOOP_WATCHDOG_STALE_THRESHOLD:-900}"
+SCANNER_LAUNCHD_LABEL="${LOOP_SCANNER_LAUNCHD_LABEL:-com.user.loop-scanner}"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [watchdog] $*"; }
+
+# _file_age_seconds <path>
+# Returns the number of seconds since the file was last modified.
+# Falls back to a very large number (heartbeat counts as infinitely stale)
+# if the file does not exist or stat fails.
+_file_age_seconds() {
+    local path="$1"
+    if [ ! -f "$path" ]; then
+        echo 999999
+        return 0
+    fi
+    local mtime now
+    mtime=$(stat -f%m "$path" 2>/dev/null || stat -c%Y "$path" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+# _restart_scanner_macos — kick the launchd agent.
+_restart_scanner_macos() {
+    local label="$SCANNER_LAUNCHD_LABEL"
+    log "restarting scanner via launchctl kickstart: $label"
+    if $DRY_RUN; then
+        log "DRY-RUN: launchctl kickstart -k gui/$(id -u)/${label}"
+        return 0
+    fi
+    if launchctl kickstart -k "gui/$(id -u)/${label}" 2>/dev/null; then
+        log "launchctl kickstart succeeded"
+    else
+        log "WARN: launchctl kickstart failed; trying launchctl stop/start"
+        launchctl stop  "$label" 2>/dev/null || true
+        launchctl start "$label" 2>/dev/null || true
+    fi
+}
+
+# _restart_scanner_linux — kill the running scanner and let systemd / cron respawn it,
+# or start the scanner script directly as a background process if no service manager.
+_restart_scanner_linux() {
+    log "restarting scanner on Linux"
+    if $DRY_RUN; then
+        log "DRY-RUN: would kill scanner and respawn"
+        return 0
+    fi
+    # Attempt systemctl first (systemd environments).
+    if command -v systemctl >/dev/null 2>&1 && systemctl is-active --quiet loop-scanner 2>/dev/null; then
+        log "restarting via systemctl"
+        systemctl restart loop-scanner
+        return 0
+    fi
+    # Fallback: kill the scanner process by lock-file PID, then respawn.
+    local lock_file="/tmp/loop-scanner.lock"
+    if [ -f "$lock_file" ]; then
+        local pid
+        pid=$(cat "$lock_file" 2>/dev/null || true)
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+            log "killing wedged scanner PID $pid"
+            kill "$pid" 2>/dev/null || true
+            sleep 2
+        fi
+    fi
+    log "spawning scanner in background"
+    nohup "$LOOP_ROOT/scanner/scanner.sh" \
+        >> "${LOOP_LOG_DIR}/loop-scanner.log" 2>&1 &
+    log "scanner spawned as PID $!"
+}
+
+main() {
+    local age
+    age=$(_file_age_seconds "$HEARTBEAT_FILE")
+    log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s file=${HEARTBEAT_FILE}"
+
+    if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+        log "scanner is healthy (heartbeat ${age}s old)"
+        exit 0
+    fi
+
+    log "ALERT: scanner heartbeat is stale (${age}s > ${STALE_THRESHOLD}s) — restarting"
+
+    case "$(uname -s)" in
+        Darwin) _restart_scanner_macos ;;
+        *)      _restart_scanner_linux ;;
+    esac
+
+    log "restart triggered"
+}
+
+main "$@"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/restart-scanner-if-stale.sh</string>
+    </array>
+    <!-- Run watchdog check every 5 minutes -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Closes #413

## Changes
- `scanner/scanner.sh`: write a UTC ISO-8601 timestamp to `${LOOP_LOG_DIR}/scanner-heartbeat` on every tick. This is the observable liveness signal the watchdog consumes.
- `scripts/restart-scanner-if-stale.sh`: watchdog script — reads heartbeat mtime; if the file is absent or older than `STALE_THRESHOLD` seconds (default 900 s = 3× the 300 s poll interval) it restarts the scanner. macOS path: `launchctl kickstart -k gui/<uid>/<label>` with fallback to stop/start. Linux path: `systemctl restart loop-scanner` with fallback to kill-by-lock-PID + nohup respawn.
- `templates/launchd/com.user.loop-scanner-watchdog.plist.template`: launchd agent that runs the watchdog every 300 s (5 min) via `StartInterval`. Follows the same `__LOOP_ROOT__` / `__LOG_DIR__` / `__HOME__` substitution conventions as the existing scanner and reconciler plists.

## Test Plan
- Manual smoke: run scanner, `kill -STOP $SCANNER_PID`, wait for heartbeat to go stale, run `restart-scanner-if-stale.sh` — confirm it logs the restart
- Verify heartbeat file is written on each tick in continuous and `--once` modes (it is skipped in `--dry-run` mode intentionally)
- `bash -n` and `shellcheck -S warning` pass on all scripts (verified locally before this PR)
- No personal identifiers in committed files