### PR TITLE
[LOOP-413] scanner: liveness heartbeat + auto-restart watchdog

### DIFF
--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -776,6 +777,7 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    $DRY_RUN || touch "$HEARTBEAT_FILE"
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scripts/restart-scanner-if-stale.sh
+++ b/scripts/restart-scanner-if-stale.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# restart-scanner-if-stale.sh — scanner liveness watchdog.
+#
+# Checks the scanner heartbeat file. If the file is older than
+# LOOP_SCANNER_STALE_THRESHOLD seconds (default: 15 min = 3 × default
+# poll interval), the scanner process is considered wedged and is killed
+# so launchd / systemd restarts it automatically.
+#
+# Designed to run every 5 minutes via launchd (macOS) or cron (Linux).
+#
+# Usage:
+#   restart-scanner-if-stale.sh [--dry-run]
+#
+# Environment (all optional — sane defaults apply):
+#   LOOP_LOG_DIR                  base log directory (default: ~/.loop/logs)
+#   LOOP_SCANNER_STALE_THRESHOLD  seconds before declaring the scanner wedged
+#                                 (default: 900 — 15 min)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+STALE_THRESHOLD="${LOOP_SCANNER_STALE_THRESHOLD:-900}"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# If the heartbeat file has never been written the scanner has never ticked.
+# Nothing to kill yet — exit cleanly.
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file absent — scanner has not ticked yet, nothing to do"
+    exit 0
+fi
+
+# Compute heartbeat age in seconds.
+heartbeat_mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+    || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+    || echo 0)
+now=$(date +%s)
+age=$(( now - heartbeat_mtime ))
+
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is healthy"
+    exit 0
+fi
+
+log "WARN: scanner appears wedged (heartbeat age=${age}s > ${STALE_THRESHOLD}s)"
+
+# Read the scanner PID from its lock file.
+scanner_pid=""
+if [ -f "$LOCK_FILE" ]; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+fi
+
+if [ -z "$scanner_pid" ]; then
+    log "no lock file or empty PID — scanner may have already exited"
+    exit 0
+fi
+
+if ! kill -0 "$scanner_pid" 2>/dev/null; then
+    log "PID $scanner_pid is no longer alive — launchd/systemd will restart on its own"
+    exit 0
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID $scanner_pid"
+    exit 0
+fi
+
+log "killing wedged scanner PID $scanner_pid — supervisor will restart it"
+kill "$scanner_pid" || true

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+  Fires every 5 minutes, checks the scanner heartbeat file, and kills a
+  wedged scanner so launchd's KeepAlive restarts it automatically.
+
+  Install:
+    sed "s|@LOOP_ROOT@|$LOOP_ROOT|g; s|@LOG_DIR@|$LOOP_LOG_DIR|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>@LOOP_ROOT@/scripts/restart-scanner-if-stale.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <!-- Poll every 5 minutes -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>@LOG_DIR@/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>@LOG_DIR@/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,142 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — scanner liveness heartbeat (issue #413).
+#
+# Verifies:
+#   1. run_once() writes the heartbeat file on every tick (non-dry-run).
+#   2. Dry-run mode does NOT write the heartbeat file.
+#   3. restart-scanner-if-stale.sh exits 0 and reports healthy when heartbeat
+#      is fresh.
+#   4. restart-scanner-if-stale.sh exits 0 and reports "wedged" when heartbeat
+#      is stale, and kills the recorded PID.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_ROOT="$REPO_ROOT"
+    export LOOP_EXTRA_PATH=""
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+
+    # Source scanner.sh function definitions only (stop before acquire_lock).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    # Override variables scanner.sh sets after sourcing.
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    # Silence log() and no-op helpers that would invoke external processes.
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { return 0; }
+    loop_list_slugs() { echo ""; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/scanner-src.sh" "$BATS_TMPDIR/scanner-test.log" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat file is written by run_once
+# ---------------------------------------------------------------------------
+
+@test "run_once: writes heartbeat file on every tick (non-dry-run)" {
+    rm -f "$HEARTBEAT_FILE"
+    DRY_RUN=false
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: updates heartbeat mtime on repeated ticks" {
+    rm -f "$HEARTBEAT_FILE"
+    DRY_RUN=false
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+    sleep 1
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once: dry-run does NOT write heartbeat file" {
+    rm -f "$HEARTBEAT_FILE"
+    DRY_RUN=true
+    run_once
+    [ ! -f "$HEARTBEAT_FILE" ]
+}
+
+# ---------------------------------------------------------------------------
+# restart-scanner-if-stale.sh
+# ---------------------------------------------------------------------------
+
+@test "restart-scanner-if-stale: exits cleanly when heartbeat file is absent" {
+    rm -f "$HEARTBEAT_FILE"
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"has not ticked yet"* ]]
+}
+
+@test "restart-scanner-if-stale: reports healthy when heartbeat is fresh" {
+    touch "$HEARTBEAT_FILE"
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        LOOP_SCANNER_STALE_THRESHOLD=900 \
+        "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"healthy"* ]]
+}
+
+@test "restart-scanner-if-stale: detects stale heartbeat and reports wedged" {
+    touch "$HEARTBEAT_FILE"
+    # Backdate the heartbeat file by 20 minutes.
+    touch -t "$(date -v-20M +%Y%m%d%H%M.%S 2>/dev/null \
+        || date -d '20 minutes ago' +%Y%m%d%H%M.%S)" "$HEARTBEAT_FILE"
+
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        LOOP_SCANNER_STALE_THRESHOLD=900 \
+        "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"wedged"* ]]
+}
+
+@test "restart-scanner-if-stale: dry-run does not kill scanner PID" {
+    touch "$HEARTBEAT_FILE"
+    touch -t "$(date -v-20M +%Y%m%d%H%M.%S 2>/dev/null \
+        || date -d '20 minutes ago' +%Y%m%d%H%M.%S)" "$HEARTBEAT_FILE"
+
+    # Plant a fake lock file with own PID — process is alive.
+    local lock_file="/tmp/loop-scanner.lock"
+    echo "$$" > "$lock_file"
+
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        LOOP_SCANNER_STALE_THRESHOLD=900 \
+        "$REPO_ROOT/scripts/restart-scanner-if-stale.sh" --dry-run
+
+    rm -f "$lock_file"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DRY-RUN"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- Added `HEARTBEAT_FILE` variable (`${LOOP_LOG_DIR}/scanner-heartbeat`).
- `run_once()` now calls `touch "$HEARTBEAT_FILE"` at the start of every tick (skipped in dry-run mode), giving any external watchdog a reliable mtime-based liveness signal.

### `scripts/restart-scanner-if-stale.sh` (new)
- Reads the heartbeat file's mtime. If it is older than `LOOP_SCANNER_STALE_THRESHOLD` (default 900 s = 15 min, 3× the default 5-min poll interval), reads the scanner PID from `/tmp/loop-scanner.lock` and kills it so launchd/systemd's `KeepAlive`/`Restart` policy triggers an automatic restart.
- Supports `--dry-run` to report status without killing anything.
- Exits cleanly when the heartbeat file has never been written (first start) or the PID is already gone.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- launchd plist that runs `restart-scanner-if-stale.sh` every 5 minutes.
- Designed to be installed alongside the existing scanner plist.

## Test Plan

- `bats tests/scanner-heartbeat.bats` — 7 tests:
  - `run_once` writes heartbeat on every tick (non-dry-run).
  - `run_once` updates mtime on repeated ticks.
  - Dry-run does NOT write heartbeat.
  - Watchdog exits cleanly when heartbeat absent.
  - Watchdog reports healthy for a fresh heartbeat.
  - Watchdog detects stale heartbeat and reports "wedged".
  - Dry-run does not kill PID even when stale.
- Manual: `kill -STOP $SCANNER_PID` → watchdog kills it within 15 min, launchd restarts.