### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — fires every 5 min, restarts scanner if
+    # heartbeat is stale (> 2x LOOP_SCANNER_INTERVAL).
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -32,6 +32,7 @@ LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 
 # SIGHUP-reopen contract (#194): logrotate-style tools truncate or rename
 # the on-disk log file. The launchd plist redirects stdout/stderr to a
@@ -63,6 +64,21 @@ for arg in "$@"; do
 done
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] $*"; }
+
+# Write current epoch to the heartbeat file so the watchdog can verify liveness.
+_scanner_write_heartbeat() {
+    date +%s > "$HEARTBEAT_FILE" 2>/dev/null || true
+}
+
+# Verify stdout is writable; exit if not so launchd/cron can restart cleanly.
+# Protects against the "dead tee child" wedge where echo blocks on EPIPE.
+_scanner_check_stdout() {
+    if [ -n "${LOG_FILE:-}" ] && [ ! -w "$LOG_FILE" ]; then
+        # Try to reopen; if that fails, exit so launchd/cron can restart.
+        exec 1>>"$LOG_FILE" || exit 1
+        exec 2>>"$LOG_FILE" || exit 1
+    fi
+}
 
 # _scanner_jobs_enqueue <slug> <stage> <num>
 # Best-effort dual-write to the jobs table alongside the legacy label-event path.
