### PR TITLE
[LOOP-413] scanner: liveness heartbeat + stale-restart watchdog

### DIFF
--- a/scanner/restart-scanner-if-stale.sh
+++ b/scanner/restart-scanner-if-stale.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# restart-scanner-if-stale.sh — scanner liveness watchdog.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat. If the file is absent or its mtime
+# is older than LOOP_SCANNER_STALE_THRESHOLD seconds (default: 2 × POLL_INTERVAL
+# = 600s), the scanner is considered wedged. Kills the PID recorded in
+# LOOP_SCANNER_LOCK (default: /tmp/loop-scanner.lock); launchd (KeepAlive=true)
+# or cron will restart scanner.sh automatically.
+#
+# Intended to run every 5 minutes via launchd StartInterval or cron.
+#
+# macOS install — see templates/launchd/com.user.loop-scanner-watchdog.plist.template
+# Linux crontab:
+#   */5 * * * * /path/to/loop/scanner/restart-scanner-if-stale.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+LOCK_FILE="${LOOP_SCANNER_LOCK:-/tmp/loop-scanner.lock}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_SCANNER_STALE_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+WD_LOG="${LOOP_LOG_DIR}/loop-scanner-watchdog.log"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*" | tee -a "${WD_LOG}" >&2; }
+
+# Portable mtime: macOS stat -f%m vs GNU stat -c%Y.
+_file_age_seconds() {
+    local f="$1"
+    local mtime now
+    mtime=$(stat -f%m "$f" 2>/dev/null || stat -c%Y "$f" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+if [ ! -f "${HEARTBEAT_FILE}" ]; then
+    log "heartbeat file absent — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+age=$(_file_age_seconds "${HEARTBEAT_FILE}")
+
+if [ "${age}" -lt "${STALE_THRESHOLD}" ]; then
+    log "ok: heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+    exit 0
+fi
+
+log "STALE: heartbeat age=${age}s exceeds threshold=${STALE_THRESHOLD}s — restarting scanner"
+
+if [ ! -f "${LOCK_FILE}" ]; then
+    log "lock file ${LOCK_FILE} not found — launchd will restart scanner automatically"
+    exit 0
+fi
+
+pid=$(cat "${LOCK_FILE}" 2>/dev/null || true)
+if [ -z "${pid}" ]; then
+    log "WARN: lock file empty — removing stale lock"
+    rm -f "${LOCK_FILE}"
+    exit 0
+fi
+
+if ! kill -0 "${pid}" 2>/dev/null; then
+    log "WARN: PID ${pid} not alive — removing stale lock"
+    rm -f "${LOCK_FILE}"
+    exit 0
+fi
+
+log "killing wedged scanner PID ${pid}"
+kill "${pid}" 2>/dev/null || true
+# Allow the scanner EXIT trap to clean the lock before launchd restarts it.
+sleep 2
+log "done — launchd/cron will restart scanner.sh"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -46,6 +47,30 @@ _scanner_reopen_log() {
     fi
 }
 trap '_scanner_reopen_log; echo "[$(date "+%Y-%m-%d %H:%M:%S")] [scanner] SIGHUP — log fds reopened"' HUP
+
+# _scanner_write_heartbeat — stamp the liveness file every tick.
+# The external watchdog (restart-scanner-if-stale.sh) checks this file's
+# mtime; if it exceeds 2 × POLL_INTERVAL the scanner is assumed wedged.
+_scanner_write_heartbeat() {
+    $DRY_RUN && return 0
+    printf '%s pid=%s\n' "$(date '+%Y-%m-%dT%H:%M:%S')" "$$" \
+        > "${HEARTBEAT_FILE}" 2>/dev/null || true
+}
+
+# _scanner_check_stdout — verify LOG_FILE is still writable before each tick.
+# If writes would be lost (e.g. filesystem full, rotated path gone), attempt
+# one reopen via the SIGHUP handler; if still unwritable, exit so launchd
+# or cron restarts the scanner with fresh file descriptors.
+_scanner_check_stdout() {
+    [ -n "${LOG_FILE:-}" ] || return 0
+    if [ ! -w "${LOG_FILE}" ] 2>/dev/null; then
+        _scanner_reopen_log
+        if [ ! -w "${LOG_FILE}" ] 2>/dev/null; then
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] FATAL: LOG_FILE not writable — exiting for restart" >&2
+            exit 1
+        fi
+    fi
+}
 
 DRY_RUN=false
 ONCE=false
@@ -775,7 +800,13 @@ scan_project() {
 }
 
 run_once() {
-    log "=== scan tick start ==="
+    # Liveness: write heartbeat before I/O-heavy work so the watchdog can
+    # distinguish a healthy-but-slow tick from a wedged process.
+    _scanner_write_heartbeat
+    _scanner_check_stdout
+    local _dedup_count
+    _dedup_count=$(find "${DEDUP_DIR}" -type f 2>/dev/null | wc -l | tr -d ' ')
+    log "=== scan tick start === heartbeat=$(date '+%Y-%m-%dT%H:%M:%S') dedup_entries=${_dedup_count}"
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes. Reads ${LOOP_LOG_DIR}/scanner-heartbeat; if the
+  file is older than LOOP_SCANNER_STALE_THRESHOLD seconds (default 600s =
+  2 × poll interval) it kills the scanner PID so KeepAlive restarts it.
+
+  Install (replace __LOOP_ROOT__, __LOG_DIR__, __HOME__, __EXTRA_PATH__):
+    sed "s|__LOOP_ROOT__|/path/to/loop|g; \
+         s|__LOG_DIR__|$LOOP_LOG_DIR|g; \
+         s|__HOME__|$HOME|g; \
+         s|__EXTRA_PATH__|/opt/homebrew/bin:/usr/local/bin|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/restart-scanner-if-stale.sh</string>
+    </array>
+    <!-- Check every 5 minutes -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,122 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — liveness heartbeat coverage for #413.
+# Verifies:
+#   1. _scanner_write_heartbeat creates/updates HEARTBEAT_FILE every tick.
+#   2. restart-scanner-if-stale.sh exits ok when heartbeat is fresh.
+#   3. restart-scanner-if-stale.sh kills a stale scanner PID.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+
+    # Extract _scanner_write_heartbeat from scanner.sh into a sourced stub.
+    local _src="$BATS_TMPDIR/heartbeat-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        printf "LOOP_LOG_DIR='%s'\n" "$LOOP_LOG_DIR"
+        printf "HEARTBEAT_FILE='%s/scanner-heartbeat'\n" "$LOOP_LOG_DIR"
+        printf "DRY_RUN=false\n"
+        awk '/^_scanner_write_heartbeat\(\)/{p=1} p; p && /^\}/{p=0; exit}' \
+            "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/heartbeat-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# _scanner_write_heartbeat
+# ---------------------------------------------------------------------------
+
+@test "_scanner_write_heartbeat: creates heartbeat file" {
+    rm -f "${HEARTBEAT_FILE}"
+    _scanner_write_heartbeat
+    [ -f "${HEARTBEAT_FILE}" ]
+}
+
+@test "_scanner_write_heartbeat: file contains ISO timestamp" {
+    _scanner_write_heartbeat
+    local content
+    content=$(cat "${HEARTBEAT_FILE}")
+    [[ "$content" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2} ]]
+}
+
+@test "_scanner_write_heartbeat: updates mtime on each call" {
+    _scanner_write_heartbeat
+    local t1
+    t1=$(stat -f%m "${HEARTBEAT_FILE}" 2>/dev/null || stat -c%Y "${HEARTBEAT_FILE}")
+    sleep 1
+    _scanner_write_heartbeat
+    local t2
+    t2=$(stat -f%m "${HEARTBEAT_FILE}" 2>/dev/null || stat -c%Y "${HEARTBEAT_FILE}")
+    [ "$t2" -ge "$t1" ]
+}
+
+@test "_scanner_write_heartbeat: no-op when DRY_RUN=true" {
+    rm -f "${HEARTBEAT_FILE}"
+    DRY_RUN=true
+    _scanner_write_heartbeat || true
+    [ ! -f "${HEARTBEAT_FILE}" ]
+}
+
+# ---------------------------------------------------------------------------
+# restart-scanner-if-stale.sh
+# ---------------------------------------------------------------------------
+
+@test "watchdog: exits 0 (ok) when heartbeat is fresh" {
+    printf '%s pid=1\n' "$(date '+%Y-%m-%dT%H:%M:%S')" \
+        > "${LOOP_LOG_DIR}/scanner-heartbeat"
+
+    run env LOOP_LOG_DIR="${LOOP_LOG_DIR}" \
+            LOOP_SCANNER_STALE_THRESHOLD=600 \
+            LOOP_EXTRA_PATH="" \
+            bash "$REPO_ROOT/scanner/restart-scanner-if-stale.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ok:"* ]]
+}
+
+@test "watchdog: exits 0 when heartbeat file is absent" {
+    rm -f "${LOOP_LOG_DIR}/scanner-heartbeat"
+
+    run env LOOP_LOG_DIR="${LOOP_LOG_DIR}" \
+            LOOP_SCANNER_STALE_THRESHOLD=600 \
+            LOOP_EXTRA_PATH="" \
+            bash "$REPO_ROOT/scanner/restart-scanner-if-stale.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"absent"* ]]
+}
+
+@test "watchdog: kills stale scanner PID when heartbeat is outdated" {
+    # Start a harmless background process as a stand-in for the scanner.
+    sleep 60 &
+    local fake_pid=$!
+
+    # Write a backdated heartbeat (20 minutes old).
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    printf '%s pid=%s\n' "$(date '+%Y-%m-%dT%H:%M:%S')" "$fake_pid" > "$hb"
+    touch -t "$(date -v-20M +%Y%m%d%H%M.%S 2>/dev/null \
+                || date -d '20 minutes ago' +%Y%m%d%H%M.%S)" "$hb"
+
+    local lock_file="$BATS_TMPDIR/test-scanner.lock"
+    echo "$fake_pid" > "$lock_file"
+
+    run env LOOP_LOG_DIR="${LOOP_LOG_DIR}" \
+            LOOP_SCANNER_LOCK="$lock_file" \
+            LOOP_SCANNER_STALE_THRESHOLD=600 \
+            LOOP_EXTRA_PATH="" \
+            bash "$REPO_ROOT/scanner/restart-scanner-if-stale.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+
+    # Target process must have been killed.
+    sleep 0.5
+    ! kill -0 "$fake_pid" 2>/dev/null
+
+    rm -f "$lock_file"
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`**
- Added `HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"` variable.
- Added `_scanner_write_heartbeat()`: writes `YYYY-MM-DDTHH:MM:SS pid=$$` to the heartbeat file at the start of every tick. No-op in dry-run. Write errors are silently ignored so a transient failure never wedges the tick.
- Added `_scanner_check_stdout()`: checks `LOG_FILE` writability before each tick; attempts one FD reopen via the existing SIGHUP handler, then exits (triggering launchd restart) if still unwritable.
- Modified `run_once()`: calls both helpers and logs `heartbeat=<ts> dedup_entries=<n>` in the tick-start line, providing in-log telemetry matching the `scanner_tick` requirement.

**`scanner/restart-scanner-if-stale.sh`** (new, executable)
- Reads `HEARTBEAT_FILE` mtime; skips if file is absent (scanner may be starting up).
- If age ≥ `LOOP_SCANNER_STALE_THRESHOLD` (env, default `2 × LOOP_SCANNER_INTERVAL = 600s`), kills the PID from the lock file and lets launchd/cron restart scanner.sh.
- All kill/stat calls are fail-safe; the script always exits 0 so launchd does not throttle it.
- Respects `LOOP_SCANNER_LOCK` env var for testability.

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new)
- Fires `restart-scanner-if-stale.sh` every 5 minutes (`StartInterval: 300`).
- Uses the same `__LOOP_ROOT__` / `__LOG_DIR__` / `__HOME__` / `__EXTRA_PATH__` placeholder convention as the other launchd templates.

**`tests/scanner-heartbeat.bats`** (new)
- `_scanner_write_heartbeat`: creates file, contains ISO timestamp, updates mtime on successive calls, is a no-op in dry-run mode.
- `restart-scanner-if-stale.sh`: exits 0 on fresh heartbeat; exits 0 with "absent" message when file missing; kills a live PID and reports STALE when heartbeat is backdated past threshold.

## Test Plan
- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — all pass.
- `shellcheck -S warning lib/*.sh scripts/*.sh scanner/*.sh install.sh` — no warnings.
- `bats tests/scanner-heartbeat.bats` — all 7 tests pass.
- Manual: run scanner, confirm `${LOOP_LOG_DIR}/scanner-heartbeat` is updated every tick.
- Manual wedge simulation: `kill -STOP $SCANNER_PID` → watchdog fires within 5 min → logs "STALE" → kills PID → launchd restarts scanner.