### PR TITLE
[LOOP-413] scanner: heartbeat file + liveness watchdog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,6 +338,25 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    # Scanner liveness watchdog — kills a wedged scanner (heartbeat stale) so
+    # launchd can restart it. Runs every 5 min, independent of the scanner.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     local digest_plist="$agents_dir/com.user.loop-digest.plist"
     if [ -f "$digest_plist" ]; then
         echo "[launchd] com.user.loop-digest already registered — skipping"
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local scanner_watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local scanner_watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $scanner_watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$scanner_watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$scanner_watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/loop.env.example
+++ b/loop.env.example
@@ -81,6 +81,12 @@ LOOP_DISPATCH_MODE="direct"
 # macOS (Homebrew): /opt/homebrew/bin:/usr/local/bin — Linux: /usr/local/bin or similar.
 LOOP_EXTRA_PATH="/opt/homebrew/bin:/usr/local/bin"
 
+# ─── Scanner liveness ─────────────────────────────────────────────────────────
+# scanner-watchdog.sh kills a wedged scanner when no heartbeat is written for
+# this many seconds. Defaults to 2 × LOOP_SCANNER_INTERVAL (600s = 10 min).
+# Raise if your poll interval is >5 min to avoid false-positive restarts.
+# LOOP_SCANNER_HEARTBEAT_TIMEOUT=600
+
 # ─── Recovery ────────────────────────────────────────────────────────────────
 # Seconds before an operational label (in-progress, in-rework, in-review) with
 # no live handler process is considered stuck. Recovery strips the label and

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -774,8 +774,15 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+
+_write_heartbeat() {
+    date '+%Y-%m-%d %H:%M:%S' > "$HEARTBEAT_FILE" 2>/dev/null || true
+}
+
 run_once() {
     log "=== scan tick start ==="
+    $DRY_RUN || _write_heartbeat
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if it stops emitting heartbeats.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written every tick by scanner.sh).
+# If the file is missing or its mtime is older than LOOP_SCANNER_HEARTBEAT_TIMEOUT
+# seconds (default: 2 × LOOP_SCANNER_INTERVAL, i.e. 10 min), the scanner is
+# considered wedged and killed so launchd/cron can restart it.
+#
+# Designed to run every 5 min via launchd StartInterval or a cron entry.
+#
+# Flags:
+#   --dry-run   report stale/ok status without killing the scanner
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+HEARTBEAT_TIMEOUT="${LOOP_SCANNER_HEARTBEAT_TIMEOUT:-$(( POLL_INTERVAL * 2 ))}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+_heartbeat_age() {
+    if [ ! -f "$HEARTBEAT_FILE" ]; then
+        echo "999999"
+        return
+    fi
+    local mtime now
+    mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+age=$(_heartbeat_age)
+
+if [ "$age" -lt "$HEARTBEAT_TIMEOUT" ]; then
+    log "ok: heartbeat age=${age}s < timeout=${HEARTBEAT_TIMEOUT}s"
+    exit 0
+fi
+
+log "WARN: heartbeat stale (age=${age}s >= timeout=${HEARTBEAT_TIMEOUT}s)"
+
+if $DRY_RUN; then
+    log "dry-run: would kill scanner"
+    exit 0
+fi
+
+# Read the scanner PID from the lock file and kill it; launchd/cron restarts it.
+if [ ! -f "$LOCK_FILE" ]; then
+    log "no lock file at $LOCK_FILE — scanner may already be dead"
+    exit 0
+fi
+
+scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+if [ -z "$scanner_pid" ]; then
+    log "empty lock file — nothing to kill"
+    exit 0
+fi
+
+if ! kill -0 "$scanner_pid" 2>/dev/null; then
+    log "scanner PID $scanner_pid already dead — lock is stale"
+    rm -f "$LOCK_FILE"
+    exit 0
+fi
+
+log "killing wedged scanner PID $scanner_pid"
+kill "$scanner_pid" 2>/dev/null || true
+# Give launchd a moment to notice before the watchdog exits.
+sleep 2
+log "done — launchd will restart the scanner"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <!-- Check every 5 minutes; 2× the default poll interval covers one missed tick -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — scanner writes heartbeat on every tick (#413).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/loop-logs-$$"
+    mkdir -p "$LOOP_LOG_DIR"
+    # Extract _write_heartbeat from scanner.sh so we can unit-test it in isolation.
+    eval "$(awk '/^HEARTBEAT_FILE=/{print} /^_write_heartbeat\(\)/{p=1} p; p && /^\}/{p=0; exit}' \
+        "$REPO_ROOT/scanner/scanner.sh")"
+    HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+}
+
+teardown() {
+    rm -rf "$LOOP_LOG_DIR"
+}
+
+@test "_write_heartbeat: creates heartbeat file" {
+    [ ! -f "$HEARTBEAT_FILE" ]
+    _write_heartbeat
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "_write_heartbeat: file contains a timestamp" {
+    _write_heartbeat
+    content=$(cat "$HEARTBEAT_FILE")
+    # Must look like YYYY-MM-DD HH:MM:SS
+    [[ "$content" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\ [0-9]{2}:[0-9]{2}:[0-9]{2}$ ]]
+}
+
+@test "_write_heartbeat: updates mtime on repeated calls" {
+    _write_heartbeat
+    mtime1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE")
+    sleep 1
+    _write_heartbeat
+    mtime2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE")
+    [ "$mtime2" -ge "$mtime1" ]
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`** — writes a timestamp to `${LOOP_LOG_DIR}/scanner-heartbeat` at the start of every tick via `_write_heartbeat()`. The file mtime is the liveness signal.

**`scripts/scanner-watchdog.sh`** (new) — standalone watchdog that reads the heartbeat mtime and kills the scanner PID (from `/tmp/loop-scanner.lock`) if the file is older than `LOOP_SCANNER_HEARTBEAT_TIMEOUT` seconds (default: `2 x LOOP_SCANNER_INTERVAL` = 600s). Launchd/cron restarts the scanner automatically after the kill. Supports `--dry-run`.

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new) — launchd plist that runs the watchdog every 5 minutes via `StartInterval`.

**`install.sh`** — registers the scanner-watchdog plist on macOS (`bootstrap_register_launchd`) and adds a `*/5` cron entry on Linux (`bootstrap_register_cron`).

**`loop.env.example`** — documents the new `LOOP_SCANNER_HEARTBEAT_TIMEOUT` variable.

**`tests/scanner-heartbeat.bats`** (new) — three bats unit tests: file created, timestamp format, mtime advances on repeated calls.

## Reconciler false-positive (IMPORTANT)

Previous PRs for this issue were all auto-closed by the reconciler with "issue #413 already resolved by merged PR#416". Root cause: PR #416 body quotes a past error message containing the text `Closes #413`, which the reconciler regex matches as a real close link — so every new PR for this issue gets closed as a duplicate. The issue is open and unresolved. Please merge this PR manually if the reconciler closes it again.

## Test Plan

- `bats tests/scanner-heartbeat.bats` — all 3 pass locally
- Manual: stop a running scanner with `kill -STOP $PID`; within 10 min the watchdog logs WARN and kills it; launchd brings it back
- Dry-run: `scripts/scanner-watchdog.sh --dry-run` reports status without side effects
- `bash -n` and `shellcheck -S warning` both clean