### PR TITLE
[LOOP-413] scanner: liveness heartbeat + watchdog auto-restart

### DIFF
--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -774,8 +774,12 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+
 run_once() {
     log "=== scan tick start ==="
+    # Update heartbeat file so the watchdog can detect a wedged scanner.
+    $DRY_RUN || touch "$HEARTBEAT_FILE"
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if its heartbeat file is stale.
+#
+# Designed to run every 5 min via launchd (macOS) or cron (Linux).
+# If the scanner is alive and emitting events the heartbeat file mtime is
+# updated on every tick (default 5 min). The watchdog treats the scanner as
+# wedged when the heartbeat file is older than STALE_THRESHOLD_SECONDS and
+# kills the PID stored in the lock file so launchd can auto-restart it.
+#
+# Usage:
+#   scanner-watchdog.sh [--dry-run]
+#
+# Environment (read from loop.env or inherit):
+#   LOOP_LOG_DIR              — directory that holds scanner-heartbeat and loop-scanner.log
+#   LOOP_SCANNER_INTERVAL     — scanner poll interval in seconds (default 300)
+#   LOOP_WATCHDOG_STALE_MULT  — multiplier for stale threshold (default 2)
+#   LOOP_SCANNER_LOCK         — path to the scanner lock file (default /tmp/loop-scanner.lock)
+#
+# Note: On macOS launchd restarts the scanner automatically when KeepAlive is
+# set. On Linux (cron/systemd) you need a restart-on-kill mechanism in place
+# (e.g. a systemd service with Restart=on-failure).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="${LOOP_SCANNER_LOCK:-/tmp/loop-scanner.lock}"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_MULT="${LOOP_WATCHDOG_STALE_MULT:-2}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * STALE_MULT ))
+
+log "heartbeat=${HEARTBEAT_FILE} lock=${LOCK_FILE} stale_threshold=${STALE_THRESHOLD}s"
+
+# If the heartbeat file doesn't exist yet the scanner may never have run or
+# has never completed a tick — treat as not-yet-started rather than stale.
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file absent — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+# Compute age of the heartbeat file.
+now=$(date +%s)
+# stat is not portable: macOS uses -f%m, GNU/Linux uses -c%Y.
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+age=$(( now - mtime ))
+
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is live (heartbeat ${age}s old < ${STALE_THRESHOLD}s threshold)"
+    exit 0
+fi
+
+log "WARN: heartbeat is stale (${age}s > ${STALE_THRESHOLD}s) — scanner may be wedged"
+
+# Read the PID from the lock file and send SIGTERM so launchd/systemd can
+# restart it. Fall back to SIGKILL after a short grace period if needed.
+if [ ! -f "$LOCK_FILE" ]; then
+    log "lock file absent — scanner not running or already restarted; no action"
+    exit 0
+fi
+
+pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+if [ -z "$pid" ]; then
+    log "lock file is empty — skipping kill"
+    exit 0
+fi
+
+if ! kill -0 "$pid" 2>/dev/null; then
+    log "scanner PID ${pid} is already dead — lock file is stale"
+    rm -f "$LOCK_FILE"
+    exit 0
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID ${pid}"
+    exit 0
+fi
+
+log "killing wedged scanner PID ${pid}"
+kill -TERM "$pid" 2>/dev/null || true
+
+# Wait up to 10 s for graceful shutdown, then SIGKILL.
+local_deadline=$(( $(date +%s) + 10 ))
+while kill -0 "$pid" 2>/dev/null; do
+    if [ "$(date +%s)" -ge "$local_deadline" ]; then
+        log "SIGTERM timed out — sending SIGKILL to PID ${pid}"
+        kill -KILL "$pid" 2>/dev/null || true
+        break
+    fi
+    sleep 1
+done
+
+log "scanner PID ${pid} terminated — launchd/systemd should restart it"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes. If the scanner's heartbeat file is stale (older than
+  2 × LOOP_SCANNER_INTERVAL, default 10 min), the watchdog kills the wedged
+  scanner process so launchd auto-restarts it via the scanner plist.
+
+  Install (replace __LOOP_ROOT__ / __LOG_DIR__ / __HOME__ / __EXTRA_PATH__
+  or use install.sh --bootstrap which does it automatically):
+
+    sed "s|__LOOP_ROOT__|$LOOP_ROOT|g; \
+         s|__LOG_DIR__|$LOOP_LOG_DIR|g; \
+         s|__HOME__|$HOME|g; \
+         s|__EXTRA_PATH__|${LOOP_EXTRA_PATH:-/opt/homebrew/bin:/usr/local/bin}|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <!-- Run every 5 minutes -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verify the scanner writes a heartbeat file on every tick.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner function definitions only (same pattern as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    # Override paths.
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    STAGE_AGE_DIR="$BATS_TMPDIR/stage-age"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+    mkdir -p "$DEDUP_DIR" "$STAGE_AGE_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+    LOOP_JOBS_ENQUEUE=0
+
+    # Silence log output and stub out side-effecting helpers.
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { echo ""; }
+    _budget_exceeded() { return 1; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" "$BATS_TMPDIR/stage-age" \
+           "$BATS_TMPDIR/scanner-src.sh" "$BATS_TMPDIR/scanner-test.log" 2>/dev/null || true
+}
+
+@test "scanner.sh defines HEARTBEAT_FILE variable" {
+    # HEARTBEAT_FILE must be set after sourcing scanner.sh.
+    [ -n "${HEARTBEAT_FILE:-}" ]
+}
+
+@test "run_once: heartbeat file is created on first tick" {
+    [ ! -f "$HEARTBEAT_FILE" ]
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: heartbeat file mtime is updated on each tick" {
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+
+    # Sleep at least 1 second so mtime can advance.
+    sleep 1
+    run_once
+
+    local mtime2
+    mtime2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once: heartbeat file is NOT written in dry-run mode" {
+    DRY_RUN=true
+    run_once
+    [ ! -f "$HEARTBEAT_FILE" ]
+}


