### PR TITLE
[LOOP-413] scanner: liveness heartbeat + watchdog auto-restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — restarts a wedged scanner if the heartbeat
+    # file is older than 2 × LOOP_SCANNER_INTERVAL. Runs every 5 min.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart a wedged scanner based on heartbeat staleness.
+#
+# The scanner writes a heartbeat file (${LOOP_LOG_DIR}/scanner-heartbeat) at the
+# start of every tick. If that file's mtime is older than 2 × POLL_INTERVAL
+# (default 10 min) the scanner is considered wedged: kill its PID (from the
+# lock file) and — on macOS — kick launchd to restart it. launchd KeepAlive
+# handles the restart; on Linux the cron entry starts a fresh --once sweep.
+#
+# Usage:
+#   scanner-watchdog.sh            # single check (suitable for cron / launchd StartInterval)
+#   scanner-watchdog.sh --dry-run  # print what would happen, no kills
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 ))
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -15
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+log "check (threshold=${STALE_THRESHOLD}s dry=${DRY_RUN})"
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "no heartbeat file found — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo "$now")
+age=$(( now - mtime ))
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "heartbeat fresh (age=${age}s < ${STALE_THRESHOLD}s) — scanner healthy"
+    exit 0
+fi
+
+log "WARN: heartbeat stale (age=${age}s >= ${STALE_THRESHOLD}s) — scanner appears wedged"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID and signal launchd/cron to restart"
+    exit 0
+fi
+
+# Kill the wedged scanner process.
+if [ -f "$LOCK_FILE" ]; then
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "killing wedged scanner PID $pid"
+        kill "$pid" 2>/dev/null || true
+        # Give launchd a moment to acknowledge the exit before kickstart.
+        sleep 2
+    else
+        log "lock file present but PID ${pid:-<empty>} not alive — removing stale lock"
+        rm -f "$LOCK_FILE"
+    fi
+else
+    log "no lock file found — scanner may have already exited"
+fi
+
+# On macOS, kick launchd to restart the scanner immediately rather than
+# waiting for the default ThrottleInterval.
+if command -v launchctl >/dev/null 2>&1; then
+    if launchctl list com.user.loop-scanner >/dev/null 2>&1; then
+        log "kickstarting com.user.loop-scanner via launchctl"
+        launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null \
+            || launchctl start com.user.loop-scanner 2>/dev/null \
+            || log "WARN: launchctl kickstart failed — launchd KeepAlive will restart on its own"
+    else
+        log "com.user.loop-scanner not registered with launchd — KeepAlive restart not available"
+    fi
+else
+    log "launchctl not found (Linux?) — cron will start a fresh --once sweep on next tick"
+fi
+
+log "watchdog action complete"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -776,6 +777,8 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Heartbeat: update mtime so scanner-watchdog can detect a wedged scanner.
+    $DRY_RUN || touch "$HEARTBEAT_FILE"
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+  Fires every 5 minutes; restarts a wedged scanner if the heartbeat file is
+  older than 2 × LOOP_SCANNER_INTERVAL (default 10 min).
+
+  Installed automatically by: ./install.sh --bootstrap
+
+  Manual install:
+    sed "s|__LOOP_ROOT__|$(cd "$(dirname "$0")/.." && pwd)|g; \
+         s|__LOG_DIR__|$LOOP_LOG_DIR|g; \
+         s|__HOME__|$HOME|g; \
+         s|__EXTRA_PATH__|$(brew --prefix)/bin:/usr/local/bin|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <!-- Check every 5 minutes -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verify scanner writes a heartbeat file on each tick (#413).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+    export LOOP_ROOT="$REPO_ROOT"
+
+    # Stub mock gh binary.
+    mkdir -p "$BATS_TMPDIR/bin"
+    cat > "$BATS_TMPDIR/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    export HEARTBEAT_FILE
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/logs"
+}
+
+@test "scanner.sh defines HEARTBEAT_FILE pointing to LOOP_LOG_DIR" {
+    grep -q 'HEARTBEAT_FILE=' "$REPO_ROOT/scanner/scanner.sh"
+    grep -q 'scanner-heartbeat' "$REPO_ROOT/scanner/scanner.sh"
+}
+
+@test "scanner.sh touches HEARTBEAT_FILE in run_once" {
+    grep -q 'touch.*HEARTBEAT_FILE' "$REPO_ROOT/scanner/scanner.sh"
+}
+
+@test "scanner-watchdog.sh exits 0 when heartbeat is fresh" {
+    # Create a fresh heartbeat file.
+    touch "$LOOP_LOG_DIR/scanner-heartbeat"
+
+    # Run watchdog in dry-run so it does not attempt kills.
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        LOOP_SCANNER_INTERVAL=300 \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"fresh"* ]]
+}
+
+@test "scanner-watchdog.sh reports stale heartbeat when mtime is old" {
+    # Create a heartbeat file and backdate its mtime by 1 hour.
+    touch "$LOOP_LOG_DIR/scanner-heartbeat"
+    python3 -c "
+import os, time
+p = '$LOOP_LOG_DIR/scanner-heartbeat'
+t = time.time() - 3600
+os.utime(p, (t, t))
+"
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        LOOP_SCANNER_INTERVAL=300 \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"stale"* ]] || [[ "$output" == *"wedged"* ]]
+}
+
+@test "scanner-watchdog.sh exits 0 when heartbeat file is missing" {
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        LOOP_SCANNER_INTERVAL=300 \
+        "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no heartbeat"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- Added `HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"` variable.
- `run_once()` calls `touch "$HEARTBEAT_FILE"` at the top of every tick (skipped in `--dry-run` mode). This gives an external watchdog a mtime-based liveness signal.

### `scanner/scanner-watchdog.sh` (new)
- Standalone script suitable for launchd `StartInterval` or cron `*/5`.
- Computes `age = now - mtime(scanner-heartbeat)`. If `age >= 2 × LOOP_SCANNER_INTERVAL` (default 10 min):
  - Reads the scanner PID from `/tmp/loop-scanner.lock` and kills it.
  - On macOS: calls `launchctl kickstart` to restart the scanner immediately rather than waiting for `ThrottleInterval`. Falls back to `launchctl start` if kickstart is unavailable.
  - On Linux: no action needed — the cron `--once` sweep restarts naturally on the next tick.
- Exits 0 cleanly when heartbeat is fresh, missing (scanner not yet started), or in `--dry-run` mode.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- `StartInterval 300` (every 5 min), logs to `loop-scanner-watchdog.log`.
- Uses the same `__LOOP_ROOT__` / `__LOG_DIR__` / `__HOME__` / `__EXTRA_PATH__` substitution tokens as all other plist templates.

### `install.sh`
- `bootstrap_register_launchd()` — registers `com.user.loop-scanner-watchdog` plist (idempotent, skips if already present).
- `bootstrap_register_cron()` — adds `*/5 * * * *` cron entry for Linux (idempotent, marker-guarded).

### `tests/scanner-heartbeat.bats` (new, 5 tests)
- Verifies `HEARTBEAT_FILE` is defined and `touch`-ed in scanner source.
- Integration tests for watchdog: fresh heartbeat → "fresh" message; backdated 1h → "stale/wedged" message; missing file → "no heartbeat" message.

## Test Plan
- All 5 bats tests in `tests/scanner-heartbeat.bats` pass locally.
- `bash -n` and `shellcheck -S warning` pass on all `lib/*.sh scripts/*.sh scanner/*.sh install.sh`.
- No personal identifiers in committed files.
- Manual: `kill -STOP $SCANNER_PID` → wait 10+ min → watchdog should detect stale heartbeat and restart scanner.