### PR TITLE
[LOOP-413] scanner: liveness heartbeat + watchdog auto-restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — kills a wedged scanner so launchd restarts it.
+    # Fires every 5 min; safe to run even when the scanner is healthy (no-ops then).
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/check-scanner-liveness.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/loop.env.example
+++ b/loop.env.example
@@ -81,6 +81,14 @@ LOOP_DISPATCH_MODE="direct"
 # macOS (Homebrew): /opt/homebrew/bin:/usr/local/bin — Linux: /usr/local/bin or similar.
 LOOP_EXTRA_PATH="/opt/homebrew/bin:/usr/local/bin"
 
+# ─── Scanner liveness watchdog ───────────────────────────────────────────────
+# check-scanner-liveness.sh (installed via --bootstrap) fires every 5 min.
+# It kills a wedged scanner process when the heartbeat file has not been
+# updated for more than this many seconds; launchd/cron then restarts it.
+# Default: 2 × LOOP_SCANNER_INTERVAL (600s for the default 300s cadence).
+# Lower values increase restart sensitivity; raise if you use a long interval.
+# LOOP_SCANNER_LIVENESS_THRESHOLD=600
+
 # ─── Recovery ────────────────────────────────────────────────────────────────
 # Seconds before an operational label (in-progress, in-rework, in-review) with
 # no live handler process is considered stuck. Recovery strips the label and

