### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,6 +338,25 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    # Scanner liveness watchdog — fires every 5 min, checks heartbeat file mtime,
+    # kills and restarts the scanner if it has been silent for 2×poll interval.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     local digest_plist="$agents_dir/com.user.loop-digest.plist"
     if [ -f "$digest_plist" ]; then
         echo "[launchd] com.user.loop-digest already registered — skipping"
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if its heartbeat goes stale.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (updated every tick by scanner.sh).
+# If the file's mtime is older than STALE_THRESHOLD_SECONDS (default: 2×poll
+# interval = 600s), kills the scanner PID from /tmp/loop-scanner.lock and
+# triggers a restart via launchctl kickstart (macOS) or by directly spawning
+# scanner.sh (Linux).
+#
+# Designed to run every 5 minutes via launchd (macOS) or cron (Linux).
+# On macOS, KeepAlive=true on the scanner plist means killing the scanner PID
+# is sufficient — launchd restarts it automatically. The kickstart call is a
+# belt-and-braces fallback in case KeepAlive stalls.
+#
+# Usage:
+#   scanner-watchdog.sh          # check once; exit 0 always
+#   scanner-watchdog.sh --dry-run  # print what would happen, don't act
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+LOCK_FILE="/tmp/loop-scanner.lock"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD_SECONDS="${LOOP_WATCHDOG_STALE_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _file_age_seconds <path>
+# Print the number of seconds since the file was last modified.
+# Returns a large number if the file does not exist (treat as maximally stale).
+_file_age_seconds() {
+    local path="$1"
+    if [ ! -f "$path" ]; then
+        echo "999999"
+        return 0
+    fi
+    local mtime now
+    mtime=$(stat -f%m "$path" 2>/dev/null || stat -c%Y "$path" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+# _scanner_pid
+# Read the PID from the lock file. Print nothing if unavailable.
+_scanner_pid() {
+    [ -f "$LOCK_FILE" ] || return 0
+    local pid
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    printf '%s' "${pid:-}"
+}
+
+# _kill_scanner <pid>
+# Send SIGTERM to the scanner process. Returns 0 on success.
+_kill_scanner() {
+    local pid="$1"
+    [ -n "$pid" ] || return 1
+    kill -TERM "$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || return 1
+}
+
+# _restart_scanner_macos
+# Use launchctl to restart the scanner service. KeepAlive handles the restart
+# automatically after kill; this is the explicit belt-and-braces path.
+_restart_scanner_macos() {
+    local plist_path="$HOME/Library/LaunchAgents/com.user.loop-scanner.plist"
+    if [ -f "$plist_path" ]; then
+        launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null \
+            || launchctl stop "com.user.loop-scanner" 2>/dev/null \
+            || true
+        log "launchctl kickstart issued for com.user.loop-scanner"
+    else
+        log "WARN: launchd plist not found at $plist_path — scanner will rely on KeepAlive restart"
+    fi
+}
+
+# _restart_scanner_linux
+# Spawn a background scanner --once. On Linux without launchd, the watchdog
+# becomes responsible for firing a single sweep; a systemd unit or cron owns
+# the continuous loop.
+_restart_scanner_linux() {
+    nohup "$LOOP_ROOT/scanner/scanner.sh" --once \
+        >> "${LOOP_LOG_DIR}/loop-scanner.log" 2>&1 &
+    log "spawned scanner.sh --once (PID $!)"
+}
+
+age=$(_file_age_seconds "$HEARTBEAT_FILE")
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD_SECONDS}s heartbeat=${HEARTBEAT_FILE}"
+
+if [ "$age" -lt "$STALE_THRESHOLD_SECONDS" ]; then
+    log "scanner healthy — no action needed"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat stale (${age}s > ${STALE_THRESHOLD_SECONDS}s) — restarting"
+
+scanner_pid=$(_scanner_pid)
+if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+    if $DRY_RUN; then
+        log "DRY-RUN: would kill scanner PID $scanner_pid"
+    else
+        log "killing scanner PID $scanner_pid"
+        _kill_scanner "$scanner_pid" || log "WARN: kill $scanner_pid failed (may have already exited)"
+        rm -f "$LOCK_FILE"
+    fi
+else
+    log "scanner PID not running (lock: ${scanner_pid:-none}) — triggering restart anyway"
+    rm -f "$LOCK_FILE"
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would restart scanner"
+    exit 0
+fi
+
+case "$(uname -s)" in
+    Darwin) _restart_scanner_macos ;;
+    *)      _restart_scanner_linux ;;
+esac

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -775,6 +775,18 @@ scan_project() {
 }
 
 run_once() {
+    # Stdout integrity check: if the log file path is set but no longer writable
+    # (e.g. log rotation deleted the inode), reopen FDs so writes resume.
+    # If the reopen itself fails, exit so launchd auto-restarts with a clean FD table.
+    if [ -n "${LOG_FILE:-}" ] && [ ! -w "$LOG_FILE" ]; then
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" || exit 1
+    fi
+
+    # Heartbeat: update mtime so scanner-watchdog.sh can detect a wedged process.
+    if ! $DRY_RUN; then
+        touch "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+    fi
+
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <!-- Fire every 5 minutes to detect a wedged scanner within one poll window -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,121 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for scanner liveness heartbeat (#413).
+#
+# Verifies:
+#   1. run_once() touches ${LOOP_LOG_DIR}/scanner-heartbeat on each tick.
+#   2. scanner-watchdog.sh exits 0 without action when heartbeat is fresh.
+#   3. scanner-watchdog.sh reports stale heartbeat and (in dry-run) would restart.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Minimal env so scanner.sh sources cleanly without a real loop.env.
+    export LOOP_SCANNER_INTERVAL=300
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner functions (same strategy as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    # Override runtime paths to stay inside tmp.
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    # Stub out log/dispatch/project scanning so run_once completes quickly.
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { :; }
+    LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/scanner-src.sh" "$BATS_TMPDIR/scanner-test.log" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat file creation
+# ---------------------------------------------------------------------------
+
+@test "run_once: creates scanner-heartbeat file" {
+    run_once
+    [ -f "$LOOP_LOG_DIR/scanner-heartbeat" ]
+}
+
+@test "run_once: updates scanner-heartbeat mtime on each call" {
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null \
+             || stat -c%Y "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null)
+    sleep 1
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null \
+             || stat -c%Y "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null)
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once: does NOT create scanner-heartbeat when DRY_RUN=true" {
+    DRY_RUN=true
+    run_once
+    [ ! -f "$LOOP_LOG_DIR/scanner-heartbeat" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh — dry-run mode
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits 0 when heartbeat is fresh" {
+    touch "$LOOP_LOG_DIR/scanner-heartbeat"
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner healthy"* ]]
+}
+
+@test "scanner-watchdog: reports stale when heartbeat file is absent" {
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"stale"* ]]
+}
+
+@test "scanner-watchdog: reports stale and dry-run restart when heartbeat is old" {
+    # Create a heartbeat file that is 800 seconds old by back-dating its mtime.
+    touch "$LOOP_LOG_DIR/scanner-heartbeat"
+    local old_time
+    old_time=$(date -v -800S +%Y%m%d%H%M.%S 2>/dev/null \
+               || date -d "800 seconds ago" +%Y%m%d%H%M.%S 2>/dev/null \
+               || echo "")
+    if [ -n "$old_time" ]; then
+        touch -t "$old_time" "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null || true
+    fi
+
+    LOOP_WATCHDOG_STALE_THRESHOLD=600 \
+        run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"stale"* ]]
+    [[ "$output" == *"DRY-RUN"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`**
- At the start of every `run_once()` tick, `touch ${LOOP_LOG_DIR}/scanner-heartbeat` so the watchdog has a reliable liveness signal.
- Added stdout integrity check at tick start: if `LOG_FILE` is not writable (e.g. inode deleted after log rotation), reopen the FD or exit so launchd auto-restarts.
- Both changes are no-ops in `--dry-run` mode.

**`scanner/scanner-watchdog.sh`** (new)
- Reads heartbeat file mtime; if age exceeds `LOOP_WATCHDOG_STALE_THRESHOLD` (default: `2 × LOOP_SCANNER_INTERVAL = 600s`), kills the scanner PID from the lock file and triggers restart.
- On macOS: `launchctl kickstart` the scanner plist (KeepAlive handles the restart; kickstart is belt-and-braces).
- On Linux: spawns `scanner.sh --once` in the background.
- Supports `--dry-run` for safe testing.

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new)
- Fires every 5 minutes (`StartInterval=300`); `RunAtLoad=false` (watchdog should not fire before the scanner has had a chance to write its first heartbeat).

**`install.sh`**
- `bootstrap_register_launchd`: installs watchdog plist alongside scanner plist.
- `bootstrap_register_cron`: adds `*/5 * * * *` watchdog cron entry for Linux.

**`tests/scanner-heartbeat.bats`** (new, 6 tests)
- `run_once` creates and updates heartbeat file; skips in dry-run.
- Watchdog reports healthy when heartbeat is fresh.
- Watchdog reports stale (with dry-run restart) when heartbeat is absent or old.

## Test Plan
- All new bats tests pass (`bats tests/scanner-heartbeat.bats` → 6/6 ok).
- `bash -n` and `shellcheck -S warning` pass on all shell scripts.
- No personal identifiers introduced.
- Pre-existing `scanner.bats` failures (5 tests) are unrelated to this PR and were present before this change.
- Manual: simulate wedge with `kill -STOP $SCANNER_PID`; watchdog should restart within 10 minutes (2×poll).