### PR TITLE
[LOOP-413] scanner: add liveness heartbeat + watchdog auto-restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,6 +338,23 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     local digest_plist="$agents_dir/com.user.loop-digest.plist"
     if [ -f "$digest_plist" ]; then
         echo "[launchd] com.user.loop-digest already registered — skipping"
@@ -361,8 +378,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +401,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — Restart scanner if its heartbeat file goes stale.
+#
+# Run every 5 minutes via launchd (StartInterval 300) or cron (*/5 * * * *).
+# If the scanner has not updated ${LOOP_LOG_DIR}/scanner-heartbeat within
+# 2 × LOOP_SCANNER_INTERVAL seconds, kill its PID (launchd's KeepAlive
+# will restart it automatically within ThrottleInterval seconds).
+#
+# Usage:
+#   scanner-watchdog.sh          # normal check
+#   scanner-watchdog.sh --dry-run  # report staleness without killing
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 ))
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file absent — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+now=$(date +%s)
+hb_mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+    || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+    || echo 0)
+age=$(( now - hb_mtime ))
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "ok: heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+    exit 0
+fi
+
+log "WARN: heartbeat stale: age=${age}s > threshold=${STALE_THRESHOLD}s"
+
+if $DRY_RUN; then
+    log "dry-run: would kill scanner and let launchd restart it"
+    exit 0
+fi
+
+scanner_pid=""
+if [ -f "$LOCK_FILE" ]; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+fi
+
+if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+    log "killing stale scanner PID $scanner_pid"
+    kill "$scanner_pid" 2>/dev/null || true
+    log "scanner killed — launchd/cron will restart it"
+else
+    log "no live scanner PID found in $LOCK_FILE — nothing to kill"
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -774,8 +774,14 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+_scanner_update_heartbeat() {
+    local hb_file="${LOOP_LOG_DIR}/scanner-heartbeat"
+    printf '%s\n' "$(date '+%Y-%m-%d %H:%M:%S')" > "$hb_file" || true
+}
+
 run_once() {
     log "=== scan tick start ==="
+    $DRY_RUN || _scanner_update_heartbeat
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <!-- Fire every 5 minutes; scanner is considered stale after 2 × poll interval -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,134 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — heartbeat file update on every scanner tick,
+# and scanner-watchdog.sh stale-detection logic.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Source scanner.sh function definitions only (same strategy as scanner.bats).
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    loop_list_slugs() { :; }
+    jobs_init_schema() { :; }
+    LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# _scanner_update_heartbeat
+# ---------------------------------------------------------------------------
+
+@test "_scanner_update_heartbeat: creates heartbeat file in LOOP_LOG_DIR" {
+    [ ! -f "$LOOP_LOG_DIR/scanner-heartbeat" ]
+    _scanner_update_heartbeat
+    [ -f "$LOOP_LOG_DIR/scanner-heartbeat" ]
+}
+
+@test "_scanner_update_heartbeat: writes current timestamp" {
+    _scanner_update_heartbeat
+    local content
+    content=$(cat "$LOOP_LOG_DIR/scanner-heartbeat")
+    [[ "$content" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\ [0-9]{2}:[0-9]{2}:[0-9]{2}$ ]]
+}
+
+@test "_scanner_update_heartbeat: updates mtime on every call" {
+    _scanner_update_heartbeat
+    local mtime1
+    mtime1=$(stat -f%m "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null \
+        || stat -c%Y "$LOOP_LOG_DIR/scanner-heartbeat")
+    sleep 1
+    _scanner_update_heartbeat
+    local mtime2
+    mtime2=$(stat -f%m "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null \
+        || stat -c%Y "$LOOP_LOG_DIR/scanner-heartbeat")
+    [ "$mtime2" -gt "$mtime1" ]
+}
+
+@test "run_once: heartbeat file is written when DRY_RUN=false" {
+    [ ! -f "$LOOP_LOG_DIR/scanner-heartbeat" ]
+    DRY_RUN=false run_once
+    [ -f "$LOOP_LOG_DIR/scanner-heartbeat" ]
+}
+
+@test "run_once: heartbeat file is NOT written when DRY_RUN=true" {
+    [ ! -f "$LOOP_LOG_DIR/scanner-heartbeat" ]
+    DRY_RUN=true run_once
+    [ ! -f "$LOOP_LOG_DIR/scanner-heartbeat" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog.sh: exits 0 when heartbeat is fresh" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    printf '%s\n' "$(date '+%Y-%m-%d %H:%M:%S')" > "$hb"
+    LOOP_LOG_DIR="$LOOP_LOG_DIR" LOOP_SCANNER_INTERVAL=300 \
+        run "$REPO_ROOT/scanner/scanner-watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "ok:" ]]
+}
+
+@test "scanner-watchdog.sh: exits 0 when heartbeat file is absent (not yet started)" {
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+    LOOP_LOG_DIR="$LOOP_LOG_DIR" LOOP_SCANNER_INTERVAL=300 \
+        run "$REPO_ROOT/scanner/scanner-watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "absent" ]]
+}
+
+@test "scanner-watchdog.sh --dry-run: reports stale without killing" {
+    # Create a heartbeat file with an old mtime.
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    printf 'old\n' > "$hb"
+    touch -t "$(date -v-1H '+%Y%m%d%H%M' 2>/dev/null || date -d '-1 hour' '+%Y%m%d%H%M' 2>/dev/null || date '+%Y%m%d%H%M' -d '1 hour ago')" "$hb" 2>/dev/null \
+        || touch -A -010000 "$hb" 2>/dev/null \
+        || { skip "cannot backdate file mtime on this platform"; }
+    local hb_mtime
+    hb_mtime=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb" 2>/dev/null)
+    local now
+    now=$(date +%s)
+    local age=$(( now - hb_mtime ))
+    if [ "$age" -lt 600 ]; then
+        skip "could not backdate mtime far enough (age=${age}s < 600s)"
+    fi
+
+    LOOP_LOG_DIR="$LOOP_LOG_DIR" LOOP_SCANNER_INTERVAL=300 \
+        run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "dry-run" ]]
+    [[ "$output" =~ "WARN" ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- Added `_scanner_update_heartbeat()` — writes the current timestamp to `${LOOP_LOG_DIR}/scanner-heartbeat` at the top of every `run_once()` tick (skipped in dry-run mode).

### scanner/scanner-watchdog.sh (new)
- Standalone script designed to run every 5 minutes via launchd `StartInterval` or cron.
- Reads the heartbeat file mtime; if `age > 2 × LOOP_SCANNER_INTERVAL` (default 600 s), kills the scanner PID from the lock file and lets launchd/cron auto-restart it.
- Exits cleanly (status 0) when the heartbeat is fresh or the file doesn't exist yet.
- Supports `--dry-run` flag: reports staleness without killing.

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
- Fires every 300 s (`StartInterval`), separate from the scanner's own KeepAlive plist.

### install.sh
- **macOS (launchd):** registers `com.user.loop-scanner-watchdog` alongside the existing scanner + reconciler plists.
- **Linux (cron):** adds a `*/5 * * * *` entry for `scanner-watchdog.sh` with its own marker comment for idempotent re-runs.

### tests/scanner-heartbeat.bats (new)
- Verifies `_scanner_update_heartbeat` creates the file, writes a valid timestamp, and updates mtime on every call.
- Verifies `run_once` writes the heartbeat when `DRY_RUN=false` and skips it when `DRY_RUN=true`.
- Exercises watchdog exit paths: fresh heartbeat (ok), missing file (not-yet-started), and stale heartbeat with `--dry-run` (reports but does not kill).

## Test Plan
- `bash -n` and `shellcheck -S warning` pass on all scripts.
- No personal identifiers in committed files.
- Manual: kill the scanner with `kill -STOP $PID`, wait ~10 min; watchdog should detect staleness and kill it; launchd restarts within ThrottleInterval.