### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-stop detection

### DIFF
--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if its heartbeat is stale.
+#
+# The scanner writes an epoch timestamp to ${LOOP_LOG_DIR}/scanner-heartbeat
+# at the start of every tick. If that file is older than STALE_THRESHOLD_SECONDS
+# the scanner is considered wedged: we kill the PID in the lock file (if any)
+# and ask launchd / systemd to restart it.
+#
+# Designed to run every 5 minutes via launchd StartInterval or cron.
+#
+# Usage:
+#   scanner-watchdog.sh [--dry-run]
+#
+# Environment:
+#   LOOP_SCANNER_INTERVAL        poll interval of the scanner (default 300s)
+#   LOOP_WATCHDOG_STALE_MULT     multiplier applied to LOOP_SCANNER_INTERVAL to
+#                                compute the stale threshold (default 2)
+#   LOOP_SCANNER_LOCK_FILE       path to the scanner's PID lock (default
+#                                /tmp/loop-scanner.lock)
+#   LOOP_SCANNER_LAUNCHD_LABEL   launchd service label to kickstart on macOS
+#                                (default com.user.loop-scanner)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_MULT="${LOOP_WATCHDOG_STALE_MULT:-2}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * STALE_MULT ))
+LOCK_FILE="${LOOP_SCANNER_LOCK_FILE:-/tmp/loop-scanner.lock}"
+LAUNCHD_LABEL="${LOOP_SCANNER_LAUNCHD_LABEL:-com.user.loop-scanner}"
+
+log "check: heartbeat=${HEARTBEAT_FILE} threshold=${STALE_THRESHOLD}s dry-run=${DRY_RUN}"
+
+# Heartbeat file absent → scanner has never run or was just freshly installed.
+# Treat as healthy to avoid false restarts on first boot.
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file not found — scanner not yet started or dry-run mode; skipping"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+age=$(( now - mtime ))
+
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is healthy"
+    exit 0
+fi
+
+log "WARN: heartbeat stale (${age}s > ${STALE_THRESHOLD}s) — scanner appears wedged"
+
+# Kill the lock-holder PID so launchd / cron restarts it cleanly.
+if [ -f "$LOCK_FILE" ]; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+        if $DRY_RUN; then
+            log "DRY-RUN: would kill scanner PID $scanner_pid"
+        else
+            log "killing wedged scanner PID $scanner_pid"
+            kill "$scanner_pid" 2>/dev/null || true
+            sleep 2
+            # Force-kill if still alive after SIGTERM grace period.
+            if kill -0 "$scanner_pid" 2>/dev/null; then
+                kill -9 "$scanner_pid" 2>/dev/null || true
+            fi
+        fi
+    fi
+fi
+
+# On macOS, launchd KeepAlive=true will restart the scanner automatically
+# once the process exits. On Linux (cron-based), invoke the scanner directly
+# in background so the watchdog job itself returns quickly.
+if $DRY_RUN; then
+    log "DRY-RUN: would restart scanner"
+    exit 0
+fi
+
+if command -v launchctl >/dev/null 2>&1; then
+    # macOS — launchd restart via kickstart (reload service).
+    log "kickstarting launchd service $LAUNCHD_LABEL"
+    launchctl kickstart -k "gui/$(id -u)/${LAUNCHD_LABEL}" 2>/dev/null \
+        || launchctl start "$LAUNCHD_LABEL" 2>/dev/null \
+        || log "WARN: launchctl restart failed — KeepAlive should handle it"
+else
+    # Linux — start scanner in background; systemd / cron KeepAlive handles it.
+    log "starting scanner directly (non-macOS)"
+    nohup "$LOOP_ROOT/scanner/scanner.sh" >> "${LOOP_LOG_DIR}/loop-scanner.log" 2>&1 &
+fi
+
+log "restart triggered"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -774,8 +774,19 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+
+# _write_heartbeat — record the current epoch to HEARTBEAT_FILE.
+# Called at the start of every tick so a watchdog can detect a wedged scanner
+# (alive PID, sleep loop intact, but no tick activity for N × poll_interval).
+_write_heartbeat() {
+    $DRY_RUN && return 0
+    date +%s > "$HEARTBEAT_FILE" 2>/dev/null || true
+}
+
 run_once() {
     log "=== scan tick start ==="
+    _write_heartbeat
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Checks the scanner heartbeat every 5 minutes; if the file is older than
+  2 × LOOP_SCANNER_INTERVAL the watchdog kills the wedged scanner so launchd
+  KeepAlive restarts it automatically.
+
+  Install:
+    sed "s|__LOOP_ROOT__|$(cd "$(dirname "$0")/../.." && pwd)|g; \
+         s|__LOG_DIR__|$LOOP_LOG_DIR|g; \
+         s|__HOME__|$HOME|g; \
+         s|__EXTRA_PATH__|$(dirname "$(command -v gh)")|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <!-- Check every 5 minutes -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — heartbeat file is written on every tick (#413).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+
+    # Isolated scratch dir for each test.
+    export LOOP_LOG_DIR="$BATS_TMPDIR/hb-logdir-$$"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Extract _write_heartbeat and its dependency variable from scanner.sh.
+    eval "$(awk '
+        /^HEARTBEAT_FILE=/{print; next}
+        /^_write_heartbeat\(\)/{p=1}
+        p
+        p && /^\}$/{p=0}
+    ' "$REPO_ROOT/scanner/scanner.sh")"
+
+    # Default: not in dry-run mode.
+    DRY_RUN=false
+}
+
+teardown() {
+    rm -rf "$LOOP_LOG_DIR"
+}
+
+@test "_write_heartbeat: creates heartbeat file" {
+    run _write_heartbeat
+    [ "$status" -eq 0 ]
+    [ -f "$LOOP_LOG_DIR/scanner-heartbeat" ]
+}
+
+@test "_write_heartbeat: file contains a valid epoch timestamp" {
+    _write_heartbeat
+    content=$(cat "$LOOP_LOG_DIR/scanner-heartbeat")
+    # Must be a string of digits (Unix epoch).
+    [[ "$content" =~ ^[0-9]+$ ]]
+    now=$(date +%s)
+    # Timestamp must be within the last 5 seconds.
+    age=$(( now - content ))
+    [ "$age" -ge 0 ]
+    [ "$age" -lt 5 ]
+}
+
+@test "_write_heartbeat: updates mtime on successive calls" {
+    _write_heartbeat
+    first=$(cat "$LOOP_LOG_DIR/scanner-heartbeat")
+    sleep 1
+    _write_heartbeat
+    second=$(cat "$LOOP_LOG_DIR/scanner-heartbeat")
+    # Second timestamp must be >= first (monotonically non-decreasing).
+    [ "$second" -ge "$first" ]
+}
+
+@test "_write_heartbeat: skips write in dry-run mode" {
+    DRY_RUN=true
+    _write_heartbeat
+    [ ! -f "$LOOP_LOG_DIR/scanner-heartbeat" ]
+}


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- Added `HEARTBEAT_FILE` variable pointing to `${LOOP_LOG_DIR}/scanner-heartbeat`
- Added `_write_heartbeat()` helper that writes the current epoch to the heartbeat file (no-op in `--dry-run` mode)
- `run_once()` calls `_write_heartbeat()` at the start of every tick so the file's mtime is always current

