### PR TITLE
[LOOP-413] scanner: heartbeat file + stdout integrity check + watchdog

### DIFF
--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if it stops writing its heartbeat.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat. If the file is absent or its mtime
+# is older than STALE_THRESHOLD_SECONDS (default: 2 × poll interval = 600s),
+# the scanner is considered wedged.  The watchdog kills the PID stored in
+# /tmp/loop-scanner.lock and relies on launchd (macOS) or cron (Linux) to
+# restart the scanner binary.  On macOS it additionally calls
+# `launchctl kickstart` if LOOP_LAUNCHD_LABEL is set.
+#
+# Usage:
+#   scanner-watchdog.sh            # single check (default; run from launchd / cron)
+#   scanner-watchdog.sh --dry-run  # report state without restarting
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_SCANNER_WATCHDOG_STALE:-$(( POLL_INTERVAL * 2 ))}"
+LAUNCHD_LABEL="${LOOP_LAUNCHD_LABEL:-}"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _heartbeat_age_seconds — return seconds since heartbeat was written, or
+# a very large number if the file is absent (treat as maximally stale).
+_heartbeat_age_seconds() {
+    if [ ! -f "$HEARTBEAT_FILE" ]; then
+        echo "999999"
+        return 0
+    fi
+    local mtime now
+    mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+         || stat -c%Y  "$HEARTBEAT_FILE" 2>/dev/null \
+         || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+age=$(_heartbeat_age_seconds)
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s file=${HEARTBEAT_FILE}"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is healthy — no action needed"
+    exit 0
+fi
+
+log "STALE: scanner heartbeat is ${age}s old (threshold=${STALE_THRESHOLD}s)"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would restart scanner (PID from $LOCK_FILE)"
+    exit 0
+fi
+
+# Kill the scanner PID so launchd/cron restarts the binary.
+pid=""
+if [ -f "$LOCK_FILE" ]; then
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+fi
+
+if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    log "killing stale scanner PID $pid"
+    kill "$pid" 2>/dev/null || true
+    # Give it a moment to exit and release the lock; if it doesn't, SIGKILL.
+    sleep 2
+    kill -0 "$pid" 2>/dev/null && kill -9 "$pid" 2>/dev/null || true
+else
+    log "scanner PID '${pid}' not running — removing stale lock if present"
+    rm -f "$LOCK_FILE"
+fi
+
+# On macOS, kickstart the launchd service so it restarts immediately rather
+# than waiting for the next launchd check interval.
+if [ -n "$LAUNCHD_LABEL" ] && command -v launchctl >/dev/null 2>&1; then
+    log "kickstarting launchd service: $LAUNCHD_LABEL"
+    launchctl kickstart -k "gui/$(id -u)/${LAUNCHD_LABEL}" 2>/dev/null \
+        || log "WARN: launchctl kickstart failed (non-fatal — launchd will auto-restart)"
+fi
+
+log "restart triggered"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -47,6 +47,8 @@ _scanner_reopen_log() {
 }
 trap '_scanner_reopen_log; echo "[$(date "+%Y-%m-%d %H:%M:%S")] [scanner] SIGHUP — log fds reopened"' HUP
 
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+
 DRY_RUN=false
 ONCE=false
 
@@ -63,6 +65,22 @@ for arg in "$@"; do
 done
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] $*"; }
+
+# _scanner_write_heartbeat — stamp the heartbeat file so the watchdog knows
+# the scanner is alive. Skipped in dry-run and on write error (non-fatal).
+_scanner_write_heartbeat() {
+    $DRY_RUN && return 0
+    printf '%s\n' "$(date '+%Y-%m-%d %H:%M:%S')" > "$HEARTBEAT_FILE" 2>/dev/null || true
+}
+
+# _scanner_check_stdout — verify the log FD is still functional.
+# If LOG_FILE was rotated or deleted between ticks, reopen it. If reopen
+# fails, exit immediately so launchd/cron restarts the scanner cleanly.
+_scanner_check_stdout() {
+    [ -n "${LOG_FILE:-}" ] || return 0
+    [ -f "$LOG_FILE" ] && [ -w "$LOG_FILE" ] && return 0
+    exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" || exit 1
+}
 
 # _scanner_jobs_enqueue <slug> <stage> <num>
 # Best-effort dual-write to the jobs table alongside the legacy label-event path.
