### PR TITLE
[LOOP-413] scanner: liveness heartbeat + watchdog for silent-wedge detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,6 +338,27 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    # Scanner liveness watchdog — kills and restarts a wedged scanner process.
+    # Fires every 5 min; considers the scanner stale if its heartbeat file is
+    # older than 2× LOOP_SCANNER_INTERVAL (default 600s). KeepAlive on the
+    # scanner plist means launchd restarts it automatically after the kill.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     local digest_plist="$agents_dir/com.user.loop-digest.plist"
     if [ -f "$digest_plist" ]; then
         echo "[launchd] com.user.loop-digest already registered — skipping"
@@ -361,8 +382,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local scanner_watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local scanner_watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $scanner_watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +405,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$scanner_watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$scanner_watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — Restart the scanner if its heartbeat file becomes stale.
+#
+# Designed to run every 5 minutes via launchd (macOS) or cron (Linux).
+# On macOS the scanner has KeepAlive=true in its plist, so killing it causes
+# launchd to restart it automatically. On Linux the cron job re-invokes it.
+#
+# The scanner writes ${LOOP_LOG_DIR}/scanner-heartbeat at the start of every
+# tick. If that file is older than 2× LOOP_SCANNER_INTERVAL (default 600s),
+# the scanner is considered wedged and is killed so it can be restarted.
+#
+# Usage:
+#   scanner-watchdog.sh            # normal mode
+#   scanner-watchdog.sh --dry-run  # print what would happen without killing
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+LOCK_FILE="${LOOP_SCANNER_LOCK:-/tmp/loop-scanner.lock}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+# Stale threshold: 2× the poll interval (default 600s / 10 min).
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 ))
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _file_age_seconds <path>
+# Returns the age of the file in seconds (now - mtime).
+_file_age_seconds() {
+    local path="$1"
+    local mtime now
+    mtime=$(stat -f%m "$path" 2>/dev/null) \
+        || mtime=$(stat -c%Y "$path" 2>/dev/null) \
+        || { echo 999999; return 1; }
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+log "checking scanner liveness (threshold=${STALE_THRESHOLD}s)"
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "no heartbeat file at ${HEARTBEAT_FILE} — scanner may not have started yet"
+    exit 0
+fi
+
+age=$(_file_age_seconds "$HEARTBEAT_FILE")
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner alive (heartbeat=${age}s ago)"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat stale (${age}s > ${STALE_THRESHOLD}s threshold)"
+
+scanner_pid=""
+if [ -f "$LOCK_FILE" ]; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID ${scanner_pid:-unknown} and remove lock"
+    exit 0
+fi
+
+if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+    log "killing stale scanner PID ${scanner_pid}"
+    kill "$scanner_pid" 2>/dev/null || true
+    log "scanner killed — launchd/cron will restart it"
+else
+    log "WARN: no live scanner process found (lock=${LOCK_FILE} pid=${scanner_pid:-empty})"
+    # Remove stale lock so the next scanner invocation is not blocked.
+    if [ -f "$LOCK_FILE" ]; then
+        rm -f "$LOCK_FILE"
+        log "removed stale lock file"
+    fi
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -46,6 +47,23 @@ _scanner_reopen_log() {
     fi
 }
 trap '_scanner_reopen_log; echo "[$(date "+%Y-%m-%d %H:%M:%S")] [scanner] SIGHUP — log fds reopened"' HUP
+
+# _scanner_heartbeat — write current timestamp to the heartbeat file so the
+# external watchdog can confirm the scanner is making progress each tick.
+_scanner_heartbeat() {
+    printf '%s %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$$" > "${HEARTBEAT_FILE}" || true
+}
+
+# _scanner_check_stdout — exit if the log file has become unwritable (e.g.,
+# the log directory was removed or the fd was closed). launchd/cron restarts
+# the scanner and recreates the file descriptor cleanly.
+_scanner_check_stdout() {
+    if [ -n "${LOG_FILE:-}" ] && [ ! -w "${LOG_FILE}" ]; then
+        printf '[%s] [scanner] WARN: LOG_FILE not writable (%s) — exiting for restart\n' \
+            "$(date '+%Y-%m-%d %H:%M:%S')" "${LOG_FILE}" >&2
+        exit 1
+    fi
+}
 
 DRY_RUN=false
 ONCE=false
@@ -776,6 +794,8 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    $DRY_RUN || _scanner_heartbeat
+    $DRY_RUN || _scanner_check_stdout
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <!-- Run every 5 minutes to detect a wedged scanner within 2× poll interval -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 scanner liveness heartbeat.
+#
+# Verifies:
+#   1. run_once() writes the heartbeat file on every tick.
+#   2. The watchdog script exits clean when heartbeat is fresh.
+#   3. The watchdog kills a stale scanner (or removes a stale lock) when the
+#      heartbeat file is older than 2× POLL_INTERVAL.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner.sh function definitions (same awk strip as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+    touch "$LOG_FILE"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    log()             { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    loop_list_slugs() { return 0; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/scanner-test.log" "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat file — written on every tick
+# ---------------------------------------------------------------------------
+
+@test "run_once: creates heartbeat file on first tick" {
+    rm -f "$HEARTBEAT_FILE"
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: updates heartbeat file mtime on each tick" {
+    touch -t 202001010000 "$HEARTBEAT_FILE"
+    local before
+    before=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+    run_once
+    local after
+    after=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+    [ "$after" -gt "$before" ]
+}
+
+@test "_scanner_heartbeat: writes PID to heartbeat file" {
+    rm -f "$HEARTBEAT_FILE"
+    _scanner_heartbeat
+    [ -f "$HEARTBEAT_FILE" ]
+    grep -q "$$" "$HEARTBEAT_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# _scanner_check_stdout — exits when log file is unwritable
+# ---------------------------------------------------------------------------
+
+@test "_scanner_check_stdout: does not exit when LOG_FILE is writable" {
+    touch "$LOG_FILE"
+    chmod 644 "$LOG_FILE"
+    run _scanner_check_stdout
+    [ "$status" -eq 0 ]
+}
+
+@test "_scanner_check_stdout: exits 1 when LOG_FILE is not writable" {
+    touch "$LOG_FILE"
+    chmod 000 "$LOG_FILE"
+    run _scanner_check_stdout
+    chmod 644 "$LOG_FILE"
+    [ "$status" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh — liveness checks
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits 0 when heartbeat file is missing (scanner not yet started)" {
+    rm -f "${LOOP_LOG_DIR}/scanner-heartbeat"
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"not have started"* ]]
+}
+
+@test "scanner-watchdog: exits 0 when heartbeat is fresh" {
+    touch "${LOOP_LOG_DIR}/scanner-heartbeat"
+    LOOP_SCANNER_INTERVAL=300 run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner alive"* ]]
+}
+
+@test "scanner-watchdog: dry-run prints kill intent when heartbeat is stale" {
+    # Create a heartbeat file with an old mtime (far in the past).
+    touch -t 202001010000 "${LOOP_LOG_DIR}/scanner-heartbeat"
+    LOOP_SCANNER_INTERVAL=300 run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DRY-RUN"* ]]
+}
+
+@test "scanner-watchdog: removes stale lock when scanner PID is dead" {
+    local fake_lock="/tmp/loop-scanner-test-$$.lock"
+    echo "99999999" > "$fake_lock"
+    touch -t 202001010000 "${LOOP_LOG_DIR}/scanner-heartbeat"
+    LOOP_SCANNER_LOCK="$fake_lock" LOOP_SCANNER_INTERVAL=300 \
+        run "$REPO_ROOT/scanner/scanner-watchdog.sh"
+    rm -f "$fake_lock"
+    # Watchdog should report that it removed the stale lock.
+    [[ "$output" == *"stale lock"* ]] || [[ "$output" == *"no live scanner"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`** — two additions at the start of each `run_once()` tick:
- `_scanner_heartbeat()`: writes a timestamp + PID to `${LOOP_LOG_DIR}/scanner-heartbeat` so an external watchdog can verify the scanner is still making forward progress
- `_scanner_check_stdout()`: exits with status 1 if `$LOG_FILE` is no longer writable (broken fd / deleted log dir); launchd's `KeepAlive=true` or cron will restart the scanner cleanly

**`scanner/scanner-watchdog.sh`** (new) — standalone liveness watchdog:
- Reads `${LOOP_LOG_DIR}/scanner-heartbeat` mtime
- If age > `2 × LOOP_SCANNER_INTERVAL` (default 600 s / 10 min), finds the scanner PID from `/tmp/loop-scanner.lock` and kills it; launchd/cron restarts automatically
- If no live PID is found, removes the stale lock file so the next invocation is not blocked
- Supports `--dry-run`; uses portable `stat -f%m` (macOS) / `stat -c%Y` (Linux)

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new) — launchd plist running the watchdog every 5 minutes (`StartInterval=300`).

**`install.sh`** — registers the watchdog in both scheduler paths:
- `bootstrap_register_launchd`: installs and loads `com.user.loop-scanner-watchdog.plist`
- `bootstrap_register_cron`: adds `*/5 * * * *` cron entry for Linux

**`tests/scanner-heartbeat.bats`** (new) — 9 bats tests:
- `run_once()` creates and updates the heartbeat file on each tick
- `_scanner_heartbeat()` writes the scanner PID
- `_scanner_check_stdout()` exits 1 when log file is unwritable
- watchdog exits clean when heartbeat is missing or fresh
- watchdog prints kill intent in `--dry-run` when heartbeat is stale
- watchdog removes stale lock when scanner PID is dead

## Test Plan

- All 9 new tests pass (`bats tests/scanner-heartbeat.bats`)
- Existing scanner tests pass (pre-existing failures on main are unchanged)
- `bash -n` and `shellcheck -S warning` pass on all shell files
- Workflow lint passes
- Manual: simulate wedge with `kill -STOP $SCANNER_PID`; watchdog fires within 10 min (2× 300 s) and kills it; launchd restarts