### scanner/scanner-watchdog.sh (new)
- Standalone script designed to run every 5 minutes via launchd `StartInterval`
- Reads the heartbeat file mtime; if `age > LOOP_WATCHDOG_STALE_MULT × LOOP_SCANNER_INTERVAL` (default: 2 × 300 s = 600 s) the scanner is considered wedged
- Kills the lock-holder PID (SIGTERM → SIGKILL after 2 s), then restarts via `launchctl kickstart` on macOS or a direct background invocation on Linux
- Supports `--dry-run` flag; honours `LOOP_SCANNER_LOCK_FILE`, `LOOP_SCANNER_LAUNCHD_LABEL`, `LOOP_WATCHDOG_STALE_MULT` env vars

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
- launchd plist that runs `scanner-watchdog.sh` every 300 s with `StartInterval`
- Follows the same placeholder conventions as existing plist templates (`__LOOP_ROOT__`, `__LOG_DIR__`, `__HOME__`, `__EXTRA_PATH__`)

### tests/scanner-heartbeat.bats (new)
- 4 bats tests verifying: file is created, contains a valid epoch, is updated on successive calls, and is skipped in dry-run mode

## Test Plan

- [ ] `bats tests/scanner-heartbeat.bats` passes (4/4 locally)
- [ ] `bash -n` syntax check clean for all scripts
- [ ] `shellcheck -S warning` clean for all scripts
- [ ] Manual: run `scanner.sh --once` and confirm `${LOOP_LOG_DIR}/scanner-heartbeat` is created with a current epoch
- [ ] Manual: install watchdog plist, `kill -STOP $SCANNER_PID`, wait 10 min → watchdog should restart the scanner
- [ ] Dry-run: `scanner-watchdog.sh --dry-run` with a backdated heartbeat file logs "would kill" / "would restart" without touching the process