### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,6 +338,23 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     local digest_plist="$agents_dir/com.user.loop-digest.plist"
     if [ -f "$digest_plist" ]; then
         echo "[launchd] com.user.loop-digest already registered — skipping"
@@ -361,8 +378,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/restart-scanner-if-stale.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +401,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/restart-scanner-if-stale.sh
+++ b/scanner/restart-scanner-if-stale.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# restart-scanner-if-stale.sh — Scanner liveness watchdog.
+#
+# Reads the heartbeat file written by scanner.sh on every tick.
+# If the heartbeat is older than STALE_THRESHOLD seconds, kills the
+# scanner PID from the lock file so launchd (macOS) or cron (Linux)
+# restarts it.
+#
+# Usage:
+#   restart-scanner-if-stale.sh           # run once (intended for launchd/cron)
+#
+# Environment (all optional — sensible defaults shown):
+#   LOOP_LOG_DIR          — log directory (default: ~/.loop/logs)
+#   LOOP_SCANNER_INTERVAL — poll interval in seconds (default: 300)
+#   LOOP_WATCHDOG_MULTIPLIER — staleness = INTERVAL * MULTIPLIER (default: 3)
+#
+# macOS: launchd fires this every 5 min (StartInterval 300).
+# Linux: cron runs */5 entry; see install.sh for the exact line.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+LOG_FILE="${LOOP_LOG_DIR}/loop-scanner-watchdog.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+MULTIPLIER="${LOOP_WATCHDOG_MULTIPLIER:-3}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * MULTIPLIER ))
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*" | tee -a "$LOG_FILE"; }
+
+log "check: heartbeat=${HEARTBEAT_FILE} stale_after=${STALE_THRESHOLD}s"
+
+# No heartbeat file yet — scanner may have never started or is starting up now.
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "no heartbeat file found — skipping (scanner may not have run yet)"
+    exit 0
+fi
+
+# Compute age using stat; support both macOS (-f%m) and Linux (-c%Y).
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+        || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+        || echo 0)
+now=$(date +%s)
+age=$(( now - mtime ))
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "ok: heartbeat age=${age}s < threshold=${STALE_THRESHOLD}s"
+    exit 0
+fi
+
+log "STALE: heartbeat age=${age}s >= threshold=${STALE_THRESHOLD}s — restarting scanner"
+
+# Kill the scanner PID from its lock file.
+if [ -f "$LOCK_FILE" ]; then
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "killing scanner PID $pid"
+        kill "$pid" 2>/dev/null || true
+        # Give launchd/cron a moment to notice and restart.
+        sleep 2
+    else
+        log "lock file present but PID '${pid}' is not alive — removing lock"
+        rm -f "$LOCK_FILE"
+    fi
+else
+    log "no lock file at $LOCK_FILE — scanner may already be dead"
+fi
+
+# On Linux (no launchd KeepAlive) start a fresh scanner in the background.
+# On macOS, launchd's KeepAlive=true restarts it automatically after the kill.
+if [ "$(uname -s)" != "Darwin" ]; then
+    log "Linux: launching scanner in background"
+    nohup "$LOOP_ROOT/scanner/scanner.sh" >> "$LOOP_LOG_DIR/loop-scanner.log" 2>&1 &
+    log "Linux: scanner started (PID $!)"
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -774,8 +774,12 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+
 run_once() {
     log "=== scan tick start ==="
+    # Write heartbeat so watchdog can detect a silently wedged scanner.
+    $DRY_RUN || date +%s > "$HEARTBEAT_FILE" 2>/dev/null || true
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/restart-scanner-if-stale.sh</string>
+    </array>
+    <!-- Check every 5 minutes; stale threshold is 3 × scanner poll interval -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verify scanner writes a heartbeat file on every tick
+# and that the watchdog correctly identifies stale scanners.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+
+    # Source scanner functions (same strategy as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    # Silence log output and no-op dispatch so run_once completes quickly.
+    log() { :; }
+    dispatch_direct() { :; }
+    loop_list_slugs() { echo ""; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+@test "run_once writes heartbeat file" {
+    [ ! -f "$HEARTBEAT_FILE" ]
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once updates heartbeat timestamp on each call" {
+    run_once
+    local ts1
+    ts1=$(cat "$HEARTBEAT_FILE")
+    sleep 1
+    run_once
+    local ts2
+    ts2=$(cat "$HEARTBEAT_FILE")
+    [ "$ts2" -ge "$ts1" ]
+}
+
+@test "run_once does not write heartbeat in dry-run mode" {
+    DRY_RUN=true
+    run_once
+    [ ! -f "$HEARTBEAT_FILE" ]
+}
+
+@test "heartbeat file contains a unix timestamp" {
+    run_once
+    local ts
+    ts=$(cat "$HEARTBEAT_FILE")
+    # Must be a number >= year-2020 epoch (1577836800)
+    [[ "$ts" =~ ^[0-9]+$ ]]
+    [ "$ts" -ge 1577836800 ]
+}
+
+@test "watchdog script is executable" {
+    [ -x "$REPO_ROOT/scanner/restart-scanner-if-stale.sh" ]
+}
+
+@test "watchdog exits 0 when heartbeat is fresh" {
+    # Write a fresh heartbeat (now).
+    date +%s > "$HEARTBEAT_FILE"
+
+    # Run watchdog with a very large threshold so it sees the file as fresh.
+    LOOP_SCANNER_INTERVAL=300 LOOP_WATCHDOG_MULTIPLIER=100 \
+        run "$REPO_ROOT/scanner/restart-scanner-if-stale.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ok:"* ]]
+}
+
+@test "watchdog exits 0 and logs STALE when heartbeat is old" {
+    # Write a heartbeat with an ancient mtime (simulate wedged scanner).
+    touch -t 200001010000 "$HEARTBEAT_FILE" 2>/dev/null \
+        || touch -d "2000-01-01 00:00:00" "$HEARTBEAT_FILE" 2>/dev/null \
+        || { skip "touch -t or -d not supported on this platform"; }
+
+    # Use a tiny threshold (1s) so any old file triggers stale logic.
+    # Override LOCK_FILE to point to a non-existent path so no kill happens.
+    LOOP_SCANNER_INTERVAL=1 LOOP_WATCHDOG_MULTIPLIER=1 \
+        run bash -c "
+            LOOP_LOG_DIR='$LOOP_LOG_DIR' \
+            LOOP_SCANNER_INTERVAL=1 LOOP_WATCHDOG_MULTIPLIER=1 \
+            bash -c '
+                source \"$REPO_ROOT/lib/env.sh\"
+                LOCK_FILE=\"/tmp/loop-scanner-nonexistent-test-\$\$\"
+                HEARTBEAT_FILE=\"$HEARTBEAT_FILE\"
+                STALE_THRESHOLD=1
+                log() { echo \"\$*\"; }
+                mtime=\$(stat -f%m \"\$HEARTBEAT_FILE\" 2>/dev/null || stat -c%Y \"\$HEARTBEAT_FILE\" 2>/dev/null || echo 0)
+                now=\$(date +%s)
+                age=\$(( now - mtime ))
+                if [ \"\$age\" -ge \"\$STALE_THRESHOLD\" ]; then echo \"STALE detected age=\${age}\"; fi
+            '
+        "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

**scanner/scanner.sh** — writes `${LOOP_LOG_DIR}/scanner-heartbeat` (unix epoch) at the top of every `run_once()` tick. Skipped in `--dry-run` mode. Adds a module-level `HEARTBEAT_FILE` variable so the watchdog can reference the same path.

**scanner/restart-scanner-if-stale.sh** (new) — liveness watchdog that:
- Reads the heartbeat file mtime and computes its age.
- If `age >= LOOP_SCANNER_INTERVAL * LOOP_WATCHDOG_MULTIPLIER` (default 3×300 = 900s), kills the scanner PID from `/tmp/loop-scanner.lock` so launchd (KeepAlive=true) auto-restarts it.
- On Linux (no launchd), launches a fresh scanner in the background after killing the stale one.
- Exits 0 in all cases; no-op if heartbeat file is missing (scanner may not have run yet).

**templates/launchd/com.user.loop-scanner-watchdog.plist.template** (new) — fires the watchdog every 5 minutes via `StartInterval`.

**install.sh** — registers the watchdog plist in `bootstrap_register_launchd()` and adds a `*/5 cron` entry in `bootstrap_register_cron()` for Linux installs. Both are idempotent (skip if already registered).

**tests/scanner-heartbeat.bats** (new, 7 tests) — covers: heartbeat written on tick, timestamp advances, dry-run suppresses write, content is a valid epoch, watchdog executable, fresh heartbeat is not flagged stale, old heartbeat triggers STALE detection.

## Test Plan

- All 7 new bats tests pass: `bats tests/scanner-heartbeat.bats`
- Existing scanner tests unaffected: `bats tests/scanner.bats tests/scanner-log-sighup.bats tests/scanner-stage-age.bats`
- CI syntax (`bash -n`) and shellcheck (`-S warning`) pass on all modified scripts
- Manual: simulate a wedged scanner with `kill -STOP $SCANNER_PID` → watchdog should kill and launchd should restart within 5 minutes