### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for liveness auto-restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — fires every 5 min; restarts scanner if
+    # heartbeat file is stale (> 2 × poll interval).
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — liveness watchdog for scanner.sh.
+# Checks ${LOOP_LOG_DIR}/scanner-heartbeat mtime. If the file is missing or
+# older than STALE_THRESHOLD_SECONDS, kills the current scanner PID and
+# restarts it via launchctl (macOS) or directly (Linux).
+#
+# Run every 5 minutes via launchd (macOS) or cron (Linux).
+#
+# Usage: scanner-watchdog.sh [--dry-run]
+#
+# Env overrides (all optional):
+#   LOOP_SCANNER_INTERVAL              — scanner poll interval in seconds (default 300)
+#   LOOP_SCANNER_WATCHDOG_THRESHOLD    — stale threshold override (default 2 × interval)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_SCANNER_WATCHDOG_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+SCANNER_LOCK_FILE="/tmp/loop-scanner.lock"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file absent — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+heartbeat_mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+    || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+    || echo 0)
+now=$(date +%s)
+age=$(( now - heartbeat_mtime ))
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "OK heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+    exit 0
+fi
+
+log "STALE heartbeat age=${age}s >= threshold=${STALE_THRESHOLD}s — restarting scanner"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner and trigger restart"
+    exit 0
+fi
+
+# Kill current scanner if its PID is in the lock file.
+if [ -f "$SCANNER_LOCK_FILE" ]; then
+    pid=$(cat "$SCANNER_LOCK_FILE" 2>/dev/null || true)
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "killing stale scanner PID $pid"
+        kill "$pid" 2>/dev/null || true
+        sleep 2
+    fi
+    rm -f "$SCANNER_LOCK_FILE"
+fi
+
+# Restart via launchctl on macOS; direct on Linux.
+if command -v launchctl >/dev/null 2>&1; then
+    uid=$(id -u)
+    if launchctl kickstart -k "gui/${uid}/com.user.loop-scanner" >/dev/null 2>&1; then
+        log "restarted scanner via launchctl kickstart gui/${uid}/com.user.loop-scanner"
+    else
+        log "WARN: launchctl kickstart failed — scanner will auto-restart via KeepAlive"
+    fi
+else
+    nohup "$LOOP_ROOT/scanner/scanner.sh" >> "$LOOP_LOG_DIR/loop-scanner.log" 2>&1 &
+    log "restarted scanner directly (PID $!)"
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -774,8 +774,14 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+_scanner_write_heartbeat() {
+    $DRY_RUN && return 0
+    date +%s > "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+}
+
 run_once() {
     log "=== scan tick start ==="
+    _scanner_write_heartbeat
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes; kills and restarts the scanner if its heartbeat file
+  is older than 2 × LOOP_SCANNER_INTERVAL (default 10 minutes).
+
+  Installed automatically by: ./install.sh --bootstrap
+  or manually:
+    sed -e "s|__LOOP_ROOT__|$(pwd)|g" \
+        -e "s|__LOG_DIR__|$LOOP_LOG_DIR|g" \
+        -e "s|__HOME__|$HOME|g" \
+        -e "s|__EXTRA_PATH__|/opt/homebrew/bin:/usr/local/bin|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 scanner liveness heartbeat.
+#
+# Verifies:
+#   1. _scanner_write_heartbeat writes an epoch timestamp to scanner-heartbeat.
+#   2. Calling it again updates the file (mtime advances).
+#   3. DRY_RUN=true suppresses the write.
+#   4. scanner-watchdog.sh exits 0 and logs OK when heartbeat is fresh.
+#   5. scanner-watchdog.sh exits 0 and logs STALE when heartbeat is old.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner.sh function definitions only (same strategy as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    # Silence log() to avoid cluttering bats output.
+    log() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# _scanner_write_heartbeat
+# ---------------------------------------------------------------------------
+
+@test "_scanner_write_heartbeat: creates heartbeat file with epoch timestamp" {
+    DRY_RUN=false
+    _scanner_write_heartbeat
+    [ -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+    local ts
+    ts=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+    # Timestamp should be a positive integer
+    [[ "$ts" =~ ^[0-9]+$ ]]
+}
+
+@test "_scanner_write_heartbeat: updates file on second call" {
+    DRY_RUN=false
+    _scanner_write_heartbeat
+    local mtime1
+    mtime1=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+        || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null)
+    sleep 1
+    _scanner_write_heartbeat
+    local mtime2
+    mtime2=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+        || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null)
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "_scanner_write_heartbeat: skipped when DRY_RUN=true" {
+    DRY_RUN=true
+    rm -f "${LOOP_LOG_DIR}/scanner-heartbeat"
+    _scanner_write_heartbeat
+    [ ! -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits 0 and prints OK when heartbeat is fresh" {
+    # Write a fresh heartbeat.
+    date +%s > "${LOOP_LOG_DIR}/scanner-heartbeat"
+
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        LOOP_SCANNER_INTERVAL=300 \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"OK heartbeat"* ]]
+}
+
+@test "scanner-watchdog: logs STALE and dry-run message when heartbeat is old" {
+    # Write a heartbeat with a timestamp far in the past (2 hours ago).
+    local past=$(( $(date +%s) - 7200 ))
+    echo "$past" > "${LOOP_LOG_DIR}/scanner-heartbeat"
+    # Backdate the file mtime so stat sees it as old.
+    touch -t "$(date -r "$past" '+%Y%m%d%H%M.%S' 2>/dev/null \
+        || date -d "@$past" '+%Y%m%d%H%M.%S' 2>/dev/null \
+        || echo '200001010000.00')" \
+        "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        LOOP_SCANNER_INTERVAL=300 \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+    [[ "$output" == *"DRY-RUN"* ]]
+}
+
+@test "scanner-watchdog: exits 0 with message when heartbeat file absent" {
+    rm -f "${LOOP_LOG_DIR}/scanner-heartbeat"
+
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"absent"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`** — `_scanner_write_heartbeat()` writes `date +%s` to `${LOOP_LOG_DIR}/scanner-heartbeat` at the top of every `run_once()` tick. Skipped in `--dry-run` mode.

**`scanner/scanner-watchdog.sh`** — new script that reads the heartbeat file mtime. If the file is absent or older than `LOOP_SCANNER_WATCHDOG_THRESHOLD` (default `2 × LOOP_SCANNER_INTERVAL`, i.e. 10 min), it kills the stale scanner PID (from `/tmp/loop-scanner.lock`) and restarts via `launchctl kickstart` on macOS or direct `nohup` on Linux. Supports `--dry-run`.

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** — fires every 300 s via `StartInterval`. Installed alongside the scanner plist.

**`install.sh`** — `bootstrap_register_launchd` registers the watchdog plist; `bootstrap_register_cron` adds a `*/5 * * * *` cron entry on Linux.

**`tests/scanner-heartbeat.bats`** — 6 tests covering:
- heartbeat file is created with an epoch timestamp
- second call updates the file
- `DRY_RUN=true` suppresses the write
- watchdog exits OK with fresh heartbeat
- watchdog logs STALE and prints DRY-RUN message when heartbeat is old
- watchdog exits OK with message when heartbeat file is absent

## Test Plan

- All 6 new bats tests pass (`bats tests/scanner-heartbeat.bats`)
- Existing `scanner.bats`, `scanner-log-sighup.bats`, `scanner-stage-age.bats` pass (pre-existing failures in tests 15/16/20/21 of scanner.bats are unrelated to this change and present on `main`)
- `bash -n` + `shellcheck -S warning` pass on all scripts
- No personal identifiers
- Manual: simulate wedge with `kill -STOP $SCANNER_PID` → watchdog restarts within 10 min