### PR TITLE
[LOOP-413] scanner: heartbeat file + stale-restart watchdog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — kills a wedged scanner (heartbeat stale > 10 min)
+    # so launchd KeepAlive on com.user.loop-scanner restarts it automatically.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -382,6 +401,16 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    local scanner_watchdog_marker="# loop-scanner-watchdog"
+    local scanner_watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/restart-scanner-if-stale.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $scanner_watchdog_marker"
+    if echo "$current_cron" | grep -qF "$scanner_watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$scanner_watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/restart-scanner-if-stale.sh
+++ b/scanner/restart-scanner-if-stale.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# restart-scanner-if-stale.sh — scanner liveness watchdog.
+#
+# Reads the scanner heartbeat file written by scanner.sh on every tick.
+# If the heartbeat is older than STALE_THRESHOLD_SECONDS (default: 2 × poll
+# interval = 600s), the scanner is considered wedged and is killed so that
+# launchd (KeepAlive) or cron restarts it.
+#
+# Run every 5 minutes via launchd StartInterval or cron */5.
+#
+# Flags:
+#   --dry-run   report staleness without killing
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_SCANNER_STALE_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# Resolve the scanner PID from the lock file.
+_scanner_pid() {
+    [ -f "$LOCK_FILE" ] || return 1
+    local pid
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && echo "$pid"
+}
+
+# mtime of a file in epoch seconds, portable across macOS/Linux.
+_mtime() {
+    stat -f%m "$1" 2>/dev/null || stat -c%Y "$1" 2>/dev/null || echo 0
+}
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file absent ($HEARTBEAT_FILE) — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+now=$(date +%s)
+last_beat=$(_mtime "$HEARTBEAT_FILE")
+age=$(( now - last_beat ))
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "ok: heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+    exit 0
+fi
+
+log "STALE: heartbeat age=${age}s exceeds threshold=${STALE_THRESHOLD}s"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner and let launchd/cron restart it"
+    exit 0
+fi
+
+pid=$(_scanner_pid || true)
+if [ -n "$pid" ]; then
+    log "killing wedged scanner PID $pid"
+    kill "$pid" 2>/dev/null || true
+    # Remove the lock so a cron-based restart can acquire it immediately.
+    rm -f "$LOCK_FILE"
+    log "scanner killed; launchd/cron will restart it"
+else
+    log "WARN: scanner not running (no live PID in $LOCK_FILE) — nothing to kill"
+    # Clean up a stale heartbeat so next watchdog tick starts fresh.
+    rm -f "$HEARTBEAT_FILE"
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -776,6 +777,18 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+
+    # Heartbeat: stamp the file so the external watchdog can detect silent wedges.
+    # Written unconditionally (even in dry-run) so the watchdog sees liveness.
+    date +%s > "$HEARTBEAT_FILE" 2>/dev/null || true
+
+    # Stdout integrity check: if our log file is no longer writable (e.g. after
+    # logrotate deleted the inode), reopen FDs so subsequent writes land in the
+    # new file; if reopen fails, exit cleanly so launchd/cron restarts us.
+    if [ -n "${LOG_FILE:-}" ] && [ ! -w "$LOG_FILE" ]; then
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" || exit 1
+    fi
+
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes and checks whether the scanner heartbeat file has been
+  updated recently. If the heartbeat is older than LOOP_SCANNER_STALE_THRESHOLD
+  seconds (default: 2 × poll interval), the wedged scanner process is killed
+  and launchd's KeepAlive on com.user.loop-scanner restarts it automatically.
+
+  Installed automatically by: ./install.sh --bootstrap
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/restart-scanner-if-stale.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,164 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 scanner liveness heartbeat.
+#
+# Verifies that:
+#   1. scanner.sh writes HEARTBEAT_FILE on every tick.
+#   2. restart-scanner-if-stale.sh exits cleanly when heartbeat is fresh.
+#   3. restart-scanner-if-stale.sh kills the target process when heartbeat is stale.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner.sh function definitions only (same awk strip as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    STAGE_AGE_DIR="$BATS_TMPDIR/stage-age"
+    mkdir -p "$DEDUP_DIR" "$STAGE_AGE_DIR"
+
+    DRY_RUN=true
+    ONCE=true
+}
+
+teardown() {
+    rm -f "$HEARTBEAT_FILE"
+}
+
+# ── scanner.sh writes heartbeat on every tick ─────────────────────────────────
+
+@test "run_once writes heartbeat file to LOOP_LOG_DIR/scanner-heartbeat" {
+    # Stub out the parts of run_once that need a real config/projects.yaml.
+    loop_list_slugs() { echo ""; }
+    jobs_init_schema() { return 0; }
+
+    run_once
+
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once heartbeat contains a unix epoch timestamp" {
+    loop_list_slugs() { echo ""; }
+    jobs_init_schema() { return 0; }
+
+    run_once
+
+    local ts
+    ts=$(cat "$HEARTBEAT_FILE")
+    # Must be a number and roughly current (within last 5 seconds).
+    [[ "$ts" =~ ^[0-9]+$ ]]
+    local now
+    now=$(date +%s)
+    local delta=$(( now - ts ))
+    [ "$delta" -ge 0 ] && [ "$delta" -lt 5 ]
+}
+
+@test "run_once updates heartbeat on repeated ticks" {
+    loop_list_slugs() { echo ""; }
+    jobs_init_schema() { return 0; }
+
+    # First tick.
+    run_once
+    local ts1
+    ts1=$(cat "$HEARTBEAT_FILE")
+
+    sleep 1
+
+    # Second tick.
+    run_once
+    local ts2
+    ts2=$(cat "$HEARTBEAT_FILE")
+
+    # Timestamp must have advanced (or at least be >= first).
+    [ "$ts2" -ge "$ts1" ]
+}
+
+# ── restart-scanner-if-stale.sh: fresh heartbeat ──────────────────────────────
+
+@test "watchdog: exits 0 and prints 'ok' when heartbeat is fresh" {
+    # Write a heartbeat that is 1 second old.
+    date +%s > "$HEARTBEAT_FILE"
+
+    LOOP_SCANNER_STALE_THRESHOLD=600 \
+    run "$REPO_ROOT/scanner/restart-scanner-if-stale.sh" --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ok:"* ]]
+}
+
+# ── restart-scanner-if-stale.sh: stale heartbeat (dry-run) ────────────────────
+
+@test "watchdog: detects stale heartbeat and reports STALE in dry-run" {
+    # Write a heartbeat timestamp 20 minutes in the past.
+    echo $(( $(date +%s) - 1200 )) > "$HEARTBEAT_FILE"
+
+    LOOP_SCANNER_STALE_THRESHOLD=600 \
+    run "$REPO_ROOT/scanner/restart-scanner-if-stale.sh" --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+    [[ "$output" == *"DRY-RUN"* ]]
+}
+
+# ── restart-scanner-if-stale.sh: no heartbeat file ────────────────────────────
+
+@test "watchdog: exits 0 and skips when heartbeat file is absent" {
+    rm -f "$HEARTBEAT_FILE"
+
+    LOOP_SCANNER_STALE_THRESHOLD=600 \
+    run "$REPO_ROOT/scanner/restart-scanner-if-stale.sh" --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"absent"* ]]
+}
+
+# ── restart-scanner-if-stale.sh: stale heartbeat kills process ────────────────
+
+@test "watchdog: kills target PID when heartbeat is stale (live PID test)" {
+    # Spawn a background sleep to act as the "scanner".
+    sleep 60 &
+    local fake_pid=$!
+
+    # Plant a lock file pointing to the fake scanner.
+    local fake_lock="$BATS_TMPDIR/loop-scanner-fake.lock"
+    echo "$fake_pid" > "$fake_lock"
+
+    # Write a heartbeat that is 20 minutes old.
+    echo $(( $(date +%s) - 1200 )) > "$HEARTBEAT_FILE"
+
+    # Run watchdog with custom lock path via env var substitution.
+    # We need to override LOCK_FILE inside the script, so we source its
+    # logic directly rather than exec-ing, to inject variables.
+    LOCK_FILE="$fake_lock" \
+    LOOP_SCANNER_STALE_THRESHOLD=600 \
+    LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+    run "$REPO_ROOT/scanner/restart-scanner-if-stale.sh"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"killing"* ]] || [[ "$output" == *"STALE"* ]]
+
+    # The fake sleep should be gone.
+    sleep 0.2
+    ! kill -0 "$fake_pid" 2>/dev/null
+
+    rm -f "$fake_lock"
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`**
- Added `HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"` variable.
- `run_once()` now writes `date +%s` to `$HEARTBEAT_FILE` at the top of every tick (unconditionally, so even dry-runs update liveness).
- Added stdout integrity check at tick start: if `$LOG_FILE` exists but is no longer writable (deleted inode after logrotate), reopens FDs 1+2 against the path; exits if reopen fails so launchd restarts cleanly.

