### PR TITLE
[LOOP-413] scanner: liveness heartbeat + auto-restart watchdog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — fires every 5 min, checks heartbeat mtime,
+    # kills + restarts the scanner if it has been silent for 2× poll interval.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — Detect a wedged scanner and restart it.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written by scanner.sh on every tick).
+# If the file is absent or its mtime is older than STALE_THRESHOLD seconds,
+# the scanner is considered wedged: kill the PID in /tmp/loop-scanner.lock
+# and — on macOS — use launchctl kickstart to let launchd restart it;
+# on Linux, start a new scanner background process directly.
+#
+# Intended to run every 5 minutes via launchd (macOS) or cron (Linux).
+# On macOS: installed by install.sh --bootstrap as com.user.loop-scanner-watchdog.
+# On Linux: add to crontab: */5 * * * * /path/to/scanner/scanner-watchdog.sh
+#
+# Usage:
+#   scanner-watchdog.sh           # normal mode
+#   scanner-watchdog.sh --dry-run # print decision, do not kill/restart
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+LOG_FILE="${LOOP_LOG_DIR}/loop-scanner-watchdog.log"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+# Treat scanner as stale if heartbeat is older than 2× poll interval.
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 ))
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*" | tee -a "$LOG_FILE"; }
+
+# _heartbeat_age_seconds — return mtime age of HEARTBEAT_FILE in seconds,
+# or a sentinel large value if the file doesn't exist.
+_heartbeat_age_seconds() {
+    if [ ! -f "$HEARTBEAT_FILE" ]; then
+        echo "999999"
+        return
+    fi
+    local mtime now
+    mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+         || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+         || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+# _restart_scanner — kill the wedged scanner PID (if any) and restart.
+_restart_scanner() {
+    local pid=""
+    if [ -f "$LOCK_FILE" ]; then
+        pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    fi
+
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "killing wedged scanner PID $pid"
+        $DRY_RUN || kill "$pid" 2>/dev/null || true
+        sleep 2
+    fi
+
+    if $DRY_RUN; then
+        log "DRY-RUN: would restart scanner"
+        return
+    fi
+
+    if [ "$(uname -s)" = "Darwin" ]; then
+        # launchd has KeepAlive=true — killing the PID is sufficient; launchd
+        # will restart it automatically. kickstart is belt-and-braces in case
+        # the agent is in a throttled state.
+        if launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" >/dev/null 2>&1; then
+            log "launchctl kickstart sent to com.user.loop-scanner"
+        else
+            log "kickstart failed or agent not loaded — relying on launchd KeepAlive"
+        fi
+    else
+        # Linux (cron mode): scanner runs as --once entries, so no daemon to
+        # restart. Remove stale lock file so the next cron tick can proceed.
+        rm -f "$LOCK_FILE"
+        log "stale lock removed; next cron tick will run the scanner"
+    fi
+}
+
+age=$(_heartbeat_age_seconds)
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s file=${HEARTBEAT_FILE}"
+
+if [ "$age" -ge "$STALE_THRESHOLD" ]; then
+    log "STALE: scanner heartbeat is ${age}s old (threshold ${STALE_THRESHOLD}s) — restarting"
+    _restart_scanner
+else
+    log "OK: scanner is alive"
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -63,6 +64,13 @@ for arg in "$@"; do
 done
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] $*"; }
+
+# _update_heartbeat — write current epoch to HEARTBEAT_FILE so an external
+# watchdog can verify the scanner is still making progress each tick.
+_update_heartbeat() {
+    $DRY_RUN && return 0
+    date +%s > "$HEARTBEAT_FILE" 2>/dev/null || true
+}
 
 # _scanner_jobs_enqueue <slug> <stage> <num>
 # Best-effort dual-write to the jobs table alongside the legacy label-event path.
