### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog auto-restart on silent wedge

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,6 +338,25 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    # Scanner liveness watchdog — kills a wedged scanner (heartbeat stale > 2×
+    # poll_interval) so launchd restarts it. Runs every 5 min independently.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     local digest_plist="$agents_dir/com.user.loop-digest.plist"
     if [ -f "$digest_plist" ]; then
         echo "[launchd] com.user.loop-digest already registered — skipping"
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if its heartbeat is stale.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written by scanner.sh every tick).
+# If the file's mtime is older than 2 × LOOP_SCANNER_INTERVAL (default 10 min),
+# the scanner is considered silently wedged: its PID is killed and the lock file
+# is removed so launchd (macOS) or cron (Linux) can restart a fresh instance.
+#
+# Designed to run every 5 min via launchd StartInterval or cron */5.
+#
+# Usage:
+#   scanner-watchdog.sh            # check and restart if stale
+#   scanner-watchdog.sh --dry-run  # report status without killing
+#   scanner-watchdog.sh --help
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 ))
+LOCK_FILE="/tmp/loop-scanner.lock"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "no heartbeat file at $HEARTBEAT_FILE — scanner may not have started yet"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+age=$(( now - mtime ))
+
+if [ "$age" -le "$STALE_THRESHOLD" ]; then
+    log "heartbeat OK (age=${age}s threshold=${STALE_THRESHOLD}s)"
+    exit 0
+fi
+
+log "STALE heartbeat detected: age=${age}s > ${STALE_THRESHOLD}s"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner and remove lock — skipping"
+    exit 0
+fi
+
+if [ -f "$LOCK_FILE" ]; then
+    local_pid=$(cat "$LOCK_FILE" 2>/dev/null || echo "")
+    if [ -n "$local_pid" ] && kill -0 "$local_pid" 2>/dev/null; then
+        log "killing wedged scanner PID $local_pid"
+        kill "$local_pid" 2>/dev/null || true
+        sleep 2
+    else
+        log "lock file present but PID '${local_pid:-empty}' not alive"
+    fi
+    rm -f "$LOCK_FILE" 2>/dev/null || true
+    log "lock file removed — launchd/cron will restart scanner"
+else
+    log "no lock file found; scanner may have already exited"
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -64,6 +64,38 @@ done
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] $*"; }
 
+# _scanner_write_heartbeat — update ${LOOP_LOG_DIR}/scanner-heartbeat on every tick.
+# A separate watchdog reads this file's mtime; if age > 2×POLL_INTERVAL the
+# scanner is considered wedged and is killed so launchd/cron restarts it.
+_scanner_write_heartbeat() {
+    local hb_file="${LOOP_LOG_DIR}/scanner-heartbeat"
+    printf '%s\n' "$(date +%s)" > "$hb_file" 2>/dev/null || true
+}
+
+# _scanner_check_log_fd — verify LOG_FILE is still writable at the top of each tick.
+# If not writable (permissions changed, filesystem full, etc.), attempt to recover
+# the file descriptor. If recovery fails, exit so launchd restarts the process.
+_scanner_check_log_fd() {
+    [ -n "${LOG_FILE:-}" ] || return 0
+    if [ ! -w "$LOG_FILE" ]; then
+        if ! touch "$LOG_FILE" 2>/dev/null; then
+            printf '[%s] [scanner] ERROR: LOG_FILE not writable — exiting for restart\n' \
+                "$(date '+%Y-%m-%d %H:%M:%S')" >&2
+            exit 1
+        fi
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" || exit 1
+    fi
+}
+
+# _scanner_emit_tick_event — append a scanner_tick JSONL line to the monitor event log.
+# Provides a stream of liveness signals that loop-monitor can surface on the dashboard.
+_scanner_emit_tick_event() {
+    local dedup_count="$1"
+    local monitor_log="${LOOP_MONITOR_LOG:-${LOOP_LOG_DIR}/loop-monitor-events.jsonl}"
+    printf '{"type":"scanner_tick","ts":%s,"dedup_count":%s}\n' \
+        "$(date +%s)" "$dedup_count" >> "$monitor_log" 2>/dev/null || true
+}
+
 # _scanner_jobs_enqueue <slug> <stage> <num>
 # Best-effort dual-write to the jobs table alongside the legacy label-event path.
 # Skipped when LOOP_JOBS_ENQUEUE=0 or --dry-run.
