### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — fires every 5 min; kills a wedged scanner
+    # so launchd can restart it automatically.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — detect a wedged scanner and restart it.
+#
+# Runs every 5 minutes (launchd StartInterval or cron */5). Reads the
+# scanner heartbeat file written by run_once() on every tick. If the
+# file has not been updated within STALE_THRESHOLD seconds, the scanner
+# is considered wedged: its PID is killed so launchd can restart it.
+#
+# Environment:
+#   LOOP_SCANNER_STALE_SECONDS  — max tolerable silence (default: 900, i.e. 3× a 300s interval)
+#   LOOP_SCANNER_LOCK_FILE      — scanner lock file path (default: /tmp/loop-scanner.lock)
+#   LOOP_LOG_DIR                — loop log directory (loaded from loop.env)
+#
+# Usage:
+#   scanner-watchdog.sh            # normal run (invoked by launchd/cron)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+LOCK_FILE="${LOOP_SCANNER_LOCK_FILE:-/tmp/loop-scanner.lock}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+STALE_THRESHOLD="${LOOP_SCANNER_STALE_SECONDS:-900}"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file missing — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+age=$(( now - mtime ))
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "heartbeat age=${age}s < threshold=${STALE_THRESHOLD}s — scanner is healthy"
+    exit 0
+fi
+
+log "WARN: heartbeat stale (age=${age}s >= threshold=${STALE_THRESHOLD}s) — scanner may be wedged"
+
+if [ ! -f "$LOCK_FILE" ]; then
+    log "no lock file at $LOCK_FILE — scanner not running; nothing to kill"
+    exit 0
+fi
+
+pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+if [ -z "$pid" ]; then
+    log "lock file empty — cannot determine scanner PID"
+    exit 0
+fi
+
+if ! kill -0 "$pid" 2>/dev/null; then
+    log "scanner PID $pid is already gone — launchd should restart it"
+    exit 0
+fi
+
+log "killing wedged scanner PID $pid (SIGTERM)"
+kill -TERM "$pid" 2>/dev/null || true
+# Give it 5s to exit cleanly before SIGKILL.
+sleep 5
+if kill -0 "$pid" 2>/dev/null; then
+    log "scanner PID $pid did not exit — sending SIGKILL"
+    kill -KILL "$pid" 2>/dev/null || true
+fi
+log "scanner PID $pid killed — launchd will restart it"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -776,6 +776,9 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Heartbeat: update mtime every tick so the scanner-watchdog can detect
+    # a wedged process (alive PID but no progress). Skipped in dry-run.
+    $DRY_RUN || touch "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <!-- Run every 5 minutes to check for a wedged scanner -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,117 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — heartbeat file written on every tick (#413).
+#
+# Verifies that run_once() touches ${LOOP_LOG_DIR}/scanner-heartbeat and that
+# the watchdog script correctly distinguishes a fresh heartbeat from a stale one.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+
+    # Build a minimal version of scanner.sh with functions only (same pattern as
+    # scanner.bats — write to temp file because bash 3.2 doesn't propagate defs
+    # from source <(...)).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    STAGE_AGE_DIR="$BATS_TMPDIR/stage-age"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR" "$STAGE_AGE_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    # Silence log() and stub out all I/O-heavy helpers.
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { :; }
+    LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/stage-age" "$BATS_TMPDIR/scanner-src.sh" \
+           "$BATS_TMPDIR/scanner-test.log" 2>/dev/null || true
+}
+
+@test "run_once: writes heartbeat file to LOOP_LOG_DIR" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    [ ! -f "$hb" ]
+    run_once
+    [ -f "$hb" ]
+}
+
+@test "run_once: updates heartbeat mtime on every call" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb" 2>/dev/null)
+    sleep 1
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb" 2>/dev/null)
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once: dry-run does NOT write heartbeat file" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    DRY_RUN=true
+    run_once
+    [ ! -f "$hb" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh unit-level checks
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog.sh: exits 0 when heartbeat is fresh" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    touch "$hb"
+
+    # Run watchdog with a very short stale threshold — heartbeat was just touched
+    # so age should be 0s, well under any threshold.
+    LOOP_SCANNER_STALE_SECONDS=900 \
+    LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+    run bash "$REPO_ROOT/scanner/scanner-watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"healthy"* ]]
+}
+
+@test "scanner-watchdog.sh: exits 0 when heartbeat file is absent" {
+    # No heartbeat file — watchdog should warn but not crash.
+    LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+    run bash "$REPO_ROOT/scanner/scanner-watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"missing"* ]]
+}
+
+@test "scanner-watchdog.sh: detects stale heartbeat and logs WARN" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    touch -t 200001010000 "$hb"   # set mtime to year 2000 — definitely stale
+
+    LOOP_SCANNER_STALE_SECONDS=900 \
+    LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+    run bash "$REPO_ROOT/scanner/scanner-watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"WARN"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- `run_once()` now calls `touch "${LOOP_LOG_DIR}/scanner-heartbeat"` at the start of every tick (skipped in `--dry-run`). The file mtime serves as a liveness indicator — if it stops advancing, the scanner is wedged.

### `scanner/scanner-watchdog.sh` (new)
- Separate script invoked every 5 minutes by launchd (macOS) or cron (Linux).
- Reads the heartbeat file mtime; if `age >= LOOP_SCANNER_STALE_SECONDS` (default 900 s = 3× the 300 s poll interval), sends SIGTERM to the scanner PID recorded in `/tmp/loop-scanner.lock`, waits 5 s, then SIGKILLs if still alive.
- launchd `KeepAlive=true` on the scanner ensures automatic restart after the kill.
- Exits 0 in all cases (missing heartbeat, dead PID, fresh heartbeat) so the watchdog itself never causes a launchd storm.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- `StartInterval 300` (every 5 min); logs to `loop-scanner-watchdog.log`.

### `install.sh`
- `bootstrap_register_launchd()`: installs the watchdog plist alongside the scanner plist (idempotent).
- `bootstrap_register_cron()`: adds a `*/5` cron entry for Linux installs.

### `tests/scanner-heartbeat.bats` (new)
- 6 bats tests: heartbeat is created by `run_once()`, updated on each call, skipped in dry-run; watchdog correctly identifies fresh/missing/stale heartbeats.

## Test Plan
- All 6 new bats tests pass: `bats tests/scanner-heartbeat.bats`
- `bash -n` and `shellcheck -S warning` pass on all scripts
- Manual test: `kill -STOP $SCANNER_PID` → watchdog should kill + launchd restarts within 5 min