### PR TITLE
[LOOP-413] scanner: add liveness heartbeat + watchdog auto-restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — fires every 5 min, restarts the scanner if
+    # its heartbeat file is stale (age > 2 × LOOP_SCANNER_INTERVAL).
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/restart-scanner-if-stale.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/loop.env.example
+++ b/loop.env.example
@@ -111,6 +111,12 @@ LOOP_EXTRA_PATH="/opt/homebrew/bin:/usr/local/bin"
 # LOOP_WATCHDOG_CONFLICT_GRACE=1800         # 30 min
 # LOOP_WATCHDOG_CI_GRACE=3600               # 60 min
 
+# Scanner liveness watchdog. The watchdog (scripts/restart-scanner-if-stale.sh,
+# installed via --bootstrap) kills a wedged scanner when its heartbeat file is
+# stale. STALE_MULTIPLIER controls how many poll intervals must pass before the
+# scanner is considered wedged. Default: 2 (stale after 2 × LOOP_SCANNER_INTERVAL).
+# LOOP_WATCHDOG_STALE_MULTIPLIER=2
+
 # ─── Progress events ─────────────────────────────────────────────────────────
 # Handlers emit periodic *_progress events to loop-monitor while an agent is
 # running. LOOP_PROGRESS_INTERVAL_SEC controls the emission cadence (default 30).

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -776,6 +776,13 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Heartbeat — update file on every tick so the watchdog can detect a
+    # wedged scanner (alive PID, no emit activity, no log output for hours).
+    if ! $DRY_RUN; then
+        local _hb_dir="${LOOP_LOG_DIR}"
+        mkdir -p "$_hb_dir" 2>/dev/null || true
+        date +%s > "${_hb_dir}/scanner-heartbeat" 2>/dev/null || true
+    fi
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scripts/restart-scanner-if-stale.sh
+++ b/scripts/restart-scanner-if-stale.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# restart-scanner-if-stale.sh — liveness watchdog for scanner.sh.
+#
+# Reads the scanner heartbeat file written at the start of every scan tick.
+# If the heartbeat is older than STALE_THRESHOLD seconds the scanner is
+# considered wedged (alive PID, broken event loop) and is killed; launchd
+# KeepAlive=true restarts it automatically.
+#
+# Intended to run on a short interval (5 min) via a launchd StartInterval
+# job (com.user.loop-scanner-watchdog). It is a no-op when the scanner is
+# not running or when --dry-run is passed.
+#
+# Usage:
+#   restart-scanner-if-stale.sh [--dry-run]
+#
+# Environment:
+#   LOOP_LOG_DIR        — directory containing scanner-heartbeat (required)
+#   LOOP_SCANNER_INTERVAL — scanner poll interval in seconds (default: 300)
+#   LOOP_WATCHDOG_STALE_MULTIPLIER — heartbeat age multiplier before restart
+#                         (default: 2; i.e. stale after 2 × poll_interval)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+DRY_RUN=false
+for _arg in "$@"; do
+    case "$_arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "Unknown flag: $_arg" >&2; exit 2 ;;
+    esac
+done
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_MULTIPLIER="${LOOP_WATCHDOG_STALE_MULTIPLIER:-2}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * STALE_MULTIPLIER ))
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+
+# Heartbeat file must exist for the watchdog to act — if it doesn't exist the
+# scanner has never run (first boot) or was just restarted.
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file not found (${HEARTBEAT_FILE}) — scanner not yet started or just restarted; no action"
+    exit 0
+fi
+
+# Compute age of heartbeat file in seconds.
+_now=$(date +%s)
+_mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+    || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+    || echo 0)
+_age=$(( _now - _mtime ))
+
+log "heartbeat age=${_age}s threshold=${STALE_THRESHOLD}s (${STALE_MULTIPLIER}×${POLL_INTERVAL}s)"
+
+if [ "$_age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is alive — no action"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat stale (${_age}s > ${STALE_THRESHOLD}s)"
+
+# Read the scanner's PID from its lock file and signal it.
+if [ ! -f "$LOCK_FILE" ]; then
+    log "lock file not found (${LOCK_FILE}) — scanner not running; no action"
+    exit 0
+fi
+_scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+
+if [ -z "$_scanner_pid" ]; then
+    log "lock file empty — cannot determine scanner PID; no action"
+    exit 0
+fi
+
+if ! kill -0 "$_scanner_pid" 2>/dev/null; then
+    log "scanner PID ${_scanner_pid} not alive — already dead or being restarted; no action"
+    exit 0
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID ${_scanner_pid} (launchd will restart)"
+    exit 0
+fi
+
+log "killing wedged scanner PID ${_scanner_pid} — launchd will restart"
+kill "$_scanner_pid" 2>/dev/null || true

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes and checks whether the scanner heartbeat file is
+  current. If the file is stale (age > 2 × LOOP_SCANNER_INTERVAL) the
+  watchdog kills the wedged scanner PID; launchd KeepAlive=true on the
+  scanner job restarts it automatically.
+
+  Installed automatically by: install.sh --bootstrap
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/restart-scanner-if-stale.sh</string>
+    </array>
+    <!-- Run every 5 minutes; harmless if scanner is healthy -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verify scanner writes the heartbeat file on
+# every tick and that the watchdog script correctly identifies stale scanners.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner.sh function definitions only (same technique as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    log() { :; }
+    dispatch_direct() { :; }
+
+    # Stub out all project iteration so run_once() returns quickly.
+    loop_list_slugs()    { return 0; }
+    jobs_init_schema()   { return 0; }
+    _sweep_stale_locks() { return 0; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat file — written on every tick
+# ---------------------------------------------------------------------------
+
+@test "run_once: creates heartbeat file in LOOP_LOG_DIR" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    rm -f "$hb"
+    run_once
+    [ -f "$hb" ]
+}
+
+@test "run_once: heartbeat file contains a unix timestamp" {
+    run_once
+    local ts
+    ts=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+    # A valid Unix timestamp is a string of digits >= 10 chars.
+    [[ "$ts" =~ ^[0-9]{10,}$ ]]
+}
+
+@test "run_once: heartbeat file is refreshed on every call" {
+    run_once
+    local t1
+    t1=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+        || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null)
+    sleep 1
+    run_once
+    local t2
+    t2=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+        || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null)
+    # mtime must advance — second call touches the file again.
+    [ "$t2" -ge "$t1" ]
+}
+
+@test "run_once: DRY_RUN=true does NOT write heartbeat file" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    rm -f "$hb"
+    DRY_RUN=true
+    run_once
+    [ ! -f "$hb" ]
+}
+
+# ---------------------------------------------------------------------------
+# restart-scanner-if-stale.sh — watchdog behaviour
+# ---------------------------------------------------------------------------
+
+@test "watchdog: exits 0 without action when heartbeat is fresh" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    date +%s > "$hb"
+
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        LOOP_SCANNER_INTERVAL=300 \
+        LOOP_WATCHDOG_STALE_MULTIPLIER=2 \
+        "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner is alive"* ]]
+}
+
+@test "watchdog: exits 0 without action when heartbeat file is missing" {
+    rm -f "${LOOP_LOG_DIR}/scanner-heartbeat"
+
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        LOOP_SCANNER_INTERVAL=300 \
+        LOOP_WATCHDOG_STALE_MULTIPLIER=2 \
+        "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"not yet started"* || "$output" == *"not found"* ]]
+}
+
+@test "watchdog: detects stale heartbeat and logs would-kill message (dry-run)" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    # Write a timestamp that is 1000s in the past.
+    echo $(( $(date +%s) - 1000 )) > "$hb"
+    # Back-date the file itself so stat -f%m / stat -c%Y reflects the age.
+    touch -t "$(date -v-1000S '+%Y%m%d%H%M.%S' 2>/dev/null \
+        || date -d '1000 seconds ago' '+%Y%m%d%H%M.%S' 2>/dev/null \
+        || date '+%Y%m%d%H%M.%S')" "$hb" 2>/dev/null || true
+
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        LOOP_SCANNER_INTERVAL=300 \
+        LOOP_WATCHDOG_STALE_MULTIPLIER=2 \
+        "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    # Should report stale and (in dry-run) a would-kill or no-action message.
+    [[ "$output" == *"stale"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- At the top of every `run_once()` tick, writes `date +%s` to `${LOOP_LOG_DIR}/scanner-heartbeat`. This file is the liveness signal the watchdog reads. Skipped in `--dry-run` mode so tests stay deterministic.

### `scripts/restart-scanner-if-stale.sh` (new)
- Watchdog script: reads the heartbeat file's mtime and compares it to `LOOP_WATCHDOG_STALE_MULTIPLIER × LOOP_SCANNER_INTERVAL` (default: 2 × 300 = 600 s). If the heartbeat is older than the threshold, reads the scanner PID from `/tmp/loop-scanner.lock` and kills it. launchd `KeepAlive=true` restarts the scanner automatically within seconds. Supports `--dry-run` for safe testing.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- launchd `StartInterval=300` job that fires every 5 minutes. Installed alongside the scanner plist by `install.sh --bootstrap`.

### `install.sh`
- `bootstrap_register_launchd`: registers `com.user.loop-scanner-watchdog` on macOS.
- `bootstrap_register_cron`: adds a `*/5 * * * *` cron entry for the watchdog on Linux.

### `loop.env.example`
- Documents `LOOP_WATCHDOG_STALE_MULTIPLIER` so operators can tune the sensitivity.

### `tests/scanner-heartbeat.bats` (new)
- 7 bats tests:
  - `run_once` creates the heartbeat file
  - heartbeat file contains a valid Unix timestamp
  - heartbeat is refreshed on every call
  - `DRY_RUN=true` suppresses the heartbeat write
  - watchdog exits cleanly when heartbeat is fresh
  - watchdog exits cleanly when heartbeat file is missing (not-yet-started scanner)
  - watchdog reports stale in dry-run when heartbeat is old

## Test Plan
- All 7 new bats tests pass locally.
- Existing scanner tests (`scanner.bats`, `scanner-log-sighup.bats`, `scanner-stage-age.bats`) are green (pre-existing failures in `scanner-jobs-enqueue.bats` and a few `scanner.bats` tests are unrelated to this change and also fail on `main`).
- Manual simulation: `kill -STOP $SCANNER_PID` → wait 10 min → watchdog detects stale heartbeat, kills PID, launchd restarts.