### PR TITLE
[LOOP-413] scanner: liveness heartbeat + stale-scanner watchdog

### DIFF
--- a/scanner/restart-scanner-if-stale.sh
+++ b/scanner/restart-scanner-if-stale.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# restart-scanner-if-stale.sh — scanner liveness watchdog.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat. If its mtime is older than
+# STALE_THRESHOLD_SECONDS (default: 2 × LOOP_SCANNER_INTERVAL = 10 min),
+# kills the scanner PID (from /tmp/loop-scanner.lock) and either
+# restarts via launchctl (macOS) or by exec-ing a fresh scanner process
+# (Linux / manual mode).
+#
+# Intended to run every 5 minutes via launchd (macOS) or cron (Linux).
+# Safe to run concurrently with a healthy scanner — it exits immediately
+# when the heartbeat is fresh.
+#
+# Flags:
+#   --dry-run   report stale/healthy status without taking action
+#   --once      (default) single check; reserved for future loop mode
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_SCANNER_WATCHDOG_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+LAUNCHD_LABEL="${LOOP_SCANNER_LAUNCHD_LABEL:-com.user.loop-scanner}"
+
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        --once)    : ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+_file_age_seconds() {
+    local f="$1"
+    local mtime now
+    mtime=$(stat -f%m "$f" 2>/dev/null || stat -c%Y "$f" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+# Returns 0 (true) if the scanner looks healthy based on the heartbeat file.
+_scanner_is_healthy() {
+    [ -f "$HEARTBEAT_FILE" ] || return 1
+    local age
+    age=$(_file_age_seconds "$HEARTBEAT_FILE")
+    [ "$age" -lt "$STALE_THRESHOLD" ]
+}
+
+_scanner_pid() {
+    [ -f "$LOCK_FILE" ] || return 1
+    cat "$LOCK_FILE" 2>/dev/null || true
+}
+
+_restart_scanner() {
+    local pid
+    pid=$(_scanner_pid || true)
+
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        log "killing stale scanner PID $pid"
+        $DRY_RUN || kill "$pid" 2>/dev/null || true
+    fi
+
+    if $DRY_RUN; then
+        log "DRY-RUN: would restart scanner"
+        return 0
+    fi
+
+    # macOS: launchd manages KeepAlive — killing the process is enough;
+    # launchd will restart it. Use kickstart for an immediate restart.
+    if command -v launchctl >/dev/null 2>&1; then
+        log "kickstarting launchd service: $LAUNCHD_LABEL"
+        launchctl kickstart -k "gui/$(id -u)/${LAUNCHD_LABEL}" 2>/dev/null \
+            || launchctl start "$LAUNCHD_LABEL" 2>/dev/null \
+            || log "WARN: launchctl restart failed; launchd KeepAlive will handle it"
+        return 0
+    fi
+
+    # Linux / no launchd: start a detached scanner process.
+    log "starting scanner directly (no launchd)"
+    nohup "$LOOP_ROOT/scanner/scanner.sh" \
+        >> "${LOOP_LOG_DIR}/loop-scanner.log" 2>&1 &
+    log "scanner started (PID $!)"
+}
+
+if _scanner_is_healthy; then
+    local_age=$(_file_age_seconds "$HEARTBEAT_FILE")
+    log "healthy (heartbeat age=${local_age}s threshold=${STALE_THRESHOLD}s)"
+    exit 0
+fi
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "WARN: heartbeat file missing — scanner may never have started"
+else
+    stale_age=$(_file_age_seconds "$HEARTBEAT_FILE")
+    log "STALE: heartbeat age=${stale_age}s > threshold=${STALE_THRESHOLD}s — restarting"
+fi
+
+_restart_scanner

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -22,6 +22,8 @@ source "$LOOP_ROOT/lib/backends/backend.sh"
 source "$LOOP_ROOT/lib/labels.sh"
 # shellcheck source=../lib/jobs.sh
 source "$LOOP_ROOT/lib/jobs.sh"
+# shellcheck source=../lib/monitor.sh
+source "$LOOP_ROOT/lib/monitor.sh"
 # workflow helpers (loop_polled_labels, loop_handler_for_label, loop_stage_trigger,
 # loop_workflow_for_project) are already loaded via lib/env.sh → lib/workflow.sh.
 # The line below is for shellcheck only.
@@ -29,6 +31,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -63,6 +66,39 @@ for arg in "$@"; do
 done
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner] $*"; }
+
+# _scanner_write_heartbeat — touch the heartbeat file so the watchdog can
+# detect a wedged scanner (file mtime stale by > 2 × POLL_INTERVAL).
+_scanner_write_heartbeat() {
+    $DRY_RUN && return 0
+    touch "${HEARTBEAT_FILE}" 2>/dev/null || true
+}
+
+# _scanner_check_stdout — if LOG_FILE is no longer writable (e.g. deleted
+# by rotation and not yet reopened), exec FDs 1+2 back to it so subsequent
+# log() calls are not silently discarded. Exit if recovery fails so launchd
+# can restart the scanner with clean FDs.
+_scanner_check_stdout() {
+    $DRY_RUN && return 0
+    [ -n "${LOG_FILE:-}" ] || return 0
+    if [ ! -w "${LOG_FILE}" ] 2>/dev/null; then
+        exec 1>>"${LOG_FILE}" 2>>"${LOG_FILE}" || exit 1
+    fi
+}
+
+# _scanner_emit_tick — send a scanner.tick event to loop-monitor (best-effort).
+# Skipped when LOOP_MONITOR_URL is unset or in dry-run mode.
+_scanner_emit_tick() {
+    $DRY_RUN && return 0
+    [ -n "${LOOP_MONITOR_URL:-}" ] || return 0
+    local dedup_count now
+    dedup_count=$(find "${DEDUP_DIR}" -type f 2>/dev/null | wc -l | tr -d ' ')
+    now=$(date '+%Y-%m-%dT%H:%M:%SZ')
+    local payload
+    payload=$(python3 -c "import json,sys; print(json.dumps({'ts': sys.argv[1], 'dedup_count': int(sys.argv[2])}))" \
+        "$now" "$dedup_count" 2>/dev/null) || return 0
+    _loop_emit_event "scanner.tick" "$payload" 2>/dev/null || true
+}
 
 # _scanner_jobs_enqueue <slug> <stage> <num>
 # Best-effort dual-write to the jobs table alongside the legacy label-event path.
@@ -775,6 +811,8 @@ scan_project() {
 }
 
 run_once() {
+    _scanner_check_stdout
+    _scanner_write_heartbeat
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
@@ -786,6 +824,7 @@ run_once() {
         scan_project "$slug" || log "scan_project $slug failed (continuing)"
     done < <(loop_list_slugs)
     log "=== scan tick done ==="
+    _scanner_emit_tick
 }
 
 acquire_lock

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Runs every 5 minutes. Checks scanner-heartbeat mtime; if stale (> 2 ×
+  LOOP_SCANNER_INTERVAL, default 10 min), kills and restarts the scanner via
+  launchctl kickstart so the pipeline self-heals without operator intervention.
+
+  Install (run from LOOP_ROOT after sourcing loop.env):
+    sed "s|__LOOP_ROOT__|$LOOP_ROOT|g; s|__LOG_DIR__|$LOOP_LOG_DIR|g; s|__HOME__|$HOME|g; s|__EXTRA_PATH__|${LOOP_EXTRA_PATH:-/opt/homebrew/bin:/usr/local/bin}|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/restart-scanner-if-stale.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 liveness heartbeat.
+#
+# Verifies that:
+#   1. _scanner_write_heartbeat touches HEARTBEAT_FILE on every call.
+#   2. run_once() updates the heartbeat file (integration check via stub).
+#   3. restart-scanner-if-stale.sh reports healthy when heartbeat is fresh.
+#   4. restart-scanner-if-stale.sh reports stale when heartbeat is old.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+
+    # Suppress LOOP_EXTRA_PATH so env.sh does not prepend /opt/homebrew/bin.
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner function definitions only (same awk extraction as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    # Override HEARTBEAT_FILE after sourcing (scanner.sh sets it from LOOP_LOG_DIR).
+    HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    log() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# _scanner_write_heartbeat
+# ---------------------------------------------------------------------------
+
+@test "_scanner_write_heartbeat creates heartbeat file" {
+    [ ! -f "$HEARTBEAT_FILE" ]
+    _scanner_write_heartbeat
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "_scanner_write_heartbeat updates mtime on every call" {
+    touch -t 200001010000 "$HEARTBEAT_FILE"   # old mtime
+    local before
+    before=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE")
+    sleep 1
+    _scanner_write_heartbeat
+    local after
+    after=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE")
+    [ "$after" -gt "$before" ]
+}
+
+@test "_scanner_write_heartbeat is a no-op in dry-run mode" {
+    DRY_RUN=true
+    _scanner_write_heartbeat
+    [ ! -f "$HEARTBEAT_FILE" ]
+    DRY_RUN=false
+}
+
+# ---------------------------------------------------------------------------
+# scanner.sh contains the HEARTBEAT_FILE declaration (regression guard)
+# ---------------------------------------------------------------------------
+
+@test "scanner.sh declares HEARTBEAT_FILE variable" {
+    grep -q 'HEARTBEAT_FILE=' "$REPO_ROOT/scanner/scanner.sh"
+}
+
+@test "scanner.sh calls _scanner_write_heartbeat in run_once" {
+    grep -q '_scanner_write_heartbeat' "$REPO_ROOT/scanner/scanner.sh"
+}
+
+# ---------------------------------------------------------------------------
+# restart-scanner-if-stale.sh — dry-run mode
+# ---------------------------------------------------------------------------
+
+@test "watchdog reports healthy when heartbeat is fresh" {
+    touch "$HEARTBEAT_FILE"
+    run "$REPO_ROOT/scanner/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"healthy"* ]]
+}
+
+@test "watchdog reports stale when heartbeat is old" {
+    touch -t 200001010000 "$HEARTBEAT_FILE"   # epoch-like old mtime
+    run "$REPO_ROOT/scanner/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]] || [[ "$output" == *"DRY-RUN"* ]]
+}
+
+@test "watchdog reports missing heartbeat file" {
+    rm -f "$HEARTBEAT_FILE"
+    run "$REPO_ROOT/scanner/restart-scanner-if-stale.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"missing"* ]] || [[ "$output" == *"DRY-RUN"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- Added `HEARTBEAT_FILE` variable (`${LOOP_LOG_DIR}/scanner-heartbeat`)
- Added `_scanner_write_heartbeat()`: touches the heartbeat file at the top of every tick; no-op in `--dry-run` mode
- Added `_scanner_check_stdout()`: checks if `LOG_FILE` is still writable at tick start; re-opens FDs 1+2 if not, exits if recovery fails so launchd can restart with clean FDs
- Added `_scanner_emit_tick()`: best-effort `scanner.tick` event to loop-monitor (`LOOP_MONITOR_URL`) with `ts` + `dedup_count`; skipped when monitor URL is unset
- Sourced `lib/monitor.sh` for `_loop_emit_event`
- `run_once()` now calls `_scanner_check_stdout` → `_scanner_write_heartbeat` before each scan, and `_scanner_emit_tick` after

### scanner/restart-scanner-if-stale.sh (new)
- Standalone watchdog script: reads heartbeat mtime, compares to `STALE_THRESHOLD` (default `2 × LOOP_SCANNER_INTERVAL = 10 min`)
- Healthy: logs age and exits 0
- Stale: kills scanner PID (from `/tmp/loop-scanner.lock`), then restarts via `launchctl kickstart` on macOS or direct `nohup` exec on Linux
- `--dry-run` mode reports without taking action
- Configurable via `LOOP_SCANNER_WATCHDOG_THRESHOLD` and `LOOP_SCANNER_LAUNCHD_LABEL`

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
- launchd plist for the watchdog, `StartInterval=300` (every 5 min)
- Logs to `${LOOP_LOG_DIR}/loop-scanner-watchdog.log`
- Install instructions in template header comment

### tests/scanner-heartbeat.bats (new)
- 8 bats tests: heartbeat file creation, mtime update, dry-run no-op, regression guards for HEARTBEAT_FILE declaration and `run_once` wiring, watchdog healthy/stale/missing-file scenarios

## Test Plan
- All 8 new bats tests pass (`bats tests/scanner-heartbeat.bats`)
- All existing scanner tests pass (pre-existing failures on main are unrelated)
- `bash -n` and `shellcheck -S warning` clean on all scripts
- Manual: simulate wedge with `kill -STOP $SCANNER_PID` → watchdog should detect stale heartbeat within 5–10 min and restart