### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog to detect and restart silent stops

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — fires every 5 min, kills stale scanner so
+    # launchd's KeepAlive restarts it automatically.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/restart-scanner-if-stale.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -776,6 +776,8 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Write heartbeat so the scanner watchdog can detect silent stops.
+    $DRY_RUN || printf '%s\n' "$(date +%s)" > "${LOOP_LOG_DIR}/scanner-heartbeat"
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scripts/restart-scanner-if-stale.sh
+++ b/scripts/restart-scanner-if-stale.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# restart-scanner-if-stale.sh — Watchdog for the Loop scanner process.
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat; if the file's mtime is older than
+# LOOP_SCANNER_STALE_SECONDS (default 900 = 15 min, i.e. 3× the default poll
+# interval), assumes the scanner is silently wedged and kills it so launchd's
+# KeepAlive=true restarts it automatically.
+#
+# Run every 5 minutes via launchd (macOS) or cron (Linux).
+# On macOS, launchd restarts the scanner via KeepAlive after the kill.
+# On Linux, the next cron --once tick fires within 5 minutes.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+STALE_SECS="${LOOP_SCANNER_STALE_SECONDS:-900}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file absent — scanner not yet started or heartbeat never written; skipping"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+age=$(( now - mtime ))
+
+log "heartbeat age=${age}s threshold=${STALE_SECS}s"
+
+if [ "$age" -lt "$STALE_SECS" ]; then
+    exit 0
+fi
+
+log "WARN: scanner heartbeat stale (${age}s > ${STALE_SECS}s) — restarting"
+
+# Kill the scanner if its PID lock file is present and the holder is alive.
+if [ -f "$LOCK_FILE" ]; then
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "killing stale scanner PID $pid"
+        kill "$pid" 2>/dev/null || true
+        sleep 2
+    fi
+fi
+
+# On macOS, kick the launchd service explicitly so the restart is immediate.
+if command -v launchctl >/dev/null 2>&1; then
+    launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null \
+        || log "WARN: launchctl kickstart failed (KeepAlive will restart on next exit)"
+fi
+
+log "watchdog action complete"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes. Checks scanner-heartbeat mtime; if stale (default
+  15 min = 3x the poll interval) kills the scanner PID so launchd's
+  KeepAlive restarts it. See scripts/restart-scanner-if-stale.sh.
+
+  Install (LOOP_LOG_DIR must be set, e.g. via your loop.env):
+    ./install.sh --bootstrap
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/restart-scanner-if-stale.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verify scanner writes a liveness heartbeat file on every tick.
+#
+# Sourcing strategy: same awk extraction used in scanner.bats — strip SCRIPT_DIR,
+# LOOP_ROOT, the arg-parsing for-loop, and stop before acquire_lock.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    export LOOP_EXTRA_PATH=""
+    mkdir -p "$LOOP_LOG_DIR"
+
+    local _src="$BATS_TMPDIR/scanner-hb-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    # Stub out everything run_once calls besides the heartbeat write.
+    log() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { printf ''; }
+    scan_project() { :; }
+    LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-hb-src.sh" 2>/dev/null || true
+}
+
+@test "run_once: writes scanner-heartbeat file to LOOP_LOG_DIR" {
+    DRY_RUN=false
+    run_once
+    [ -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+@test "run_once: heartbeat content is a unix timestamp (digits only)" {
+    DRY_RUN=false
+    run_once
+    local ts
+    ts=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+    [[ "$ts" =~ ^[0-9]+$ ]]
+}
+
+@test "run_once: heartbeat is NOT written in dry-run mode" {
+    DRY_RUN=true
+    run_once
+    [ ! -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+@test "run_once: heartbeat mtime is updated on each tick" {
+    DRY_RUN=false
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+             || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null)
+
+    # Ensure at least one second elapses between ticks.
+    sleep 1
+    run_once
+
+    local mtime2
+    mtime2=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+             || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null)
+
+    [ "$mtime2" -ge "$mtime1" ]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- At the start of every `run_once()` tick, writes `date +%s` (unix timestamp) to `${LOOP_LOG_DIR}/scanner-heartbeat`. Skipped in `--dry-run` mode. This gives an external watchdog a ground-truth signal that the scanner is still alive and iterating.

### `scripts/restart-scanner-if-stale.sh` (new)
- Reads the heartbeat file mtime. If it is older than `LOOP_SCANNER_STALE_SECONDS` (default 900 s = 15 min = 3× the default poll interval), considers the scanner silently wedged.
- Kills the scanner PID (from `/tmp/loop-scanner.lock`) so launchd's `KeepAlive=true` restarts it automatically on macOS.
- On macOS also calls `launchctl kickstart` for an immediate restart rather than waiting for launchd's throttle window.
- Exits cleanly if the heartbeat file is absent (scanner never started) or mtime is fresh.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- `StartInterval=300` (every 5 min).
- Logs to `loop-scanner-watchdog.log`.

### `install.sh`
- `bootstrap_register_launchd`: registers `com.user.loop-scanner-watchdog` plist (idempotent, skips if already loaded).
- `bootstrap_register_cron`: adds a `*/5 * * * *` cron entry for the watchdog on Linux.

### `tests/scanner-heartbeat.bats` (new)
- 4 tests: file is created, content is a unix timestamp, file is absent in dry-run, mtime advances across ticks.

## Test Plan
- `bats tests/scanner-heartbeat.bats` — all 4 pass
- `bats tests/scanner.bats` — all 45 existing tests pass
- `bash -n lib/*.sh scripts/*.sh scanner/*.sh install.sh` — no errors
- `shellcheck -S warning lib/*.sh scripts/*.sh scanner/*.sh install.sh` — no warnings
- No personal identifiers in committed files
- Manual: `kill -STOP $SCANNER_PID` → watchdog should restart scanner within 15 min (or sooner via `launchctl kickstart`)