### PR TITLE
[LOOP-413] scanner: heartbeat file + liveness watchdog to prevent silent outages

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,24 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — kills a wedged scanner so launchd restarts it.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +379,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/restart-scanner-if-stale.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +402,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -775,6 +775,22 @@ scan_project() {
 }
 
 run_once() {
+    # Heartbeat — write current epoch every tick so the watchdog can detect a
+    # wedged-but-alive scanner that has stopped emitting events or logging.
+    if ! $DRY_RUN; then
+        printf '%s\n' "$(date +%s)" > "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+    fi
+
+    # Stdout integrity check — if the log file has become unwritable (inode
+    # unlinked after log rotation while FD still points at old inode), exit
+    # immediately so launchd restarts us with a fresh file descriptor.
+    if [ -n "${LOG_FILE:-}" ] && ! $DRY_RUN; then
+        if [ -e "$LOG_FILE" ] && [ ! -w "$LOG_FILE" ]; then
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] WARN: log file not writable — exiting for restart" >&2
+            exit 1
+        fi
+    fi
+
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/scripts/restart-scanner-if-stale.sh
+++ b/scripts/restart-scanner-if-stale.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# restart-scanner-if-stale.sh — Scanner liveness watchdog.
+#
+# Fires every 5 minutes (via launchd StartInterval or cron */5).
+# Reads the heartbeat file written each tick by scanner.sh.
+# If the heartbeat is older than LOOP_SCANNER_STALE_THRESHOLD seconds
+# (default 900 = 15 min, ~3x the default 300s poll interval) AND the
+# scanner lock file PID is alive, kills the PID and removes the lock so
+# launchd KeepAlive (macOS) or the next cron tick (Linux) restarts it.
+#
+# Environment variables:
+#   LOOP_SCANNER_STALE_THRESHOLD  — stale age in seconds (default: 900)
+#   LOOP_LOG_DIR                  — log directory (from loop.env / env.sh)
+#
+# Flags:
+#   --dry-run   diagnose only, no kill
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+LOCK_FILE="/tmp/loop-scanner.lock"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+STALE_THRESHOLD="${LOOP_SCANNER_STALE_THRESHOLD:-900}"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -25
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _file_age <path> — seconds since last modification; 0 if file absent.
+_file_age() {
+    [ -f "$1" ] || { echo 0; return; }
+    local mtime now
+    mtime=$(stat -f%m "$1" 2>/dev/null || stat -c%Y "$1" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file absent — scanner has not run yet; skipping"
+    exit 0
+fi
+
+heartbeat_age=$(_file_age "$HEARTBEAT_FILE")
+log "heartbeat age=${heartbeat_age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$heartbeat_age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is alive (heartbeat fresh)"
+    exit 0
+fi
+
+# Heartbeat is stale — check whether a scanner process is holding the lock.
+if [ ! -f "$LOCK_FILE" ]; then
+    log "stale heartbeat but no lock file — scanner not running; nothing to kill"
+    exit 0
+fi
+
+scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || echo "")
+if [ -z "$scanner_pid" ]; then
+    log "WARN: lock file empty — removing stale lock"
+    $DRY_RUN || rm -f "$LOCK_FILE"
+    exit 0
+fi
+
+if ! kill -0 "$scanner_pid" 2>/dev/null; then
+    log "WARN: lock PID $scanner_pid not alive — removing stale lock"
+    $DRY_RUN || rm -f "$LOCK_FILE"
+    exit 0
+fi
+
+# PID alive but heartbeat stale — scanner is wedged.
+log "ALERT: scanner PID $scanner_pid alive but heartbeat stale (${heartbeat_age}s > ${STALE_THRESHOLD}s) — restarting"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill PID $scanner_pid and remove $LOCK_FILE"
+    exit 0
+fi
+
+kill "$scanner_pid" 2>/dev/null || true
+rm -f "$LOCK_FILE"
+# launchd KeepAlive restarts on macOS within ~60s; on Linux the next cron
+# tick fires scanner.sh --once which clears the missing lock and runs normally.
+log "killed PID $scanner_pid; launchd/cron will restart scanner"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd plist.
+  Fires every 5 minutes. Reads scanner-heartbeat mtime; if stale, kills the
+  wedged scanner PID so launchd KeepAlive restarts it automatically.
+
+  Installed by: install.sh --bootstrap (bootstrap_register_launchd)
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/restart-scanner-if-stale.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for scanner liveness heartbeat (#413).
+# Verifies that run_once() writes the heartbeat file on every tick and that
+# DRY_RUN suppresses the write.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_EXTRA_PATH=""
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export DEDUP_DIR="$BATS_TMPDIR/dedup"
+    mkdir -p "$DEDUP_DIR"
+
+    # Extract scanner.sh definitions up to acquire_lock, same pattern as scanner.bats.
+    local _src="$BATS_TMPDIR/scanner-hb-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    # Stub out functions that require live network or config.
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { :; }
+    LOOP_JOBS_ENQUEUE=0
+    DRY_RUN=false
+    LOG_FILE="$BATS_TMPDIR/scanner.log"
+    touch "$LOG_FILE"
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/scanner-hb-src.sh" "$BATS_TMPDIR/scanner.log" 2>/dev/null || true
+}
+
+@test "scanner.sh: heartbeat write is present in source" {
+    grep -q "scanner-heartbeat" "$REPO_ROOT/scanner/scanner.sh"
+}
+
+@test "run_once: creates heartbeat file in LOOP_LOG_DIR" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    [ ! -f "$hb" ]
+    run_once
+    [ -f "$hb" ]
+}
+
+@test "run_once: heartbeat file contains a Unix epoch integer" {
+    run_once
+    local val
+    val=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+    [[ "$val" =~ ^[0-9]+$ ]]
+    [ "$val" -gt 0 ]
+}
+
+@test "run_once: heartbeat timestamp is non-decreasing across ticks" {
+    run_once
+    local ts1
+    ts1=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+    sleep 1
+    run_once
+    local ts2
+    ts2=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+    [ "$ts2" -ge "$ts1" ]
+}
+
+@test "run_once: DRY_RUN=true does not write heartbeat file" {
+    DRY_RUN=true
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    [ ! -f "$hb" ]
+    run_once
+    [ ! -f "$hb" ]
+}


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- **Heartbeat file**: at the start of every `run_once()` tick (before the sweep), writes `date +%s` to `${LOOP_LOG_DIR}/scanner-heartbeat`. Skipped in `--dry-run` mode.
- **Stdout integrity check**: if `$LOG_FILE` exists but is not writable (orphaned FD after log rotation), exits immediately so launchd KeepAlive restarts the process with a fresh file descriptor.

