### PR TITLE
[LOOP-413] scanner: add liveness heartbeat + auto-restart watchdog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — fires every 5 min; kills a wedged scanner so
+    # launchd (KeepAlive=true on the scanner plist) restarts it automatically.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart a silently-wedged scanner process.
+#
+# Reads the heartbeat file written by scanner.sh on every tick. If the file is
+# older than LOOP_WATCHDOG_STALE_SECONDS (default: 2 × poll interval = 600s),
+# the scanner is considered wedged: kill its PID so launchd / the cron wrapper
+# can restart it. On Linux (cron mode) the script simply exits after the kill;
+# the next cron firing of scanner.sh --once will start a fresh run.
+#
+# Usage:
+#   scanner-watchdog.sh           # normal mode: kill stale scanner and exit
+#   scanner-watchdog.sh --dry-run # print diagnosis, no kill
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_WATCHDOG_STALE_SECONDS:-$(( POLL_INTERVAL * 2 ))}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "no heartbeat file at $HEARTBEAT_FILE — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+age=$(( now - mtime ))
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "heartbeat ok (age=${age}s threshold=${STALE_THRESHOLD}s)"
+    exit 0
+fi
+
+log "STALE: heartbeat age=${age}s exceeds threshold=${STALE_THRESHOLD}s — scanner appears wedged"
+
+if [ ! -f "$LOCK_FILE" ]; then
+    log "no lock file at $LOCK_FILE — scanner not running; nothing to kill"
+    exit 0
+fi
+
+scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+if [ -z "$scanner_pid" ]; then
+    log "lock file empty — nothing to kill"
+    exit 0
+fi
+
+if ! kill -0 "$scanner_pid" 2>/dev/null; then
+    log "scanner PID $scanner_pid already dead — lock is stale; launchd will restart"
+    exit 0
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID $scanner_pid"
+    exit 0
+fi
+
+log "killing wedged scanner PID $scanner_pid (SIGTERM)"
+kill "$scanner_pid" 2>/dev/null || true
+sleep 2
+if kill -0 "$scanner_pid" 2>/dev/null; then
+    log "scanner PID $scanner_pid still alive after SIGTERM — sending SIGKILL"
+    kill -9 "$scanner_pid" 2>/dev/null || true
+fi
+log "done — launchd (KeepAlive=true) will restart the scanner"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -776,6 +776,8 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Write heartbeat so the scanner-watchdog can detect a silently-wedged process.
+    $DRY_RUN || printf '%s\n' "$(date +%s)" > "${LOOP_LOG_DIR}/scanner-heartbeat"
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+  Fires every 5 minutes; kills + restarts a silently-wedged scanner.
+  Requires com.user.loop-scanner (KeepAlive=true) so launchd restarts after kill.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-watchdog.bats
+++ b/tests/scanner-watchdog.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+# tests/scanner-watchdog.bats — unit tests for scanner-watchdog.sh and
+# the heartbeat file written by scanner.sh on every tick.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    export LOOP_EXTRA_PATH=""
+    mkdir -p "$LOOP_LOG_DIR"
+
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    LOCK_FILE="/tmp/loop-scanner.lock"
+
+    # Remove stale lock file from previous test runs.
+    rm -f "$LOCK_FILE"
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" 2>/dev/null || true
+    rm -f "$LOCK_FILE" 2>/dev/null || true
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Heartbeat — scanner.sh writes it on every tick
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "scanner.sh run_once writes heartbeat file to LOOP_LOG_DIR" {
+    # Source scanner definitions (same technique as tests/scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    # Stub out everything that would touch GitHub or dispatch handlers.
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { echo ""; }
+    LOOP_JOBS_ENQUEUE=0
+    DRY_RUN=false
+
+    run_once
+
+    [ -f "$HEARTBEAT_FILE" ]
+    local content
+    content=$(cat "$HEARTBEAT_FILE")
+    [ -n "$content" ]
+    # Content should be a unix epoch (all digits).
+    [[ "$content" =~ ^[0-9]+$ ]]
+}
+
+@test "scanner.sh run_once skips heartbeat write in DRY_RUN mode" {
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=true"; print "ONCE=true"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { echo ""; }
+    LOOP_JOBS_ENQUEUE=0
+    DRY_RUN=true
+
+    run_once
+
+    [ ! -f "$HEARTBEAT_FILE" ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Watchdog — scanner-watchdog.sh
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "watchdog: exits cleanly when no heartbeat file exists" {
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no heartbeat file"* ]]
+}
+
+@test "watchdog: reports ok when heartbeat is fresh" {
+    printf '%s\n' "$(date +%s)" > "$HEARTBEAT_FILE"
+    # Use a very large threshold so a fresh file is always under it.
+    LOOP_WATCHDOG_STALE_SECONDS=99999 \
+        run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"heartbeat ok"* ]]
+}
+
+@test "watchdog: dry-run does not kill any process" {
+    printf '%s\n' "$(date +%s)" > "$HEARTBEAT_FILE"
+    # Write a lock file pointing to a real (harmless) PID — our own shell.
+    printf '%s\n' "$$" > "$LOCK_FILE"
+
+    LOOP_WATCHDOG_STALE_SECONDS=0 \
+        run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DRY-RUN"* ]]
+    # Our process must still be alive.
+    kill -0 "$$"
+}
+
+@test "watchdog: stale heartbeat with no lock file exits cleanly" {
+    printf '%s\n' "$(date +%s)" > "$HEARTBEAT_FILE"
+    rm -f "$LOCK_FILE"
+
+    LOOP_WATCHDOG_STALE_SECONDS=0 \
+        run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+    [[ "$output" == *"no lock file"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- At the top of each `run_once()` tick, writes the current epoch to `${LOOP_LOG_DIR}/scanner-heartbeat`. Skipped in `--dry-run` mode so dry-run tests stay side-effect-free.

### `scanner/scanner-watchdog.sh` (new)
- Reads the heartbeat file; if its mtime is older than `LOOP_WATCHDOG_STALE_SECONDS` (default: `2 × LOOP_SCANNER_INTERVAL` = 600 s), reads the scanner PID from `/tmp/loop-scanner.lock`, sends SIGTERM (then SIGKILL if still alive), and exits. launchd's `KeepAlive=true` on the scanner plist restarts it automatically. Supports `--dry-run`.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- Runs `scanner-watchdog.sh` every 5 minutes via launchd `StartInterval`.

### `install.sh`
- `bootstrap_register_launchd`: installs the new watchdog plist alongside the existing scanner/reconciler plists.
- `bootstrap_register_cron` (Linux): adds `*/5 * * * *` crontab entry for the watchdog.

### `tests/scanner-watchdog.bats` (new)
- 6 tests: heartbeat file created on tick, skipped in dry-run, watchdog exits cleanly with no file, reports ok for fresh heartbeat, dry-run prints kill intent without actually killing, stale+no-lock path exits cleanly.

## Test Plan
- All 6 new BATS tests pass locally (`bats tests/scanner-watchdog.bats`).
- `bash -n` + `shellcheck -S warning` pass on all modified/new scripts.
- No personal identifiers introduced.
- Manual simulation: `kill -STOP $SCANNER_PID` → watchdog detects stale heartbeat within one 5-min firing and kills the process → launchd restarts.