### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog auto-restart on silent wedge

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — fires every 5 min, kills a wedged scanner so
+    # launchd's KeepAlive restarts it. Requires scanner.sh to write the heartbeat.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — detect and recover a silently-wedged scanner.
+#
+# Checks the scanner-heartbeat file written by scanner.sh on every tick.
+# If the heartbeat is older than LOOP_SCANNER_WATCHDOG_STALE_SECONDS (default:
+# 2 × LOOP_SCANNER_INTERVAL = 600s), the scanner is considered wedged:
+# its PID is killed so that launchd (KeepAlive=true) or cron auto-restarts it.
+#
+# Designed to run every 5 min via launchd StartInterval / cron */5.
+# Safe to run even when the scanner is healthy — it exits 0 immediately.
+#
+# Flags:
+#   --dry-run   report stale/ok status but do not kill the scanner
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_SCANNER_WATCHDOG_STALE_SECONDS:-$(( POLL_INTERVAL * 2 ))}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file absent — scanner has not run yet or LOOP_LOG_DIR is wrong"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+age=$(( now - mtime ))
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "OK: heartbeat age=${age}s < threshold=${STALE_THRESHOLD}s"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat is ${age}s old (threshold=${STALE_THRESHOLD}s) — scanner may be wedged"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner and let launchd/cron restart it"
+    exit 0
+fi
+
+if [ ! -f "$LOCK_FILE" ]; then
+    log "lock file $LOCK_FILE not found — scanner not holding a lock; launchd should restart it"
+    exit 0
+fi
+
+pid=$(cat "$LOCK_FILE" 2>/dev/null || echo "")
+if [ -z "$pid" ]; then
+    log "lock file is empty — cannot determine scanner PID"
+    exit 0
+fi
+
+if ! kill -0 "$pid" 2>/dev/null; then
+    log "scanner PID $pid is already dead — launchd/cron should restart it soon"
+    exit 0
+fi
+
+log "killing wedged scanner PID $pid"
+kill "$pid" 2>/dev/null || true
+log "scanner PID $pid killed — launchd (KeepAlive) or cron will restart it"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -775,6 +775,17 @@ scan_project() {
 }
 
 run_once() {
+    # Stdout/FD integrity: if the log file has disappeared under us (logrotate
+    # deleted the inode while launchd held the FD open), reopen it now.
+    # If we cannot open it at all, exit so launchd's KeepAlive restarts us.
+    if [ -n "${LOG_FILE:-}" ] && [ ! -f "$LOG_FILE" ]; then
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" || exit 1
+    fi
+    # Heartbeat — write timestamp every tick so scanner-watchdog.sh can detect
+    # a wedged scanner (alive PID, sleep loop intact, but no event output).
+    if ! $DRY_RUN; then
+        printf '%s\n' "$(date '+%Y-%m-%d %H:%M:%S')" > "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+    fi
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes. Checks the scanner heartbeat file; if the scanner has
+  been silent for >2× LOOP_SCANNER_INTERVAL (default 600s) it kills the scanner
+  PID so that launchd's KeepAlive restarts it automatically.
+
+  Install via: ./install.sh --bootstrap  (registered automatically)
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`**
- Added stdout/FD integrity check at the top of each `run_once()` tick: if the log file has disappeared (e.g. logrotate deleted the inode), reopen the FD so writes resume; exits 1 on failure to let launchd's KeepAlive restart the process.
- Writes a timestamp heartbeat to `${LOOP_LOG_DIR}/scanner-heartbeat` on every tick (skipped in `--dry-run` mode). The watchdog uses this mtime to detect a wedged scanner.

**`scanner/scanner-watchdog.sh`** (new)
- Fires every 5 min via launchd/cron. Reads `scanner-heartbeat` mtime; if older than `LOOP_SCANNER_WATCHDOG_STALE_SECONDS` (default: 2 × `LOOP_SCANNER_INTERVAL` = 600s), reads the PID from `/tmp/loop-scanner.lock` and kills it. launchd's `KeepAlive=true` (or cron on Linux) auto-restarts the scanner within one poll cycle.
- Supports `--dry-run` for safe testing.

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new)
- `StartInterval: 300` (5 min), writes to `loop-scanner-watchdog.log`.

**`install.sh`**
- `bootstrap_register_launchd`: registers `com.user.loop-scanner-watchdog` plist alongside the existing plists.
- `bootstrap_register_cron`: adds `*/5 * * * *` cron entry for `scanner-watchdog.sh` on Linux.

## Test Plan

- Syntax + shellcheck: all pass locally.
- Manual wedge test: `kill -STOP $SCANNER_PID` → heartbeat age grows → watchdog fires within 5 min and kills the stopped process → launchd restarts scanner.
- `--dry-run` flag on watchdog: verify it logs stale/ok status without killing anything.
- Fresh bootstrap: `./install.sh --bootstrap` registers the new plist and logs `[launchd] com.user.loop-scanner-watchdog loaded`.