### PR TITLE
[LOOP-413] scanner: liveness heartbeat + watchdog auto-restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — kills and restarts a silently-wedged scanner.
+    # Runs every 5 min; checks heartbeat file mtime against 2 × poll interval.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -775,7 +776,23 @@ scan_project() {
 }
 
 run_once() {
+    # Stdout integrity guard: if the log file has become unwritable (e.g. after
+    # log rotation leaves a stale FD), exit so launchd restarts with a fresh FD.
+    if [ -n "${LOG_FILE:-}" ] && [ ! -w "$LOG_FILE" ] 2>/dev/null; then
+        # Attempt reopen first (same path as SIGHUP handler).
+        # Redirect stdout first, then stderr separately to avoid SC2261.
+        exec 1>>"$LOG_FILE" || exit 1
+        exec 2>>"$LOG_FILE" || true
+    fi
+
     log "=== scan tick start ==="
+
+    # Write heartbeat so scanner-watchdog can detect silent-stop.
+    # File contains ISO timestamp + PID for watchdog diagnostics.
+    if ! $DRY_RUN; then
+        printf '%s pid=%s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$$" > "$HEARTBEAT_FILE" 2>/dev/null || true
+    fi
+
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — detect and recover a silently-wedged scanner.
+#
+# The scanner can become wedged (alive PID, sleep loop intact) but emit no
+# events for hours. This watchdog checks the heartbeat file written by
+# scanner.sh at every tick. If the heartbeat is stale for more than
+# 2 × POLL_INTERVAL seconds, the scanner PID is killed so launchd/cron
+# can restart it.
+#
+# Usage:
+#   scanner-watchdog.sh [--dry-run]
+#
+# Designed to run every 5 minutes via launchd (StartInterval 300) or cron.
+# On macOS launchd setups, after killing the scanner PID it also tries
+# `launchctl kickstart` to force an immediate restart without waiting for
+# KeepAlive's ThrottleInterval.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+# Stale threshold: 2 × poll interval (default 10 min). Set
+# LOOP_WATCHDOG_STALE_SECONDS to override.
+STALE_SECONDS="${LOOP_WATCHDOG_STALE_SECONDS:-$(( POLL_INTERVAL * 2 ))}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# If the heartbeat file does not exist, the scanner may never have started or
+# may be running a very old version — do not kill anything, just warn.
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file not found: $HEARTBEAT_FILE — scanner may not have started yet"
+    exit 0
+fi
+
+# Compute age of heartbeat file in seconds.
+heartbeat_age=$(( $(date +%s) - $(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0) ))
+log "heartbeat age=${heartbeat_age}s stale_threshold=${STALE_SECONDS}s"
+
+if [ "$heartbeat_age" -lt "$STALE_SECONDS" ]; then
+    log "scanner is healthy (heartbeat ${heartbeat_age}s old)"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat stale (${heartbeat_age}s > ${STALE_SECONDS}s) — triggering restart"
+
+# Read the scanner PID from the lock file.
+scanner_pid=""
+if [ -f "$LOCK_FILE" ]; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID ${scanner_pid:-unknown} and restart"
+    exit 0
+fi
+
+# Kill the wedged scanner so launchd/cron can restart it.
+if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+    log "killing wedged scanner PID $scanner_pid"
+    kill "$scanner_pid" 2>/dev/null || true
+    # Give it a moment; escalate to SIGKILL if still alive.
+    sleep 2
+    if kill -0 "$scanner_pid" 2>/dev/null; then
+        log "scanner still alive after SIGTERM — sending SIGKILL"
+        kill -9 "$scanner_pid" 2>/dev/null || true
+    fi
+else
+    log "scanner PID ${scanner_pid:-unknown} not found — may have already exited"
+fi
+
+# Remove the lock file so the restarted scanner can acquire it immediately.
+rm -f "$LOCK_FILE" 2>/dev/null || true
+
+# On macOS, kick launchd to restart immediately instead of waiting for
+# ThrottleInterval (60s default).
+if [ "$(uname -s)" = "Darwin" ] && command -v launchctl >/dev/null 2>&1; then
+    if launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" >/dev/null 2>&1; then
+        log "launchctl kickstart sent — scanner will restart immediately"
+    else
+        log "launchctl kickstart failed (will rely on KeepAlive ThrottleInterval)"
+    fi
+fi
+
+log "restart triggered"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Runs every 5 minutes. If the scanner heartbeat file is older than
+  2 × LOOP_SCANNER_INTERVAL (default 10 min), kills the wedged scanner
+  PID and lets KeepAlive restart it.
+
+  Install via ./install.sh --bootstrap, or manually:
+    sed "s|__LOOP_ROOT__|$(cd "$(dirname "$0")/.." && pwd)|g; \
+         s|__LOG_DIR__|${LOOP_LOG_DIR}|g; \
+         s|__HOME__|${HOME}|g; \
+         s|__EXTRA_PATH__|$(dirname $(which gh))|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 scanner liveness heartbeat.
+#
+# Verifies:
+#   1. scanner.sh writes HEARTBEAT_FILE at every tick (source-level check).
+#   2. scanner-watchdog.sh exits cleanly when heartbeat is fresh.
+#   3. scanner-watchdog.sh kills a wedged scanner when heartbeat is stale.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    export LOOP_EXTRA_PATH=""
+    mkdir -p "$LOOP_LOG_DIR"
+}
+
+teardown() {
+    rm -rf "$LOOP_LOG_DIR"
+}
+
+@test "scanner.sh writes HEARTBEAT_FILE variable and touches it in run_once" {
+    # Regression guard: HEARTBEAT_FILE must be defined and written in run_once.
+    grep -q 'HEARTBEAT_FILE=' "$REPO_ROOT/scanner/scanner.sh"
+    grep -q 'HEARTBEAT_FILE' "$REPO_ROOT/scanner/scanner.sh"
+    # The heartbeat write must be inside run_once (before or after the log line)
+    awk '/^run_once\(\)/{found=1} found && /HEARTBEAT_FILE/{print; exit}' \
+        "$REPO_ROOT/scanner/scanner.sh" | grep -q 'HEARTBEAT_FILE'
+}
+
+@test "scanner-watchdog.sh: exits 0 when heartbeat is fresh" {
+    local heartbeat="$LOOP_LOG_DIR/scanner-heartbeat"
+    printf '%s pid=99999\n' "$(date '+%Y-%m-%d %H:%M:%S')" > "$heartbeat"
+
+    # Set stale threshold to 600s — a brand-new file is well within it.
+    run env LOOP_WATCHDOG_STALE_SECONDS=600 \
+        "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner is healthy"* ]]
+}
+
+@test "scanner-watchdog.sh: reports stale heartbeat in dry-run mode" {
+    local heartbeat="$LOOP_LOG_DIR/scanner-heartbeat"
+    printf '%s pid=99999\n' "$(date '+%Y-%m-%d %H:%M:%S')" > "$heartbeat"
+
+    # Back-date the heartbeat by touching it with a timestamp 30 min ago.
+    local old_time
+    old_time=$(date -v -30M '+%Y%m%d%H%M' 2>/dev/null \
+        || date -d '30 minutes ago' '+%Y%m%d%H%M' 2>/dev/null \
+        || true)
+
+    if [ -z "$old_time" ]; then
+        skip "platform does not support date back-dating"
+    fi
+    touch -t "$old_time" "$heartbeat"
+
+    run env LOOP_WATCHDOG_STALE_SECONDS=600 \
+        "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DRY-RUN"* ]]
+}
+
+@test "scanner-watchdog.sh: exits 0 when heartbeat file is missing" {
+    # No heartbeat file — scanner may not have started yet; watchdog must not crash.
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"not found"* ]]
+}
+
+@test "scanner-watchdog.sh: syntax check passes" {
+    bash -n "$REPO_ROOT/scripts/scanner-watchdog.sh"
+}


