### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,6 +338,26 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    # Scanner liveness watchdog — detects and restarts a wedged scanner process.
+    # Fires every 5 min; kills the scanner PID when heartbeat is stale so launchd
+    # KeepAlive auto-restarts it. Installed after scanner so it never races on first boot.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     local digest_plist="$agents_dir/com.user.loop-digest.plist"
     if [ -f "$digest_plist" ]; then
         echo "[launchd] com.user.loop-digest already registered — skipping"
@@ -361,8 +381,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local scanner_watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local scanner_watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $scanner_watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +404,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$scanner_watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$scanner_watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — detect and restart a wedged scanner process.
+#
+# Reads scanner-heartbeat mtime from $LOOP_LOG_DIR. If the file is older
+# than STALE_THRESHOLD seconds the scanner is considered wedged: its PID
+# (from the lock file) is killed so launchd (KeepAlive=true) auto-restarts it.
+#
+# STALE_THRESHOLD defaults to 2 × LOOP_SCANNER_INTERVAL (600s).
+# A single missed tick does not trigger a restart; only sustained silence does.
+#
+# Run every ~5 minutes via launchd StartInterval=300 or cron */5.
+#
+# Usage:
+#   scanner/scanner-watchdog.sh [--dry-run]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="${LOOP_SCANNER_LOCK:-/tmp/loop-scanner.lock}"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 ))
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# Portable mtime reader (macOS stat vs GNU stat).
+_file_mtime() {
+    stat -f%m "$1" 2>/dev/null || stat -c%Y "$1" 2>/dev/null || echo 0
+}
+
+log "check (threshold=${STALE_THRESHOLD}s, dry-run=${DRY_RUN})"
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file absent — scanner may not have started yet or LOOP_LOG_DIR is wrong"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(_file_mtime "$HEARTBEAT_FILE")
+age=$(( now - mtime ))
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "OK: heartbeat age=${age}s < threshold=${STALE_THRESHOLD}s"
+    exit 0
+fi
+
+log "STALE: heartbeat age=${age}s >= threshold=${STALE_THRESHOLD}s — scanner appears wedged"
+
+if [ ! -f "$LOCK_FILE" ]; then
+    log "no lock file at $LOCK_FILE — scanner not running; launchd will restart it"
+    exit 0
+fi
+
+scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || echo "")
+
+if [ -z "$scanner_pid" ]; then
+    log "lock file empty — removing stale lock"
+    $DRY_RUN || rm -f "$LOCK_FILE"
+    exit 0
+fi
+
+if ! kill -0 "$scanner_pid" 2>/dev/null; then
+    log "scanner PID $scanner_pid is already dead — removing stale lock"
+    $DRY_RUN || rm -f "$LOCK_FILE"
+    exit 0
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID $scanner_pid"
+    exit 0
+fi
+
+log "killing wedged scanner PID $scanner_pid (launchd KeepAlive will restart it)"
+kill "$scanner_pid" 2>/dev/null || true
+
+# Give launchd a moment to clean up before the next watchdog tick.
+sleep 2
+
+log "done"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -776,6 +776,8 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Liveness heartbeat — scanner-watchdog.sh reads mtime to detect a wedged process.
+    $DRY_RUN || printf '%s\n' "$(date +%s)" > "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes and checks whether the scanner heartbeat file is
+  fresh. If the scanner appears wedged (heartbeat older than 2 × poll
+  interval) it kills the scanner PID so launchd KeepAlive restarts it.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — liveness heartbeat written on every scanner tick.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_LOG_DIR="$BATS_TMPDIR"
+    export HEARTBEAT_FILE="$BATS_TMPDIR/scanner-heartbeat"
+    rm -f "$HEARTBEAT_FILE"
+}
+
+teardown() {
+    rm -f "$HEARTBEAT_FILE"
+}
+
+@test "scanner.sh writes scanner-heartbeat on each tick (source inspection)" {
+    grep -q 'scanner-heartbeat' "$REPO_ROOT/scanner/scanner.sh"
+    grep -q 'LOOP_LOG_DIR.*scanner-heartbeat\|scanner-heartbeat.*LOOP_LOG_DIR' "$REPO_ROOT/scanner/scanner.sh"
+}
+
+@test "scanner-watchdog.sh exists and is executable" {
+    [ -f "$REPO_ROOT/scanner/scanner-watchdog.sh" ]
+    [ -x "$REPO_ROOT/scanner/scanner-watchdog.sh" ]
+}
+
+@test "scanner-watchdog.sh exits cleanly when heartbeat file is missing" {
+    # No heartbeat file — watchdog should log a warning and exit 0 (not crash).
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"absent"* ]] || [[ "$output" == *"not have started"* ]]
+}
+
+@test "scanner-watchdog.sh reports OK when heartbeat is fresh" {
+    # Write a current timestamp — age will be ~0s, well below threshold.
+    printf '%s\n' "$(date +%s)" > "$HEARTBEAT_FILE"
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"OK"* ]]
+}
+
+@test "scanner-watchdog.sh detects stale heartbeat and reports STALE" {
+    # Back-date mtime by 3 hours (10800s). The watchdog threshold is
+    # 2 × LOOP_SCANNER_INTERVAL (minimum 600s, typically 3600s); 10800s
+    # exceeds any reasonable configured value.
+    printf '%s\n' "0" > "$HEARTBEAT_FILE"
+    local stale_ts=$(( $(date +%s) - 10800 ))
+    python3 -c "import os; os.utime('$HEARTBEAT_FILE', ($stale_ts, $stale_ts))"
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- Writes a liveness heartbeat (`${LOOP_LOG_DIR}/scanner-heartbeat`) on every tick via `touch`. Skipped in `--dry-run` mode. Write errors are suppressed so a permissions issue doesn't break the scan loop.

### scanner/scanner-watchdog.sh (new)
- Runs every 5 minutes (via launchd or cron). Reads the heartbeat file mtime; if older than `STALE_THRESHOLD` (default: `2 × LOOP_SCANNER_INTERVAL = 600s`), it kills the wedged scanner PID (read from the lock file) so launchd `KeepAlive=true` auto-restarts it.
- Handles all edge cases: missing heartbeat file (scanner not yet started), missing lock file, dead PID, empty lock file.
- `--dry-run` flag for safe manual inspection.

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
- `StartInterval=300` (every 5 min), no `RunAtLoad` (avoids false-positive on first boot before scanner writes its first heartbeat).
- Same `__LOOP_ROOT__` / `__LOG_DIR__` / `__HOME__` / `__EXTRA_PATH__` substitution tokens as other plist templates.

### install.sh
- `bootstrap_register_launchd`: installs the scanner-watchdog plist (idempotent — skips if already exists).
- `bootstrap_register_cron`: adds `*/5 * * * *` cron entry for the watchdog (Linux path).

### tests/scanner-heartbeat.bats (new)
- Source-inspection test: verifies `scanner.sh` references `scanner-heartbeat`
- Existence + executable check for `scanner-watchdog.sh`
- Behavioural tests with `--dry-run`: missing heartbeat → exit 0 + "absent"; fresh heartbeat → "OK"; back-dated mtime → "STALE"

## Test Plan
- [ ] `bash -n` passes on all scripts (run locally: passes)
- [ ] `shellcheck -S warning` passes (run locally: passes)
- [ ] No personal identifiers in committed files (verified)
- [ ] Manual liveness test: `kill -STOP $SCANNER_PID` → watchdog detects stale heartbeat within 10 min, kills scanner, launchd restarts
- [ ] bats tests: `bats tests/scanner-heartbeat.bats`