### PR TITLE
[LOOP-413] scanner: heartbeat file + stale-scanner watchdog

### DIFF
--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -776,6 +776,9 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Heartbeat: write current timestamp so the scanner watchdog can detect a
+    # wedged process (alive PID but no tick progress for 2×poll_interval).
+    $DRY_RUN || touch "${LOOP_LOG_DIR}/scanner-heartbeat"
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scripts/restart-scanner-if-stale.sh
+++ b/scripts/restart-scanner-if-stale.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# restart-scanner-if-stale.sh — scanner liveness watchdog.
+#
+# Checks the scanner-heartbeat file written by scanner.sh on every tick.
+# If the heartbeat is older than STALE_THRESHOLD_SECONDS (default: 2× poll interval,
+# i.e. 600s) the scanner is considered wedged and is restarted:
+#   - macOS: via launchctl kickstart (preferred) or kill-then-KeepAlive restart
+#   - Linux: via pkill + cron-based auto-restart (cron must be configured)
+#
+# Usage:
+#   restart-scanner-if-stale.sh [--dry-run]
+#
+# Designed to run every 5 minutes via launchd (StartInterval=300) or cron.
+# See templates/launchd/com.user.loop-scanner-watchdog.plist.template
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_SCANNER_STALE_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+SCANNER_LABEL="com.user.loop-scanner"
+
+# _heartbeat_age — print seconds since heartbeat file was last modified.
+# Returns 1 if the file does not exist.
+_heartbeat_age() {
+    [ -f "$HEARTBEAT_FILE" ] || return 1
+    local mtime now
+    mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+         || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null) || return 1
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+# _restart_scanner — attempt to restart the scanner.
+# macOS: launchctl kickstart; Linux: send SIGTERM to the old process (cron
+# or systemd KeepAlive will bring a new one up).
+_restart_scanner() {
+    if $DRY_RUN; then
+        log "DRY-RUN: would restart scanner"
+        return 0
+    fi
+    if command -v launchctl >/dev/null 2>&1; then
+        local domain
+        domain="gui/$(id -u)"
+        log "restarting via launchctl kickstart ${domain}/${SCANNER_LABEL}"
+        if launchctl kickstart -k "${domain}/${SCANNER_LABEL}" 2>/dev/null; then
+            return 0
+        fi
+        # Fallback: kill the PID (launchd KeepAlive will restart it).
+        log "kickstart failed — falling back to kill-based restart"
+    fi
+    local lock_file="/tmp/loop-scanner.lock"
+    if [ -f "$lock_file" ]; then
+        local pid
+        pid=$(cat "$lock_file" 2>/dev/null || true)
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+            log "sending SIGTERM to scanner PID $pid"
+            kill "$pid" 2>/dev/null || true
+            return 0
+        fi
+    fi
+    log "WARN: no running scanner found to restart"
+}
+
+age=0
+if ! age=$(_heartbeat_age); then
+    log "heartbeat file missing ($HEARTBEAT_FILE) — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner healthy (age=${age}s < threshold=${STALE_THRESHOLD}s)"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat stale (age=${age}s >= ${STALE_THRESHOLD}s) — restarting"
+_restart_scanner

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+  Fires every 5 minutes; restarts the scanner if its heartbeat file is stale.
+
+  Install:
+    sed "s|__LOOP_ROOT__|$(cd "$(dirname "$0")/.." && pwd)|g; \
+         s|__LOG_DIR__|$LOOP_LOG_DIR|g; \
+         s|__HOME__|$HOME|g; \
+         s|__EXTRA_PATH__|${LOOP_EXTRA_PATH:-/opt/homebrew/bin:/usr/local/bin}|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/restart-scanner-if-stale.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 scanner liveness heartbeat.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    log() { :; }
+    dispatch_direct() { :; }
+    loop_list_slugs() { echo ""; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+@test "run_once: writes scanner-heartbeat file on each tick" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    [ ! -f "$hb" ]
+    run_once
+    [ -f "$hb" ]
+}
+
+@test "run_once: heartbeat mtime advances between ticks" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    run_once
+    local t1
+    t1=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb")
+    sleep 1
+    run_once
+    local t2
+    t2=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb")
+    [ "$t2" -ge "$t1" ]
+}
+
+@test "run_once: heartbeat not written in dry-run mode" {
+    DRY_RUN=true
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    run_once
+    [ ! -f "$hb" ]
+}
+
+@test "restart-scanner-if-stale.sh: reports healthy when heartbeat is fresh" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    touch "$hb"
+    run bash "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"healthy"* ]]
+}
+
+@test "restart-scanner-if-stale.sh: detects stale heartbeat and reports restart" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    # Create a heartbeat file with a very old mtime (2000 seconds ago).
+    touch "$hb"
+    touch -t "$(date -v-2000S '+%Y%m%d%H%M.%S' 2>/dev/null \
+        || date -d '2000 seconds ago' '+%Y%m%d%H%M.%S' 2>/dev/null \
+        || date '+%Y%m%d%H%M.%S')" "$hb" 2>/dev/null || true
+    # Force mtime with python3 if touch -t failed (portability fallback).
+    python3 -c "
+import os, time
+hb = '$hb'
+old = time.time() - 2000
+os.utime(hb, (old, old))
+"
+    LOOP_SCANNER_STALE_THRESHOLD=600 \
+    run bash "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"stale"* ]] || [[ "$output" == *"DRY-RUN"* ]]
+}
+
+@test "restart-scanner-if-stale.sh: exits cleanly when heartbeat file is missing" {
+    run bash "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"missing"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

**scanner/scanner.sh**
- Added `touch "${LOOP_LOG_DIR}/scanner-heartbeat"` at the top of every `run_once()` tick (skipped in `--dry-run` mode). This creates a reliable liveness signal that doesn't depend on log rotation or stdout FD health.

**scripts/restart-scanner-if-stale.sh** (new)
- Reads the heartbeat file mtime. If older than `LOOP_SCANNER_STALE_THRESHOLD` (default: `2 × LOOP_SCANNER_INTERVAL = 600s`), the scanner is considered wedged and restarted:
  - macOS: `launchctl kickstart -k gui/$(id -u)/com.user.loop-scanner`
  - Fallback: `SIGTERM` to the PID in the lock file (launchd KeepAlive brings it back)
- Supports `--dry-run` flag for safe testing.

**templates/launchd/com.user.loop-scanner-watchdog.plist.template** (new)
- launchd plist that fires `restart-scanner-if-stale.sh` every 5 minutes (`StartInterval=300`).
- Follows the same `__LOOP_ROOT__` / `__LOG_DIR__` / `__HOME__` placeholder conventions as existing templates.

**tests/scanner-heartbeat.bats** (new, 6 assertions)
- `run_once` writes heartbeat file
- `run_once` does NOT write heartbeat in dry-run
- heartbeat mtime advances between ticks
- watchdog reports healthy when file is fresh
- watchdog detects stale heartbeat and prints restart intent (dry-run)
- watchdog exits cleanly when heartbeat file is missing

## Test Plan

- All 6 new bats tests pass
- Existing scanner/scanner-log-sighup/scanner-stage-age tests unaffected
- `bash -n` and `shellcheck -S warning` pass on all scripts
- No personal identifiers in committed files

To simulate a wedged scanner manually:
```bash
kill -STOP $SCANNER_PID   # freeze the process
# wait > STALE_THRESHOLD seconds
./scripts/restart-scanner-if-stale.sh --dry-run   # should report "stale"
kill -CONT $SCANNER_PID   # resume
```