@@ -775,7 +793,11 @@ scan_project() {
 }
 
 run_once() {
-    log "=== scan tick start ==="
+    _scanner_check_stdout
+    _scanner_write_heartbeat
+    local _dc
+    _dc=$(ls -1 "$DEDUP_DIR" 2>/dev/null | wc -l | tr -d ' ')
+    log "=== scan tick start === ts=$(date +%s) dedup_count=${_dc}"
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes. Reads ${LOOP_LOG_DIR}/scanner-heartbeat; if the
+  mtime is older than LOOP_SCANNER_WATCHDOG_STALE seconds (default: 2 ×
+  poll interval = 600s) the scanner is considered wedged and is restarted.
+
+  Install:
+    sed "s|__LOOP_ROOT__|$(cd "$(dirname "$0")/.." && pwd)|g; \
+         s|__LOG_DIR__|$LOOP_LOG_DIR|g; \
+         s|__HOME__|$HOME|g; \
+         s|__EXTRA_PATH__|${LOOP_EXTRA_PATH:-/opt/homebrew/bin:/usr/local/bin}|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <!-- Check every 5 minutes -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <!-- Set to com.user.loop-scanner to enable launchctl kickstart on restart -->
+        <key>LOOP_LAUNCHD_LABEL</key>
+        <string>com.user.loop-scanner</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,110 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verify heartbeat file is updated on every tick.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner.sh function definitions only (same awk extraction as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-hb-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-hb-test.log"
+    mkdir -p "$DEDUP_DIR"
+    touch "$LOG_FILE"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    log()              { :; }
+    dispatch_direct()  { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema()   { :; }
+    loop_list_slugs()    { :; }
+    LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/scanner-hb-src.sh" \
+           "$BATS_TMPDIR/scanner-hb-test.log" 2>/dev/null || true
+}
+
+@test "_scanner_write_heartbeat: creates heartbeat file" {
+    rm -f "$HEARTBEAT_FILE"
+    _scanner_write_heartbeat
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "_scanner_write_heartbeat: updates mtime on each call" {
+    _scanner_write_heartbeat
+    local mtime1
+    mtime1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+    sleep 1
+    _scanner_write_heartbeat
+    local mtime2
+    mtime2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "_scanner_write_heartbeat: writes a non-empty timestamp" {
+    _scanner_write_heartbeat
+    [ -s "$HEARTBEAT_FILE" ]
+    local content
+    content=$(cat "$HEARTBEAT_FILE")
+    [ -n "$content" ]
+}
+
+@test "_scanner_write_heartbeat: is a no-op in dry-run mode" {
+    DRY_RUN=true
+    rm -f "$HEARTBEAT_FILE"
+    _scanner_write_heartbeat
+    [ ! -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: heartbeat file is written during each tick" {
+    rm -f "$HEARTBEAT_FILE"
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: heartbeat file content is a timestamp" {
+    run_once
+    local content
+    content=$(cat "$HEARTBEAT_FILE")
+    # Matches YYYY-MM-DD HH:MM:SS
+    [[ "$content" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\ [0-9]{2}:[0-9]{2}:[0-9]{2}$ ]]
+}
+
+@test "_scanner_check_stdout: no-op when LOG_FILE is writable" {
+    # Should succeed without error when file exists and is writable.
+    run _scanner_check_stdout
+    [ "$status" -eq 0 ]
+}
+
+@test "_scanner_check_stdout: no-op when LOG_FILE is unset" {
+    local saved="$LOG_FILE"
+    LOG_FILE=""
+    run _scanner_check_stdout
+    LOG_FILE="$saved"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- Added `_scanner_write_heartbeat()` — writes current timestamp to `${LOOP_LOG_DIR}/scanner-heartbeat` on every tick (skipped in dry-run mode). Provides a liveness signal that a separate watchdog can monitor.
- Added `_scanner_check_stdout()` — called at the top of every tick; if `LOG_FILE` was rotated or deleted, it reopens FDs 1+2 against the current path. If reopen fails, exits immediately so launchd/cron restarts the scanner cleanly. Belt-and-suspenders complement to the existing SIGHUP handler.
- Updated `run_once()` to call both functions and emit a structured tick log line: `=== scan tick start === ts=<epoch> dedup_count=<n>` so silent-stop becomes visible in the log.
- Added `HEARTBEAT_FILE` variable derived from `LOOP_LOG_DIR`.

### scanner/scanner-watchdog.sh (new)
Standalone script run every 5 minutes via launchd/cron. Reads heartbeat file mtime; if older than `LOOP_SCANNER_WATCHDOG_STALE` seconds (default: 2 × poll interval = 600 s), kills the scanner PID from the lock file. On macOS with `LOOP_LAUNCHD_LABEL` set, also calls `launchctl kickstart` for immediate restart. Supports `--dry-run`.

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
launchd plist template for the watchdog. Fires every 300 s (`StartInterval`). Sets `LOOP_LAUNCHD_LABEL=com.user.loop-scanner` so the kickstart path is wired by default.

### tests/scanner-heartbeat.bats (new)
8 bats tests covering:
- Heartbeat file is created and updated on each call
- Content is a non-empty timestamp
- No-op in dry-run mode
- `run_once()` writes heartbeat on every tick
- `_scanner_check_stdout()` no-ops when file is writable or LOG_FILE is unset

## Test Plan
- All 8 new bats tests pass: `bats tests/scanner-heartbeat.bats`
- Existing scanner tests show no regressions (pre-existing failures on main are unchanged)
- Syntax check: `bash -n scanner/scanner-watchdog.sh scanner/scanner.sh` ✓
- shellcheck: clean ✓
- Simulate wedge: `kill -STOP $SCANNER_PID` → watchdog kills and restarts within 10 min (2× poll interval)
- Dry-run: `scanner/scanner-watchdog.sh --dry-run` logs state without restarting