### PR TITLE
[LOOP-413] scanner: liveness heartbeat + auto-restart watchdog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,24 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — kills a wedged scanner so launchd restarts it.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +379,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +402,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the Loop scanner if its heartbeat goes stale.
+#
+# Runs every 5 minutes via launchd (macOS) or cron (Linux).
+# Checks ${LOOP_LOG_DIR}/scanner-heartbeat mtime; if older than
+# LOOP_SCANNER_WATCHDOG_STALE_SECONDS (default: 2 × poll interval = 600s)
+# the scanner process is killed so launchd/cron can restart it.
+#
+# Usage:
+#   scanner-watchdog.sh            # normal run
+#   scanner-watchdog.sh --dry-run  # report stale state without killing
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+LOG_FILE="${LOOP_LOG_DIR}/loop-scanner-watchdog.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_SCANNER_WATCHDOG_STALE_SECONDS:-$(( POLL_INTERVAL * 2 ))}"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -15
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*" | tee -a "$LOG_FILE"; }
+
+_file_age_seconds() {
+    local f="$1"
+    [ -f "$f" ] || { echo "999999"; return; }
+    local mtime now
+    mtime=$(stat -f%m "$f" 2>/dev/null || stat -c%Y "$f" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+_scanner_pid() {
+    local pid=""
+    [ -f "$LOCK_FILE" ] && pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    printf '%s' "$pid"
+}
+
+_kill_scanner() {
+    local pid
+    pid=$(_scanner_pid)
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "killing stale scanner PID $pid"
+        kill "$pid" 2>/dev/null || true
+        return 0
+    fi
+    # No live PID — remove stale lock so the next scanner start isn't blocked.
+    if [ -f "$LOCK_FILE" ]; then
+        log "removing stale lock $LOCK_FILE (no live PID)"
+        rm -f "$LOCK_FILE"
+    fi
+    return 0
+}
+
+_restart_scanner_linux() {
+    # On Linux the scanner runs via cron (--once). Killing any stuck continuous
+    # instance clears the way; cron fires a fresh --once invocation within 5 min.
+    pkill -f "scanner/scanner.sh" 2>/dev/null || true
+    log "killed any running scanner.sh processes (cron will restart)"
+}
+
+_restart_scanner_macos() {
+    # On macOS launchd keeps the scanner alive — kill the PID and launchd
+    # restarts it automatically within ThrottleInterval seconds.
+    _kill_scanner
+    log "scanner killed; launchd KeepAlive will restart it"
+}
+
+age=$(_file_age_seconds "$HEARTBEAT_FILE")
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "heartbeat ok (age=${age}s threshold=${STALE_THRESHOLD}s)"
+    exit 0
+fi
+
+log "STALE heartbeat detected (age=${age}s threshold=${STALE_THRESHOLD}s)"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would restart scanner (not killing)"
+    exit 0
+fi
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    _restart_scanner_macos
+else
+    _restart_scanner_linux
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -776,6 +777,8 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Heartbeat: record tick start time so the scanner watchdog can detect stalls.
+    $DRY_RUN || date +%s > "$HEARTBEAT_FILE" 2>/dev/null || true
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <!-- Check heartbeat every 5 minutes -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,152 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — heartbeat file is written on every scanner tick.
+#
+# Coverage for issue #413: scanner liveness heartbeat + watchdog.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+}
+
+teardown() {
+    rm -rf "$LOOP_LOG_DIR"
+}
+
+# ---------------------------------------------------------------------------
+# Structural checks (scanner.sh)
+# ---------------------------------------------------------------------------
+
+@test "scanner.sh defines HEARTBEAT_FILE pointing to LOOP_LOG_DIR" {
+    grep -q 'HEARTBEAT_FILE=.*LOOP_LOG_DIR.*scanner-heartbeat' \
+        "$REPO_ROOT/scanner/scanner.sh"
+}
+
+@test "scanner.sh writes heartbeat in run_once" {
+    # The heartbeat write must be inside run_once (between the function open brace
+    # and the closing brace that ends run_once).
+    python3 - "$REPO_ROOT/scanner/scanner.sh" <<'PY'
+import sys, re
+
+with open(sys.argv[1]) as f:
+    src = f.read()
+
+# Extract run_once body
+m = re.search(r'run_once\(\)\s*\{(.+?)^\}', src, re.DOTALL | re.MULTILINE)
+assert m, "run_once() not found"
+body = m.group(1)
+assert 'HEARTBEAT_FILE' in body, "HEARTBEAT_FILE not referenced in run_once"
+assert 'date' in body, "date command not found in run_once heartbeat write"
+PY
+}
+
+# ---------------------------------------------------------------------------
+# Behavioural: heartbeat file is updated by each tick
+# ---------------------------------------------------------------------------
+
+@test "heartbeat file is created/updated on each scanner tick" {
+    # Build a minimal run_once stub that reproduces only the heartbeat logic.
+    local stub="$BATS_TMPDIR/stub-heartbeat.sh"
+    cat > "$stub" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+LOOP_LOG_DIR="$LOOP_LOG_DIR"
+HEARTBEAT_FILE="\${LOOP_LOG_DIR}/scanner-heartbeat"
+DRY_RUN=false
+run_once() {
+    \$DRY_RUN || date +%s > "\$HEARTBEAT_FILE" 2>/dev/null || true
+}
+run_once
+STUB
+    chmod +x "$stub"
+    bash "$stub"
+    [ -f "$HEARTBEAT_FILE" ]
+    local ts
+    ts=$(cat "$HEARTBEAT_FILE")
+    [ -n "$ts" ]
+    # Value must be a unix timestamp (all digits)
+    [[ "$ts" =~ ^[0-9]+$ ]]
+}
+
+@test "heartbeat file mtime advances between consecutive ticks" {
+    local stub="$BATS_TMPDIR/stub-tick.sh"
+    cat > "$stub" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+LOOP_LOG_DIR="$LOOP_LOG_DIR"
+HEARTBEAT_FILE="\${LOOP_LOG_DIR}/scanner-heartbeat"
+DRY_RUN=false
+run_once() {
+    \$DRY_RUN || date +%s > "\$HEARTBEAT_FILE" 2>/dev/null || true
+}
+run_once
+STUB
+    chmod +x "$stub"
+
+    bash "$stub"
+    local mtime1
+    mtime1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE")
+
+    sleep 1.1  # ensure mtime advances by at least 1 second
+    bash "$stub"
+    local mtime2
+    mtime2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE")
+
+    [ "$mtime2" -gt "$mtime1" ]
+}
+
+@test "heartbeat file is NOT written in dry-run mode" {
+    local stub="$BATS_TMPDIR/stub-dryrun.sh"
+    cat > "$stub" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+LOOP_LOG_DIR="$LOOP_LOG_DIR"
+HEARTBEAT_FILE="\${LOOP_LOG_DIR}/scanner-heartbeat"
+DRY_RUN=true
+run_once() {
+    \$DRY_RUN || date +%s > "\$HEARTBEAT_FILE" 2>/dev/null || true
+}
+run_once
+STUB
+    chmod +x "$stub"
+    rm -f "$HEARTBEAT_FILE"
+    bash "$stub"
+    [ ! -f "$HEARTBEAT_FILE" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh structural checks
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog.sh exists and is executable" {
+    [ -x "$REPO_ROOT/scanner/scanner-watchdog.sh" ]
+}
+
+@test "scanner-watchdog.sh sources lib/env.sh" {
+    grep -q 'source.*lib/env.sh' "$REPO_ROOT/scanner/scanner-watchdog.sh"
+}
+
+@test "scanner-watchdog.sh respects --dry-run flag" {
+    # With a stale heartbeat (or missing file) and --dry-run, it must not kill anything.
+    # We verify by checking it exits 0 and logs DRY-RUN.
+    rm -f "$HEARTBEAT_FILE"
+
+    # Stub lib/env.sh so the watchdog doesn't need a real loop.env.
+    local fake_env="$BATS_TMPDIR/fake-env.sh"
+    cat > "$fake_env" <<ENVSH
+export LOOP_LOG_DIR="$LOOP_LOG_DIR"
+export LOOP_SCANNER_INTERVAL=300
+ENVSH
+
+    # Patch the watchdog to source our fake env instead.
+    local patched="$BATS_TMPDIR/patched-watchdog.sh"
+    sed "s|source \"\$LOOP_ROOT/lib/env.sh\"|source '$fake_env'|" \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" > "$patched"
+    chmod +x "$patched"
+
+    run bash "$patched" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DRY-RUN"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- Added `HEARTBEAT_FILE` variable pointing to `${LOOP_LOG_DIR}/scanner-heartbeat`
- `run_once()` writes the current unix timestamp to the heartbeat file at the start of every tick (skipped in `--dry-run` mode)

### scanner/scanner-watchdog.sh (new)
- Reads heartbeat file mtime and compares against `LOOP_SCANNER_WATCHDOG_STALE_SECONDS` (default: `2 × LOOP_SCANNER_INTERVAL` = 600s)
- On macOS: kills the scanner PID (from lock file) so launchd's `KeepAlive` auto-restarts it
- On Linux: uses `pkill` to kill any stuck scanner processes (cron fires a fresh `--once` run within 5 min)
- Supports `--dry-run` flag that logs the stale state without killing
- Logs to `${LOOP_LOG_DIR}/loop-scanner-watchdog.log`

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
- Fires every 5 minutes (`StartInterval=300`) — fast enough to catch stalls within one poll cycle

### install.sh
- `bootstrap_register_launchd()`: registers `com.user.loop-scanner-watchdog` plist alongside scanner/reconciler
- `bootstrap_register_cron()`: adds `*/5 * * * *` watchdog cron entry for Linux

## Test Plan
- `tests/scanner-heartbeat.bats` (8 tests, all passing):
  - Structural checks: `HEARTBEAT_FILE` defined, heartbeat write is inside `run_once`
  - Behavioural: file is created, contains a unix timestamp, mtime advances between ticks, skipped in dry-run
  - Watchdog checks: script exists + executable, sources `lib/env.sh`, `--dry-run` works
- Manual simulation: `kill -STOP $SCANNER_PID` → watchdog detects stale heartbeat after threshold, kills/restarts