### PR TITLE
[LOOP-413] scanner: liveness heartbeat + watchdog auto-restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,6 +338,26 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    # Scanner liveness watchdog — fires every 5 min, restarts scanner if heartbeat
+    # goes stale (age > 2× poll interval). Guards against silent wedge scenarios
+    # where the scanner PID is alive but emits no events.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     local digest_plist="$agents_dir/com.user.loop-digest.plist"
     if [ -f "$digest_plist" ]; then
         echo "[launchd] com.user.loop-digest already registered — skipping"
@@ -361,8 +381,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local scanner_watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local scanner_watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $scanner_watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +404,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$scanner_watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$scanner_watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -774,8 +774,14 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+_heartbeat_write() {
+    local hb_file="${LOOP_LOG_DIR}/scanner-heartbeat"
+    printf '%s\n' "$(date +%s)" > "$hb_file" 2>/dev/null || true
+}
+
 run_once() {
     log "=== scan tick start ==="
+    $DRY_RUN || _heartbeat_write
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if its heartbeat goes stale.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written each tick by scanner.sh).
+# If the file is absent or its mtime/content is older than STALE_THRESHOLD
+# seconds, kills the current scanner PID and kicks launchd/cron to restart it.
+#
+# Designed to run every 5 minutes via launchd (StartInterval=300) or cron.
+# On macOS: launchctl kickstart re-launches the KeepAlive scanner service.
+# On Linux: kill of the scanner PID lets the cron entry restart it next tick.
+#
+# Usage:
+#   scanner-watchdog.sh [--dry-run]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+# 2× the default poll interval (300s). Override via loop.env.
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 ))
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+
+# _scanner_pid — read the PID from the scanner lock file, return empty if absent/dead.
+_scanner_pid() {
+    [ -f "$LOCK_FILE" ] || return 0
+    local pid
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && echo "$pid"
+}
+
+# _heartbeat_age_seconds — seconds since the heartbeat was last written.
+# Reads the epoch written by _heartbeat_write in scanner.sh.
+# Falls back to file mtime if the content is not a valid integer.
+# Returns a very large number if the file is absent.
+_heartbeat_age_seconds() {
+    if [ ! -f "$HEARTBEAT_FILE" ]; then
+        echo 999999
+        return
+    fi
+    local now written
+    now=$(date +%s)
+    written=$(cat "$HEARTBEAT_FILE" 2>/dev/null | tr -d '[:space:]')
+    if [[ "$written" =~ ^[0-9]+$ ]]; then
+        echo $(( now - written ))
+    else
+        # Fallback: use file mtime.
+        local mtime
+        mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+                || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+                || echo 0)
+        echo $(( now - mtime ))
+    fi
+}
+
+# _restart_scanner — kill existing PID and kick the scheduler to restart.
+_restart_scanner() {
+    local pid="$1"
+    if [ -n "$pid" ]; then
+        log "killing stale scanner PID $pid"
+        $DRY_RUN || kill "$pid" 2>/dev/null || true
+    fi
+    if [ "$(uname -s)" = "Darwin" ]; then
+        log "kickstarting com.user.loop-scanner via launchctl"
+        $DRY_RUN || launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null || true
+    else
+        log "scanner PID killed; cron will restart it on next tick"
+    fi
+}
+
+age=$(_heartbeat_age_seconds)
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is healthy — no action needed"
+    exit 0
+fi
+
+pid=$(_scanner_pid)
+log "STALE: scanner heartbeat is ${age}s old (threshold=${STALE_THRESHOLD}s) — restarting"
+_restart_scanner "$pid"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes. Reads ${LOOP_LOG_DIR}/scanner-heartbeat; if the
+  heartbeat is older than 2× LOOP_SCANNER_INTERVAL (default 600s), kills the
+  wedged scanner PID and calls `launchctl kickstart` so launchd restarts it.
+
+  Install via `./install.sh --bootstrap` (idempotent).
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <!-- Check every 5 minutes -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 scanner liveness heartbeat.
+#
+# Verifies that:
+#   1. _heartbeat_write creates/updates the heartbeat file on every tick.
+#   2. scanner-watchdog.sh considers a fresh heartbeat healthy.
+#   3. scanner-watchdog.sh detects a stale heartbeat and would restart.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner.sh function definitions only (same strategy as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    log() { :; }
+}
+
+teardown() {
+    rm -rf "$LOOP_LOG_DIR" "$BATS_TMPDIR/logs" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# _heartbeat_write
+# ---------------------------------------------------------------------------
+
+@test "_heartbeat_write creates heartbeat file" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    [ ! -f "$hb" ]
+    _heartbeat_write
+    [ -f "$hb" ]
+}
+
+@test "_heartbeat_write writes a unix timestamp" {
+    _heartbeat_write
+    local val
+    val=$(cat "$LOOP_LOG_DIR/scanner-heartbeat")
+    # Must be a number and close to now.
+    [[ "$val" =~ ^[0-9]+$ ]]
+    local now
+    now=$(date +%s)
+    local diff=$(( now - val ))
+    [ "$diff" -ge 0 ] && [ "$diff" -lt 5 ]
+}
+
+@test "_heartbeat_write updates mtime on repeated calls" {
+    _heartbeat_write
+    local mtime1
+    mtime1=$(stat -f%m "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null \
+             || stat -c%Y "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null)
+    sleep 1
+    _heartbeat_write
+    local mtime2
+    mtime2=$(stat -f%m "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null \
+             || stat -c%Y "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null)
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh: dry-run behaviour
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog.sh exits 0 when heartbeat is fresh" {
+    # Write a fresh heartbeat.
+    printf '%s\n' "$(date +%s)" > "$LOOP_LOG_DIR/scanner-heartbeat"
+
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner is healthy"* ]]
+}
+
+@test "scanner-watchdog.sh reports STALE when heartbeat is old" {
+    # Set interval to 60s so the stale threshold is 2×60=120s.
+    # Write a heartbeat 300s old — clearly stale regardless of loop.env.
+    export LOOP_SCANNER_INTERVAL=60
+    local old_ts=$(( $(date +%s) - 300 ))
+    printf '%s\n' "$old_ts" > "$LOOP_LOG_DIR/scanner-heartbeat"
+
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+}
+
+@test "scanner-watchdog.sh reports STALE when heartbeat file is absent" {
+    # No heartbeat file at all.
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- Added `_heartbeat_write()` that writes the current epoch to `${LOOP_LOG_DIR}/scanner-heartbeat` on every tick.
- Called at the top of `run_once()` (skipped in `--dry-run` mode), so the file's content always reflects when the last tick began.

### `scripts/scanner-watchdog.sh` (new)
- Periodic watchdog that reads the heartbeat file and computes its age.
- Stale threshold: `2 × LOOP_SCANNER_INTERVAL` (default 600s). Configurable via `LOOP_SCANNER_INTERVAL` in `loop.env`.
- On stale: kills the scanner PID (from `/tmp/loop-scanner.lock`) then runs `launchctl kickstart` on macOS; on Linux the kill alone is sufficient since cron restarts the scanner on the next tick.
- Supports `--dry-run` for manual inspection without taking action.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- `StartInterval=300` (every 5 min) — fires independently of the scanner's own sleep loop.
- Logs to `loop-scanner-watchdog.log`.

### `install.sh`
- `bootstrap_register_launchd`: registers `com.user.loop-scanner-watchdog` alongside the existing scanner/reconciler plists.
- `bootstrap_register_cron`: adds `*/5 * * * *` watchdog entry for Linux.

### `tests/scanner-heartbeat.bats` (new)
- 6 tests covering: file creation, content format, mtime update, watchdog healthy/stale/absent scenarios.

## Test Plan
- `bats tests/scanner-heartbeat.bats` → all 6 pass
- `bats tests/scanner.bats tests/scanner-log-sighup.bats tests/scanner-stage-age.bats` → no regressions
- Manual: `kill -STOP $SCANNER_PID` → watchdog fires within 5 min and restarts via launchd