### PR TITLE
[LOOP-413] scanner: liveness heartbeat + watchdog auto-restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -316,6 +316,25 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    # Scanner liveness watchdog — detects a wedged scanner (alive PID, no events)
+    # and restarts it. Fires every 5 min; stale threshold is 2× poll interval.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     # PR auto-rework watchdog — labels stale loop-authored PRs needs-rework so
     # the dev-rework handler picks them up. Independent of scanner; runs every
     # 15 min on its own cadence. Only acts on PRs whose author is in the

--- a/scanner/restart-scanner-if-stale.sh
+++ b/scanner/restart-scanner-if-stale.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# restart-scanner-if-stale.sh — liveness watchdog for the loop scanner.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat written by scanner.sh every tick.
+# If the heartbeat mtime is older than STALE_THRESHOLD (default: 2 × poll
+# interval = 600 s), the scanner is considered wedged and is restarted.
+#
+# On macOS: launchctl kickstart -k gui/$UID/com.user.loop-scanner
+# On Linux/cron: SIGTERM the PID from /tmp/loop-scanner.lock; cron restarts.
+#
+# Usage:
+#   restart-scanner-if-stale.sh            # live mode
+#   restart-scanner-if-stale.sh --dry-run  # log what would happen, don't act
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20; exit 0 ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 ))
+LOCK_FILE="/tmp/loop-scanner.lock"
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file not found ($HEARTBEAT_FILE) — scanner may not have started yet"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo "$now")
+age=$(( now - mtime ))
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "ok: heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat stale (age=${age}s >= threshold=${STALE_THRESHOLD}s)"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would restart scanner"
+    exit 0
+fi
+
+# macOS: use launchctl so KeepAlive=true immediately respawns the scanner.
+if command -v launchctl >/dev/null 2>&1 \
+        && launchctl list com.user.loop-scanner >/dev/null 2>&1; then
+    service_uid=$(id -u)
+    log "restarting via launchctl kickstart -k gui/${service_uid}/com.user.loop-scanner"
+    launchctl kickstart -k "gui/${service_uid}/com.user.loop-scanner" 2>/dev/null \
+        || launchctl stop com.user.loop-scanner 2>/dev/null \
+        || true
+    exit 0
+fi
+
+# Linux / cron fallback: SIGTERM the PID recorded in the lock file. The cron
+# entry for scanner.sh --once will spawn a fresh instance on the next tick.
+if [ -f "$LOCK_FILE" ]; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+        log "sending SIGTERM to stale scanner PID $scanner_pid"
+        kill "$scanner_pid" 2>/dev/null || true
+        exit 0
+    fi
+fi
+
+log "no running scanner found to restart — launchd/cron will handle next start"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -775,6 +775,20 @@ scan_project() {
 }
 
 run_once() {
+    # Heartbeat: record the current epoch every tick so the watchdog can detect
+    # a wedged scanner (alive PID, no events). Written before everything else
+    # so even a partial/slow tick keeps the watchdog happy.
+    if ! $DRY_RUN; then
+        printf '%s\n' "$(date +%s)" > "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+    fi
+
+    # Stdout integrity: if the log file exists but is no longer writable (e.g.
+    # log rotation without SIGHUP), reopen FDs. On failure, exit so launchd
+    # restarts with a fresh descriptor set.
+    if [ -n "${LOG_FILE:-}" ] && [ -e "$LOG_FILE" ] && [ ! -w "$LOG_FILE" ]; then
+        exec 1>>"$LOG_FILE" 2>&1 || exit 1
+    fi
+
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/restart-scanner-if-stale.sh</string>
+    </array>
+    <!-- Run every 5 minutes; stale threshold is 2× poll interval (default 10 min) -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,144 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verify that scanner.sh writes the heartbeat
+# file on every tick and that restart-scanner-if-stale.sh correctly detects
+# stale vs. fresh heartbeats.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Expose mock-gh.sh for any backend calls that leak through.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export LOOP_EXTRA_PATH=""
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    # Source scanner.sh function definitions only (same awk pattern as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-hb-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-hb-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    # Silence helpers to keep test output clean.
+    log()            { :; }
+    dispatch_direct(){ :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema()   { :; }
+    loop_list_slugs()    { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-hb-src.sh" \
+           "$BATS_TMPDIR/scanner-hb-test.log" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat file — written by run_once on every tick
+# ---------------------------------------------------------------------------
+
+@test "run_once: writes scanner-heartbeat file to LOOP_LOG_DIR" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    rm -f "$hb"
+
+    run_once
+
+    [ -f "$hb" ]
+}
+
+@test "run_once: heartbeat file contains a numeric epoch timestamp" {
+    run_once
+
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    local ts
+    ts=$(cat "$hb")
+    # Must be a positive integer (Unix epoch is > 1_000_000_000 since 2001)
+    [[ "$ts" =~ ^[0-9]+$ ]]
+    [ "$ts" -gt 1000000000 ]
+}
+
+@test "run_once: heartbeat mtime is updated on successive ticks" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb" 2>/dev/null || echo 0)
+
+    # Force at least one second between ticks.
+    sleep 1
+
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb" 2>/dev/null || echo 0)
+
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once: heartbeat is NOT written in dry-run mode" {
+    DRY_RUN=true
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    rm -f "$hb"
+
+    run_once
+
+    [ ! -f "$hb" ]
+}
+
+# ---------------------------------------------------------------------------
+# restart-scanner-if-stale.sh — stale/fresh detection logic
+# ---------------------------------------------------------------------------
+
+@test "restart-scanner-if-stale: exits 0 without acting when heartbeat is fresh" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    # Write a heartbeat that is only 10 seconds old (well within threshold).
+    printf '%s\n' "$(date +%s)" > "$hb"
+
+    run "$REPO_ROOT/scanner/restart-scanner-if-stale.sh" --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"would restart"* ]]
+}
+
+@test "restart-scanner-if-stale: detects stale heartbeat and logs restart intent" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    # Create an obviously stale heartbeat (epoch 1 = 1970-01-01).
+    printf '1\n' > "$hb"
+    # Back-date the file so mtime also looks old.
+    touch -t 197001010000 "$hb" 2>/dev/null || touch -d "1970-01-01 00:00:00" "$hb" 2>/dev/null || true
+
+    run "$REPO_ROOT/scanner/restart-scanner-if-stale.sh" --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"would restart"* ]]
+}
+
+@test "restart-scanner-if-stale: exits 0 when heartbeat file does not exist" {
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+
+    run "$REPO_ROOT/scanner/restart-scanner-if-stale.sh" --dry-run
+
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- **Heartbeat write**: at the start of every `run_once` tick, writes the current Unix epoch to `${LOOP_LOG_DIR}/scanner-heartbeat`. Written before all other work so even a slow or partially-stuck tick keeps the watchdog satisfied.
- **Stdout integrity check**: if `LOG_FILE` exists but is no longer writable (log rotation without SIGHUP), reopens FDs 1+2 via `exec 1>>"$LOG_FILE" 2>&1`; exits on failure so launchd restarts with fresh descriptors.

### `scanner/restart-scanner-if-stale.sh` (new)
Watchdog script:
- Reads `${LOOP_LOG_DIR}/scanner-heartbeat` mtime
- Compares against `STALE_THRESHOLD = 2 × LOOP_SCANNER_INTERVAL` (default 600 s / 10 min)
- If stale: on macOS uses `launchctl kickstart -k` to restart the launchd-managed scanner; on Linux/cron sends SIGTERM to the PID in `/tmp/loop-scanner.lock`
- `--dry-run` flag logs what would happen without acting

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
launchd plist running `restart-scanner-if-stale.sh` every 5 minutes (`StartInterval=300`). Uses the same `__LOOP_ROOT__`/`__LOG_DIR__`/`__HOME__`/`__EXTRA_PATH__` substitution pattern as other plists.

### `install.sh`
Registers the scanner watchdog plist alongside the scanner in `bootstrap_register_launchd()`. Idempotent: skips if already present.

### `tests/scanner-heartbeat.bats` (new)
7 bats tests covering: heartbeat file written to `LOOP_LOG_DIR`, valid numeric epoch content, mtime updates across ticks, dry-run suppression, watchdog fresh/stale/missing heartbeat detection.

## Test Plan
- `bats tests/scanner-heartbeat.bats` — all 7 pass
- `bash -n` + `shellcheck -S warning` pass on all changed files
- No personal identifiers introduced
- Manual: `kill -STOP $SCANNER_PID` → watchdog should log restart intent within 10 min (2× 300 s poll interval)