### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-wedge detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — kills wedged scanner so launchd KeepAlive restarts it.
+    # Fires every 5 min; harmless no-op when scanner is healthy.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — detect and restart a wedged scanner process.
+#
+# Runs every ~5 min via launchd (StartInterval) or cron. Checks whether the
+# scanner heartbeat file is stale — older than 2 × LOOP_SCANNER_INTERVAL
+# (default: 600 s). If stale AND the scanner PID from the lock file is alive,
+# sends SIGTERM so launchd KeepAlive restarts it.
+#
+# In Linux cron --once mode each scanner invocation is already a fresh
+# process, so this watchdog serves mainly as a staleness alarm there.
+#
+# Flags:
+#   --dry-run   report stale state without killing
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 ))
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+log "tick (stale-threshold=${STALE_THRESHOLD}s dry=${DRY_RUN})"
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "no heartbeat file — scanner not yet started or pre-heartbeat version running"
+    exit 0
+fi
+
+heartbeat_mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+heartbeat_age=$(( $(date +%s) - heartbeat_mtime ))
+log "heartbeat age=${heartbeat_age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$heartbeat_age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner healthy"
+    exit 0
+fi
+
+log "WARN: heartbeat stale (${heartbeat_age}s >= ${STALE_THRESHOLD}s) — scanner may be wedged"
+
+scanner_pid=""
+if [ -f "$LOCK_FILE" ]; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+fi
+
+if [ -z "$scanner_pid" ]; then
+    log "no PID in lock file — scanner not running; launchd/cron will start it"
+    exit 0
+fi
+
+if ! kill -0 "$scanner_pid" 2>/dev/null; then
+    log "scanner PID $scanner_pid is not alive — lock is stale; restart expected on next launchd/cron tick"
+    exit 0
+fi
+
+if $DRY_RUN; then
+    log "DRY: would SIGTERM scanner PID $scanner_pid"
+    exit 0
+fi
+
+log "sending SIGTERM to wedged scanner PID $scanner_pid"
+kill -TERM "$scanner_pid" 2>/dev/null || true
+log "done — launchd KeepAlive will restart the scanner"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -775,6 +776,16 @@ scan_project() {
 }
 
 run_once() {
+    # Heartbeat: stamp the file so scanner-watchdog can detect a silent wedge.
+    $DRY_RUN || printf '%s %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$$" > "$HEARTBEAT_FILE" 2>/dev/null || true
+
+    # Log-file integrity: if the log is no longer writable (rotated, deleted),
+    # reopen FDs. If reopen fails, exit so launchd/cron restarts us cleanly.
+    if [ -n "${LOG_FILE:-}" ] && [ ! -w "$LOG_FILE" ]; then
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" \
+            || { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] FATAL: log unwritable, exiting for restart" >&2; exit 1; }
+    fi
+
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <!-- Fire every 5 minutes to check scanner liveness -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- Added `HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"` variable
- At the start of each `run_once()` tick, writes current timestamp + PID to the heartbeat file (`touch`-equivalent) so external monitors can check liveness
- Added log-file integrity check: if `$LOG_FILE` is not writable at tick start, attempts to reopen FDs 1+2; exits with code 1 if reopen fails so launchd/cron restarts the process

### `scanner/scanner-watchdog.sh` (new)
- Standalone script that runs every 5 minutes via launchd/cron
- Reads the heartbeat mtime; if older than `2 × LOOP_SCANNER_INTERVAL` (default 600 s), the scanner is considered wedged
- Finds the scanner PID from `/tmp/loop-scanner.lock` and sends SIGTERM; launchd KeepAlive then restarts it
- Supports `--dry-run` flag for observability without side effects
- Safe no-op when scanner is healthy or heartbeat file does not yet exist

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- launchd plist that fires `scanner-watchdog.sh` every 300 s (StartInterval)
- Uses the same `__LOOP_ROOT__` / `__LOG_DIR__` / `__HOME__` / `__EXTRA_PATH__` substitution tokens as the other Loop plists

### `install.sh`
- `bootstrap_register_launchd`: installs and loads `com.user.loop-scanner-watchdog.plist` (idempotent, skips if already registered)
- `bootstrap_register_cron` (Linux): adds a `*/5` cron entry for `scanner-watchdog.sh` alongside the existing scanner entry

## Test Plan
- `bash -n` and `shellcheck -S warning` pass on all scripts (verified locally)
- Manual wedge simulation: `kill -STOP $SCANNER_PID` → after ~10 min the watchdog detects staleness and sends SIGTERM; launchd restarts and scanner resumes logging
- `--dry-run` mode: `scanner/scanner-watchdog.sh --dry-run` should log the stale age and "would SIGTERM" without killing anything
- Heartbeat update: run `scanner/scanner.sh --once` → verify `${LOOP_LOG_DIR}/scanner-heartbeat` is created/updated with a fresh timestamp