### PR DESCRIPTION
Closes #413

## Changes

**scanner/scanner.sh**
- Defines `HEARTBEAT_FILE` (`${LOOP_LOG_DIR}/scanner-heartbeat`)
- In `run_once()`: writes current timestamp + PID to the heartbeat file at every tick (skipped in `--dry-run` mode)
- Stdout integrity guard at top of `run_once()`: if `LOG_FILE` is unwritable, attempts reopen then exits — letting launchd restart with a clean FD

**scripts/scanner-watchdog.sh** (new)
- Reads `scanner-heartbeat` mtime; compares against `LOOP_WATCHDOG_STALE_SECONDS` (default `2 × LOOP_SCANNER_INTERVAL = 600s`)
- If stale: kills the scanner PID (from `/tmp/loop-scanner.lock`), removes the lock file, and on macOS sends `launchctl kickstart` for immediate restart
- Gracefully handles missing heartbeat file (scanner not yet started) and missing lock file
- Supports `--dry-run` flag

**templates/launchd/com.user.loop-scanner-watchdog.plist.template** (new)
- Runs every 5 minutes via `StartInterval 300`

**install.sh**
- `bootstrap_register_launchd`: registers `com.user.loop-scanner-watchdog` plist (idempotent)
- `bootstrap_register_cron`: adds `*/5 * * * *` watchdog cron entry (idempotent, Linux)

**tests/scanner-heartbeat.bats** (new)
- Verifies `HEARTBEAT_FILE` is defined and written inside `run_once()`
- Verifies watchdog exits 0 with "healthy" message on fresh heartbeat
- Verifies watchdog reports stale + DRY-RUN on backdated heartbeat
- Verifies watchdog exits 0 when heartbeat file is missing
- Syntax check on watchdog script

## Test Plan
- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — all pass
- `shellcheck -S warning` on all shell files — no warnings
- Personal-identifier grep — clean
- Manual: run `scanner-watchdog.sh --dry-run` with fresh heartbeat → "healthy"; backdate heartbeat file → "stale / DRY-RUN"
- Manual: `kill -STOP $SCANNER_PID` to wedge it, wait for heartbeat to go stale (>10 min), confirm watchdog kills and launchd restarts it