@@ -776,6 +808,15 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Liveness: write heartbeat so the watchdog can detect a wedged scanner.
+    $DRY_RUN || _scanner_write_heartbeat
+    # Integrity: exit if the log file is no longer writable so launchd restarts.
+    _scanner_check_log_fd
+    # Tick telemetry: count active dedup entries and emit to monitor event log.
+    local _tick_dedup_count
+    _tick_dedup_count=$(ls -1 "$DEDUP_DIR" 2>/dev/null | wc -l | tr -d ' ')
+    log "scanner_tick ts=$(date +%s) dedup_count=${_tick_dedup_count}"
+    $DRY_RUN || _scanner_emit_tick_event "$_tick_dedup_count"
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <!-- Check every 5 min; stale threshold is 2 × LOOP_SCANNER_INTERVAL (default 10 min) -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — heartbeat file and watchdog restart logic.
+#
+# Covers:
+#   - _scanner_write_heartbeat creates/updates the heartbeat file every tick
+#   - scanner-watchdog.sh reports OK when heartbeat is fresh
+#   - scanner-watchdog.sh reports STALE when heartbeat is old (dry-run)
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Source scanner.sh function definitions only (same pattern as scanner.bats).
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+    log() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/scanner-src.sh" "$BATS_TMPDIR/scanner-test.log" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# _scanner_write_heartbeat
+# ---------------------------------------------------------------------------
+
+@test "_scanner_write_heartbeat: creates heartbeat file" {
+    _scanner_write_heartbeat
+    [ -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+@test "_scanner_write_heartbeat: heartbeat contains current epoch timestamp" {
+    local before after ts
+    before=$(date +%s)
+    _scanner_write_heartbeat
+    after=$(date +%s)
+    ts=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+    [ "$ts" -ge "$before" ]
+    [ "$ts" -le "$after" ]
+}
+
+@test "_scanner_write_heartbeat: repeated calls update mtime" {
+    _scanner_write_heartbeat
+    sleep 1
+    _scanner_write_heartbeat
+    local age
+    age=$(( $(date +%s) - $(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+        || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || echo 0) ))
+    [ "$age" -le 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh (dry-run mode — no kills)
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog.sh: exits 0 with OK when heartbeat is fresh" {
+    # Write a fresh heartbeat; regardless of LOOP_SCANNER_INTERVAL the file
+    # was just written so mtime age is near 0.
+    printf '%s\n' "$(date +%s)" > "${LOOP_LOG_DIR}/scanner-heartbeat"
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" LOOP_SCANNER_INTERVAL=60 \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"heartbeat OK"* ]]
+}
+
+@test "scanner-watchdog.sh: reports STALE when heartbeat mtime is old" {
+    # Use a short poll interval (60s) so the stale threshold is 120s.
+    # Backdate the heartbeat by 300s (well past the 120s threshold).
+    printf '%s\n' "old" > "${LOOP_LOG_DIR}/scanner-heartbeat"
+    python3 -c "
+import os, time
+p = '${LOOP_LOG_DIR}/scanner-heartbeat'
+old = time.time() - 300
+os.utime(p, (old, old))
+"
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" LOOP_SCANNER_INTERVAL=60 \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+}
+
+@test "scanner-watchdog.sh: exits 0 gracefully when no heartbeat file exists" {
+    # No heartbeat file — scanner not yet started.
+    rm -f "${LOOP_LOG_DIR}/scanner-heartbeat"
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" LOOP_SCANNER_INTERVAL=60 \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no heartbeat file"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

**scanner/scanner.sh:**
- `_scanner_write_heartbeat()` — writes current epoch timestamp to `${LOOP_LOG_DIR}/scanner-heartbeat` at the start of every tick. A stale mtime signals a silently-wedged scanner.
- `_scanner_check_log_fd()` — checks that `$LOG_FILE` is writable at each tick entry; if not, attempts to reopen the fd and exits on failure so launchd restarts cleanly.
- `_scanner_emit_tick_event()` — appends a `scanner_tick` JSONL line (ts + dedup_count) to `loop-monitor-events.jsonl` for dashboard visibility.
- `run_once()` calls all three helpers at the top of each tick, logging `scanner_tick ts=... dedup_count=...` to the scanner log as well.

**scanner/scanner-watchdog.sh (new):**
- Reads `scanner-heartbeat` mtime. If age > `2 × LOOP_SCANNER_INTERVAL` (default 10 min), kills the scanner PID from the lock file and removes the lock so launchd (macOS) or cron (Linux) restarts a fresh instance.
- Supports `--dry-run` for testing without killing.
- Exits cleanly when no heartbeat file exists (scanner not yet started).

**templates/launchd/com.user.loop-scanner-watchdog.plist.template (new):**
- `StartInterval 300` — runs watchdog every 5 min, comfortably under the 10-min stale threshold.

**install.sh:**
- `bootstrap_register_launchd`: registers `com.user.loop-scanner-watchdog` plist.
- `bootstrap_register_cron`: adds `*/5 * * * *` cron entry for Linux.

**tests/scanner-heartbeat.bats (new):**
- 6 bats tests: heartbeat file creation, epoch timestamp content, mtime freshness, watchdog OK/STALE/missing-file cases.

## Test Plan
- Run `bats tests/scanner-heartbeat.bats` — all 6 tests pass.
- Manual: `kill -STOP $SCANNER_PID` → watchdog fires within 10 min and restarts scanner.
- Verify heartbeat file at `${LOOP_LOG_DIR}/scanner-heartbeat` is updated every tick.
- Check `${LOOP_LOG_DIR}/loop-monitor-events.jsonl` for `scanner_tick` entries.