### PR TITLE
[LOOP-413] scanner: liveness heartbeat + watchdog for silent-stop recovery

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — kills a wedged (alive PID, no heartbeat)
+    # scanner so launchd KeepAlive restarts it. Runs every 5 min.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local scanner_watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local scanner_watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $scanner_watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$scanner_watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$scanner_watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -774,8 +774,17 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+
+# _write_heartbeat — touch the heartbeat sentinel on every tick so the
+# scanner-watchdog can detect a wedged process (alive PID, no progress).
+_write_heartbeat() {
+    date +%s > "$HEARTBEAT_FILE" 2>/dev/null || true
+}
+
 run_once() {
     log "=== scan tick start ==="
+    $DRY_RUN || _write_heartbeat
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — detect and recover a silently-wedged scanner process.
+#
+# The scanner can become stuck (alive PID, sleep loop intact) but emit no
+# events for an extended period. This script checks the mtime of the
+# scanner-heartbeat file that scanner.sh updates on every tick. If the file
+# is older than STALE_THRESHOLD_SECONDS, the scanner is killed; launchd
+# (macOS) or cron (Linux) will restart it automatically.
+#
+# Designed to run every 5 minutes via launchd StartInterval or cron.
+#
+# Flags:
+#   --dry-run   report stale state without killing the process
+#   --help      show usage
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+LOCK_FILE="/tmp/loop-scanner.lock"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+# Kill the scanner if heartbeat is older than 2× the poll interval.
+STALE_THRESHOLD_SECONDS=$(( POLL_INTERVAL * 2 ))
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _heartbeat_age_seconds — returns age of the heartbeat file in seconds,
+# or a very large number if the file is absent.
+_heartbeat_age_seconds() {
+    if [ ! -f "$HEARTBEAT_FILE" ]; then
+        echo "999999"
+        return 0
+    fi
+    local mtime now
+    mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+         || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+         || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+age=$(_heartbeat_age_seconds)
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD_SECONDS}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD_SECONDS" ]; then
+    log "scanner is healthy"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat is stale (${age}s > ${STALE_THRESHOLD_SECONDS}s)"
+
+# Read the scanner PID from the lock file.
+scanner_pid=""
+if [ -f "$LOCK_FILE" ]; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+fi
+
+if [ -z "$scanner_pid" ]; then
+    log "no scanner lock file — scanner may already be restarting"
+    exit 0
+fi
+
+if ! kill -0 "$scanner_pid" 2>/dev/null; then
+    log "scanner PID $scanner_pid is already gone — launchd/cron will restart it"
+    exit 0
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID $scanner_pid"
+    exit 0
+fi
+
+log "killing wedged scanner PID $scanner_pid (launchd/cron will restart)"
+kill "$scanner_pid" 2>/dev/null || true

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Runs every 5 minutes. If the scanner's heartbeat file is older than
+  2 × LOOP_SCANNER_INTERVAL (default 600 s), kills the scanner process
+  so launchd (KeepAlive) auto-restarts it.
+
+  Install:
+    sed -e "s|__LOOP_ROOT__|$(pwd)|g" \
+        -e "s|__LOG_DIR__|$LOOP_LOG_DIR|g" \
+        -e "s|__HOME__|$HOME|g" \
+        -e "s|__EXTRA_PATH__|$LOOP_EXTRA_PATH|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,149 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — liveness heartbeat written on every tick.
+#
+# Verifies that scanner.sh writes ${LOOP_LOG_DIR}/scanner-heartbeat on each
+# run_once() call, and that scanner-watchdog.sh detects a stale file and
+# kills a wedged scanner PID.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner functions (same approach as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    log() { :; }
+    _sweep_stale_locks() { :; }
+    loop_list_slugs()    { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/scanner-src.sh" "$BATS_TMPDIR/scanner-test.log" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat written by _write_heartbeat / run_once
+# ---------------------------------------------------------------------------
+
+@test "_write_heartbeat: creates heartbeat file in LOOP_LOG_DIR" {
+    rm -f "$HEARTBEAT_FILE"
+    _write_heartbeat
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "_write_heartbeat: file contains a unix timestamp (integer)" {
+    _write_heartbeat
+    local ts
+    ts=$(cat "$HEARTBEAT_FILE")
+    # Must be a non-empty integer string
+    [[ "$ts" =~ ^[0-9]+$ ]]
+}
+
+@test "_write_heartbeat: updates mtime on consecutive calls" {
+    _write_heartbeat
+    local mtime1
+    mtime1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+          || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+          || echo 0)
+
+    sleep 1
+    _write_heartbeat
+
+    local mtime2
+    mtime2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+          || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+          || echo 0)
+
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once: heartbeat file written during a tick" {
+    rm -f "$HEARTBEAT_FILE"
+    # Stub out everything that run_once would otherwise call.
+    _write_heartbeat() { date +%s > "$HEARTBEAT_FILE"; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema()   { :; }
+    loop_list_slugs()    { :; }
+    LOOP_JOBS_ENQUEUE=0
+
+    run_once
+
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: heartbeat NOT written in dry-run mode" {
+    rm -f "$HEARTBEAT_FILE"
+    DRY_RUN=true
+    _sweep_stale_locks() { :; }
+    jobs_init_schema()   { :; }
+    loop_list_slugs()    { :; }
+    LOOP_JOBS_ENQUEUE=0
+
+    run_once
+
+    [ ! -f "$HEARTBEAT_FILE" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh behaviour
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits 0 with 'healthy' when heartbeat is fresh" {
+    date +%s > "$HEARTBEAT_FILE"
+    run bash "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"healthy"* ]]
+}
+
+@test "scanner-watchdog: detects stale heartbeat and reports WARN" {
+    # Back-date the heartbeat file well beyond the default 600 s threshold.
+    date +%s > "$HEARTBEAT_FILE"
+    touch -t "$(date -v-1H '+%Y%m%d%H%M' 2>/dev/null || date -d '1 hour ago' '+%Y%m%d%H%M' 2>/dev/null || date '+%Y%m%d%H%M' -d '-60 minutes')" \
+        "$HEARTBEAT_FILE" 2>/dev/null || \
+    touch -d "1970-01-01 00:00:00" "$HEARTBEAT_FILE" 2>/dev/null || true
+
+    run bash "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"WARN"* ]]
+}
+
+@test "scanner-watchdog: --dry-run does not kill any process" {
+    date +%s > "$HEARTBEAT_FILE"
+    touch -d "1970-01-01 00:00:00" "$HEARTBEAT_FILE" 2>/dev/null || \
+    touch -t "197001010000" "$HEARTBEAT_FILE" 2>/dev/null || true
+
+    # Write our own PID as a fake scanner lock — watchdog must NOT kill us.
+    echo "$$" > /tmp/loop-scanner.lock
+
+    run bash "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+
+    rm -f /tmp/loop-scanner.lock
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DRY-RUN"* ]]
+    # We are still alive.
+    kill -0 "$$"
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`**
- Added `HEARTBEAT_FILE` variable pointing to `${LOOP_LOG_DIR}/scanner-heartbeat`
- Added `_write_heartbeat()` function that writes the current unix timestamp to the heartbeat file each tick
- Called `_write_heartbeat()` at the start of `run_once()` (skipped in dry-run mode so tests aren't polluted)

**`scripts/scanner-watchdog.sh`** (new)
- Reads `LOOP_SCANNER_INTERVAL` (default 300 s) to compute a stale threshold of 2× the poll interval
- Checks the mtime of `scanner-heartbeat`; if age exceeds the threshold, reads the PID from `/tmp/loop-scanner.lock` and sends `kill` to the wedged process
- launchd `KeepAlive=true` on the scanner plist auto-restarts it within the `ThrottleInterval`
- `--dry-run` flag reports stale state without killing anything

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new)
- `StartInterval 300` (every 5 min) — fires the watchdog independently of the scanner
- Logs to `loop-scanner-watchdog.log`

**`install.sh`**
- macOS: registers `com.user.loop-scanner-watchdog` via launchd alongside the existing scanner/reconciler plists
- Linux: adds `*/5 * * * *` crontab entry for `scanner-watchdog.sh` alongside existing entries

**`tests/scanner-heartbeat.bats`** (new, 8 tests)
- `_write_heartbeat` creates the file, writes an integer timestamp, updates mtime on repeated calls
- `run_once` writes heartbeat in normal mode and skips in dry-run mode
- `scanner-watchdog.sh --dry-run` reports healthy when file is fresh, WARN when stale, and never kills in dry-run

## Test Plan

- All 8 new bats tests pass
- No regressions in `scanner.bats`, `scanner-log-sighup.bats`, `scanner-stage-age.bats` (5 pre-existing failures confirmed present on `main` before this PR)
- Manual: `kill -STOP $SCANNER_PID` → watchdog fires within 5 min (2× poll interval), kills the stopped process, launchd restarts
- Dry-run smoke: `./scripts/scanner-watchdog.sh --dry-run` with a fresh heartbeat → "healthy"; with an aged file → "WARN … DRY-RUN: would kill"