### PR TITLE
[LOOP-413] scanner: liveness heartbeat + stale-scanner watchdog

### DIFF
--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -63,6 +64,31 @@ for arg in "$@"; do
 done
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] $*"; }
+
+# _scanner_write_heartbeat — update the heartbeat file once per tick so the
+# external watchdog can detect a wedged scanner (alive PID, zero emit activity).
+# Format: "<pid> <epoch>" — watchdog checks mtime, not content.
+_scanner_write_heartbeat() {
+    local dedup_count
+    dedup_count=$(find "$DEDUP_DIR" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
+    printf '%s %s %s\n' "$$" "$(date +%s)" "$dedup_count" > "$HEARTBEAT_FILE" 2>/dev/null || true
+}
+
+# _scanner_check_stdout — at the top of each tick verify stdout is writable.
+# If the log file path is set but the file is not writable (e.g. after a log
+# rotation that the SIGHUP handler did not catch), reopen and log the recovery.
+# If reopen also fails, exit so launchd restarts the scanner cleanly.
+_scanner_check_stdout() {
+    [ -z "${LOG_FILE:-}" ] && return 0
+    if [ ! -w "$LOG_FILE" ] && [ -e "$LOG_FILE" ]; then
+        # Attempt recovery: reopen FDs 1+2 against the current path.
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" || {
+            # Reopen failed; exit so launchd restarts with a fresh log FD.
+            exit 1
+        }
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] WARN: log not writable — reopened FDs"
+    fi
+}
 
 # _scanner_jobs_enqueue <slug> <stage> <num>
 # Best-effort dual-write to the jobs table alongside the legacy label-event path.
