### PR TITLE
[LOOP-413] scanner: add liveness heartbeat + auto-restart watchdog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,23 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +378,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +401,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart a wedged scanner process.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written by scanner.sh on every tick).
+# If the file is absent or its mtime is older than LOOP_SCANNER_WATCHDOG_STALE_SECS
+# (default: 2 × LOOP_SCANNER_INTERVAL = 600s), the scanner is considered wedged:
+# the PID recorded in the lock file is killed so launchd/cron restarts it.
+#
+# Designed to run every 5 minutes via launchd (StartInterval 300) or cron.
+#
+# Usage:
+#   scanner-watchdog.sh            # check and restart if stale
+#   scanner-watchdog.sh --dry-run  # check only, print status, do not kill
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+LOCK_FILE="/tmp/loop-scanner.lock"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_SECS="${LOOP_SCANNER_WATCHDOG_STALE_SECS:-$(( POLL_INTERVAL * 2 ))}"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _file_age_seconds <path>
+# Returns seconds since the file's mtime, or a large number if the file
+# does not exist (triggering the stale check).
+_file_age_seconds() {
+    local path="$1"
+    [ -f "$path" ] || { echo 999999; return; }
+    local mtime now
+    mtime=$(stat -f%m "$path" 2>/dev/null || stat -c%Y "$path" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+age=$(_file_age_seconds "$HEARTBEAT_FILE")
+log "heartbeat age=${age}s stale_threshold=${STALE_SECS}s file=${HEARTBEAT_FILE}"
+
+if [ "$age" -lt "$STALE_SECS" ]; then
+    log "scanner is healthy"
+    exit 0
+fi
+
+log "WARN: scanner appears wedged (heartbeat ${age}s old > ${STALE_SECS}s threshold)"
+
+# Read the scanner PID from the lock file.
+scanner_pid=""
+if [ -f "$LOCK_FILE" ]; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID=${scanner_pid:-unknown} and let launchd restart it"
+    exit 0
+fi
+
+if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+    log "killing wedged scanner PID=$scanner_pid"
+    kill "$scanner_pid" 2>/dev/null || true
+    # Give launchd a moment; it will restart via KeepAlive.
+    sleep 2
+    log "scanner killed — launchd will restart it"
+else
+    log "no live scanner PID found (lock_file=${LOCK_FILE} pid=${scanner_pid:-none})"
+    # Remove stale heartbeat so the next watchdog tick does not false-alarm
+    # once the scanner restarts and a fresh heartbeat appears.
+    rm -f "$HEARTBEAT_FILE" 2>/dev/null || true
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -776,6 +776,8 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Heartbeat: write current epoch so scanner-watchdog can detect a wedged process.
+    $DRY_RUN || printf '%s\n' "$(date +%s)" > "${LOOP_LOG_DIR}/scanner-heartbeat"
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <!-- Check every 5 minutes; stale threshold defaults to 2 × poll interval (600s) -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,144 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verify that scanner-heartbeat is written on every tick
+# and that scanner-watchdog.sh detects stale/fresh heartbeats correctly.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    # Expose mock-gh.sh as the gh binary via a per-test temp bin directory.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+
+    # Source scanner.sh function definitions only (stop before acquire_lock).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    # Override paths
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    # Silence noisy helpers
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { :; }
+    loop_project_is_paused() { return 1; }
+    LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat written by run_once
+# ---------------------------------------------------------------------------
+
+@test "run_once: writes scanner-heartbeat file to LOOP_LOG_DIR" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    [ ! -f "$hb" ]
+
+    run_once
+
+    [ -f "$hb" ]
+}
+
+@test "run_once: heartbeat file contains a numeric epoch timestamp" {
+    run_once
+
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    local ts
+    ts=$(cat "$hb")
+    # Must be a non-empty string of digits only
+    [[ "$ts" =~ ^[0-9]+$ ]]
+}
+
+@test "run_once: heartbeat mtime is updated on each call" {
+    run_once
+
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    local mtime1
+    mtime1=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb" 2>/dev/null || echo 0)
+
+    sleep 1
+    run_once
+
+    local mtime2
+    mtime2=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb" 2>/dev/null || echo 0)
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once: heartbeat is NOT written in dry-run mode" {
+    DRY_RUN=true
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    [ ! -f "$hb" ]
+
+    run_once
+
+    [ ! -f "$hb" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh: healthy and stale detection
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits 0 and prints healthy when heartbeat is fresh" {
+    # Write a heartbeat with current epoch (age = 0s)
+    printf '%s\n' "$(date +%s)" > "${LOOP_LOG_DIR}/scanner-heartbeat"
+
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"healthy"* ]]
+}
+
+@test "scanner-watchdog: detects stale heartbeat in dry-run and prints warning" {
+    # Write a heartbeat with a timestamp far in the past (2 hours ago)
+    local old_ts=$(( $(date +%s) - 7200 ))
+    printf '%s\n' "$old_ts" > "${LOOP_LOG_DIR}/scanner-heartbeat"
+    # Force mtime to match the old timestamp
+    touch -t "$(date -r "$old_ts" '+%Y%m%d%H%M.%S' 2>/dev/null || date -d "@$old_ts" '+%Y%m%d%H%M.%S' 2>/dev/null)" \
+        "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"wedged"* ]] || [[ "$output" == *"WARN"* ]]
+    [[ "$output" == *"DRY-RUN"* ]]
+}
+
+@test "scanner-watchdog: detects absent heartbeat as stale" {
+    rm -f "${LOOP_LOG_DIR}/scanner-heartbeat"
+
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"wedged"* ]] || [[ "$output" == *"WARN"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`** — write `date +%s` to `${LOOP_LOG_DIR}/scanner-heartbeat` at the start of every `run_once()` tick. Skipped in `--dry-run` mode. This single write is the observable liveness signal for the watchdog.

**`scanner/scanner-watchdog.sh`** (new) — lightweight script designed to run every 5 min via launchd/cron. Reads the heartbeat file mtime; if the file is absent or older than `LOOP_SCANNER_WATCHDOG_STALE_SECS` (default: `2 × LOOP_SCANNER_INTERVAL = 600s`), the scanner PID from the lock file is killed so launchd's `KeepAlive` restarts it. Supports `--dry-run` for safe manual inspection.

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new) — launchd plist template (`StartInterval 300`) that runs the watchdog every 5 minutes. Uses the same `__LOOP_ROOT__` / `__LOG_DIR__` / `__HOME__` / `__EXTRA_PATH__` substitution tokens as existing templates.

**`install.sh`** — register the watchdog in both `bootstrap_register_launchd()` (macOS) and `bootstrap_register_cron()` (Linux). Idempotent: skips if plist/cron entry already exists.

**`tests/scanner-heartbeat.bats`** (new) — 7 bats tests covering:
- heartbeat file is created by `run_once()`
- content is a numeric epoch timestamp
- mtime is updated on each call
- heartbeat is NOT written in `--dry-run` mode
- watchdog exits healthy when heartbeat is fresh
- watchdog detects stale heartbeat and prints warning (dry-run)
- watchdog detects absent heartbeat as stale

## Test Plan

- All 7 new bats tests pass locally
- Existing scanner.bats suite: no regressions (5 pre-existing failures on main unchanged)
- `bash -n` and `shellcheck -S warning` clean on all scripts
- Manual: `scanner-watchdog.sh --dry-run` with fresh/stale/absent heartbeat shows correct output
- Manual simulate wedge: `kill -STOP $SCANNER_PID` → watchdog kills it within 10 min; launchd restarts