--- a/scanner/check-scanner-liveness.sh
+++ b/scanner/check-scanner-liveness.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# check-scanner-liveness.sh — watchdog for the continuous scanner process.
+#
+# Reads the heartbeat file written by scanner.sh on every tick. If the file
+# is absent or its mtime is older than LOOP_SCANNER_LIVENESS_THRESHOLD seconds
+# (default: 2 × LOOP_SCANNER_INTERVAL, i.e. 600s), the scanner is considered
+# wedged: its PID (from the lock file) is killed so that launchd (macOS) or
+# cron (Linux) can restart it.
+#
+# Designed to run every 5 minutes (launchd StartInterval=300 / cron */5).
+#
+# Flags:
+#   --dry-run   print what would be done without killing the scanner
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+# Default threshold: 2 × poll interval (600s for the default 300s cadence).
+LIVENESS_THRESHOLD="${LOOP_SCANNER_LIVENESS_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# No heartbeat file means the scanner has never ticked (or was just started).
+# Don't kill it — give it at least one full threshold window to write.
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file not found (${HEARTBEAT_FILE}) — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+# Compute heartbeat age in seconds.
+heartbeat_age=$(( $(date +%s) - $(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0) ))
+
+if [ "$heartbeat_age" -lt "$LIVENESS_THRESHOLD" ]; then
+    log "OK: heartbeat age=${heartbeat_age}s threshold=${LIVENESS_THRESHOLD}s"
+    exit 0
+fi
+
+log "STALE: heartbeat age=${heartbeat_age}s exceeds threshold=${LIVENESS_THRESHOLD}s"
+
+# Read the scanner PID from the lock file.
+if [ ! -f "$LOCK_FILE" ]; then
+    log "no lock file at ${LOCK_FILE} — scanner not running; nothing to kill"
+    exit 0
+fi
+
+scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+if [ -z "$scanner_pid" ]; then
+    log "lock file empty — cannot determine scanner PID"
+    exit 0
+fi
+
+if ! kill -0 "$scanner_pid" 2>/dev/null; then
+    log "PID ${scanner_pid} is not alive — stale lock file; launchd will restart scanner"
+    exit 0
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID ${scanner_pid}"
+    exit 0
+fi
+
+log "killing wedged scanner PID ${scanner_pid} (launchd will restart it)"
+kill "$scanner_pid" 2>/dev/null || true

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -775,6 +776,19 @@ scan_project() {
 }
 
 run_once() {
+    # Liveness heartbeat: update mtime so the scanner-watchdog can detect a
+    # wedged process (alive PID, no progress). Also recover a non-writable log
+    # FD by exiting early — launchd will restart the scanner cleanly.
+    if ! $DRY_RUN; then
+        touch "${HEARTBEAT_FILE}" 2>/dev/null \
+            || log "WARN: could not update heartbeat file ${HEARTBEAT_FILE}"
+        # Only check writability when the file already exists — a missing log
+        # file is normal on first start (launchd creates it on first write).
+        if [ -n "${LOG_FILE:-}" ] && [ -e "${LOG_FILE}" ] && [ ! -w "${LOG_FILE}" ]; then
+            log "WARN: log file not writable (${LOG_FILE}) — exiting for launchd restart"
+            exit 1
+        fi
+    fi
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes, reads the scanner heartbeat file, and kills the
+  scanner process if its last tick was more than LOOP_SCANNER_LIVENESS_THRESHOLD
+  seconds ago (default 600s = 2 × poll interval). launchd then auto-restarts
+  the scanner via KeepAlive on com.user.loop-scanner.
+
+  Installed automatically by ./install.sh --bootstrap.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/check-scanner-liveness.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,132 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — liveness heartbeat written on every tick.
+#
+# Verifies that scanner.sh's run_once() touches the heartbeat file on every
+# tick, and that check-scanner-liveness.sh correctly classifies fresh vs stale.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Expose mock-gh binary so env.sh / config.sh loading doesn't fail.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner.sh definitions (same approach as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    # Override paths set by scanner.sh after source (env.sh may have read
+    # a local loop.env with different values — set explicitly here).
+    HEARTBEAT_FILE="$BATS_TMPDIR/scanner-heartbeat"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    # Silence log() / dispatch_direct so run_once() doesn't emit real work.
+    log() { :; }
+    dispatch_direct() { :; }
+    # Stub out functions that would call gh or python3 to list projects.
+    loop_list_slugs() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/logs" \
+           "$BATS_TMPDIR/dedup" "$BATS_TMPDIR/scanner-src.sh" \
+           "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-heartbeat" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat file: written on every tick
+# ---------------------------------------------------------------------------
+
+@test "run_once: creates heartbeat file on first tick" {
+    [ ! -f "$HEARTBEAT_FILE" ]
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: updates heartbeat mtime on subsequent ticks" {
+    touch -t 200001010000 "$HEARTBEAT_FILE"   # backdate to year 2000
+    local before
+    before=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+    run_once
+    local after
+    after=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+    [ "$after" -gt "$before" ]
+}
+
+@test "run_once: heartbeat file is not written in dry-run mode" {
+    DRY_RUN=true
+    run_once
+    [ ! -f "$HEARTBEAT_FILE" ]
+}
+
+# ---------------------------------------------------------------------------
+# check-scanner-liveness.sh: source-level logic tests
+# ---------------------------------------------------------------------------
+
+@test "check-scanner-liveness: fresh heartbeat file is not stale" {
+    local hb="$BATS_TMPDIR/hb-fresh"
+    touch "$hb"
+    local age
+    age=$(( $(date +%s) - $(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb" 2>/dev/null || echo 0) ))
+    # Threshold of 600s; a just-created file has age ~0
+    [ "$age" -lt 600 ]
+}
+
+@test "check-scanner-liveness: backdated heartbeat exceeds threshold" {
+    local hb="$BATS_TMPDIR/hb-stale"
+    touch -t 200001010000 "$hb"   # year 2000 → thousands of seconds old
+    local age threshold=600
+    age=$(( $(date +%s) - $(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb" 2>/dev/null || echo 0) ))
+    [ "$age" -ge "$threshold" ]
+}
+
+@test "check-scanner-liveness.sh: exits 0 with OK message for fresh heartbeat" {
+    local hb="$BATS_TMPDIR/logs/scanner-heartbeat"
+    touch "$hb"
+    # Run with an isolated LOOP_ROOT pointing at a loop.env-free dir so env.sh
+    # does not source the operator's loop.env and override LOOP_LOG_DIR.
+    local fake_root="$BATS_TMPDIR/fakeroot"
+    mkdir -p "$fake_root/lib" "$fake_root/config"
+    # Symlink only what we need: env.sh (for LOOP_LOG_DIR export), no loop.env.
+    ln -sf "$REPO_ROOT/lib/env.sh"      "$fake_root/lib/env.sh"
+    ln -sf "$REPO_ROOT/lib/version.sh"  "$fake_root/lib/version.sh"
+    ln -sf "$REPO_ROOT/lib/workflow.sh" "$fake_root/lib/workflow.sh"
+    ln -sf "$REPO_ROOT/config/workflows" "$fake_root/config/workflows"
+    # Build a minimal scanner/check-scanner-liveness.sh that uses fake_root.
+    local stub_script="$BATS_TMPDIR/check-liveness-stub.sh"
+    sed "s|LOOP_ROOT=.*|LOOP_ROOT='$fake_root'|" \
+        "$REPO_ROOT/scanner/check-scanner-liveness.sh" > "$stub_script"
+    chmod +x "$stub_script"
+    run env LOOP_LOG_DIR="$BATS_TMPDIR/logs" \
+        LOOP_SCANNER_LIVENESS_THRESHOLD=600 \
+        bash "$stub_script" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"OK:"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- Writes `${LOOP_LOG_DIR}/scanner-heartbeat` (via `touch`) at the start of every `run_once()` tick so a watchdog can detect a wedged process by checking file mtime.
- Skips the heartbeat write in `--dry-run` mode.
- Adds a log file writability check: if `LOG_FILE` exists but is not writable (e.g. wrong permissions after log rotation), exits with code 1 so launchd auto-restarts cleanly instead of silently dropping all log output.

### scanner/check-scanner-liveness.sh (new)
- Watchdog script: reads the heartbeat file mtime; if age exceeds `LOOP_SCANNER_LIVENESS_THRESHOLD` (default: `2 × LOOP_SCANNER_INTERVAL = 600s`), reads the scanner PID from the lock file and kills it so launchd (macOS) or cron (Linux) restarts it.
- No-ops when: heartbeat is fresh, no heartbeat file yet (scanner just started), no lock file, or PID is already dead.
- Supports `--dry-run` flag.

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
- LaunchAgent template: `StartInterval=300` (every 5 min), runs `check-scanner-liveness.sh`.

### install.sh
- `bootstrap_register_launchd()`: installs `com.user.loop-scanner-watchdog.plist` alongside the other Loop agents.
- `bootstrap_register_cron()`: adds `*/5 * * * *` cron entry for `check-scanner-liveness.sh` on Linux.

### loop.env.example
- Documents `LOOP_SCANNER_LIVENESS_THRESHOLD` with rationale.

### tests/scanner-heartbeat.bats (new)
- 6 tests covering: heartbeat file created on first tick, mtime updated on subsequent ticks, no write in dry-run mode, threshold logic, and watchdog script exit behaviour for fresh heartbeat.

## Test Plan
- All 6 new bats tests pass: `bats tests/scanner-heartbeat.bats`
- Existing scanner tests unaffected: `bats tests/scanner.bats tests/scanner-log-sighup.bats tests/scanner-stage-age.bats`
- `bash -n` and `shellcheck -S warning` pass on all scripts
- Manual: simulate wedge with `kill -STOP $SCANNER_PID`; watchdog should restart within 5 min (next cron/launchd tick after threshold elapsed)