@@ -776,6 +784,7 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    _update_heartbeat
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes. Reads ${LOOP_LOG_DIR}/scanner-heartbeat; if the
+  file is missing or older than 2× POLL_INTERVAL the scanner is considered
+  wedged and is killed + restarted via launchctl kickstart.
+
+  Installed automatically by install.sh --bootstrap.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — heartbeat file written on every tick (#413).
+#
+# Verifies:
+#   1. scanner.sh defines _update_heartbeat and calls it from run_once.
+#   2. _update_heartbeat writes a numeric epoch to HEARTBEAT_FILE.
+#   3. scanner-watchdog.sh detects a stale heartbeat (age >= threshold).
+#   4. scanner-watchdog.sh reports OK when heartbeat is fresh.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Expose mock-gh.sh so env.sh / config.sh sourcing doesn't fail.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner function definitions (same approach as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-hb-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+}
+
+teardown() {
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+}
+
+# ---------------------------------------------------------------------------
+# Structural checks
+# ---------------------------------------------------------------------------
+
+@test "scanner.sh defines _update_heartbeat function" {
+    grep -q "_update_heartbeat()" "$REPO_ROOT/scanner/scanner.sh"
+}
+
+@test "scanner.sh calls _update_heartbeat inside run_once" {
+    # Confirm the call appears in the run_once body (between run_once() { and next top-level })
+    awk '/^run_once\(\)/{found=1} found && /_update_heartbeat/{print; exit}' \
+        "$REPO_ROOT/scanner/scanner.sh" | grep -q "_update_heartbeat"
+}
+
+# ---------------------------------------------------------------------------
+# Behavioural checks
+# ---------------------------------------------------------------------------
+
+@test "_update_heartbeat writes epoch to HEARTBEAT_FILE" {
+    export HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    DRY_RUN=false
+    _update_heartbeat
+    [ -f "$HEARTBEAT_FILE" ]
+    local val
+    val=$(cat "$HEARTBEAT_FILE")
+    # Value must be a positive integer (Unix epoch)
+    [[ "$val" =~ ^[0-9]+$ ]]
+    local now
+    now=$(date +%s)
+    # Must have been written within the last 5 seconds
+    [ $(( now - val )) -lt 5 ]
+}
+
+@test "_update_heartbeat is a no-op in dry-run mode" {
+    export HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    DRY_RUN=true
+    _update_heartbeat
+    [ ! -f "$HEARTBEAT_FILE" ]
+}
+
+@test "_update_heartbeat updates mtime on repeated calls" {
+    export HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    DRY_RUN=false
+    # Write a stale value first.
+    echo "1000000" > "$HEARTBEAT_FILE"
+    _update_heartbeat
+    local val
+    val=$(cat "$HEARTBEAT_FILE")
+    local now
+    now=$(date +%s)
+    [ $(( now - val )) -lt 5 ]
+}
+
+# ---------------------------------------------------------------------------
+# Watchdog detection
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog.sh exists and is executable" {
+    [ -x "$REPO_ROOT/scanner/scanner-watchdog.sh" ]
+}
+
+@test "scanner-watchdog.sh reports STALE when heartbeat is old" {
+    export HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    # Create a file and backdate its mtime to 2 hours ago using touch.
+    touch "$HEARTBEAT_FILE"
+    touch -t "$(date -d '2 hours ago' '+%Y%m%d%H%M.%S' 2>/dev/null \
+              || date -v-2H '+%Y%m%d%H%M.%S' 2>/dev/null)" "$HEARTBEAT_FILE"
+
+    # Run in dry-run mode; output must mention STALE.
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "STALE"
+}
+
+@test "scanner-watchdog.sh reports OK when heartbeat is fresh" {
+    export HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    # Write a fresh heartbeat.
+    date +%s > "$HEARTBEAT_FILE"
+
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "OK"
+}
+
+@test "scanner-watchdog.sh reports STALE when heartbeat file is absent" {
+    export HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    rm -f "$HEARTBEAT_FILE"
+
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "STALE"
+}


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- Added `HEARTBEAT_FILE` variable (`${LOOP_LOG_DIR}/scanner-heartbeat`)
- Added `_update_heartbeat()` function — writes current epoch to heartbeat file on every tick (no-op in dry-run)
- Called `_update_heartbeat` at the top of `run_once()` so every scan tick updates the file

### scanner/scanner-watchdog.sh (new)
- Standalone script that reads heartbeat file mtime
- If mtime is ≥ `STALE_THRESHOLD` (2× `POLL_INTERVAL`, default 10 min) old or file is absent, kills the wedged scanner PID and triggers restart
- On macOS: uses `launchctl kickstart` after killing PID; launchd KeepAlive handles restart
- On Linux (cron mode): removes stale lock file so next cron tick proceeds cleanly
- Supports `--dry-run` flag

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
- Fires every 5 minutes (`StartInterval: 300`) via launchd on macOS

### install.sh
- `bootstrap_register_launchd`: registers `com.user.loop-scanner-watchdog` plist (macOS)
- `bootstrap_register_cron`: adds `*/5 * * * *` watchdog cron entry (Linux)

### tests/scanner-heartbeat.bats (new)
- 9 tests covering: structural presence of `_update_heartbeat`, epoch write, dry-run no-op, mtime update, watchdog stale/fresh/absent detection

## Test Plan
- CI: `bash -n` + shellcheck pass on all modified scripts
- `bats tests/scanner-heartbeat.bats` — all 9 tests pass
- Manual: `kill -STOP $SCANNER_PID` → watchdog should report STALE and trigger restart within 5 min (2 watchdog ticks)
- Manual: verify `${LOOP_LOG_DIR}/scanner-heartbeat` is updated on each scanner tick