### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-hang detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -316,6 +316,26 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    # Scanner liveness watchdog — detects silent scanner hangs by checking
+    # heartbeat file mtime and kills+restarts the scanner if stale.
+    # Fires every 5 min; stale threshold is 2 × poll interval (default 10 min).
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     # PR auto-rework watchdog — labels stale loop-authored PRs needs-rework so
     # the dev-rework handler picks them up. Independent of scanner; runs every
     # 15 min on its own cadence. Only acts on PRs whose author is in the

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -776,6 +776,14 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Write heartbeat so the scanner-watchdog can detect silent hangs.
+    $DRY_RUN || touch "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+    # Stdout integrity check: if an existing log file is no longer writable
+    # (e.g. inode recycled after rotation), exit so launchd restarts cleanly.
+    if ! $DRY_RUN && [ -n "${LOG_FILE:-}" ] && [ -e "$LOG_FILE" ] && [ ! -w "$LOG_FILE" ]; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] FATAL: $LOG_FILE not writable — exiting for launchd restart" >&2
+        exit 1
+    fi
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — detect and recover a silently-wedged scanner.
+#
+# Checks ${LOOP_LOG_DIR}/scanner-heartbeat mtime. If the file is older than
+# 2 × LOOP_SCANNER_INTERVAL (default 10 min), the scanner is considered wedged:
+# its lock-file PID is killed and launchd KeepAlive auto-restarts it within
+# ThrottleInterval seconds.
+#
+# On Linux (cron), the stale lock is cleared so the next cron invocation
+# starts a fresh scanner process.
+#
+# Designed to run every 5 minutes via launchd StartInterval or cron.
+#
+# Flags:
+#   --dry-run   report staleness without killing/restarting
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 ))
+HEARTBEAT="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+if [ ! -f "$HEARTBEAT" ]; then
+    log "no heartbeat file found at $HEARTBEAT — scanner not yet started or LOOP_LOG_DIR unconfigured"
+    exit 0
+fi
+
+heartbeat_mtime=$(stat -f%m "$HEARTBEAT" 2>/dev/null || stat -c%Y "$HEARTBEAT" 2>/dev/null || echo 0)
+age=$(( $(date +%s) - heartbeat_mtime ))
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "ok: heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+    exit 0
+fi
+
+log "ALERT: scanner heartbeat stale (age=${age}s >= threshold=${STALE_THRESHOLD}s)"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner and trigger restart"
+    exit 0
+fi
+
+# Kill the wedged scanner so launchd KeepAlive (macOS) or cron (Linux) restarts it.
+if [ -f "$LOCK_FILE" ]; then
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || echo "")
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "killing wedged scanner PID $pid"
+        kill "$pid" 2>/dev/null || true
+        sleep 2
+    else
+        log "lock file present but PID ${pid:-<empty>} not alive — removing stale lock"
+        rm -f "$LOCK_FILE"
+    fi
+fi
+
+# On macOS launchd, KeepAlive=true auto-restarts the scanner after the kill.
+# kickstart is belt-and-braces for the case where launchd needs nudging.
+if command -v launchctl >/dev/null 2>&1; then
+    log "kickstarting com.user.loop-scanner via launchctl"
+    launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null \
+        || log "WARN: launchctl kickstart failed — KeepAlive will auto-restart shortly"
+else
+    log "non-macOS: stale lock cleared — cron will restart scanner on next invocation"
+fi

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <!-- Fire every 5 minutes (300s); stale threshold is 2 × poll interval (default 10 min). -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verifies scanner writes heartbeat on every tick (#413).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    # Stub out everything that touches GitHub or dispatches.
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+@test "run_once: creates heartbeat file on first tick" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    rm -f "$hb"
+    run_once
+    [ -f "$hb" ]
+}
+
+@test "run_once: heartbeat mtime is updated on each tick" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    # Create a stale heartbeat (1 hour ago via backdated touch on macOS/Linux).
+    touch -t "$(date -v-1H '+%Y%m%d%H%M' 2>/dev/null || date -d '1 hour ago' '+%Y%m%d%H%M' 2>/dev/null || date '+%Y%m%d%H%M')" "$hb" 2>/dev/null \
+        || touch "$hb"
+    local before_mtime
+    before_mtime=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb" 2>/dev/null || echo 0)
+
+    sleep 1
+    run_once
+
+    local after_mtime
+    after_mtime=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb" 2>/dev/null || echo 0)
+    [ "$after_mtime" -gt "$before_mtime" ]
+}
+
+@test "run_once: heartbeat not written in dry-run mode" {
+    DRY_RUN=true
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    rm -f "$hb"
+    run_once
+    [ ! -f "$hb" ]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- **Heartbeat file**: `run_once()` now calls `touch ${LOOP_LOG_DIR}/scanner-heartbeat` at the top of every tick (skipped in `--dry-run`). The mtime of this file is the canonical liveness signal.
- **Stdout integrity check**: if `loop-scanner.log` exists but is not writable (e.g. stale inode after log rotation was not caught by SIGHUP), the scanner exits immediately so launchd KeepAlive triggers a clean restart.

### `scripts/scanner-watchdog.sh` (new)
Standalone watchdog script designed to run every 5 minutes via launchd. Reads `scanner-heartbeat` mtime; if age ≥ `2 × LOOP_SCANNER_INTERVAL` (default 10 min):
1. Kills the wedged scanner PID (from the lock file).
2. On macOS calls `launchctl kickstart` as belt-and-braces (KeepAlive auto-restarts regardless).
3. On Linux, clearing the lock is sufficient for the next cron invocation.
Supports `--dry-run` for operator inspection without side-effects.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
LaunchAgent template that fires `scanner-watchdog.sh` every 300 s (5 min). Uses the same `__LOOP_ROOT__` / `__LOG_DIR__` / `__HOME__` / `__EXTRA_PATH__` placeholders as the existing scanner plist.

### `install.sh`
`bootstrap_register_launchd()` now installs and loads `com.user.loop-scanner-watchdog` alongside the scanner and reconciler plists (idempotent — skips if plist already present).

### `tests/scanner-heartbeat.bats` (new)
Three bats tests:
- Heartbeat file is created on first tick.
- Heartbeat mtime is updated on subsequent ticks.
- Heartbeat is NOT written in `--dry-run` mode.

## Test Plan
- All bats tests pass: `bats tests/scanner-heartbeat.bats`
- CI: `bash -n` + `shellcheck -S warning` + workflow lint + no-personal-identifiers — all clean
- Manual: simulate wedge with `kill -STOP $SCANNER_PID`, observe watchdog log after ~10 min; scanner should be killed and restarted within 5 min of the watchdog firing