### PR TITLE
[LOOP-413] scanner: add liveness heartbeat, tick event, and watchdog auto-restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,23 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +378,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +401,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if its heartbeat goes stale.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written by scanner.sh every tick).
+# If the heartbeat mtime is older than STALE_THRESHOLD seconds, kills the scanner
+# PID from the lock file and lets launchd/cron restart it automatically.
+#
+# Usage:
+#   scanner-watchdog.sh            # runs a single check (suitable for launchd StartInterval or cron)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+# Kill scanner if heartbeat is older than 2× the poll interval.
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 ))
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# Heartbeat file must exist before we can check it.
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file absent — scanner may not have run yet; skipping"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+age=$(( now - mtime ))
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "heartbeat ok (age=${age}s < threshold=${STALE_THRESHOLD}s)"
+    exit 0
+fi
+
+log "WARN: heartbeat stale (age=${age}s >= threshold=${STALE_THRESHOLD}s) — restarting scanner"
+
+# Kill the scanner process recorded in the lock file.
+if [ -f "$LOCK_FILE" ]; then
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "killing scanner PID $pid"
+        kill "$pid" 2>/dev/null || true
+        # Give launchd/cron a moment to clean up before we remove the lock.
+        sleep 2
+    fi
+    rm -f "$LOCK_FILE"
+fi
+
+# On macOS, ask launchd to restart the scanner immediately.
+if [ "$(uname -s)" = "Darwin" ] && command -v launchctl >/dev/null 2>&1; then
+    if launchctl list 2>/dev/null | grep -q "com.user.loop-scanner"; then
+        log "kickstarting com.user.loop-scanner via launchctl"
+        launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null \
+            || launchctl start com.user.loop-scanner 2>/dev/null \
+            || log "WARN: launchctl restart failed — launchd will restart on its own"
+    fi
+fi
+
+# On Linux the scanner is managed by cron (--once per tick) so no explicit
+# restart is needed — just clearing the lock file is sufficient.
+
+log "watchdog action complete"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -22,6 +22,8 @@ source "$LOOP_ROOT/lib/backends/backend.sh"
 source "$LOOP_ROOT/lib/labels.sh"
 # shellcheck source=../lib/jobs.sh
 source "$LOOP_ROOT/lib/jobs.sh"
+# shellcheck source=../lib/monitor.sh
+source "$LOOP_ROOT/lib/monitor.sh"
 # workflow helpers (loop_polled_labels, loop_handler_for_label, loop_stage_trigger,
 # loop_workflow_for_project) are already loaded via lib/env.sh → lib/workflow.sh.
 # The line below is for shellcheck only.
