### PR TITLE
[LOOP-413] scanner: heartbeat file + stale-scanner watchdog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — checks heartbeat file every 5 min and kills
+    # a wedged scanner so launchd KeepAlive restarts it.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.

--- a/scanner/restart-scanner-if-stale.sh
+++ b/scanner/restart-scanner-if-stale.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# restart-scanner-if-stale.sh — Liveness watchdog for the continuous scanner.
+#
+# Checks the scanner heartbeat file written at every scan tick.  If the file
+# has not been touched within LOOP_SCANNER_WATCHDOG_STALE_SECONDS (default 900)
+# the watchdog kills the scanner PID and lets launchd restart it.
+#
+# On Linux the scanner runs --once per cron tick and cannot get stuck in a
+# persistent loop; this script exits immediately on non-macOS hosts.
+#
+# Usage:
+#   restart-scanner-if-stale.sh [--dry-run]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# Linux uses --once cron ticks; persistent wedge cannot happen there.
+if [ "$(uname -s)" != "Darwin" ]; then
+    log "non-macOS host — watchdog is a no-op on Linux (cron runs --once)"
+    exit 0
+fi
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+# 900s = 3× the default 300s poll interval; generous enough to tolerate a slow
+# tick (heavy gh API calls, large backlogs) without false positives.
+STALE_THRESHOLD="${LOOP_SCANNER_WATCHDOG_STALE_SECONDS:-900}"
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file absent (${HEARTBEAT_FILE}) — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+# Read the epoch written by scanner.sh.  Reading content is more reliable
+# than mtime: mtime can be affected by filesystem events unrelated to the
+# scanner (e.g., backup tools, log rotators touching the file).
+LAST_BEAT=$(cat "$HEARTBEAT_FILE" 2>/dev/null | tr -cd '0-9' || echo 0)
+[ -n "$LAST_BEAT" ] || LAST_BEAT=0
+NOW=$(date +%s)
+AGE=$(( NOW - LAST_BEAT ))
+
+if [ "$AGE" -lt "$STALE_THRESHOLD" ]; then
+    log "ok: heartbeat age=${AGE}s < threshold=${STALE_THRESHOLD}s"
+    exit 0
+fi
+
+log "STALE: heartbeat age=${AGE}s >= threshold=${STALE_THRESHOLD}s"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID and request launchd restart"
+    exit 0
+fi
+
+# Kill the scanner PID recorded in the lock file; launchd KeepAlive restarts it.
+if [ -f "$LOCK_FILE" ]; then
+    SCANNER_PID=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    if [ -n "$SCANNER_PID" ] && kill -0 "$SCANNER_PID" 2>/dev/null; then
+        log "killing wedged scanner PID $SCANNER_PID"
+        kill "$SCANNER_PID" || true
+    else
+        log "lock file present but PID ${SCANNER_PID:-<empty>} not alive"
+    fi
+fi
+
+# Belt-and-suspenders: launchctl kickstart stops any running instance and
+# starts a fresh one, even if the kill above was already sufficient.
+if launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null; then
+    log "launchctl kickstart sent — scanner restarting"
+else
+    log "WARN: launchctl kickstart failed (scanner may have already restarted via KeepAlive)"
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -775,6 +775,9 @@ scan_project() {
 }
 
 run_once() {
+    # Liveness heartbeat: write current epoch to scanner-heartbeat so the
+    # scanner watchdog can detect a wedged process (alive PID, no tick).
+    $DRY_RUN || printf '%s\n' "$(date +%s)" > "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/restart-scanner-if-stale.sh</string>
+    </array>
+    <!-- RunAtLoad false: no point checking immediately on install -->
+    <key>RunAtLoad</key>
+    <false/>
+    <!-- Check every 5 minutes; threshold default is 900s so a single stale
+         check window is at most 600s (2 missed ticks + one watchdog cycle). -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,113 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — scanner liveness heartbeat + watchdog (#413).
+#
+# Two concerns tested here:
+#   1. scanner.sh run_once() writes an epoch to scanner-heartbeat.
+#   2. restart-scanner-if-stale.sh correctly detects a stale heartbeat.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/hb-logs-$$"
+    mkdir -p "$LOOP_LOG_DIR"
+}
+
+teardown() {
+    rm -rf "$LOOP_LOG_DIR"
+}
+
+# ---------------------------------------------------------------------------
+# 1. scanner.sh heartbeat write
+# ---------------------------------------------------------------------------
+
+@test "scanner.sh run_once writes scanner-heartbeat" {
+    # Run scanner --once in a minimal subshell. Stub out everything that
+    # touches GitHub or the jobs DB; use an empty projects list.
+    TMPCONF="$BATS_TMPDIR/projects-empty-$$.yaml"
+    printf 'projects: []\n' > "$TMPCONF"
+
+    run bash -c "
+        export LOOP_ROOT='$REPO_ROOT'
+        export LOOP_LOG_DIR='$LOOP_LOG_DIR'
+        export LOOP_JOBS_ENQUEUE=0
+        export LOOP_LOCK_DIR='$BATS_TMPDIR/locks-$$'
+        mkdir -p \"\$LOOP_LOCK_DIR\"
+        # Override acquire_lock so it does not exit when lock exists.
+        acquire_lock() { trap 'rm -f /tmp/loop-scanner-hbtest-$$.lock' EXIT; return 0; }
+        export -f acquire_lock
+        # Point config loader to an empty project list.
+        loop_list_slugs() { :; }
+        export -f loop_list_slugs
+        # Run --once; heartbeat is skipped in --dry-run so use --once.
+        '$REPO_ROOT/scanner/scanner.sh' --once 2>/dev/null
+        exit 0
+    " || true  # tolerate non-zero exit from stubs
+    [ -f "$LOOP_LOG_DIR/scanner-heartbeat" ]
+}
+
+@test "scanner-heartbeat file contains a recent epoch" {
+    TMPCONF="$BATS_TMPDIR/projects-empty2-$$.yaml"
+    printf 'projects: []\n' > "$TMPCONF"
+
+    bash -c "
+        export LOOP_ROOT='$REPO_ROOT'
+        export LOOP_LOG_DIR='$LOOP_LOG_DIR'
+        export LOOP_JOBS_ENQUEUE=0
+        acquire_lock() { return 0; }
+        loop_list_slugs() { :; }
+        export -f acquire_lock loop_list_slugs
+        '$REPO_ROOT/scanner/scanner.sh' --once 2>/dev/null
+        exit 0
+    " || true
+
+    [ -f "$LOOP_LOG_DIR/scanner-heartbeat" ] || skip "heartbeat not written (env issue)"
+    local beat; beat=$(cat "$LOOP_LOG_DIR/scanner-heartbeat")
+    local now; now=$(date +%s)
+    [[ "$beat" =~ ^[0-9]+$ ]]
+    [ $(( now - beat )) -lt 60 ]
+}
+
+# ---------------------------------------------------------------------------
+# 2. restart-scanner-if-stale.sh watchdog logic
+# ---------------------------------------------------------------------------
+
+@test "watchdog: fresh heartbeat exits 0 with ok message" {
+    printf '%s\n' "$(date +%s)" > "$LOOP_LOG_DIR/scanner-heartbeat"
+
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        LOOP_SCANNER_WATCHDOG_STALE_SECONDS=900 \
+        "$REPO_ROOT/scanner/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ok:"* ]]
+}
+
+@test "watchdog: stale heartbeat logs STALE and DRY-RUN in dry-run mode" {
+    # Write a heartbeat 1000 seconds old as file content.
+    printf '%s\n' "$(( $(date +%s) - 1000 ))" > "$LOOP_LOG_DIR/scanner-heartbeat"
+
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        LOOP_SCANNER_WATCHDOG_STALE_SECONDS=900 \
+        "$REPO_ROOT/scanner/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+    [[ "$output" == *"DRY-RUN"* ]]
+}
+
+@test "watchdog: missing heartbeat exits 0 with absent message" {
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        LOOP_SCANNER_WATCHDOG_STALE_SECONDS=900 \
+        "$REPO_ROOT/scanner/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"absent"* ]]
+}
+
+@test "watchdog: heartbeat just under threshold is not stale" {
+    # 800s old < 900s threshold → ok.
+    printf '%s\n' "$(( $(date +%s) - 800 ))" > "$LOOP_LOG_DIR/scanner-heartbeat"
+
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        LOOP_SCANNER_WATCHDOG_STALE_SECONDS=900 \
+        "$REPO_ROOT/scanner/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ok:"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- Write `$(date +%s)` to `${LOOP_LOG_DIR}/scanner-heartbeat` at the start of every `run_once()` tick (skipped in `--dry-run`). This proves the scanner is actively ticking, not just alive-but-wedged.

### scanner/restart-scanner-if-stale.sh (new)
- Watchdog script intended to run every 5 minutes.
- Reads the epoch from `scanner-heartbeat`; if `now - beat >= LOOP_SCANNER_WATCHDOG_STALE_SECONDS` (default 900s = 3× poll interval), kills the scanner PID from the lock file and calls `launchctl kickstart -k` so launchd KeepAlive restarts a fresh scanner process.
- Exits immediately on non-macOS hosts (Linux uses `--once` cron ticks, which cannot wedge).
- `--dry-run` flag for safe testing.

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
- launchd plist that fires `restart-scanner-if-stale.sh` every 300s.

### install.sh
- Registers `com.user.loop-scanner-watchdog` in `bootstrap_register_launchd()` (idempotent, same pattern as existing services).

### tests/scanner-heartbeat.bats (new)
- 6 bats tests: scanner writes heartbeat on `--once`, epoch is recent, watchdog correctly classifies fresh/stale/absent heartbeat, threshold boundary check.

## Test Plan
- All 6 new bats tests pass locally
- `bash -n` + `shellcheck -S warning` clean on all scripts
- No personal identifiers
- Manual: `kill -STOP $SCANNER_PID` → watchdog should restart within 15 min (2–3 watchdog cycles)
- Manual: `scanner/restart-scanner-if-stale.sh --dry-run` to inspect output without side effects