### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -316,6 +316,25 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    # Scanner liveness watchdog — kills a wedged scanner (alive PID, no heartbeat
+    # updates) so launchd KeepAlive restarts it. Fires every 5 min.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     # PR auto-rework watchdog — labels stale loop-authored PRs needs-rework so
     # the dev-rework handler picks them up. Independent of scanner; runs every
     # 15 min on its own cadence. Only acts on PRs whose author is in the
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — detect and restart a wedged scanner.
+#
+# A scanner is wedged when its heartbeat file has not been updated for longer
+# than LOOP_SCANNER_STALE_THRESHOLD seconds (default: 2 × poll_interval = 600s).
+# The scanner writes this file at the top of every tick via run_once().
+#
+# Recovery: send SIGTERM to the scanner PID from the lock file so launchd
+# (KeepAlive=true) auto-restarts it. On Linux the script is idempotent — cron
+# restarts the scanner on its next scheduled interval after the PID is gone.
+#
+# Run via launchd every 5 min (StartInterval=300) on macOS, or cron (*/5) on Linux.
+#
+# Flags:
+#   --dry-run   report what would happen without killing anything
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+LOCK_FILE="/tmp/loop-scanner.lock"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_SCANNER_STALE_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _file_age_seconds <path>
+# Prints the age of the file in seconds (now - mtime), or "" if not found.
+_file_age_seconds() {
+    local path="$1"
+    [ -f "$path" ] || { printf ''; return; }
+    local mtime now
+    mtime=$(stat -f%m "$path" 2>/dev/null || stat -c%Y "$path" 2>/dev/null || printf '')
+    [ -z "$mtime" ] && { printf ''; return; }
+    now=$(date +%s)
+    printf '%s' "$(( now - mtime ))"
+}
+
+log "check (stale_threshold=${STALE_THRESHOLD}s dry=${DRY_RUN})"
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "no heartbeat file — scanner not yet started or completing first tick"
+    exit 0
+fi
+
+age=$(_file_age_seconds "$HEARTBEAT_FILE")
+if [ -z "$age" ]; then
+    log "could not stat heartbeat file — skipping"
+    exit 0
+fi
+
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "ok (heartbeat fresh)"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat stale (${age}s > ${STALE_THRESHOLD}s) — initiating restart"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner and let launchd restart"
+    exit 0
+fi
+
+pid=""
+if [ -f "$LOCK_FILE" ]; then
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+fi
+
+if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    log "sending SIGTERM to wedged scanner PID $pid"
+    kill "$pid" 2>/dev/null || true
+    sleep 2
+    if kill -0 "$pid" 2>/dev/null; then
+        kill -9 "$pid" 2>/dev/null || true
+        log "SIGKILL sent to PID $pid (did not exit after SIGTERM)"
+    fi
+else
+    log "no live scanner PID in lock file — removing stale lock so next start can acquire it"
+    rm -f "$LOCK_FILE"
+fi
+
+log "restart triggered — launchd/cron will restart the scanner"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -775,6 +775,18 @@ scan_project() {
 }
 
 run_once() {
+    # Liveness heartbeat: write current epoch so scanner-watchdog can detect a
+    # wedged scanner (alive PID but not completing ticks) and restart it.
+    if ! $DRY_RUN; then
+        date +%s > "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+    fi
+    # Log file integrity guard: if the log file exists but is no longer writable
+    # (e.g. permissions changed or replaced by a non-writable file after rotation),
+    # exit so launchd restarts the scanner with fresh file descriptors.
+    if ! $DRY_RUN && [ -n "${LOG_FILE:-}" ] && [ -e "$LOG_FILE" ] && [ ! -w "$LOG_FILE" ]; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] ERROR: log file not writable — exiting for launchd restart" >&2
+        exit 1
+    fi
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <!-- Fire every 5 min. Two missed ticks (10 min) = heartbeat stale at 2× poll_interval (600s default). -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,156 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — liveness heartbeat + watchdog (#413).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+    export LOOP_SCANNER_INTERVAL=300
+}
+
+teardown() {
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+}
+
+# ── scanner.sh: heartbeat written on every tick ───────────────────────────────
+
+@test "scanner run_once writes heartbeat file to LOOP_LOG_DIR" {
+    # Source scanner definitions (same extraction pattern as scanner.bats).
+    local src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$src"
+    # shellcheck disable=SC1090
+    source "$src"
+
+    # Stub out everything that touches GitHub / project config so run_once
+    # only needs to complete the heartbeat write and tick-start log.
+    loop_list_slugs()          { printf ''; }
+    _sweep_stale_locks()       { :; }
+    jobs_init_schema()         { :; }
+    LOOP_JOBS_ENQUEUE=0
+
+    run_once
+
+    [ -f "$LOOP_LOG_DIR/scanner-heartbeat" ]
+    local ts
+    ts=$(cat "$LOOP_LOG_DIR/scanner-heartbeat")
+    # Content must be a unix epoch (numeric, non-empty).
+    [[ "$ts" =~ ^[0-9]+$ ]]
+}
+
+@test "scanner run_once updates heartbeat timestamp on each call" {
+    local src="$BATS_TMPDIR/scanner-src2.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$src"
+    # shellcheck disable=SC1090
+    source "$src"
+
+    loop_list_slugs()    { printf ''; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema()   { :; }
+    LOOP_JOBS_ENQUEUE=0
+
+    run_once
+    local t1
+    t1=$(cat "$LOOP_LOG_DIR/scanner-heartbeat")
+
+    sleep 1
+
+    run_once
+    local t2
+    t2=$(cat "$LOOP_LOG_DIR/scanner-heartbeat")
+
+    # Second tick must have a timestamp >= first tick.
+    [ "$t2" -ge "$t1" ]
+}
+
+@test "scanner run_once does NOT write heartbeat in dry-run mode" {
+    local src="$BATS_TMPDIR/scanner-src3.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=true"; print "ONCE=true"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$src"
+    # shellcheck disable=SC1090
+    source "$src"
+
+    loop_list_slugs()    { printf ''; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema()   { :; }
+    LOOP_JOBS_ENQUEUE=0
+
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+    run_once
+
+    [ ! -f "$LOOP_LOG_DIR/scanner-heartbeat" ]
+}
+
+# ── scanner-watchdog.sh ───────────────────────────────────────────────────────
+
+@test "scanner-watchdog exits ok when heartbeat is fresh" {
+    # Write a heartbeat timestamped now.
+    date +%s > "$LOOP_LOG_DIR/scanner-heartbeat"
+
+    export LOOP_SCANNER_STALE_THRESHOLD=600
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ok (heartbeat fresh)"* ]]
+}
+
+@test "scanner-watchdog exits ok when no heartbeat file exists" {
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+
+    export LOOP_SCANNER_STALE_THRESHOLD=600
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"not yet started"* ]]
+}
+
+@test "scanner-watchdog reports stale heartbeat in dry-run" {
+    # Write a heartbeat from 700s ago by back-dating the file mtime.
+    date +%s > "$LOOP_LOG_DIR/scanner-heartbeat"
+    touch -t "$(date -v-700S '+%Y%m%d%H%M.%S' 2>/dev/null \
+               || date --date='700 seconds ago' '+%Y%m%d%H%M.%S' 2>/dev/null \
+               || date '+%Y%m%d%H%M.%S')" \
+          "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null || \
+    python3 -c "
+import os, time
+path='$LOOP_LOG_DIR/scanner-heartbeat'
+t = time.time() - 700
+os.utime(path, (t, t))
+"
+
+    export LOOP_SCANNER_STALE_THRESHOLD=600
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"stale"* ]]
+    [[ "$output" == *"DRY-RUN"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`**
- `run_once()` now writes `${LOOP_LOG_DIR}/scanner-heartbeat` (unix epoch) at the top of every tick. Skip in `--dry-run` mode.
- Added log file integrity guard: if `$LOG_FILE` exists but is not writable (e.g. permissions changed post-rotation without SIGHUP), exit immediately so launchd restarts the scanner with fresh file descriptors.

**`scanner/scanner-watchdog.sh`** (new)
- Standalone script that reads the heartbeat file mtime and compares against `LOOP_SCANNER_STALE_THRESHOLD` (default: `2 × LOOP_SCANNER_INTERVAL = 600s`).
- If stale: sends SIGTERM to the scanner PID from the lock file (SIGKILL after 2s if still alive), then exits — launchd KeepAlive restarts the scanner automatically.
- If no heartbeat file: exits silently (scanner may be in its first tick).
- Supports `--dry-run` for manual inspection.

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new)
- Runs `scanner-watchdog.sh` every 5 min (`StartInterval=300`).
- Shares `__LOOP_ROOT__`/`__LOG_DIR__`/`__HOME__`/`__EXTRA_PATH__` substitution pattern with all other launchd templates.

**`install.sh`**
- `bootstrap_register_launchd`: registers the scanner watchdog plist alongside scanner/reconciler/pr-watchdog.
- `bootstrap_register_cron`: adds `*/5` cron entry for the watchdog on Linux.

**`tests/scanner-heartbeat.bats`** (new, 6 tests)
- `run_once` writes heartbeat file with a numeric epoch timestamp.
- `run_once` updates the heartbeat on successive calls.
- `--dry-run` mode skips the heartbeat write.
- Watchdog exits OK when heartbeat is fresh.
- Watchdog exits OK when heartbeat file does not exist yet.
- Watchdog reports stale heartbeat + `DRY-RUN` output when file is back-dated.

## Test Plan
- All 6 new bats tests pass (`bats tests/scanner-heartbeat.bats`).
- `bash -n` and `shellcheck -S warning` clean on all scripts.
- No personal identifiers in committed files.
- Manual: `kill -STOP $SCANNER_PID` for >600s → watchdog fires and kills the PID; launchd restarts scanner within seconds.
- Manual: `ls -la ~/.loop/logs/scanner-heartbeat` after a tick — mtime updates each poll cycle.