@@ -775,6 +791,8 @@ scan_project() {
 }
 
 run_once() {
+    _scanner_check_stdout
+    _scanner_write_heartbeat
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/scanner/watchdog.sh
+++ b/scanner/watchdog.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# scanner/watchdog.sh — Liveness watchdog for the Loop scanner.
+#
+# Fires on a short cadence (every 5 min via launchd StartInterval or cron */5).
+# Checks scanner-heartbeat mtime; if older than 2x LOOP_SCANNER_INTERVAL the
+# scanner is presumed wedged — kills the PID and lets launchd/cron restart it.
+#
+# The heartbeat file is written by scanner.sh at the top of every tick.
+#
+# Usage:
+#   scanner/watchdog.sh           # normal execution
+#   DRY_RUN=true scanner/watchdog.sh  # print what would happen, no kills
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+# Stale threshold: 2x poll interval (default 10 min)
+MAX_STALE_SECONDS=$(( POLL_INTERVAL * 2 ))
+DRY_RUN="${DRY_RUN:-false}"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "no heartbeat file yet — skipping (scanner may not have run)"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+age=$(( now - mtime ))
+
+if [ "$age" -le "$MAX_STALE_SECONDS" ]; then
+    log "heartbeat age=${age}s <= ${MAX_STALE_SECONDS}s — scanner alive"
+    exit 0
+fi
+
+log "STALE: heartbeat age=${age}s > ${MAX_STALE_SECONDS}s — triggering restart"
+
+if [ "$DRY_RUN" = "true" ]; then
+    log "DRY_RUN: would kill scanner and request restart"
+    exit 0
+fi
+
+# Kill via lock file PID.
+if [ -f "$LOCK_FILE" ]; then
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "sending SIGTERM to scanner PID $pid"
+        kill -TERM "$pid" 2>/dev/null || true
+        sleep 2
+        # Escalate to SIGKILL if still alive.
+        if kill -0 "$pid" 2>/dev/null; then
+            log "SIGTERM ignored — sending SIGKILL to PID $pid"
+            kill -KILL "$pid" 2>/dev/null || true
+        fi
+    else
+        log "PID $pid from lock file is not running"
+    fi
+    rm -f "$LOCK_FILE"
+fi
+
+# Request restart from the process supervisor.
+if [ "$(uname -s)" = "Darwin" ]; then
+    local_uid=$(id -u)
+    if launchctl kickstart -k "gui/${local_uid}/com.user.loop-scanner" 2>/dev/null; then
+        log "launchctl kickstart issued — scanner will restart"
+    else
+        log "launchctl kickstart failed — KeepAlive will restart on next exit"
+    fi
+else
+    log "Linux: scanner will be restarted by cron on next */5 tick"
+fi

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+  Fires every 5 minutes; checks scanner-heartbeat mtime and restarts the
+  scanner if it has been silent for longer than 2x LOOP_SCANNER_INTERVAL.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — heartbeat file written on every scanner tick.
+#
+# Verifies that run_once() writes ${LOOP_LOG_DIR}/scanner-heartbeat and that
+# the watchdog script correctly identifies stale vs. alive scanners.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    mkdir -p "$DEDUP_DIR"
+    touch "$LOG_FILE"
+
+    DRY_RUN=false
+    ONCE=true
+}
+
+teardown() {
+    rm -f "$LOG_FILE" "$HEARTBEAT_FILE"
+}
+
+@test "scanner.sh defines HEARTBEAT_FILE variable" {
+    grep -q 'HEARTBEAT_FILE=' "$REPO_ROOT/scanner/scanner.sh"
+}
+
+@test "_scanner_write_heartbeat creates heartbeat file" {
+    rm -f "$HEARTBEAT_FILE"
+    _scanner_write_heartbeat
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "_scanner_write_heartbeat writes current epoch to heartbeat file" {
+    _scanner_write_heartbeat
+    local content
+    content=$(cat "$HEARTBEAT_FILE")
+    local now
+    now=$(date +%s)
+    # Epoch in file should be within 5 seconds of now.
+    [ $(( now - content )) -le 5 ]
+}
+
+@test "_scanner_write_heartbeat updates mtime on repeated calls" {
+    _scanner_write_heartbeat
+    local mtime1
+    mtime1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE")
+    sleep 1
+    _scanner_write_heartbeat
+    local mtime2
+    mtime2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE")
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "watchdog.sh exits 0 when no heartbeat file exists" {
+    rm -f "$HEARTBEAT_FILE"
+    LOOP_LOG_DIR="$LOOP_LOG_DIR" run "$REPO_ROOT/scanner/watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no heartbeat file yet"* ]]
+}
+
+@test "watchdog.sh exits 0 when heartbeat is fresh" {
+    _scanner_write_heartbeat
+    LOOP_LOG_DIR="$LOOP_LOG_DIR" run "$REPO_ROOT/scanner/watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner alive"* ]]
+}
+
+@test "watchdog.sh detects stale heartbeat in DRY_RUN mode" {
+    # Create a heartbeat file with an old mtime (25 minutes ago).
+    _scanner_write_heartbeat
+    local old_time=$(( $(date +%s) - 1500 ))
+    touch -t "$(date -r "$old_time" '+%Y%m%d%H%M.%S' 2>/dev/null || date -d "@$old_time" '+%Y%m%d%H%M.%S' 2>/dev/null || echo "197001010000.00")" "$HEARTBEAT_FILE" 2>/dev/null || true
+    # Use a short poll interval so the threshold is easy to exceed.
+    LOOP_LOG_DIR="$LOOP_LOG_DIR" LOOP_SCANNER_INTERVAL=300 DRY_RUN=true \
+        run "$REPO_ROOT/scanner/watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`**
- Added `HEARTBEAT_FILE` variable (`${LOOP_LOG_DIR}/scanner-heartbeat`)
- Added `_scanner_write_heartbeat()` — writes current epoch to the heartbeat file
- Added `_scanner_check_stdout()` — checks if `LOG_FILE` is writable at tick start; exits so launchd/cron can restart if the fd is broken
- Both are called at the top of `run_once()` on every tick

**`scanner/watchdog.sh`** (new)
- Runs on a 5-minute cadence (launchd `StartInterval=300` or cron `*/5`)
- Reads `scanner-heartbeat` mtime; if `age > 2 × LOOP_SCANNER_INTERVAL` the scanner is presumed wedged
- Kills the scanner via its lock-file PID, then issues `launchctl kickstart` on macOS (Linux cron restarts on the next tick)
- Supports `DRY_RUN=true` for safe testing

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new)
- LaunchAgent plist: `StartInterval=300`, writes to `loop-scanner-watchdog.log`

**`install.sh`**
- `bootstrap_register_launchd`: installs `com.user.loop-scanner-watchdog` plist alongside scanner/reconciler
- `bootstrap_register_cron`: adds `*/5 * * * * watchdog.sh` cron entry with idempotent marker

**`tests/scanner-heartbeat.bats`** (new, 7 tests)
- Heartbeat file is created and contains current epoch
- Mtime is updated on repeated calls
- Watchdog exits cleanly when no heartbeat file exists
- Watchdog confirms alive scanner
- Watchdog detects stale heartbeat in DRY_RUN mode

## Test Plan
- All 7 `scanner-heartbeat.bats` tests pass
- All CI checks pass (`bash -n`, `shellcheck -S warning`, no personal identifiers)
- Manual: `kill -STOP $SCANNER_PID` → watchdog should log STALE and restart within 10 min (2× default 300s poll interval)