**`scanner/restart-scanner-if-stale.sh`** (new)
- Reads the heartbeat file mtime; if age > `LOOP_SCANNER_STALE_THRESHOLD` (default: `2 × LOOP_SCANNER_INTERVAL` = 600s), kills the scanner PID found in `/tmp/loop-scanner.lock`.
- launchd KeepAlive on `com.user.loop-scanner` then auto-restarts the scanner within seconds.
- Supports `--dry-run` flag for safe testing.
- Removes stale lock file after kill so a cron-based restart can acquire it immediately.

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new)
- Fires every 5 minutes (`StartInterval=300`); runs `restart-scanner-if-stale.sh`.
- Logs to `$LOOP_LOG_DIR/loop-scanner-watchdog.log`.

**`install.sh`**
- `bootstrap_register_launchd`: installs the `com.user.loop-scanner-watchdog` plist alongside the existing scanner/reconciler plists.
- `bootstrap_register_cron`: adds a `*/5 * * * *` crontab entry for the watchdog (Linux).

**`tests/scanner-heartbeat.bats`** (new)
- 6 bats tests covering: heartbeat written on `run_once`, timestamp is current epoch, heartbeat advances on repeated ticks, watchdog exits ok on fresh heartbeat, watchdog detects stale heartbeat in dry-run, watchdog kills the target PID when heartbeat is stale.

## Test Plan
- `bash -n` passes on all changed/new scripts.
- `shellcheck -S warning` passes on all changed/new scripts.
- Manual: simulate a wedged scanner with `kill -STOP $SCANNER_PID` → watchdog should detect stale heartbeat within 10 min and restart.
- bats: `bats tests/scanner-heartbeat.bats`