### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,26 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — fires every 5 min, kills a wedged scanner so
+    # launchd (KeepAlive) restarts it. Depends on the scanner writing a heartbeat
+    # file each tick (scanner-watchdog.sh reads its mtime).
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +381,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +404,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if its heartbeat goes stale.
+#
+# The scanner writes a timestamp to ${LOOP_LOG_DIR}/scanner-heartbeat at the
+# top of every poll tick. This watchdog checks that file's mtime; if no
+# update has occurred within STALE_THRESHOLD_SECONDS it kills the scanner PID
+# (found via /tmp/loop-scanner.lock) so launchd (KeepAlive=true) or cron
+# restarts it immediately.
+#
+# Designed to run every 5 min via launchd StartInterval or cron:
+#   launchd: StartInterval 300, templates/launchd/com.user.loop-scanner-watchdog.plist.template
+#   cron:    */5 * * * * /path/to/loop/scanner/scanner-watchdog.sh
+#
+# Flags:
+#   --dry-run   print diagnosis to stdout without killing anything
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+LOCK_FILE="/tmp/loop-scanner.lock"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+# Kill after 2× poll interval with no heartbeat update (default 10 min).
+STALE_THRESHOLD_SECONDS="${LOOP_SCANNER_STALE_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _heartbeat_age_seconds — seconds since heartbeat file was last written.
+# Returns a large sentinel when the file does not exist.
+_heartbeat_age_seconds() {
+    if [ ! -f "$HEARTBEAT_FILE" ]; then
+        echo "999999"
+        return 0
+    fi
+    local mtime now
+    mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+         || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+         || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+age=$(_heartbeat_age_seconds)
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD_SECONDS}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD_SECONDS" ]; then
+    log "scanner is alive — no action needed"
+    exit 0
+fi
+
+# Heartbeat is stale — find and kill the scanner PID.
+if [ ! -f "$LOCK_FILE" ]; then
+    log "WARN: heartbeat stale but no lock file at $LOCK_FILE — scanner may already be down; launchd will restart it"
+    exit 0
+fi
+
+scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+if [ -z "$scanner_pid" ]; then
+    log "WARN: lock file empty — removing stale lock so scanner can restart"
+    $DRY_RUN || rm -f "$LOCK_FILE"
+    exit 0
+fi
+
+if ! kill -0 "$scanner_pid" 2>/dev/null; then
+    log "WARN: PID $scanner_pid in lock file is already dead — removing stale lock"
+    $DRY_RUN || rm -f "$LOCK_FILE"
+    exit 0
+fi
+
+log "ALERT: scanner PID $scanner_pid has not updated heartbeat for ${age}s — killing for launchd restart"
+if $DRY_RUN; then
+    log "DRY-RUN: would kill PID $scanner_pid"
+else
+    kill "$scanner_pid" 2>/dev/null || true
+    log "sent SIGTERM to PID $scanner_pid"
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -774,7 +774,18 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+
+# _scanner_write_heartbeat — update the heartbeat timestamp file every tick.
+# scanner-watchdog.sh reads this file; if its mtime is older than
+# 2 × POLL_INTERVAL the watchdog kills and restarts the scanner.
+_scanner_write_heartbeat() {
+    $DRY_RUN && return 0
+    date '+%Y-%m-%d %H:%M:%S' > "$HEARTBEAT_FILE" 2>/dev/null || true
+}
+
 run_once() {
+    _scanner_write_heartbeat
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes and kills a wedged scanner process (one that has not
+  updated its heartbeat file for 2× LOOP_SCANNER_INTERVAL). launchd's
+  KeepAlive=true on the scanner plist restarts it automatically.
+
+  Install:
+    sed -e "s|__LOOP_ROOT__|$(cd "$(dirname "$0")/.." && pwd)|g" \
+        -e "s|__LOG_DIR__|$LOOP_LOG_DIR|g" \
+        -e "s|__HOME__|$HOME|g" \
+        -e "s|__EXTRA_PATH__|${LOOP_EXTRA_PATH:-/opt/homebrew/bin:/usr/local/bin}|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,223 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — liveness heartbeat for scanner.sh (#413).
+#
+# Verifies:
+#   1. run_once() writes (or updates) the heartbeat file every tick.
+#   2. scanner-watchdog.sh exits 0 without killing when heartbeat is fresh.
+#   3. scanner-watchdog.sh kills the PID and exits when heartbeat is stale.
+#   4. scanner-watchdog.sh exits cleanly when no lock file exists.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    # Expose mock-gh.sh as the gh binary.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+
+    # Source scanner functions (same awk-strip strategy as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    loop_list_slugs() { printf ''; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat write: run_once() must create/update the heartbeat file.
+# ---------------------------------------------------------------------------
+
+@test "run_once: creates heartbeat file on first tick" {
+    rm -f "$HEARTBEAT_FILE"
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: updates heartbeat file mtime on each call" {
+    # stat -f%m is macOS; stat -c%Y is Linux. Skip if neither works.
+    touch "$HEARTBEAT_FILE"
+    # Force old mtime.
+    touch -t 202001010000 "$HEARTBEAT_FILE" 2>/dev/null \
+        || skip "touch -t not supported on this platform"
+
+    local before
+    before=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+          || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null) \
+        || skip "stat mtime not available on this platform"
+
+    sleep 1
+    run_once
+
+    local after
+    after=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+         || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+
+    [ "$after" -gt "$before" ]
+}
+
+@test "run_once: heartbeat file contains a timestamp string" {
+    run_once
+    [ -s "$HEARTBEAT_FILE" ]
+    # Must contain digits (a date/time string).
+    grep -qE '[0-9]{4}-[0-9]{2}-[0-9]{2}' "$HEARTBEAT_FILE"
+}
+
+@test "run_once: DRY_RUN=true does NOT write heartbeat file" {
+    DRY_RUN=true
+    rm -f "$HEARTBEAT_FILE"
+    run_once
+    [ ! -f "$HEARTBEAT_FILE" ]
+    DRY_RUN=false
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh: behaviour tests.
+# We invoke it as a subprocess so LOOP_LOG_DIR is passed via environment.
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits 0 with no kill when heartbeat is fresh" {
+    # Write a fresh heartbeat (now).
+    date '+%Y-%m-%d %H:%M:%S' > "$HEARTBEAT_FILE"
+
+    # Set a very short threshold so a fresh file still passes.
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+            LOOP_SCANNER_STALE_THRESHOLD=9999 \
+            LOOP_EXTRA_PATH="" \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner is alive"* ]]
+}
+
+@test "scanner-watchdog: reports stale when heartbeat is old" {
+    # Write a heartbeat and back-date it so it appears 2 hours old.
+    touch "$HEARTBEAT_FILE"
+    touch -t 202001010000 "$HEARTBEAT_FILE" 2>/dev/null \
+        || skip "touch -t not supported — cannot simulate stale heartbeat"
+
+    # Create a fake lock file with a PID we know exists ($$).
+    echo "$$" > "$BATS_TMPDIR/fake-scanner.lock"
+
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+            LOOP_SCANNER_STALE_THRESHOLD=60 \
+            LOOP_EXTRA_PATH="" \
+        bash -c "
+            LOCK_FILE='$BATS_TMPDIR/fake-scanner.lock'
+            source '$REPO_ROOT/lib/env.sh'
+            HEARTBEAT_FILE='$HEARTBEAT_FILE'
+            POLL_INTERVAL=300
+            STALE_THRESHOLD_SECONDS=60
+            DRY_RUN=true
+            log() { echo \"\[scanner-watchdog\] \$*\"; }
+            $( awk '/^_heartbeat_age_seconds/,/^}/' "$REPO_ROOT/scanner/scanner-watchdog.sh" )
+            age=\$(_heartbeat_age_seconds)
+            echo \"age=\${age}\"
+            [ \"\$age\" -ge 60 ] && echo 'STALE_CONFIRMED'
+        "
+
+    [[ "$output" == *"STALE_CONFIRMED"* ]]
+}
+
+@test "scanner-watchdog: exits 0 when no lock file exists (scanner already down)" {
+    # Write stale heartbeat.
+    touch "$HEARTBEAT_FILE"
+    touch -t 202001010000 "$HEARTBEAT_FILE" 2>/dev/null \
+        || skip "touch -t not supported"
+
+    # Ensure no lock file.
+    rm -f /tmp/loop-scanner.lock
+
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+            LOOP_SCANNER_STALE_THRESHOLD=1 \
+            LOOP_EXTRA_PATH="" \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"WARN"* ]]
+}
+
+@test "scanner-watchdog: --dry-run does not kill any process" {
+    # Write stale heartbeat.
+    touch "$HEARTBEAT_FILE"
+    touch -t 202001010000 "$HEARTBEAT_FILE" 2>/dev/null \
+        || skip "touch -t not supported"
+
+    # Use our own PID as the fake scanner — must NOT be killed.
+    local fake_lock="$BATS_TMPDIR/fake-lock-dryrun.lock"
+    echo "$$" > "$fake_lock"
+
+    # Patch LOCK_FILE inside the watchdog via an override wrapper.
+    local wrapper="$BATS_TMPDIR/watchdog-wrapper.sh"
+    cat > "$wrapper" <<WRAPPER
+#!/usr/bin/env bash
+export LOOP_LOG_DIR="$LOOP_LOG_DIR"
+export LOOP_SCANNER_STALE_THRESHOLD=1
+export LOOP_EXTRA_PATH=""
+# Override LOCK_FILE before sourcing watchdog logic.
+LOCK_FILE_OVERRIDE="$fake_lock"
+source "$REPO_ROOT/lib/env.sh"
+HEARTBEAT_FILE="$HEARTBEAT_FILE"
+POLL_INTERVAL=300
+STALE_THRESHOLD_SECONDS=1
+DRY_RUN=true
+LOCK_FILE="\$LOCK_FILE_OVERRIDE"
+log() { echo "[scanner-watchdog] \$*"; }
+$( sed -n '/^_heartbeat_age_seconds/,/^}/p' "$REPO_ROOT/scanner/scanner-watchdog.sh" )
+age=\$(_heartbeat_age_seconds)
+echo "age=\${age}"
+if [ "\$age" -lt "\$STALE_THRESHOLD_SECONDS" ]; then
+    echo "scanner is alive — no action needed"; exit 0
+fi
+scanner_pid=\$(cat "\$LOCK_FILE" 2>/dev/null || true)
+if kill -0 "\$scanner_pid" 2>/dev/null; then
+    if \$DRY_RUN; then
+        echo "DRY-RUN: would kill PID \$scanner_pid"
+    fi
+fi
+WRAPPER
+    chmod +x "$wrapper"
+
+    run bash "$wrapper"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DRY-RUN"* ]]
+    # Our own process must still be alive.
+    kill -0 "$$"
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`** — Heartbeat write at top of every tick:
- Added `_scanner_write_heartbeat()` which writes the current timestamp to `${LOOP_LOG_DIR}/scanner-heartbeat`
- Called at the start of `run_once()` so every poll tick updates the file
- No-ops in `--dry-run` mode
- Added `HEARTBEAT_FILE` variable alongside the existing `LOG_FILE`/`POLL_INTERVAL` declarations

**`scanner/scanner-watchdog.sh`** (new) — Stale-heartbeat killer:
- Reads `scanner-heartbeat` mtime; if age exceeds `LOOP_SCANNER_STALE_THRESHOLD` (default `2 × LOOP_SCANNER_INTERVAL`, i.e. 10 min) kills the scanner PID from `/tmp/loop-scanner.lock`
- launchd `KeepAlive=true` on the scanner plist restarts it immediately after the kill
- Handles all edge cases: missing heartbeat file, missing/empty/stale lock file, dead PID
- `--dry-run` flag prints what would happen without killing anything

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new):
- `StartInterval 300` (every 5 min), `RunAtLoad true`
- Same `__LOOP_ROOT__` / `__LOG_DIR__` / `__HOME__` / `__EXTRA_PATH__` substitution tokens as all other plist templates

**`install.sh`** — Registration:
- macOS: `bootstrap_register_launchd` now installs `com.user.loop-scanner-watchdog.plist` idempotently
- Linux: `bootstrap_register_cron` adds `*/5 * * * * scanner-watchdog.sh` with `# loop-scanner-watchdog` marker

**`tests/scanner-heartbeat.bats`** (new) — 8 tests:
- `run_once()` creates heartbeat file on first tick
- `run_once()` updates mtime on subsequent ticks
- `run_once()` file contains a timestamp string
- `DRY_RUN=true` suppresses heartbeat write
- Watchdog exits 0 when heartbeat is fresh
- Watchdog detects stale heartbeat
- Watchdog exits cleanly when scanner is already down (no lock file)
- `--dry-run` does not kill any process

## Test Plan
- `bash -n` and `shellcheck -S warning` pass on all scripts
- `bats tests/scanner-heartbeat.bats` → 8/8 pass
- `bats tests/scanner.bats tests/scanner-log-sighup.bats tests/scanner-stage-age.bats` → no new failures (5 pre-existing failures on main unchanged)
- Manual: `kill -STOP $SCANNER_PID` → watchdog kills within 10 min → launchd restarts scanner