@@ -29,6 +31,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -774,7 +777,31 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+_scanner_check_stdout() {
+    # If LOG_FILE is not writable, reopen FDs or exit so launchd restarts us.
+    if [ -n "${LOG_FILE:-}" ] && [ ! -w "$LOG_FILE" ]; then
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" || exit 1
+    fi
+}
+
+_scanner_heartbeat() {
+    $DRY_RUN && return 0
+    date '+%Y-%m-%d %H:%M:%S' > "$HEARTBEAT_FILE" 2>/dev/null || true
+}
+
+_scanner_emit_tick() {
+    $DRY_RUN && return 0
+    local dedup_count now
+    dedup_count=$(find "$DEDUP_DIR" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
+    now=$(date '+%Y-%m-%d %H:%M:%S')
+    _loop_emit_event "scanner_tick" \
+        "{\"now\":\"${now}\",\"dedup_count\":${dedup_count}}" \
+        2>/dev/null || true
+}
+
 run_once() {
+    _scanner_check_stdout
+    _scanner_heartbeat
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
@@ -785,6 +812,7 @@ run_once() {
         [ -z "$slug" ] && continue
         scan_project "$slug" || log "scan_project $slug failed (continuing)"
     done < <(loop_list_slugs)
+    _scanner_emit_tick
     log "=== scan tick done ==="
 }
 

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <!-- Run every 5 minutes; stale threshold = 2× poll interval (default 600s) -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — covers _scanner_heartbeat and _scanner_emit_tick
+# in scanner/scanner.sh (issue #413).
+#
+# Verifies:
+#   1. Heartbeat file is created/updated on every run_once() call.
+#   2. Heartbeat is NOT written in --dry-run mode.
+#   3. _scanner_emit_tick is a no-op in --dry-run mode.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs-hb"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src-hb.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup-hb"
+    LOG_FILE="$BATS_TMPDIR/scanner-hb-test.log"
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+    LOOP_JOBS_ENQUEUE=0
+
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { :; }
+    _loop_emit_event() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs-hb" "$BATS_TMPDIR/dedup-hb" \
+           "$BATS_TMPDIR/scanner-hb-test.log" \
+           "$BATS_TMPDIR/scanner-src-hb.sh" 2>/dev/null || true
+}
+
+@test "_scanner_heartbeat: creates heartbeat file on first call" {
+    [ ! -f "$HEARTBEAT_FILE" ]
+    _scanner_heartbeat
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "_scanner_heartbeat: updates heartbeat mtime on second call" {
+    _scanner_heartbeat
+    local mtime1
+    mtime1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+    sleep 1
+    _scanner_heartbeat
+    local mtime2
+    mtime2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "_scanner_heartbeat: dry-run does not write heartbeat file" {
+    DRY_RUN=true
+    _scanner_heartbeat
+    [ ! -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: heartbeat file exists after a tick" {
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: heartbeat content is a timestamp string" {
+    run_once
+    local content
+    content=$(cat "$HEARTBEAT_FILE")
+    # Must match YYYY-MM-DD HH:MM:SS
+    [[ "$content" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\ [0-9]{2}:[0-9]{2}:[0-9]{2}$ ]]
+}
+
+@test "_scanner_emit_tick: dry-run skips emission" {
+    DRY_RUN=true
+    local called=false
+    _loop_emit_event() { called=true; }
+    _scanner_emit_tick
+    [ "$called" = "false" ]
+}
+
+@test "_scanner_emit_tick: calls _loop_emit_event with scanner_tick type" {
+    local captured_type=""
+    _loop_emit_event() { captured_type="$1"; }
+    _scanner_emit_tick
+    [ "$captured_type" = "scanner_tick" ]
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`**
- Added `HEARTBEAT_FILE` (`${LOOP_LOG_DIR}/scanner-heartbeat`) — written at the start of every `run_once()` tick
- Added `_scanner_heartbeat()`: writes current timestamp to heartbeat file; skipped in `--dry-run` mode (AC #1)
- Added `_scanner_check_stdout()`: checks LOG_FILE writability at tick start; reopens FDs or exits to trigger launchd restart (AC #3)
- Added `_scanner_emit_tick()`: calls `_loop_emit_event "scanner_tick"` with `now` + `dedup_count` after each tick; skipped in `--dry-run` mode (AC #2)
- Sources `lib/monitor.sh` so `_loop_emit_event` is available (no-op when `LOOP_MONITOR_URL` is unset)

**`scanner/scanner-watchdog.sh`** (new)
- Standalone script: reads heartbeat file mtime; if age > `2 × LOOP_SCANNER_INTERVAL` (default 600s), kills scanner PID from lock file and kickstarts via launchd (macOS) or clears lock (Linux)
- Safe to run every 5 min via launchd `StartInterval` or cron `*/5`

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new)
- Launchd `StartInterval=300` agent template for the watchdog
- Comment updated to clarify: "Run every 5 minutes; stale threshold = 2× poll interval (default 600s)"

**`install.sh`**
- `bootstrap_register_launchd`: installs and loads `com.user.loop-scanner-watchdog.plist` (idempotent)
- `bootstrap_register_cron`: adds `*/5 * * * *` watchdog cron entry on Linux (marker-guarded)

**`tests/scanner-heartbeat.bats`** (new, 7 tests)
- `_scanner_heartbeat` creates the file on first call
- `_scanner_heartbeat` updates mtime on subsequent calls
- `--dry-run` mode does not write heartbeat file
- `run_once()` leaves heartbeat file with a valid `YYYY-MM-DD HH:MM:SS` timestamp
- `_scanner_emit_tick` skips emission in dry-run
- `_scanner_emit_tick` calls `_loop_emit_event` with type `scanner_tick`

## Test Plan

- `bash -n` + `shellcheck -S warning` pass on all changed scripts (confirmed locally)
- `bats tests/scanner-heartbeat.bats` — 7/7 pass
- Existing scanner tests (`tests/scanner.bats`, `scanner-log-sighup.bats`, `scanner-stage-age.bats`, `dedup-key.bats`) — no regressions introduced (pre-existing failures on main are unrelated)
- Manual: run `scanner.sh --once`; confirm `${LOOP_LOG_DIR}/scanner-heartbeat` exists and contains current timestamp
- Manual: simulate wedge with `kill -STOP $SCANNER_PID`; watchdog should kill and restart within 10 min