### scripts/restart-scanner-if-stale.sh (new)
Watchdog script designed to run every 5 minutes via launchd or cron:
1. Reads `scanner-heartbeat` mtime; if age < `LOOP_SCANNER_STALE_THRESHOLD` (default 900s = 15 min), exits cleanly.
2. If stale and the lock-file PID is alive, kills the process and removes the lock file — launchd KeepAlive restarts within ~60s; on Linux the next cron tick resumes normally.
3. Handles edge cases: absent heartbeat (first run), absent lock file (scanner stopped cleanly), dead PID (stale lock cleanup).
4. Supports `--dry-run` for safe diagnosis.

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
`StartInterval=300` plist; `install.sh --bootstrap` registers it as `com.user.loop-scanner-watchdog`.

### install.sh
- `bootstrap_register_launchd`: registers scanner-watchdog plist (idempotent).
- `bootstrap_register_cron`: adds `*/5 * * * *` watchdog cron entry (Linux, idempotent).

### tests/scanner-heartbeat.bats (new)
5 bats unit tests:
- heartbeat code present in scanner.sh source (regression guard)
- `run_once()` creates heartbeat file
- heartbeat contains a valid epoch integer
- heartbeat is non-decreasing across successive ticks
- `DRY_RUN=true` suppresses write

## Test Plan
- `bats tests/scanner-heartbeat.bats` — all 5 pass
- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — all pass
- `shellcheck -S warning` — no new warnings
- No personal identifiers introduced
- Manual: `kill -STOP $SCANNER_PID` → watchdog fires within 5 min, kills wedged PID, launchd restarts scanner