@@ -775,6 +801,8 @@ scan_project() {
 }
 
 run_once() {
+    $DRY_RUN || _scanner_check_stdout
+    $DRY_RUN || _scanner_write_heartbeat
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/scripts/restart-scanner-if-stale.sh
+++ b/scripts/restart-scanner-if-stale.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# restart-scanner-if-stale.sh — Scanner liveness watchdog.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written by scanner.sh every tick).
+# If the heartbeat file is older than STALE_THRESHOLD_SECONDS the scanner is
+# considered wedged: kills the PID recorded in the lock file and, on macOS,
+# asks launchd to restart the service. On Linux the process is simply killed so
+# the host cron/systemd supervisor can restart it.
+#
+# Intended schedule: every 5 minutes (StartInterval 300 in launchd, or
+# */5 * * * * in cron).
+#
+# Usage: restart-scanner-if-stale.sh [--dry-run]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+DRY_RUN=false
+for _arg in "$@"; do
+    case "$_arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20; exit 0 ;;
+        *) echo "Unknown flag: $_arg" >&2; exit 2 ;;
+    esac
+done
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+# Stale threshold: 2× poll interval (default 10 min).
+STALE_THRESHOLD="${LOOP_SCANNER_STALE_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# Age of a file in seconds; returns a very large number if the file is absent.
+_file_age() {
+    local f="$1"
+    [ -f "$f" ] || { echo 999999; return 0; }
+    local mtime now
+    mtime=$(stat -f%m "$f" 2>/dev/null || stat -c%Y "$f" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+hb_age=$(_file_age "$HEARTBEAT_FILE")
+
+if [ "$hb_age" -lt "$STALE_THRESHOLD" ]; then
+    log "OK: heartbeat age=${hb_age}s < threshold=${STALE_THRESHOLD}s"
+    exit 0
+fi
+
+log "STALE: heartbeat age=${hb_age}s >= threshold=${STALE_THRESHOLD}s — restarting scanner"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner and trigger restart"
+    exit 0
+fi
+
+# Kill the scanner PID recorded in the lock file (if alive).
+if [ -f "$LOCK_FILE" ]; then
+    _lock_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    if [ -n "$_lock_pid" ] && kill -0 "$_lock_pid" 2>/dev/null; then
+        log "killing wedged scanner PID $_lock_pid"
+        kill "$_lock_pid" 2>/dev/null || true
+        sleep 2
+        # Force-kill if still alive after grace period.
+        if kill -0 "$_lock_pid" 2>/dev/null; then
+            kill -9 "$_lock_pid" 2>/dev/null || true
+        fi
+    fi
+    rm -f "$LOCK_FILE"
+fi
+
+# On macOS, ask launchd to restart the scanner service (KeepAlive=true ensures
+# it comes back, but kickstart is faster than waiting for the implicit restart).
+if command -v launchctl >/dev/null 2>&1; then
+    _label="com.user.loop-scanner"
+    if launchctl list "$_label" >/dev/null 2>&1; then
+        log "launchctl kickstart gui/$(id -u)/$_label"
+        launchctl kickstart "gui/$(id -u)/$_label" 2>/dev/null \
+            || log "WARN: launchctl kickstart failed (launchd will auto-restart via KeepAlive)"
+    fi
+fi
+
+log "watchdog done"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Checks the scanner heartbeat file every 5 minutes. If the heartbeat is
+  older than 2 × LOOP_SCANNER_INTERVAL (default 10 min), kills the wedged
+  scanner process so launchd's KeepAlive restarts it automatically.
+
+  Install:
+    sed "s|__LOOP_ROOT__|$(cd "$(dirname "$0")/.." && pwd)|g; \
+         s|__LOG_DIR__|$LOOP_LOG_DIR|g; \
+         s|__HOME__|$HOME|g; \
+         s|__EXTRA_PATH__|${LOOP_EXTRA_PATH:-/opt/homebrew/bin:/usr/local/bin}|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/restart-scanner-if-stale.sh</string>
+    </array>
+    <!-- Run every 5 minutes -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,126 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 scanner liveness heartbeat.
+#
+# Verifies that _scanner_write_heartbeat updates the heartbeat file on every
+# tick, and that restart-scanner-if-stale.sh correctly detects a fresh vs
+# stale heartbeat.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Suppress LOOP_EXTRA_PATH so env.sh does not shadow mock binaries.
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner.sh function definitions only (same strategy as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    # Override paths set after sourcing.
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    HEARTBEAT_FILE="$BATS_TMPDIR/logs/scanner-heartbeat"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    log() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/scanner-src.sh" "$BATS_TMPDIR/scanner-test.log" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# _scanner_write_heartbeat
+# ---------------------------------------------------------------------------
+
+@test "_scanner_write_heartbeat: creates heartbeat file when absent" {
+    rm -f "$HEARTBEAT_FILE"
+    _scanner_write_heartbeat
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "_scanner_write_heartbeat: heartbeat file contains PID and epoch" {
+    _scanner_write_heartbeat
+    local content
+    content=$(cat "$HEARTBEAT_FILE")
+    # Format: "<pid> <epoch> <dedup_count>"
+    [[ "$content" =~ ^[0-9]+\ [0-9]+\ [0-9]+$ ]]
+}
+
+@test "_scanner_write_heartbeat: updates mtime on every call" {
+    _scanner_write_heartbeat
+    local mtime1
+    mtime1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+    # Sleep 1s so the mtime can advance.
+    sleep 1
+    _scanner_write_heartbeat
+    local mtime2
+    mtime2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "_scanner_write_heartbeat: records current dedup_count in heartbeat" {
+    # Plant two files in the dedup dir to simulate prior emits.
+    touch "$DEDUP_DIR/aaaa" "$DEDUP_DIR/bbbb"
+    _scanner_write_heartbeat
+    local count_in_file
+    count_in_file=$(awk '{print $3}' "$HEARTBEAT_FILE")
+    [ "$count_in_file" -eq 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# restart-scanner-if-stale.sh (dry-run mode)
+# ---------------------------------------------------------------------------
+
+@test "watchdog --dry-run: exits 0 and reports OK when heartbeat is fresh" {
+    # Write a fresh heartbeat.
+    printf '%s %s 0\n' "$$" "$(date +%s)" > "$HEARTBEAT_FILE"
+    # Export LOOP_LOG_DIR so the watchdog script finds the heartbeat file.
+    LOOP_LOG_DIR="$BATS_TMPDIR/logs" \
+    LOOP_SCANNER_INTERVAL=300 \
+    run "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"OK:"* ]]
+}
+
+@test "watchdog --dry-run: exits 0 and reports STALE when heartbeat is old" {
+    # Write a heartbeat with a timestamp 20 minutes in the past.
+    local old_epoch
+    old_epoch=$(( $(date +%s) - 1200 ))
+    printf '%s %s 0\n' "$$" "$old_epoch" > "$HEARTBEAT_FILE"
+    # Manually set mtime to match (touch -t or via a Python one-liner).
+    python3 -c "import os, time; os.utime('$HEARTBEAT_FILE', (time.time()-1200, time.time()-1200))" 2>/dev/null \
+        || touch -t "$(date -v-20M '+%Y%m%d%H%M.%S' 2>/dev/null || date -d '20 minutes ago' '+%Y%m%d%H%M.%S' 2>/dev/null)" \
+           "$HEARTBEAT_FILE" 2>/dev/null || true
+    LOOP_LOG_DIR="$BATS_TMPDIR/logs" \
+    LOOP_SCANNER_INTERVAL=300 \
+    run "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE:"* ]]
+    [[ "$output" == *"DRY-RUN"* ]]
+}
+
+@test "watchdog --dry-run: treats absent heartbeat file as stale" {
+    rm -f "$HEARTBEAT_FILE"
+    LOOP_LOG_DIR="$BATS_TMPDIR/logs" \
+    LOOP_SCANNER_INTERVAL=300 \
+    run "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE:"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- Added `HEARTBEAT_FILE` variable pointing to `${LOOP_LOG_DIR}/scanner-heartbeat`
- Added `_scanner_write_heartbeat()` — writes `<pid> <epoch> <dedup_count>` to the heartbeat file on every tick; watchdog reads mtime, not content
- Added `_scanner_check_stdout()` — at the top of each tick, checks whether the log file path is writable; if not, attempts FD reopen (same mechanism as the SIGHUP handler) and exits if that also fails so launchd restarts cleanly
- Both are called at the top of `run_once()`, skipped in `--dry-run` mode

### scripts/restart-scanner-if-stale.sh (new)
- Watchdog script: reads heartbeat file mtime; if age ≥ `LOOP_SCANNER_STALE_THRESHOLD` (default `2 × POLL_INTERVAL = 10 min`), kills the scanner PID from the lock file and asks launchd to `kickstart` the service (KeepAlive ensures restart even if kickstart fails)
- `--dry-run` flag for safe local testing

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
- `StartInterval 300` (every 5 min) — fires the watchdog on a separate schedule from the scanner itself

### tests/scanner-heartbeat.bats (new)
- 7 bats tests covering: heartbeat file creation, format, mtime update, dedup_count recording, watchdog OK/STALE/absent-file detection (all in `--dry-run` mode)

## Test Plan
- All 7 new tests pass: `bats tests/scanner-heartbeat.bats`
- No regressions in existing scanner tests (pre-existing failures in tests 15/16/20/21/28 are unchanged)
- Simulate wedge: `kill -STOP $SCANNER_PID` → heartbeat goes stale → watchdog fires within 10 min and restarts scanner
- Manual check: `cat ${LOOP_LOG_DIR}/scanner-heartbeat` should update on every 5-min tick