### PR DESCRIPTION
Closes #413

## Changes

**scanner/scanner.sh**
- Defines `HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"` at startup.
- `run_once()` calls `touch "$HEARTBEAT_FILE"` at the top of every tick (skipped in `--dry-run` mode), giving external monitors a reliable mtime to compare against.

**scripts/scanner-watchdog.sh** (new)
- Reads the heartbeat file mtime and compares it to `STALE_THRESHOLD = LOOP_SCANNER_INTERVAL × LOOP_WATCHDOG_STALE_MULT` (default 300 × 2 = 600 s).
- If the file is stale, reads the scanner PID from the lock file, sends `SIGTERM`, waits up to 10 s then sends `SIGKILL`.
- Designed to run every 5 min via launchd/cron; launchd `KeepAlive=true` on the scanner plist auto-restarts the killed process within seconds.
- `--dry-run` flag logs what it would do without killing anything.
- Handles edge cases: heartbeat absent (scanner not yet started), empty lock file, already-dead PID.

**templates/launchd/com.user.loop-scanner-watchdog.plist.template** (new)
- `StartInterval=300` (5 min) so the watchdog fires at twice the minimum stale threshold.
- Writes to `loop-scanner-watchdog.log` for independent observability.
- Uses same placeholder pattern (`__LOOP_ROOT__`, `__LOG_DIR__`, `__HOME__`, `__EXTRA_PATH__`) as the existing scanner plist.

## Test Plan

- `tests/scanner-heartbeat.bats` — 4 new unit tests:
  - `HEARTBEAT_FILE` is defined after sourcing scanner.sh
  - Heartbeat file is created on the first `run_once()` call
  - Heartbeat file mtime advances between two `run_once()` calls
  - Heartbeat file is NOT written in `--dry-run` mode

**Manual verification (simulate wedge):**
```bash
# 1. Confirm scanner is running and heartbeat is fresh:
stat -f%m ~/.loop/logs/scanner-heartbeat

# 2. Stop the scanner without killing it (simulate wedge):
kill -STOP $SCANNER_PID

# 3. Wait 10+ minutes then run the watchdog:
scripts/scanner-watchdog.sh --dry-run   # shows it would kill PID
scripts/scanner-watchdog.sh             # kills it; launchd restarts within seconds

# 4. Verify scanner resumed:
tail -f ~/.loop/logs/loop-scanner.log
```