### PR TITLE
[LOOP-413] scanner: add liveness heartbeat + watchdog auto-restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,23 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +378,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +401,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if its heartbeat goes stale.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written by scanner.sh every tick).
+# If the heartbeat mtime is older than STALE_THRESHOLD seconds, kills the scanner
+# PID from the lock file and lets launchd/cron restart it automatically.
+#
+# Usage:
+#   scanner-watchdog.sh            # runs a single check (suitable for launchd StartInterval or cron)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+# Kill scanner if heartbeat is older than 2× the poll interval.
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 ))
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# Heartbeat file must exist and be writable before we can check it.
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file absent — scanner may not have run yet; skipping"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+age=$(( now - mtime ))
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "heartbeat ok (age=${age}s < threshold=${STALE_THRESHOLD}s)"
+    exit 0
+fi
+
+log "WARN: heartbeat stale (age=${age}s >= threshold=${STALE_THRESHOLD}s) — restarting scanner"
+
+# Kill the scanner process recorded in the lock file.
+if [ -f "$LOCK_FILE" ]; then
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "killing scanner PID $pid"
+        kill "$pid" 2>/dev/null || true
+        # Give launchd/cron a moment to clean up before we remove the lock.
+        sleep 2
+    fi
+    rm -f "$LOCK_FILE"
+fi
+
+# On macOS, ask launchd to restart the scanner immediately.
+if [ "$(uname -s)" = "Darwin" ] && command -v launchctl >/dev/null 2>&1; then
+    if launchctl list 2>/dev/null | grep -q "com.user.loop-scanner"; then
+        log "kickstarting com.user.loop-scanner via launchctl"
+        launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null \
+            || launchctl start com.user.loop-scanner 2>/dev/null \
+            || log "WARN: launchctl restart failed — launchd will restart on its own"
+    fi
+fi
+
+# On Linux the scanner is managed by cron (--once per tick) so no explicit
+# restart is needed — just clearing the lock file is sufficient.
+
+log "watchdog action complete"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -774,7 +775,21 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+_scanner_check_stdout() {
+    # If LOG_FILE is not writable, reopen FDs or exit so launchd restarts us.
+    if [ -n "${LOG_FILE:-}" ] && [ ! -w "$LOG_FILE" ]; then
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" || exit 1
+    fi
+}
+
+_scanner_heartbeat() {
+    $DRY_RUN && return 0
+    date '+%Y-%m-%d %H:%M:%S' > "$HEARTBEAT_FILE" 2>/dev/null || true
+}
+
 run_once() {
+    _scanner_check_stdout
+    _scanner_heartbeat
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <!-- Check every 5 minutes (2× the default 300s poll interval) -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`**
- Added `HEARTBEAT_FILE` variable (`${LOOP_LOG_DIR}/scanner-heartbeat`)
- Added `_scanner_heartbeat()`: writes current timestamp to the heartbeat file at the start of every `run_once()` tick (skipped in `--dry-run` mode)
- Added `_scanner_check_stdout()`: at the start of each tick, checks whether `LOG_FILE` is writable; if not, attempts to reopen FDs 1+2 against the log path or exits so launchd restarts the process

**`scanner/scanner-watchdog.sh`** (new)
- Standalone script that reads the heartbeat file mtime
- If age > `2 × LOOP_SCANNER_INTERVAL` (default 600s), kills the scanner PID from the lock file and asks launchd to `kickstart` the scanner service
- On Linux (cron mode) just clearing the stale lock file is sufficient since each cron invocation is a fresh process
- Designed to run every 5 min via launchd `StartInterval` or cron `*/5`

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new)
- Launchd agent template (`StartInterval=300`) for the watchdog
- Uses same `__LOOP_ROOT__` / `__LOG_DIR__` / `__HOME__` / `__EXTRA_PATH__` substitution tokens as existing templates

**`install.sh`**
- `bootstrap_register_launchd`: installs and loads `com.user.loop-scanner-watchdog.plist` (idempotent, skips if already registered)
- `bootstrap_register_cron`: adds a `*/5 * * * *` cron entry for the watchdog on Linux (idempotent, marker-guarded)

## Test Plan

- Run `./scanner/scanner.sh --dry-run` — confirm `scanner-heartbeat` is NOT written (dry-run guard)
- Run `./scanner/scanner.sh --once` — confirm `${LOOP_LOG_DIR}/scanner-heartbeat` exists and contains current timestamp
- Simulate stale scanner: `kill -STOP $SCANNER_PID`, wait 11+ minutes; confirm watchdog kills PID and launchd restarts the scanner
- Verify `bash -n` + `shellcheck -S warning` pass on all changed scripts (confirmed locally)
- Verify no personal identifiers in changed files (confirmed locally)