### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog auto-restart for silent wedge

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,6 +338,25 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    # Scanner liveness watchdog — kills and lets launchd restart a wedged scanner.
+    # Runs every 5 min; harmless when the scanner is healthy.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     local digest_plist="$agents_dir/com.user.loop-digest.plist"
     if [ -f "$digest_plist" ]; then
         echo "[launchd] com.user.loop-digest already registered — skipping"
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local scanner_watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local scanner_watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $scanner_watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$scanner_watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$scanner_watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -775,6 +775,8 @@ scan_project() {
 }
 
 run_once() {
+    # Touch heartbeat file so scanner-watchdog can confirm liveness.
+    touch "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/scripts/scanner-watchdog.sh
+++ b/scripts/scanner-watchdog.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if its heartbeat is stale.
+#
+# Runs every 5 min via launchd (macOS) or cron (Linux). If the heartbeat
+# file (${LOOP_LOG_DIR}/scanner-heartbeat) has not been touched for more
+# than LOOP_SCANNER_WATCHDOG_THRESHOLD seconds (default: 2 × poll interval,
+# i.e. 600s), the scanner is considered wedged. The watchdog kills the PID
+# recorded in /tmp/loop-scanner.lock and lets the scheduler restart it.
+#
+# On macOS with KeepAlive=true in the launchd plist, launchd auto-restarts
+# the scanner within seconds of the kill. On Linux the next cron invocation
+# fires within 5 min.
+#
+# Usage:
+#   scanner-watchdog.sh [--dry-run]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+LOCK_FILE="${LOOP_SCANNER_LOCK:-/tmp/loop-scanner.lock}"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+THRESHOLD="${LOOP_SCANNER_WATCHDOG_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# heartbeat_age_seconds — returns the age of the heartbeat file in seconds,
+# or a large value (9999999) if the file does not exist.
+heartbeat_age_seconds() {
+    [ -f "$HEARTBEAT_FILE" ] || { echo 9999999; return; }
+    local mtime now
+    mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+        || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+        || { echo 9999999; return; })
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+log "check: threshold=${THRESHOLD}s heartbeat=${HEARTBEAT_FILE}"
+
+age=$(heartbeat_age_seconds)
+log "heartbeat age=${age}s"
+
+if [ "$age" -lt "$THRESHOLD" ]; then
+    log "scanner is healthy (age=${age}s < threshold=${THRESHOLD}s)"
+    exit 0
+fi
+
+log "WARN: heartbeat stale for ${age}s (threshold=${THRESHOLD}s) — scanner may be wedged"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner and let scheduler restart it"
+    exit 0
+fi
+
+# Read the scanner PID from the lock file.
+if [ ! -f "$LOCK_FILE" ]; then
+    log "WARN: lock file $LOCK_FILE not found — scanner may already be stopped; skipping kill"
+    exit 0
+fi
+
+pid=$(cat "$LOCK_FILE" 2>/dev/null || echo "")
+if [ -z "$pid" ]; then
+    log "WARN: lock file empty — skipping kill"
+    exit 0
+fi
+
+if ! kill -0 "$pid" 2>/dev/null; then
+    log "WARN: scanner PID $pid is not alive — lock is already stale"
+    rm -f "$LOCK_FILE"
+    exit 0
+fi
+
+log "killing wedged scanner PID $pid"
+kill "$pid" 2>/dev/null || true
+
+# Give launchd / cron up to 5s to release the lock file, then clean it up
+# ourselves so the next invocation is not blocked by a stale lock.
+local_wait=0
+while [ -f "$LOCK_FILE" ] && [ "$local_wait" -lt 5 ]; do
+    sleep 1
+    local_wait=$(( local_wait + 1 ))
+done
+if [ -f "$LOCK_FILE" ]; then
+    log "lock file still present after kill — removing to unblock restart"
+    rm -f "$LOCK_FILE"
+fi
+
+log "scanner killed; scheduler will restart it automatically"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+  Runs scanner-watchdog.sh every 5 minutes to detect and restart a wedged scanner.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,165 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — liveness heartbeat for scanner (#413).
+#
+# Verifies:
+#   1. run_once writes/updates the scanner-heartbeat file on every tick.
+#   2. scanner-watchdog.sh exits 0 (healthy) when heartbeat is fresh.
+#   3. scanner-watchdog.sh kills the recorded PID when heartbeat is stale.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Expose mock-gh.sh as gh.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_EXTRA_PATH=""
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+
+    # Source scanner.sh functions (same pattern as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    log() { :; }
+    dispatch_direct() { :; }
+
+    # Stub out project scanning so run_once completes without real gh calls.
+    loop_list_slugs() { return 0; }
+    scan_project() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" \
+           "$BATS_TMPDIR/lock" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat written by run_once
+# ---------------------------------------------------------------------------
+
+@test "run_once: creates scanner-heartbeat file on first tick" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    rm -f "$hb"
+    run_once
+    [ -f "$hb" ]
+}
+
+@test "run_once: updates scanner-heartbeat mtime on each tick" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    touch -t 200001010000 "$hb" 2>/dev/null || touch "$hb"
+    local before
+    before=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb" 2>/dev/null || echo 0)
+    sleep 1
+    run_once
+    local after
+    after=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb" 2>/dev/null || echo 0)
+    [ "$after" -ge "$before" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh — healthy case
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits 0 when heartbeat is fresh" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    touch "$hb"
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner is healthy"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh — stale heartbeat
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: reports stale and kills wedged scanner PID" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    local lock_file="/tmp/loop-scanner.lock"
+
+    # Start a long-running background process that we will use as the fake scanner PID.
+    sleep 300 &
+    local fake_pid=$!
+
+    # Write the fake PID to the lock file.
+    echo "$fake_pid" > "$lock_file"
+
+    # Make the heartbeat appear ancient (set mtime to epoch via a very old touch).
+    touch -t 200001010000 "$hb" 2>/dev/null || {
+        # Fallback: skip if touch -t is not available.
+        kill "$fake_pid" 2>/dev/null || true
+        rm -f "$lock_file"
+        skip "touch -t not supported on this platform"
+    }
+
+    # Set a very short threshold so the stale condition fires immediately.
+    export LOOP_SCANNER_WATCHDOG_THRESHOLD=1
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh"
+
+    # Clean up.
+    kill "$fake_pid" 2>/dev/null || true
+    rm -f "$lock_file"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"stale"* ]] || [[ "$output" == *"killed"* ]] || [[ "$output" == *"killing"* ]]
+}
+
+@test "scanner-watchdog --dry-run: reports stale but does not kill" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    local lock_file="/tmp/loop-scanner.lock"
+
+    sleep 300 &
+    local fake_pid=$!
+    echo "$fake_pid" > "$lock_file"
+
+    touch -t 200001010000 "$hb" 2>/dev/null || {
+        kill "$fake_pid" 2>/dev/null || true
+        rm -f "$lock_file"
+        skip "touch -t not supported on this platform"
+    }
+
+    export LOOP_SCANNER_WATCHDOG_THRESHOLD=1
+    run "$REPO_ROOT/scripts/scanner-watchdog.sh" --dry-run
+
+    local alive=0
+    kill -0 "$fake_pid" 2>/dev/null && alive=1
+
+    # Clean up.
+    kill "$fake_pid" 2>/dev/null || true
+    rm -f "$lock_file"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DRY-RUN"* ]]
+    [ "$alive" -eq 1 ]
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`** — `run_once()` now calls `touch "${LOOP_LOG_DIR}/scanner-heartbeat"` at the top of every tick. This is the liveness signal the watchdog reads.

**`scripts/scanner-watchdog.sh`** — new script. Runs every 5 minutes. Reads the heartbeat file mtime; if age exceeds `LOOP_SCANNER_WATCHDOG_THRESHOLD` (default `2 × POLL_INTERVAL` = 600 s), kills the PID from `/tmp/loop-scanner.lock` and lets launchd/cron restart the scanner automatically. `--dry-run` flag reports but does not kill. Threshold auto-scales when `LOOP_SCANNER_INTERVAL` is changed.

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** — launchd plist, `StartInterval=300` (every 5 min). Uses the same `__TOKEN__` substitution pattern as other Loop plists.

**`install.sh`** — registers `com.user.loop-scanner-watchdog` in `bootstrap_register_launchd` (macOS) and adds a `*/5 * * * *` cron entry in `bootstrap_register_cron` (Linux). Both are idempotent.

**`tests/scanner-heartbeat.bats`** — 5 bats tests covering heartbeat creation, mtime update, healthy watchdog exit, stale-PID kill, and dry-run no-kill.

## Test Plan

- `bats tests/scanner-heartbeat.bats` — all 5 pass.
- `bash -n` syntax check: clean.
- `shellcheck -S warning`: clean.
- Personal-identifiers grep: no hits.
- Manual: `kill -STOP $SCANNER_PID` → watchdog kills it within the next 5-min tick; launchd restarts within seconds.