### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-wedge detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,6 +338,25 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    # Scanner liveness watchdog — kills wedged scanner so launchd restarts it.
+    # Runs every 5 min and checks the scanner-heartbeat file mtime.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     local digest_plist="$agents_dir/com.user.loop-digest.plist"
     if [ -f "$digest_plist" ]; then
         echo "[launchd] com.user.loop-digest already registered — skipping"
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -775,6 +775,15 @@ scan_project() {
 }
 
 run_once() {
+    # Heartbeat: record tick timestamp so scanner-watchdog.sh can detect wedging.
+    $DRY_RUN || printf '%s\n' "$(date +%s)" > "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+
+    # Stdout integrity check: if the on-disk log file is not writable (e.g. after
+    # a rotation that didn't send SIGHUP), reopen file descriptors so writes resume.
+    if [ -n "${LOG_FILE:-}" ] && [ ! -w "${LOG_FILE}" ]; then
+        exec 1>>"${LOG_FILE}" 2>>"${LOG_FILE}" || exit 1
+    fi
+
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the Loop scanner if it stops writing heartbeats.
+#
+# Checks ${LOOP_LOG_DIR}/scanner-heartbeat mtime. If it is older than
+# LOOP_SCANNER_STALE_SECONDS (default: 2 × LOOP_SCANNER_INTERVAL = 600 s),
+# the scanner is considered wedged and is killed so launchd / cron restarts it.
+#
+# Designed to run every 5 min via launchd (StartInterval 300) or cron (*/5).
+#
+# Flags:
+#   --dry-run   report stale status without killing the scanner
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_SCANNER_STALE_SECONDS:-$(( POLL_INTERVAL * 2 ))}"
+LOCK_FILE="/tmp/loop-scanner.lock"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -15
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# Portable mtime: macOS stat -f%m vs GNU stat -c%Y
+_mtime() {
+    stat -f%m "$1" 2>/dev/null || stat -c%Y "$1" 2>/dev/null || echo 0
+}
+
+log "check (threshold=${STALE_THRESHOLD}s dry=${DRY_RUN})"
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "no heartbeat file yet — scanner may not have started"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(_mtime "$HEARTBEAT_FILE")
+age=$(( now - mtime ))
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "ok (heartbeat age=${age}s threshold=${STALE_THRESHOLD}s)"
+    exit 0
+fi
+
+log "STALE: heartbeat age=${age}s > ${STALE_THRESHOLD}s — scanner appears wedged"
+
+scanner_pid=""
+if [ -f "$LOCK_FILE" ]; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID ${scanner_pid:-unknown}"
+    exit 0
+fi
+
+if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+    log "killing scanner PID $scanner_pid"
+    kill "$scanner_pid" 2>/dev/null || true
+    log "scanner killed — launchd/cron will restart"
+else
+    log "WARN: no live scanner PID found (pid=${scanner_pid:-none}) — launchd/cron should restart automatically"
+fi

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+  Fires every 5 min and kills the scanner if its heartbeat file is stale.
+
+  Install via: ./install.sh --bootstrap
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- **Heartbeat write**: at the top of each `run_once()` tick, writes `$(date +%s)` to `${LOOP_LOG_DIR}/scanner-heartbeat`. The watchdog reads this file's mtime to detect a wedged scanner.
- **Stdout integrity check**: if `LOG_FILE` is set but not writable (e.g. after log rotation without a SIGHUP), reopens FDs 1+2 against the path so writes resume immediately without waiting for the next SIGHUP.

### scripts/scanner-watchdog.sh (new)
- Checks `scanner-heartbeat` mtime. If age > `LOOP_SCANNER_STALE_SECONDS` (default: `2 × LOOP_SCANNER_INTERVAL` = 600 s), the scanner is declared wedged.
- Reads `/tmp/loop-scanner.lock` to find the PID and sends `SIGTERM`. launchd (KeepAlive) or cron restarts the scanner automatically.
- Supports `--dry-run` for safe manual inspection.
- Designed to run every 5 min (launchd `StartInterval 300` or cron `*/5`).

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
- launchd plist template for the watchdog agent (fires every 5 min, logs to `loop-scanner-watchdog.log`).

### install.sh
- `bootstrap_register_launchd`: registers `com.user.loop-scanner-watchdog` plist (idempotent).
- `bootstrap_register_cron`: adds `*/5 * * * *` watchdog cron entry with `# loop-scanner-watchdog` marker (idempotent).

## Test Plan

- `bash -n` and `shellcheck -S warning` pass on all scripts (verified locally).
- Manual wedge test: run scanner, then `kill -STOP $SCANNER_PID` to suspend it. After `>600s`, watchdog run should log "STALE" and kill the scanner. launchd KeepAlive restarts it within 60s.
- Dry-run: `scripts/scanner-watchdog.sh --dry-run` should report heartbeat age without killing anything.
- Heartbeat bats: confirm `${LOOP_LOG_DIR}/scanner-heartbeat` is written on every `run_once` invocation.