### PR TITLE
[LOOP-413] scanner: liveness heartbeat + stale-restart watchdog

### DIFF
--- a/scanner/restart-scanner-if-stale.sh
+++ b/scanner/restart-scanner-if-stale.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# restart-scanner-if-stale.sh — scanner liveness watchdog.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat. If the file is absent or its mtime
+# is older than STALE_THRESHOLD_SECONDS (default: 2 × LOOP_SCANNER_INTERVAL,
+# i.e. 600s), the scanner is considered wedged. The script then kills the PID
+# recorded in /tmp/loop-scanner.lock; launchd (KeepAlive=true) or cron will
+# restart it automatically.
+#
+# Intended to run every 5 minutes via launchd StartInterval or cron.
+# Install on macOS:
+#   cp templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+#      ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+#   # then edit __LOOP_ROOT__, __LOG_DIR__, __HOME__, __EXTRA_PATH__
+#   launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+#
+# Install on Linux (add to crontab):
+#   */5 * * * * /path/to/loop/scanner/restart-scanner-if-stale.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+LOCK_FILE="${LOOP_SCANNER_LOCK:-/tmp/loop-scanner.lock}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_SCANNER_STALE_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+LOG_FILE="${LOOP_LOG_DIR}/loop-scanner-watchdog.log"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*" | tee -a "$LOG_FILE" >&2; }
+
+# Resolve mtime portably (macOS stat vs GNU stat).
+_file_age_seconds() {
+    local f="$1"
+    local mtime now
+    mtime=$(stat -f%m "$f" 2>/dev/null || stat -c%Y "$f" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+# Check heartbeat freshness.
+if [ ! -f "${HEARTBEAT_FILE}" ]; then
+    log "heartbeat file absent — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+age=$(_file_age_seconds "${HEARTBEAT_FILE}")
+
+if [ "${age}" -lt "${STALE_THRESHOLD}" ]; then
+    log "ok: heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+    exit 0
+fi
+
+log "STALE: heartbeat age=${age}s exceeds threshold=${STALE_THRESHOLD}s — restarting scanner"
+
+# Kill the recorded scanner PID so launchd (KeepAlive) or cron restarts it.
+if [ ! -f "${LOCK_FILE}" ]; then
+    log "lock file ${LOCK_FILE} not found — nothing to kill (launchd will restart)"
+    exit 0
+fi
+
+pid=$(cat "${LOCK_FILE}" 2>/dev/null || true)
+if [ -z "${pid}" ]; then
+    log "WARN: lock file empty — removing and exiting"
+    rm -f "${LOCK_FILE}"
+    exit 0
+fi
+
+if ! kill -0 "${pid}" 2>/dev/null; then
+    log "WARN: PID ${pid} from lock file is not alive — removing stale lock"
+    rm -f "${LOCK_FILE}"
+    exit 0
+fi
+
+log "killing wedged scanner PID ${pid}"
+kill "${pid}" 2>/dev/null || true
+# Give launchd a moment; do not force-remove the lock — the scanner's EXIT
+# trap handles that, and launchd needs to observe the exit before restarting.
+sleep 2
+log "done — launchd/cron will restart scanner.sh"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -46,6 +47,30 @@ _scanner_reopen_log() {
     fi
 }
 trap '_scanner_reopen_log; echo "[$(date "+%Y-%m-%d %H:%M:%S")] [scanner] SIGHUP — log fds reopened"' HUP
+
+# _scanner_write_heartbeat — update the liveness file every tick.
+# The watchdog (restart-scanner-if-stale.sh) reads this file's mtime;
+# if it is older than 2× POLL_INTERVAL the scanner is assumed wedged.
+_scanner_write_heartbeat() {
+    $DRY_RUN && return 0
+    printf '%s pid=%s\n' "$(date '+%Y-%m-%dT%H:%M:%S')" "$$" \
+        > "${HEARTBEAT_FILE}" 2>/dev/null || true
+}
+
+# _scanner_check_stdout — verify the log file is still writable each tick.
+# If the path became unwritable (e.g. permission change, full filesystem),
+# attempt one FD reopen via the SIGHUP handler; if still unwritable, exit so
+# launchd/cron restarts the scanner with a fresh file descriptor.
+_scanner_check_stdout() {
+    [ -n "${LOG_FILE:-}" ] || return 0
+    if [ ! -w "${LOG_FILE}" ] 2>/dev/null; then
+        _scanner_reopen_log
+        if [ ! -w "${LOG_FILE}" ] 2>/dev/null; then
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] FATAL: LOG_FILE not writable after reopen — exiting for launchd restart" >&2
+            exit 1
+        fi
+    fi
+}
 
 DRY_RUN=false
 ONCE=false
@@ -775,7 +800,13 @@ scan_project() {
 }
 
 run_once() {
-    log "=== scan tick start ==="
+    # Liveness: write heartbeat before any I/O-heavy work so the watchdog
+    # can distinguish a healthy-but-slow tick from a wedged process.
+    _scanner_write_heartbeat
+    _scanner_check_stdout
+    local _dedup_count
+    _dedup_count=$(find "${DEDUP_DIR}" -type f 2>/dev/null | wc -l | tr -d ' ')
+    log "=== scan tick start === heartbeat=$(date '+%Y-%m-%dT%H:%M:%S') dedup_entries=${_dedup_count}"
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes. Reads ${LOOP_LOG_DIR}/scanner-heartbeat; if the file
+  is older than LOOP_SCANNER_STALE_THRESHOLD seconds (default: 2×poll interval,
+  600s) it kills the scanner PID and lets launchd restart it via KeepAlive.
+
+  Install (set LOOP_ROOT and LOG_DIR to your actual paths):
+    sed "s|__LOOP_ROOT__|/path/to/loop|g; \
+         s|__LOG_DIR__|/path/to/logs|g; \
+         s|__HOME__|$HOME|g; \
+         s|__EXTRA_PATH__|/opt/homebrew/bin:/usr/local/bin|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/restart-scanner-if-stale.sh</string>
+    </array>
+    <!-- Check every 5 minutes -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,123 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for scanner liveness heartbeat (#413).
+# Verifies that:
+#   1. _scanner_write_heartbeat writes/updates HEARTBEAT_FILE on each tick.
+#   2. restart-scanner-if-stale.sh exits 0 (ok) when heartbeat is fresh.
+#   3. restart-scanner-if-stale.sh kills a stale scanner PID and exits cleanly.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+
+    # Extract _scanner_write_heartbeat from scanner.sh.
+    local _src="$BATS_TMPDIR/heartbeat-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        printf "LOOP_LOG_DIR='%s'\n" "$LOOP_LOG_DIR"
+        printf "HEARTBEAT_FILE='%s/scanner-heartbeat'\n" "$LOOP_LOG_DIR"
+        printf "DRY_RUN=false\n"
+        awk '/^_scanner_write_heartbeat\(\)/{p=1} p; p && /^\}/{p=0; exit}' \
+            "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/heartbeat-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# _scanner_write_heartbeat
+# ---------------------------------------------------------------------------
+
+@test "_scanner_write_heartbeat: creates heartbeat file" {
+    rm -f "${HEARTBEAT_FILE}"
+    _scanner_write_heartbeat
+    [ -f "${HEARTBEAT_FILE}" ]
+}
+
+@test "_scanner_write_heartbeat: file contains current timestamp" {
+    _scanner_write_heartbeat
+    local content
+    content=$(cat "${HEARTBEAT_FILE}")
+    # File must start with a date-time pattern.
+    [[ "$content" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2} ]]
+}
+
+@test "_scanner_write_heartbeat: updates mtime on each call" {
+    _scanner_write_heartbeat
+    local t1
+    t1=$(stat -f%m "${HEARTBEAT_FILE}" 2>/dev/null || stat -c%Y "${HEARTBEAT_FILE}")
+    sleep 1
+    _scanner_write_heartbeat
+    local t2
+    t2=$(stat -f%m "${HEARTBEAT_FILE}" 2>/dev/null || stat -c%Y "${HEARTBEAT_FILE}")
+    [ "$t2" -ge "$t1" ]
+}
+
+@test "_scanner_write_heartbeat: no-op when DRY_RUN=true" {
+    rm -f "${HEARTBEAT_FILE}"
+    DRY_RUN=true _scanner_write_heartbeat || true
+    [ ! -f "${HEARTBEAT_FILE}" ]
+}
+
+# ---------------------------------------------------------------------------
+# restart-scanner-if-stale.sh — freshness checks
+# ---------------------------------------------------------------------------
+
+@test "restart-scanner-if-stale.sh: exits 0 (ok) when heartbeat is fresh" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    printf '%s pid=1\n' "$(date '+%Y-%m-%dT%H:%M:%S')" > "$hb"
+
+    run env LOOP_LOG_DIR="${LOOP_LOG_DIR}" \
+            LOOP_SCANNER_STALE_THRESHOLD=600 \
+            LOOP_EXTRA_PATH="" \
+            bash "$REPO_ROOT/scanner/restart-scanner-if-stale.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ok:"* ]]
+}
+
+@test "restart-scanner-if-stale.sh: exits 0 when heartbeat file absent" {
+    rm -f "${LOOP_LOG_DIR}/scanner-heartbeat"
+
+    run env LOOP_LOG_DIR="${LOOP_LOG_DIR}" \
+            LOOP_SCANNER_STALE_THRESHOLD=600 \
+            LOOP_EXTRA_PATH="" \
+            bash "$REPO_ROOT/scanner/restart-scanner-if-stale.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"absent"* ]]
+}
+
+@test "restart-scanner-if-stale.sh: kills stale scanner PID" {
+    # Start a harmless background process to get a live PID.
+    sleep 60 &
+    local fake_pid=$!
+
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    printf '%s pid=%s\n' "$(date '+%Y-%m-%dT%H:%M:%S')" "$fake_pid" > "$hb"
+    # Backdate the heartbeat file by 20 minutes.
+    touch -t "$(date -v-20M +%Y%m%d%H%M.%S 2>/dev/null \
+                || date -d '20 minutes ago' +%Y%m%d%H%M.%S)" "$hb"
+
+    # Write a lock file pointing at that PID.
+    local lock_file="$BATS_TMPDIR/test-scanner.lock"
+    echo "$fake_pid" > "$lock_file"
+
+    run env LOOP_LOG_DIR="${LOOP_LOG_DIR}" \
+            LOOP_SCANNER_LOCK="$lock_file" \
+            LOOP_SCANNER_STALE_THRESHOLD=600 \
+            LOOP_EXTRA_PATH="" \
+            bash "$REPO_ROOT/scanner/restart-scanner-if-stale.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"killing"* ]] || [[ "$output" == *"STALE"* ]]
+
+    # The target process must have been killed.
+    sleep 0.5
+    ! kill -0 "$fake_pid" 2>/dev/null
+
+    rm -f "$lock_file"
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`**
- Added `HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"` variable.
- Added `_scanner_write_heartbeat()`: writes a timestamped line (`YYYY-MM-DDTHH:MM:SS pid=$$`) to the heartbeat file at the start of every tick. No-op in `--dry-run` mode. Errors are silently ignored so a write failure never wedges the tick itself.
- Added `_scanner_check_stdout()`: verifies `LOG_FILE` is writable at the start of each tick. If not, attempts one FD reopen via the existing SIGHUP handler; if still unwritable, exits so launchd restarts the scanner.
- Modified `run_once()` to call both helpers and to log `heartbeat=<timestamp> dedup_entries=<n>` in the tick-start line, surfacing the `scanner_tick` telemetry requested by the issue.

**`scanner/restart-scanner-if-stale.sh`** (new, `chmod +x`)
- Reads `HEARTBEAT_FILE` mtime; if absent, logs and exits 0 (scanner may be starting).
- If age ≥ `LOOP_SCANNER_STALE_THRESHOLD` (default: `2 × LOOP_SCANNER_INTERVAL = 600s`), kills the PID from `/tmp/loop-scanner.lock` and lets launchd/cron restart the scanner.
- All kill/stat operations are fail-safe; the script never hard-exits non-zero on environmental errors so launchd does not throttle it.

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new)
- Runs `restart-scanner-if-stale.sh` every 5 minutes (`StartInterval: 300`).
- Follows the same `__LOOP_ROOT__` / `__LOG_DIR__` / `__HOME__` / `__EXTRA_PATH__` placeholder convention as the existing scanner/reconciler templates.

**`tests/scanner-heartbeat.bats`** (new)
- `_scanner_write_heartbeat`: creates file, contains timestamp, updates mtime on successive calls, no-op in dry-run mode.
- `restart-scanner-if-stale.sh`: exits 0 on fresh heartbeat, exits 0 (with "absent" message) when file is missing, kills a live PID when heartbeat is backdated past the stale threshold.

## Test Plan
- Run `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — all pass.
- Run `shellcheck -S warning lib/*.sh scripts/*.sh scanner/*.sh install.sh` — no warnings.
- Run `bats tests/scanner-heartbeat.bats` to exercise heartbeat write and watchdog logic.
- Manual: start scanner, verify `${LOOP_LOG_DIR}/scanner-heartbeat` is written every tick and its content matches `YYYY-MM-DDTHH:MM:SS pid=<scanner-pid>`.
- Manual: `kill -STOP $SCANNER_PID` to simulate wedge → wait one watchdog cycle (≤5 min) → watchdog should log "STALE" and kill the PID → launchd restarts scanner.