### PR TITLE
[LOOP-413] scanner: heartbeat file, scanner_tick event, and watchdog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — fires every 5 min, restarts scanner if
+    # heartbeat is stale (> 2x LOOP_SCANNER_INTERVAL).
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -22,6 +22,8 @@ source "$LOOP_ROOT/lib/backends/backend.sh"
 source "$LOOP_ROOT/lib/labels.sh"
 # shellcheck source=../lib/jobs.sh
 source "$LOOP_ROOT/lib/jobs.sh"
+# shellcheck source=../lib/monitor.sh
+source "$LOOP_ROOT/lib/monitor.sh"
 # workflow helpers (loop_polled_labels, loop_handler_for_label, loop_stage_trigger,
 # loop_workflow_for_project) are already loaded via lib/env.sh → lib/workflow.sh.
 # The line below is for shellcheck only.
@@ -32,6 +34,7 @@ LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 
 # SIGHUP-reopen contract (#194): logrotate-style tools truncate or rename
 # the on-disk log file. The launchd plist redirects stdout/stderr to a
@@ -63,6 +66,33 @@ for arg in "$@"; do
 done
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] $*"; }
+
+# Write current epoch to the heartbeat file so the watchdog can verify liveness.
+_scanner_write_heartbeat() {
+    date +%s > "$HEARTBEAT_FILE" 2>/dev/null || true
+}
+
+# Verify stdout is writable; exit if not so launchd/cron can restart cleanly.
+# Protects against the "dead tee child" wedge where echo blocks on EPIPE.
+_scanner_check_stdout() {
+    if [ -n "${LOG_FILE:-}" ] && [ ! -w "$LOG_FILE" ]; then
+        exec 1>>"$LOG_FILE" || exit 1
+        exec 2>>"$LOG_FILE" || exit 1
+    fi
+}
+
+# Emit a scanner_tick event to loop-monitor (best-effort, never blocks the tick).
+# Payload: epoch timestamp + count of dedup entries (proxy for total events seen).
+_scanner_emit_tick() {
+    local now dedup_count payload
+    now=$(date +%s)
+    dedup_count=$(find "$DEDUP_DIR" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
+    payload=$(python3 -c "
+import json, sys
+print(json.dumps({'ts': int(sys.argv[1]), 'dedup_count': int(sys.argv[2])}))
+" "$now" "$dedup_count" 2>/dev/null || echo "")
+    [ -n "$payload" ] && _loop_emit_event "scanner_tick" "$payload" || true
+}
 
 # _scanner_jobs_enqueue <slug> <stage> <num>
 # Best-effort dual-write to the jobs table alongside the legacy label-event path.
@@ -775,6 +805,9 @@ scan_project() {
 }
 
 run_once() {
+    _scanner_check_stdout
+    _scanner_write_heartbeat
+    $DRY_RUN || _scanner_emit_tick
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/scanner/watchdog.sh
+++ b/scanner/watchdog.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# scanner/watchdog.sh — Liveness watchdog for the Loop scanner.
+#
+# Fires on a short cadence (every 5 min via launchd StartInterval or cron */5).
+# Checks scanner-heartbeat mtime; if older than 2x LOOP_SCANNER_INTERVAL the
+# scanner is presumed wedged — kills the PID and lets launchd/cron restart it.
+#
+# The heartbeat file is written by scanner.sh at the top of every tick.
+#
+# Usage:
+#   scanner/watchdog.sh               # normal execution
+#   DRY_RUN=true scanner/watchdog.sh  # print what would happen, no kills
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+# Stale threshold: 2x poll interval (default 10 min)
+MAX_STALE_SECONDS=$(( POLL_INTERVAL * 2 ))
+DRY_RUN="${DRY_RUN:-false}"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "no heartbeat file yet — skipping (scanner may not have run)"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+age=$(( now - mtime ))
+
+if [ "$age" -le "$MAX_STALE_SECONDS" ]; then
+    log "heartbeat age=${age}s <= ${MAX_STALE_SECONDS}s — scanner alive"
+    exit 0
+fi
+
+log "STALE: heartbeat age=${age}s > ${MAX_STALE_SECONDS}s — triggering restart"
+
+if [ "$DRY_RUN" = "true" ]; then
+    log "DRY_RUN: would kill scanner and request restart"
+    exit 0
+fi
+
+# Kill via lock file PID.
+if [ -f "$LOCK_FILE" ]; then
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "sending SIGTERM to scanner PID $pid"
+        kill -TERM "$pid" 2>/dev/null || true
+        sleep 2
+        if kill -0 "$pid" 2>/dev/null; then
+            log "SIGTERM ignored — sending SIGKILL to PID $pid"
+            kill -KILL "$pid" 2>/dev/null || true
+        fi
+    else
+        log "PID $pid from lock file is not running"
+    fi
+    rm -f "$LOCK_FILE"
+fi
+
+# Request restart from the process supervisor.
+if [ "$(uname -s)" = "Darwin" ]; then
+    local_uid=$(id -u)
+    if launchctl kickstart -k "gui/${local_uid}/com.user.loop-scanner" 2>/dev/null; then
+        log "launchctl kickstart issued — scanner will restart"
+    else
+        log "launchctl kickstart failed — KeepAlive will restart on next exit"
+    fi
+else
+    log "Linux: scanner will be restarted by cron on next */5 tick"
+fi

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+  Fires every 5 minutes; checks scanner-heartbeat mtime and restarts the
+  scanner if it has been silent for longer than 2x LOOP_SCANNER_INTERVAL.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,170 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — liveness heartbeat and scanner_tick event.
+#
+# Covers acceptance criteria from #413:
+#   1. Heartbeat file written on every tick.
+#   2. scanner_tick event emitted to loop-monitor on every tick.
+#   3. Watchdog detects stale vs. alive scanner.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    mkdir -p "$DEDUP_DIR"
+    touch "$LOG_FILE"
+
+    DRY_RUN=false
+    ONCE=true
+}
+
+teardown() {
+    rm -f "$LOG_FILE" "$HEARTBEAT_FILE"
+}
+
+# ── Heartbeat file ────────────────────────────────────────────────────────────
+
+@test "scanner.sh defines HEARTBEAT_FILE variable" {
+    grep -q 'HEARTBEAT_FILE=' "$REPO_ROOT/scanner/scanner.sh"
+}
+
+@test "_scanner_write_heartbeat creates heartbeat file" {
+    rm -f "$HEARTBEAT_FILE"
+    _scanner_write_heartbeat
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "_scanner_write_heartbeat writes current epoch to heartbeat file" {
+    _scanner_write_heartbeat
+    local content
+    content=$(cat "$HEARTBEAT_FILE")
+    local now
+    now=$(date +%s)
+    [ $(( now - content )) -le 5 ]
+}
+
+@test "_scanner_write_heartbeat updates mtime on repeated calls" {
+    _scanner_write_heartbeat
+    local mtime1
+    mtime1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE")
+    sleep 1
+    _scanner_write_heartbeat
+    local mtime2
+    mtime2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE")
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+# ── scanner_tick event ────────────────────────────────────────────────────────
+
+@test "scanner.sh defines _scanner_emit_tick function" {
+    declare -f _scanner_emit_tick >/dev/null
+}
+
+@test "_scanner_emit_tick calls _loop_emit_event when LOOP_MONITOR_URL is set" {
+    local call_log="$BATS_TMPDIR/emit_calls.log"
+    # Override _loop_emit_event to capture calls.
+    _loop_emit_event() { echo "called:$1:$2" >> "$call_log"; }
+    LOOP_MONITOR_URL="http://localhost:9999"
+    mkdir -p "$DEDUP_DIR"
+    _scanner_emit_tick
+    [ -f "$call_log" ]
+    grep -q "called:scanner_tick:" "$call_log"
+}
+
+@test "_scanner_emit_tick payload contains ts and dedup_count fields" {
+    local captured=""
+    _loop_emit_event() { captured="$2"; }
+    LOOP_MONITOR_URL="http://localhost:9999"
+    mkdir -p "$DEDUP_DIR"
+    _scanner_emit_tick
+    # Payload must be valid JSON with ts and dedup_count.
+    echo "$captured" | python3 -c "
+import json, sys
+p = json.load(sys.stdin)
+assert 'ts' in p, 'missing ts'
+assert 'dedup_count' in p, 'missing dedup_count'
+assert isinstance(p['ts'], int), 'ts must be int'
+assert isinstance(p['dedup_count'], int), 'dedup_count must be int'
+"
+}
+
+@test "_scanner_emit_tick dedup_count reflects files in DEDUP_DIR" {
+    local captured_count=-1
+    _loop_emit_event() {
+        captured_count=$(echo "$2" | python3 -c "import json,sys; print(json.load(sys.stdin)['dedup_count'])")
+    }
+    LOOP_MONITOR_URL="http://localhost:9999"
+    mkdir -p "$DEDUP_DIR"
+    touch "$DEDUP_DIR/abc123" "$DEDUP_DIR/def456"
+    _scanner_emit_tick
+    [ "$captured_count" -eq 2 ]
+}
+
+@test "_scanner_emit_tick is skipped when DRY_RUN is true (run_once guard)" {
+    local called=false
+    _loop_emit_event() { called=true; }
+    LOOP_MONITOR_URL="http://localhost:9999"
+    # The guard $DRY_RUN || _scanner_emit_tick is in run_once, not the function itself.
+    # Verify the pattern exists in the source.
+    grep -q 'DRY_RUN.*_scanner_emit_tick' "$REPO_ROOT/scanner/scanner.sh"
+}
+
+# ── Watchdog script ───────────────────────────────────────────────────────────
+
+@test "watchdog.sh exits 0 when no heartbeat file exists" {
+    rm -f "$HEARTBEAT_FILE"
+    LOOP_LOG_DIR="$LOOP_LOG_DIR" run "$REPO_ROOT/scanner/watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no heartbeat file yet"* ]]
+}
+
+@test "watchdog.sh exits 0 and logs alive when heartbeat is fresh" {
+    _scanner_write_heartbeat
+    LOOP_LOG_DIR="$LOOP_LOG_DIR" run "$REPO_ROOT/scanner/watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner alive"* ]]
+}
+
+@test "watchdog.sh detects stale heartbeat in DRY_RUN mode" {
+    # Backdate heartbeat 25 minutes to exceed 2x default 300s interval.
+    _scanner_write_heartbeat
+    local old_epoch=$(( $(date +%s) - 1500 ))
+    printf '%s\n' "$old_epoch" > "$HEARTBEAT_FILE"
+    touch -t "$(date -r "$old_epoch" '+%Y%m%d%H%M.%S' 2>/dev/null \
+        || date -d "@$old_epoch" '+%Y%m%d%H%M.%S' 2>/dev/null \
+        || echo '202001010000.00')" "$HEARTBEAT_FILE" 2>/dev/null || true
+    LOOP_LOG_DIR="$LOOP_LOG_DIR" LOOP_SCANNER_INTERVAL=300 DRY_RUN=true \
+        run "$REPO_ROOT/scanner/watchdog.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+    [[ "$output" == *"DRY_RUN"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

Implements all three acceptance criteria from #413.

**Criterion 1 — Heartbeat file** (`scanner/scanner.sh`, `scanner/watchdog.sh`, `templates/launchd/com.user.loop-scanner-watchdog.plist.template`, `install.sh`)
- `HEARTBEAT_FILE=${LOOP_LOG_DIR}/scanner-heartbeat` written at the top of every tick via `_scanner_write_heartbeat()`
- `scanner/watchdog.sh` (new): fires every 5 min via launchd `StartInterval=300` or cron `*/5`; checks heartbeat mtime; if `age > 2 × LOOP_SCANNER_INTERVAL` kills the PID and issues `launchctl kickstart` on macOS (Linux leaves restart to cron). Supports `DRY_RUN=true` for safe testing.
- `install.sh`: registers `com.user.loop-scanner-watchdog` in both `bootstrap_register_launchd` (macOS) and `bootstrap_register_cron` (Linux)

**Criterion 2 — Tick-counter event** (`scanner/scanner.sh`)
- `_scanner_emit_tick()`: builds `{"ts": <epoch>, "dedup_count": <n>}` payload and calls `_loop_emit_event("scanner_tick", ...)` from `lib/monitor.sh`
- Called in `run_once()` after `_scanner_write_heartbeat`, skipped when `DRY_RUN=true`
- `lib/monitor.sh` is now sourced in scanner.sh (best-effort: no-ops when `LOOP_MONITOR_URL` is unset)

**Criterion 3 — Stdout file integrity check** (`scanner/scanner.sh`)
- `_scanner_check_stdout()`: if `LOG_FILE` is not writable, tries to reopen fd 1+2; exits with code 1 on failure so launchd/cron restarts the process cleanly
- Called at the very top of `run_once()`, before any log output

**Tests** (`tests/scanner-heartbeat.bats`, 12 tests)
- Heartbeat file created and epoch written correctly
- Mtime updated on repeated calls
- `_scanner_emit_tick` calls `_loop_emit_event` with correct type
- Payload validates as JSON with `ts` (int) and `dedup_count` (int)
- `dedup_count` reflects actual files in `DEDUP_DIR`
- DRY_RUN guard pattern verified in source
- Watchdog: exits cleanly when no heartbeat file
- Watchdog: logs "scanner alive" when heartbeat is fresh
- Watchdog: detects stale heartbeat and logs STALE + DRY_RUN

## Test Plan
- All 12 `scanner-heartbeat.bats` tests pass
- All CI checks pass (`bash -n`, `shellcheck -S warning`, no personal identifiers)
- Manual wedge test: `kill -STOP $SCANNER_PID` → watchdog logs STALE and kills within 10 min (2× 300s default); launchd restarts automatically via KeepAlive