### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — fires every 5 min, kills a wedged scanner
+    # (alive PID, stale heartbeat) so launchd KeepAlive restarts it cleanly.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — Liveness watchdog for the Loop scanner.
+#
+# Reads the scanner heartbeat file written by scanner.sh on every tick.
+# If the heartbeat is older than the stale threshold, the scanner is
+# considered wedged and is killed so launchd (KeepAlive) restarts it.
+#
+# Designed to run every 5 min via launchd (StartInterval 300) or cron.
+#
+# Usage:
+#   scanner-watchdog.sh [--dry-run]
+#
+# Configuration (via loop.env or environment):
+#   LOOP_SCANNER_INTERVAL        poll cadence in seconds (default 300)
+#   LOOP_WATCHDOG_STALE_FACTOR   multiplier applied to LOOP_SCANNER_INTERVAL
+#                                to derive the stale threshold (default 2,
+#                                so stale = 2 × interval = 10 min at defaults)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_FACTOR="${LOOP_WATCHDOG_STALE_FACTOR:-2}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * STALE_FACTOR ))
+HB_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+
+log "check: heartbeat=${HB_FILE} stale_threshold=${STALE_THRESHOLD}s"
+
+if [ ! -f "$HB_FILE" ]; then
+    log "INFO: no heartbeat file yet — scanner may not have completed its first tick"
+    exit 0
+fi
+
+# Portable mtime: try macOS stat first, fall back to GNU stat.
+hb_mtime=$(stat -f%m "$HB_FILE" 2>/dev/null || stat -c%Y "$HB_FILE" 2>/dev/null || echo 0)
+now=$(date +%s)
+age=$(( now - hb_mtime ))
+
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "ok: scanner is live"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat stale (${age}s > ${STALE_THRESHOLD}s) — attempting restart"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner and let launchd restart it"
+    exit 0
+fi
+
+# Find scanner PID from the lock file.
+scanner_pid=""
+if [ -f "$LOCK_FILE" ]; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+fi
+
+if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+    log "killing stale scanner PID $scanner_pid"
+    kill "$scanner_pid" 2>/dev/null || true
+    # Give launchd a moment to observe the exit before we log completion.
+    sleep 2
+    log "scanner PID $scanner_pid terminated — launchd (KeepAlive) will restart it"
+else
+    log "scanner lock PID '${scanner_pid}' not found or not alive — launchd will restart on its own"
+    # Remove a stale lock file so the next scanner invocation can acquire it.
+    rm -f "$LOCK_FILE"
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -776,6 +776,27 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+
+    # Heartbeat — write current epoch to the heartbeat file so the scanner
+    # watchdog can detect a wedged process (alive PID, no tick activity).
+    # Done before any I/O so a hang in _sweep_stale_locks or scan_project
+    # is immediately visible via mtime lag.
+    if ! $DRY_RUN; then
+        local _hb_file="${LOOP_LOG_DIR}/scanner-heartbeat"
+        local _dedup_count
+        _dedup_count=$(find "$DEDUP_DIR" -type f 2>/dev/null | wc -l | tr -d ' ')
+        printf '%s dedup_count=%s\n' "$(date +%s)" "$_dedup_count" > "$_hb_file" || true
+    fi
+
+    # Stdout integrity check — if the log file exists but is no longer
+    # writable (e.g. chmod'd by a log-rotation script without SIGHUP), exit
+    # so launchd restarts the process with a fresh FD. Skips when the file
+    # does not exist yet (first tick before launchd creates it).
+    if ! $DRY_RUN && [ -n "${LOG_FILE:-}" ] && [ -e "$LOG_FILE" ] && [ ! -w "$LOG_FILE" ]; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] WARN: LOG_FILE not writable — exiting for launchd restart" >&2
+        exit 1
+    fi
+
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes, reads the scanner heartbeat file, and kills a wedged
+  scanner process (alive PID but no tick activity) so KeepAlive restarts it.
+
+  Install via: ./install.sh --bootstrap
+  or manually:
+    sed "s|__LOOP_ROOT__|$LOOP_ROOT|g; \
+         s|__LOG_DIR__|$LOOP_LOG_DIR|g; \
+         s|__HOME__|$HOME|g; \
+         s|__EXTRA_PATH__|$EXTRA_PATH|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <!-- Fire every 5 minutes; stale threshold is 2× scanner interval (10 min default) -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,155 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 scanner liveness heartbeat.
+#
+# Verifies that run_once() writes the heartbeat file on every tick and that
+# scanner-watchdog.sh correctly detects a stale heartbeat.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    # Expose mock-gh.sh as the gh binary via a per-test temp bin directory.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+    touch "$LOG_FILE"
+
+    DRY_RUN=false
+    ONCE=false
+
+    # Stub loop_list_slugs to return nothing (no projects to scan).
+    loop_list_slugs() { true; }
+    # Stub jobs_init_schema to avoid DB setup.
+    jobs_init_schema() { return 0; }
+    # Stub _sweep_stale_locks to be a no-op.
+    _sweep_stale_locks() { return 0; }
+
+    export LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat file
+# ---------------------------------------------------------------------------
+
+@test "run_once: writes heartbeat file to LOOP_LOG_DIR" {
+    local hb_file="$LOOP_LOG_DIR/scanner-heartbeat"
+    [ ! -f "$hb_file" ]
+
+    run_once
+
+    [ -f "$hb_file" ]
+}
+
+@test "run_once: heartbeat file contains current epoch timestamp" {
+    local hb_file="$LOOP_LOG_DIR/scanner-heartbeat"
+    local before after content ts
+
+    before=$(date +%s)
+    run_once
+    after=$(date +%s)
+
+    content=$(cat "$hb_file")
+    # First token is the epoch timestamp.
+    ts=$(echo "$content" | awk '{print $1}')
+    [ "$ts" -ge "$before" ]
+    [ "$ts" -le "$after" ]
+}
+
+@test "run_once: heartbeat file contains dedup_count field" {
+    run_once
+    grep -q "dedup_count=" "$LOOP_LOG_DIR/scanner-heartbeat"
+}
+
+@test "run_once: heartbeat mtime updated on second call" {
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null \
+          || stat -c%Y "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null)
+
+    # Sleep just enough for mtime to advance (1s resolution on most FSes).
+    sleep 1
+    run_once
+
+    local mtime2
+    mtime2=$(stat -f%m "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null \
+          || stat -c%Y "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null)
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once: heartbeat NOT written in dry-run mode" {
+    DRY_RUN=true
+    local hb_file="$LOOP_LOG_DIR/scanner-heartbeat"
+    run_once
+    [ ! -f "$hb_file" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits 0 when no heartbeat file exists yet" {
+    local hb_file="$LOOP_LOG_DIR/scanner-heartbeat"
+    rm -f "$hb_file"
+
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no heartbeat file yet"* ]]
+}
+
+@test "scanner-watchdog: reports ok when heartbeat is fresh" {
+    local hb_file="$LOOP_LOG_DIR/scanner-heartbeat"
+    printf '%s dedup_count=0\n' "$(date +%s)" > "$hb_file"
+
+    # Use a very large stale factor so the just-written file is never stale.
+    LOOP_WATCHDOG_STALE_FACTOR=9999 \
+        LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner is live"* ]]
+}
+
+@test "scanner-watchdog: detects stale heartbeat and logs warning" {
+    local hb_file="$LOOP_LOG_DIR/scanner-heartbeat"
+    # Write a heartbeat with a timestamp 1 hour in the past.
+    printf '%s dedup_count=0\n' "$(( $(date +%s) - 3600 ))" > "$hb_file"
+    # Back-date the file mtime to 1 hour ago (touch -t or touch -d).
+    touch -t "$(date -v-1H '+%Y%m%d%H%M' 2>/dev/null || date -d '1 hour ago' '+%Y%m%d%H%M' 2>/dev/null || date '+%Y%m%d%H%M')" "$hb_file" 2>/dev/null || true
+
+    LOOP_SCANNER_INTERVAL=300 \
+        LOOP_WATCHDOG_STALE_FACTOR=2 \
+        LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+        run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"stale"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- `run_once()` now writes `<epoch> dedup_count=<N>` to `${LOOP_LOG_DIR}/scanner-heartbeat` at the start of every tick (before any blocking I/O), making wedge detection possible via file mtime.
- Added a stdout integrity check: if `LOG_FILE` exists but is no longer writable, the process exits so launchd KeepAlive can restart it with fresh FDs.

### scanner/scanner-watchdog.sh (new)
- Reads the heartbeat file mtime; if age exceeds `LOOP_SCANNER_INTERVAL × LOOP_WATCHDOG_STALE_FACTOR` (default: 2 × 300s = 10 min), kills the scanner PID so launchd restarts it.
- Supports `--dry-run` for safe testing.
- Configurable via `LOOP_WATCHDOG_STALE_FACTOR` env var.

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
- Runs `scanner-watchdog.sh` every 5 min (StartInterval 300) via launchd on macOS.

### install.sh
- `bootstrap_register_launchd()` now installs the scanner watchdog plist alongside the existing scanner plist.
- `bootstrap_register_cron()` now adds a `*/5` cron entry for the watchdog on Linux.

### tests/scanner-heartbeat.bats (new)
- 8 bats tests covering: heartbeat file creation, timestamp correctness, dedup_count field, mtime update on second call, dry-run skips, and all three watchdog states (no file, fresh, stale).

## Test Plan
- All 8 new bats tests pass: `bats tests/scanner-heartbeat.bats`
- No regressions in `tests/scanner.bats` (4 pre-existing failures unrelated to this change)
- `bash -n` and `shellcheck -S warning` both clean
- Manual simulation: `kill -STOP $SCANNER_PID` → heartbeat goes stale → watchdog detects after ≤10 min → scanner restarts