### PR TITLE
[LOOP-413] scanner: liveness heartbeat + watchdog auto-restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,26 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — kills and restarts the scanner when its
+    # heartbeat file goes stale (> 2 × LOOP_SCANNER_INTERVAL, min 600s).
+    # Runs every 5 minutes independently of the scanner's own KeepAlive.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +381,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +404,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if its heartbeat goes stale.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat written by scanner.sh every tick.
+# If the file is missing or older than STALE_THRESHOLD_SECONDS (default:
+# 2 × LOOP_SCANNER_INTERVAL, min 600s), the scanner is considered wedged:
+#   - macOS: launchctl kickstart forces launchd to restart the scanner service.
+#   - Linux: kill the PID from the heartbeat file; the cron entry spawns a new one.
+#
+# Designed to run every 5 minutes via launchd StartInterval or cron */5.
+#
+# Flags:
+#   --dry-run   report stale/fresh status without taking action
+#   --once      single check (default)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_SCANNER_WATCHDOG_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+# Ensure a floor of 600s so a brief scan delay doesn't trigger a spurious restart.
+if [ "$STALE_THRESHOLD" -lt 600 ] 2>/dev/null; then
+    STALE_THRESHOLD=600
+fi
+
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        --once)    : ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+
+_heartbeat_age() {
+    [ -f "$HEARTBEAT_FILE" ] || { echo "999999"; return; }
+    local mtime now
+    mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+         || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+         || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+_scanner_pid_from_heartbeat() {
+    [ -f "$HEARTBEAT_FILE" ] || return 1
+    awk '{print $1; exit}' "$HEARTBEAT_FILE" 2>/dev/null
+}
+
+_kill_scanner() {
+    local pid
+    pid=$(_scanner_pid_from_heartbeat 2>/dev/null || true)
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "killing stale scanner PID $pid"
+        kill "$pid" 2>/dev/null || true
+    fi
+}
+
+_restart_scanner() {
+    local os
+    os=$(uname -s)
+    if [ "$os" = "Darwin" ]; then
+        local service_label="com.user.loop-scanner"
+        if launchctl list "$service_label" >/dev/null 2>&1; then
+            log "kickstarting $service_label via launchctl"
+            launchctl kickstart -k "gui/$(id -u)/$service_label" 2>/dev/null \
+                || launchctl stop "$service_label" 2>/dev/null || true
+        else
+            log "WARN: $service_label not found in launchctl — scanner may not be managed by launchd"
+        fi
+    else
+        # Linux: kill the old PID; cron will spawn a new scanner on the next tick.
+        _kill_scanner
+        log "killed stale scanner (cron will respawn)"
+    fi
+}
+
+age=$(_heartbeat_age)
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s file=${HEARTBEAT_FILE}"
+
+if [ "$age" -ge "$STALE_THRESHOLD" ]; then
+    if $DRY_RUN; then
+        log "DRY-RUN: scanner heartbeat stale (${age}s >= ${STALE_THRESHOLD}s) — would restart"
+    else
+        log "scanner heartbeat stale (${age}s >= ${STALE_THRESHOLD}s) — restarting"
+        _kill_scanner
+        _restart_scanner
+    fi
+else
+    log "scanner heartbeat fresh (${age}s < ${STALE_THRESHOLD}s) — ok"
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -774,8 +775,24 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+_scanner_check_stdout() {
+    # If the log file is no longer writable (e.g. deleted by log rotation without
+    # a SIGHUP, or on a broken pipe), reopen or exit so launchd restarts clean.
+    if [ -n "${LOG_FILE:-}" ] && [ ! -w "$LOG_FILE" ]; then
+        # Attempt recovery by reopening both fds against the log path.
+        # On failure, exit so launchd KeepAlive triggers a fresh start.
+        exec 1>>"$LOG_FILE" || exit 1
+        exec 2>>"$LOG_FILE" || exit 1
+    fi
+}
+
 run_once() {
+    $DRY_RUN || _scanner_check_stdout
     log "=== scan tick start ==="
+    # Heartbeat: record PID + timestamp so the watchdog can detect a wedged scanner.
+    if ! $DRY_RUN; then
+        printf '%s %s\n' "$$" "$(date +%s)" > "${HEARTBEAT_FILE}" 2>/dev/null || true
+    fi
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \
@@ -785,7 +802,9 @@ run_once() {
         [ -z "$slug" ] && continue
         scan_project "$slug" || log "scan_project $slug failed (continuing)"
     done < <(loop_list_slugs)
-    log "=== scan tick done ==="
+    local _dedup_count
+    _dedup_count=$(find "$DEDUP_DIR" -type f 2>/dev/null | wc -l | tr -d ' ')
+    log "=== scan tick done (dedup_entries=${_dedup_count}) ==="
 }
 
 acquire_lock

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Checks scanner liveness every 5 minutes. If the scanner heartbeat is stale
+  (older than 2 × LOOP_SCANNER_INTERVAL, min 600s), kills and restarts it.
+
+  Install:
+    sed -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+        -e "s|__LOG_DIR__|$LOOP_LOG_DIR|g" \
+        -e "s|__HOME__|$HOME|g" \
+        -e "s|__EXTRA_PATH__|$LOOP_EXTRA_PATH|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,154 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — liveness heartbeat and watchdog tests (#413).
+#
+# Covers:
+#   1. scanner.sh writes the heartbeat file on every tick.
+#   2. scanner-watchdog.sh exits 0 + prints "fresh" when heartbeat is recent.
+#   3. scanner-watchdog.sh prints "stale" and takes action when heartbeat is old.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    # Expose mock-gh.sh as the gh binary via a per-test temp bin directory.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+
+    # Source scanner.sh function definitions only (same strategy as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    # Override paths used by scanner.
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    log() { :; }
+    dispatch_direct() { :; }
+    loop_list_slugs() { :; }
+    jobs_init_schema() { :; }
+    _sweep_stale_locks() { :; }
+    _scanner_check_stdout() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat file written by run_once
+# ---------------------------------------------------------------------------
+
+@test "run_once: heartbeat file is created on every tick" {
+    rm -f "$HEARTBEAT_FILE"
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: heartbeat file contains PID and timestamp" {
+    run_once
+    local pid ts
+    read -r pid ts < "$HEARTBEAT_FILE"
+    [ -n "$pid" ]
+    [ -n "$ts" ]
+    # PID must be numeric
+    [[ "$pid" =~ ^[0-9]+$ ]]
+    # Timestamp must be numeric (epoch seconds)
+    [[ "$ts" =~ ^[0-9]+$ ]]
+}
+
+@test "run_once: heartbeat mtime is updated on each invocation" {
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+    sleep 1
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once: heartbeat is NOT written in --dry-run mode" {
+    DRY_RUN=true
+    rm -f "$HEARTBEAT_FILE"
+    run_once
+    [ ! -f "$HEARTBEAT_FILE" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh: fresh heartbeat
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: reports fresh when heartbeat is recent" {
+    # Write a heartbeat that is 5 seconds old.
+    printf '%s %s\n' "$$" "$(date +%s)" > "$HEARTBEAT_FILE"
+    # Use a threshold of 600s so 5s is well within the fresh window.
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+            LOOP_SCANNER_INTERVAL=300 \
+            LOOP_SCANNER_WATCHDOG_THRESHOLD=600 \
+            LOOP_EXTRA_PATH="" \
+            "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"fresh"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh: stale heartbeat
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: reports stale when heartbeat file is missing" {
+    rm -f "$HEARTBEAT_FILE"
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+            LOOP_SCANNER_INTERVAL=300 \
+            LOOP_SCANNER_WATCHDOG_THRESHOLD=600 \
+            LOOP_EXTRA_PATH="" \
+            "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"stale"* ]]
+}
+
+@test "scanner-watchdog: reports stale when heartbeat is older than threshold" {
+    # Write a heartbeat and backdate it by 700 seconds using touch.
+    printf '%s %s\n' "$$" "$(( $(date +%s) - 700 ))" > "$HEARTBEAT_FILE"
+    local past
+    past=$(date -v -700S "+%Y%m%d%H%M.%S" 2>/dev/null \
+        || date -d "700 seconds ago" "+%Y%m%d%H%M.%S" 2>/dev/null \
+        || true)
+    [ -n "$past" ] && touch -t "$past" "$HEARTBEAT_FILE" 2>/dev/null || true
+
+    run env LOOP_LOG_DIR="$LOOP_LOG_DIR" \
+            LOOP_SCANNER_INTERVAL=300 \
+            LOOP_SCANNER_WATCHDOG_THRESHOLD=600 \
+            LOOP_EXTRA_PATH="" \
+            "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"stale"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`**
- Added `HEARTBEAT_FILE` variable pointing to `${LOOP_LOG_DIR}/scanner-heartbeat`
- New `_scanner_check_stdout()` function: checks log file writability at the start of each tick; reopens fd or exits (triggering launchd KeepAlive restart) if non-writable
- `run_once()` now writes `PID timestamp` to the heartbeat file at tick start (skipped in `--dry-run` mode)
- `run_once()` logs dedup entry count at end of each tick: `scan tick done (dedup_entries=N)`

**`scanner/scanner-watchdog.sh`** (new)
- Runs independently every 5 minutes
- Reads heartbeat file mtime; if stale by more than `LOOP_SCANNER_WATCHDOG_THRESHOLD` (default: `2 × LOOP_SCANNER_INTERVAL`, floor 600s), kills the wedged PID and restarts:
  - macOS: `launchctl kickstart -k gui/<uid>/com.user.loop-scanner`
  - Linux: kills the PID; cron respawns on next tick
- Supports `--dry-run` for safe inspection

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new)
- launchd plist with `StartInterval=300` (5 min), logs to `loop-scanner-watchdog.log`

**`install.sh`**
- `bootstrap_register_launchd()`: registers `com.user.loop-scanner-watchdog` alongside existing agents
- `bootstrap_register_cron()`: adds `*/5` cron entry for `scanner-watchdog.sh` on Linux

**`tests/scanner-heartbeat.bats`** (new)
- 7 bats tests covering: heartbeat created on tick, file contains PID+timestamp, mtime updates, dry-run suppression, watchdog fresh/stale detection with missing file and backdated mtime

## Test Plan
- `bats tests/scanner-heartbeat.bats` — all 7 pass
- `bash -n` and `shellcheck -S warning` — clean
- Manual: start scanner, check `$LOOP_LOG_DIR/scanner-heartbeat` is updated every 300s; `kill -STOP $SCANNER_PID`, wait 10 min, watchdog should log "stale" and restart