### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-wedge detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,26 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — fires every 5 min and restarts the scanner
+    # if its heartbeat file has not been updated within 2× the poll interval.
+    # Guards against silent wedge (alive PID, no log activity).
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +381,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +404,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -775,6 +775,20 @@ scan_project() {
 }
 
 run_once() {
+    # Liveness heartbeat: updated every tick so scanner-watchdog.sh can detect
+    # a wedged process (alive PID, zero log activity) and restart it.
+    if ! $DRY_RUN; then
+        touch "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+    fi
+
+    # Stdout integrity check: if the log file exists but is not writable (e.g.
+    # permissions changed, filesystem issue), reopen the FD or exit so launchd
+    # restarts with a fresh file descriptor.
+    if [ -n "${LOG_FILE:-}" ] && [ -e "$LOG_FILE" ] && [ ! -w "$LOG_FILE" ]; then
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" \
+            || { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] FATAL: cannot reopen log — exiting for restart" >&2; exit 1; }
+    fi
+
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if it has been silent for too long.
+#
+# Reads the heartbeat file written by scanner.sh on every tick. If the
+# heartbeat mtime is older than STALE_THRESHOLD seconds, kills the scanner
+# process (by PID from its lock file) so launchd (macOS) or cron (Linux)
+# restarts it automatically.
+#
+# Run every 5 minutes via launchd StartInterval or crontab */5.
+#
+# Configuration (env vars, sourced from loop.env):
+#   LOOP_SCANNER_WATCHDOG_THRESHOLD — stale threshold in seconds
+#                                     (default: 2 × LOOP_SCANNER_INTERVAL = 600s)
+#   LOOP_SCANNER_INTERVAL           — scanner poll interval (default: 300s)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_SCANNER_WATCHDOG_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# If the heartbeat file has never been written, the scanner may not have
+# completed its first tick yet — give it the benefit of the doubt.
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "no heartbeat file yet — scanner may not have started; skipping"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo "$now")
+age=$(( now - mtime ))
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "heartbeat age=${age}s < threshold=${STALE_THRESHOLD}s — scanner OK"
+    exit 0
+fi
+
+log "STALE: heartbeat age=${age}s >= threshold=${STALE_THRESHOLD}s — initiating restart"
+
+# Kill the scanner by its lock-file PID. The lock's EXIT trap removes the
+# file on clean exit, so on SIGTERM launchd will restart it promptly.
+if [ -f "$LOCK_FILE" ]; then
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "sending SIGTERM to scanner PID $pid"
+        kill "$pid" 2>/dev/null || true
+        # Give it 5 s to exit cleanly before forcing.
+        local_deadline=$(( now + 5 ))
+        while kill -0 "$pid" 2>/dev/null && [ "$(date +%s)" -lt "$local_deadline" ]; do
+            sleep 1
+        done
+        if kill -0 "$pid" 2>/dev/null; then
+            log "scanner PID $pid still alive — sending SIGKILL"
+            kill -9 "$pid" 2>/dev/null || true
+        fi
+        rm -f "$LOCK_FILE"
+    else
+        log "lock file present but PID ${pid:-<empty>} is not alive — removing stale lock"
+        rm -f "$LOCK_FILE"
+    fi
+else
+    log "no lock file found — scanner is not running"
+fi
+
+# On macOS, ask launchd to restart it immediately (KeepAlive would do so on
+# its own after ThrottleInterval, but kickstart triggers it without the delay).
+if [ "$(uname -s)" = "Darwin" ] && command -v launchctl >/dev/null 2>&1; then
+    launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null \
+        && log "launchctl kickstart sent — scanner will restart momentarily" \
+        || log "WARN: launchctl kickstart failed (launchd will restart via KeepAlive)"
+fi
+
+log "done"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <!-- RunAtLoad false: no point checking before the scanner has had a tick -->
+    <key>RunAtLoad</key>
+    <false/>
+    <!-- Fire every 5 minutes (300s). With a default stale threshold of 2×poll
+         (600s) this gives a worst-case restart latency of ~10 minutes. -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verify scanner.sh writes the liveness
+# heartbeat file on every tick (acceptance criteria for #413).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export LOOP_EXTRA_PATH=""
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+
+    # Source scanner.sh function definitions (same strategy as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-hb-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    # Silence log() and no-op side-effectful functions.
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-hb-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat file
+# ---------------------------------------------------------------------------
+
+@test "run_once: creates heartbeat file in LOOP_LOG_DIR" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    rm -f "$hb"
+
+    run_once
+
+    [ -f "$hb" ]
+}
+
+@test "run_once: updates heartbeat mtime on each tick" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+
+    # First tick
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb" 2>/dev/null)
+
+    # Ensure at least 1 second passes so mtime can differ.
+    sleep 1.1
+
+    # Second tick
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb" 2>/dev/null)
+
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once: heartbeat skipped in dry-run mode" {
+    DRY_RUN=true
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    rm -f "$hb"
+
+    run_once
+
+    [ ! -f "$hb" ]
+}


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- **Heartbeat write**: `run_once()` now calls `touch ${LOOP_LOG_DIR}/scanner-heartbeat` at the start of every tick (skipped in `--dry-run` mode). This gives the watchdog a reliable mtime signal.
- **Stdout integrity check**: at the top of each tick, if `LOG_FILE` exists but is not writable, attempts to reopen the FD via `exec`; exits with code 1 (triggering launchd restart) if that also fails.

### scripts/scanner-watchdog.sh (new)
Standalone watchdog that fires every 5 minutes. Reads the heartbeat file mtime; if `now - mtime >= STALE_THRESHOLD` (default: `2 × LOOP_SCANNER_INTERVAL = 600s`), it:
1. Reads the scanner PID from `/tmp/loop-scanner.lock`
2. Sends SIGTERM, waits 5 s, then SIGKILL if still alive
3. Removes the stale lock file
4. On macOS, sends `launchctl kickstart` so the scanner restarts immediately rather than waiting for ThrottleInterval

Configurable via `LOOP_SCANNER_WATCHDOG_THRESHOLD` and `LOOP_SCANNER_INTERVAL`.

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
macOS launchd plist for the watchdog. Fires every 300 s (StartInterval), no RunAtLoad (avoids spurious restart before the first tick).

### install.sh
- **macOS**: registers `com.user.loop-scanner-watchdog` plist in `bootstrap_register_launchd`
- **Linux**: adds `*/5 * * * *` crontab entry in `bootstrap_register_cron`

Both are idempotent (skip if already registered).

### tests/scanner-heartbeat.bats (new)
Three bats tests verifying:
- `run_once` creates the heartbeat file
- `run_once` updates the mtime on subsequent ticks
- heartbeat is skipped in `--dry-run` mode

## Test Plan
- `bats tests/scanner-heartbeat.bats` — all 3 pass
- `bash -n` + `shellcheck -S warning` — no new errors
- Personal-identifier grep — clean
- Pre-existing scanner.bats failures (tests 15, 16, 20, 21) are unrelated to this PR (also fail on main)
- Manual: `kill -STOP $SCANNER_PID` → heartbeat goes stale → watchdog kills + launchd restarts within 10 min