### PR TITLE
[LOOP-413] scanner: liveness heartbeat + watchdog auto-restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,6 +338,26 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    # Scanner liveness watchdog — fires every 5 min, restarts scanner if heartbeat
+    # goes stale (age > 2x poll interval). Guards against silent wedge scenarios
+    # where the scanner PID is alive but emits no events.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     local digest_plist="$agents_dir/com.user.loop-digest.plist"
     if [ -f "$digest_plist" ]; then
         echo "[launchd] com.user.loop-digest already registered — skipping"
@@ -361,8 +381,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local scanner_watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local scanner_watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $scanner_watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +404,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$scanner_watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$scanner_watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -774,8 +774,14 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+_heartbeat_write() {
+    local hb_file="${LOOP_LOG_DIR}/scanner-heartbeat"
+    printf '%s\n' "$(date +%s)" > "$hb_file" 2>/dev/null || true
+}
+
 run_once() {
     log "=== scan tick start ==="
+    $DRY_RUN || _heartbeat_write
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if its heartbeat goes stale.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written each tick by scanner.sh).
+# If the file is absent or its recorded epoch is older than STALE_THRESHOLD
+# seconds, kills the current scanner PID and kicks the scheduler to restart it.
+#
+# Designed to run every 5 minutes via launchd (StartInterval=300) or cron.
+# On macOS: launchctl kickstart re-launches the KeepAlive scanner service.
+# On Linux: killing the PID lets the cron entry restart it on the next tick.
+#
+# Usage:
+#   scanner-watchdog.sh [--dry-run]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+# Stale threshold: 2× the scanner poll interval. Override LOOP_SCANNER_INTERVAL
+# in loop.env to adjust (must match scanner.sh's POLL_INTERVAL).
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 ))
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+
+# _scanner_pid — print the PID from the scanner lock file if the process is alive.
+_scanner_pid() {
+    [ -f "$LOCK_FILE" ] || return 0
+    local pid
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && echo "$pid"
+}
+
+# _heartbeat_age_seconds — seconds since the epoch stored in the heartbeat file.
+# Falls back to file mtime when the content is not a valid integer.
+# Returns a very large number when the file is absent.
+_heartbeat_age_seconds() {
+    if [ ! -f "$HEARTBEAT_FILE" ]; then
+        echo 999999
+        return
+    fi
+    local now written
+    now=$(date +%s)
+    written=$(tr -d '[:space:]' < "$HEARTBEAT_FILE" 2>/dev/null || true)
+    if [[ "$written" =~ ^[0-9]+$ ]]; then
+        echo $(( now - written ))
+    else
+        local mtime
+        mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+                || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+                || echo 0)
+        echo $(( now - mtime ))
+    fi
+}
+
+# _restart_scanner — kill existing PID and kick the scheduler.
+_restart_scanner() {
+    local pid="$1"
+    if [ -n "$pid" ]; then
+        log "killing stale scanner PID $pid"
+        $DRY_RUN || kill "$pid" 2>/dev/null || true
+    fi
+    if [ "$(uname -s)" = "Darwin" ]; then
+        log "kickstarting com.user.loop-scanner via launchctl"
+        $DRY_RUN || launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null || true
+    else
+        log "scanner PID killed; cron will restart it on next tick"
+    fi
+}
+
+age=$(_heartbeat_age_seconds)
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is healthy — no action needed"
+    exit 0
+fi
+
+pid=$(_scanner_pid || true)
+log "STALE: scanner heartbeat is ${age}s old (threshold=${STALE_THRESHOLD}s) — restarting"
+_restart_scanner "${pid:-}"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes. Reads ${LOOP_LOG_DIR}/scanner-heartbeat; if the
+  heartbeat is older than 2x LOOP_SCANNER_INTERVAL (default 600s), kills the
+  wedged scanner PID and calls `launchctl kickstart` so launchd restarts it.
+
+  Install via `./install.sh --bootstrap` (idempotent).
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <!-- Check every 5 minutes -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 scanner liveness heartbeat.
+#
+# Verifies:
+#   1. _heartbeat_write creates/updates the heartbeat file on every tick.
+#   2. scanner-watchdog.sh considers a fresh heartbeat healthy (exits 0, no restart).
+#   3. scanner-watchdog.sh detects a stale heartbeat and would restart.
+#   4. scanner-watchdog.sh handles a missing heartbeat file as stale.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Prevent env.sh from prepending /opt/homebrew/bin and shadowing any mock bin.
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner.sh function definitions only (same strategy as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    # Silence log() so test output stays clean.
+    log() { :; }
+}
+
+teardown() {
+    rm -rf "$LOOP_LOG_DIR" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# _heartbeat_write
+# ---------------------------------------------------------------------------
+
+@test "_heartbeat_write creates heartbeat file" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    [ ! -f "$hb" ]
+    _heartbeat_write
+    [ -f "$hb" ]
+}
+
+@test "_heartbeat_write writes a unix timestamp close to now" {
+    _heartbeat_write
+    local val
+    val=$(cat "$LOOP_LOG_DIR/scanner-heartbeat")
+    [[ "$val" =~ ^[0-9]+$ ]]
+    local now diff
+    now=$(date +%s)
+    diff=$(( now - val ))
+    [ "$diff" -ge 0 ] && [ "$diff" -lt 5 ]
+}
+
+@test "_heartbeat_write updates the file on repeated calls" {
+    _heartbeat_write
+    local v1
+    v1=$(cat "$LOOP_LOG_DIR/scanner-heartbeat")
+    sleep 1
+    _heartbeat_write
+    local v2
+    v2=$(cat "$LOOP_LOG_DIR/scanner-heartbeat")
+    [ "$v2" -ge "$v1" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh — dry-run behaviour
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog.sh exits 0 and reports healthy when heartbeat is fresh" {
+    printf '%s\n' "$(date +%s)" > "$LOOP_LOG_DIR/scanner-heartbeat"
+
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner is healthy"* ]]
+}
+
+@test "scanner-watchdog.sh reports STALE when heartbeat epoch is old" {
+    # Set interval to 60s → threshold = 120s; write a 300s-old heartbeat.
+    export LOOP_SCANNER_INTERVAL=60
+    local old_ts=$(( $(date +%s) - 300 ))
+    printf '%s\n' "$old_ts" > "$LOOP_LOG_DIR/scanner-heartbeat"
+
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+}
+
+@test "scanner-watchdog.sh reports STALE when heartbeat file is absent" {
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
Added `_heartbeat_write()` that writes the current Unix epoch to `${LOOP_LOG_DIR}/scanner-heartbeat` at the start of every `run_once()` tick. Skipped in `--dry-run` mode.

### `scripts/scanner-watchdog.sh` (new)
Periodic watchdog that reads the epoch from the heartbeat file and computes its age. If age exceeds `2 × LOOP_SCANNER_INTERVAL` (default 600s), it kills the scanner PID (from `/tmp/loop-scanner.lock`) and restarts it:
- macOS: `launchctl kickstart -k gui/<uid>/com.user.loop-scanner`
- Linux: kill alone; cron restarts scanner on next tick

Supports `--dry-run` for manual inspection.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
LaunchAgent with `StartInterval=300` (every 5 min), logging to `loop-scanner-watchdog.log`. Installed by `bootstrap_register_launchd`.

### `install.sh`
- `bootstrap_register_launchd`: registers `com.user.loop-scanner-watchdog` plist alongside existing services.
- `bootstrap_register_cron`: adds `*/5 * * * *` watchdog entry for Linux.

## Test Plan
- `bats tests/scanner-heartbeat.bats` → 6 tests pass (heartbeat write, content, update, watchdog healthy/stale/absent)
- `bats tests/scanner.bats tests/scanner-log-sighup.bats tests/scanner-stage-age.bats` → no regressions (52 tests pass)
- Manual verification: `kill -STOP $SCANNER_PID` → watchdog fires within 5 min and kicks `launchctl kickstart`