### PR TITLE
[LOOP-413] scanner: heartbeat file + liveness watchdog to detect silent-stop

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — fires every 5 min and restarts the scanner if
+    # its heartbeat file is stale (no tick for >2× poll interval).
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -775,6 +776,15 @@ scan_project() {
 }
 
 run_once() {
+    # Heartbeat: stamp every tick so scanner-watchdog can detect a silent wedge.
+    $DRY_RUN || date +%s > "$HEARTBEAT_FILE"
+
+    # Stdout integrity: if the log file is gone or unwritable (e.g. after log
+    # rotation removed the inode), reopen FDs or exit so launchd restarts.
+    if [ -n "${LOG_FILE:-}" ] && [ ! -w "$LOG_FILE" ] 2>/dev/null; then
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" || exit 1
+    fi
+
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if its heartbeat file is stale.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written by scanner on every tick).
+# If the file is older than STALE_THRESHOLD seconds (default: 2 × poll interval),
+# the scanner is considered wedged and is restarted:
+#   macOS: launchctl kickstart -k gui/<uid>/com.user.loop-scanner
+#   Linux: kill the PID recorded in /tmp/loop-scanner.lock; cron restarts it.
+#
+# Designed to run every 5 min via launchd (StartInterval 300) or cron.
+#
+# Flags:
+#   --dry-run   print what would happen without taking action
+#   --stale <s> override stale threshold in seconds (also LOOP_SCANNER_WATCHDOG_STALE)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_SCANNER_WATCHDOG_STALE:-$(( POLL_INTERVAL * 2 ))}"
+SCANNER_LOCK="/tmp/loop-scanner.lock"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+DRY_RUN=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run)    DRY_RUN=true ;;
+        --stale)      shift; STALE_THRESHOLD="$1" ;;
+        --stale=*)    STALE_THRESHOLD="${1#--stale=}" ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _file_age_seconds <path>
+# Prints the age of the file in seconds; returns 1 if file does not exist.
+_file_age_seconds() {
+    local path="$1"
+    [ -f "$path" ] || return 1
+    local mtime now
+    mtime=$(stat -f%m "$path" 2>/dev/null || stat -c%Y "$path" 2>/dev/null) || return 1
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+# _restart_scanner
+# Restarts the scanner via the OS-appropriate mechanism.
+_restart_scanner() {
+    local scanner_pid=""
+    if [ -f "$SCANNER_LOCK" ]; then
+        scanner_pid=$(cat "$SCANNER_LOCK" 2>/dev/null || true)
+    fi
+
+    if [ "$(uname)" = "Darwin" ]; then
+        local uid
+        uid=$(id -u)
+        log "macOS: kickstarting com.user.loop-scanner (uid=$uid)"
+        if $DRY_RUN; then
+            log "DRY-RUN: would run: launchctl kickstart -k gui/${uid}/com.user.loop-scanner"
+            return 0
+        fi
+        if launchctl kickstart -k "gui/${uid}/com.user.loop-scanner" 2>/dev/null; then
+            log "scanner restarted via launchctl kickstart"
+            return 0
+        fi
+        # Fallback: kill the PID; launchd KeepAlive will restart the process.
+        if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+            log "launchctl kickstart failed — killing PID $scanner_pid (launchd will restart)"
+            kill "$scanner_pid" 2>/dev/null || true
+        else
+            log "WARN: launchctl kickstart failed and no live PID found — manual restart needed"
+            return 1
+        fi
+    else
+        # Linux: kill PID from lock file; cron will restart scanner on next tick.
+        if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+            log "Linux: killing scanner PID $scanner_pid (cron will restart)"
+            if $DRY_RUN; then
+                log "DRY-RUN: would kill $scanner_pid"
+                return 0
+            fi
+            kill "$scanner_pid" 2>/dev/null || true
+        else
+            log "WARN: no live scanner PID found — scanner may already be stopped"
+        fi
+    fi
+}
+
+age=$(_file_age_seconds "$HEARTBEAT_FILE" || echo "")
+
+if [ -z "$age" ]; then
+    log "heartbeat file missing: $HEARTBEAT_FILE — scanner not yet started or heartbeat not written"
+    exit 0
+fi
+
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is healthy (age ${age}s < ${STALE_THRESHOLD}s)"
+    exit 0
+fi
+
+log "STALE: heartbeat is ${age}s old (threshold=${STALE_THRESHOLD}s) — restarting scanner"
+_restart_scanner

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <!-- Check every 5 minutes; default stale threshold is 2x poll interval (600s) -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- Declares `HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"`.
- At the top of each `run_once()` tick: writes epoch seconds to `HEARTBEAT_FILE` (skipped in `--dry-run`).
- Per-tick stdout integrity check: if `LOG_FILE` is no longer writable (e.g. after log rotation removed the inode), reopen FDs 1+2 against the path or exit so launchd restarts cleanly.

### scripts/scanner-watchdog.sh (new)
- Reads the heartbeat file mtime and computes its age.
- If `age >= STALE_THRESHOLD` (default `2 × LOOP_SCANNER_INTERVAL` = 600 s), the scanner is considered wedged and is restarted:
  - **macOS**: `launchctl kickstart -k gui/<uid>/com.user.loop-scanner`; falls back to killing the PID so launchd KeepAlive restarts it.
  - **Linux**: kills the PID from `/tmp/loop-scanner.lock`; cron restarts on the next 5-min tick.
- Threshold is overridable via `LOOP_SCANNER_WATCHDOG_STALE` env var or `--stale <s>` flag.
- `--dry-run` prints what would happen without touching anything.

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
- `StartInterval 300` (every 5 min), logs to `loop-scanner-watchdog.log`.

### install.sh
- `bootstrap_register_launchd`: installs the watchdog plist alongside scanner/reconciler/pr-watchdog.
- `bootstrap_register_cron` (Linux): adds `*/5 * * * *` cron entry for `scanner-watchdog.sh`.

## Test Plan
- **Healthy**: run `./scripts/scanner-watchdog.sh` with a fresh heartbeat — should log "scanner is healthy" and exit 0.
- **Stale simulation**: `kill -STOP $SCANNER_PID`; after `STALE_THRESHOLD` seconds the watchdog should log "STALE" and restart the scanner.
- **Dry-run**: `./scripts/scanner-watchdog.sh --dry-run` with stale heartbeat — logs would-restart message, no launchctl call.
- **Heartbeat written**: verify `${LOOP_LOG_DIR}/scanner-heartbeat` is updated after each scan tick.