### PR TITLE
[LOOP-413] scanner: liveness heartbeat + stale-scanner watchdog

### DIFF
--- a/scanner/restart-scanner-if-stale.sh
+++ b/scanner/restart-scanner-if-stale.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# restart-scanner-if-stale.sh — watchdog: restart the scanner if its heartbeat
+# file has not been updated recently, which indicates the scanner is silently
+# wedged (alive PID, sleep loop intact, but no tick activity).
+#
+# Intended to run every 5 minutes via launchd (macOS) or cron (Linux). Because
+# the scanner plist uses KeepAlive=true, killing the wedged PID is sufficient —
+# launchd will restart the scanner automatically within ThrottleInterval seconds.
+#
+# Configuration (via loop.env or environment):
+#   LOOP_SCANNER_STALE_THRESHOLD — seconds before heartbeat is considered stale
+#                                   (default: 900 = 3 × default 300 s poll interval)
+#
+# Usage:
+#   restart-scanner-if-stale.sh [--dry-run]
+#   restart-scanner-if-stale.sh --help
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+# 900 s = 3 × default 300 s poll interval; tolerates one slow tick before
+# raising a false alarm.
+STALE_THRESHOLD="${LOOP_SCANNER_STALE_THRESHOLD:-900}"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+SCANNER_LOCK_FILE="/tmp/loop-scanner.lock"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -15
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# If the heartbeat file doesn't exist, the scanner may have just started or
+# the operator upgraded before the first tick wrote one. Do not restart; wait.
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file missing — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+age=$(( now - mtime ))
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "ok: heartbeat age=${age}s < threshold=${STALE_THRESHOLD}s"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat stale (age=${age}s >= threshold=${STALE_THRESHOLD}s) — triggering restart"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would restart scanner"
+    exit 0
+fi
+
+# Read the scanner PID from the lock file and kill the wedged process.
+# launchd (KeepAlive=true) will restart it automatically.
+scanner_pid=""
+if [ -f "$SCANNER_LOCK_FILE" ]; then
+    scanner_pid=$(cat "$SCANNER_LOCK_FILE" 2>/dev/null || true)
+fi
+
+if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+    log "killing wedged scanner (PID $scanner_pid) — launchd/supervisor will restart"
+    kill "$scanner_pid" || true
+else
+    log "scanner PID not alive; attempting launchctl kickstart"
+    if command -v launchctl >/dev/null 2>&1; then
+        launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null \
+            || log "WARN: launchctl kickstart failed (scanner may not be loaded as a LaunchAgent)"
+    fi
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -776,6 +777,17 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Verify LOG_FILE is still writable each tick. If not (e.g. filesystem
+    # went read-only, disk full, or inode replaced without a SIGHUP), exit
+    # so launchd/supervisor restarts us cleanly rather than wedging silently.
+    if [ -n "${LOG_FILE:-}" ] && [ -e "$LOG_FILE" ] && ! [ -w "$LOG_FILE" ]; then
+        printf '[%s] [scanner] WARN: log file not writable — exiting for restart\n' \
+            "$(date '+%Y-%m-%d %H:%M:%S')" >&2
+        exit 1
+    fi
+    # Touch the heartbeat file so the watchdog can detect a silently wedged
+    # scanner (alive PID, sleep loop intact, but no events emitted for hours).
+    touch "$HEARTBEAT_FILE" 2>/dev/null || true
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Runs restart-scanner-if-stale.sh every 5 minutes. If the scanner heartbeat
+  file is older than LOOP_SCANNER_STALE_THRESHOLD seconds (default 900), the
+  watchdog kills the wedged scanner PID so launchd auto-restarts it.
+
+  Install (LOOP_LOG_DIR and LOOP_ROOT must be set):
+    sed "s|__LOOP_ROOT__|$LOOP_ROOT|g; \
+         s|__LOG_DIR__|$LOOP_LOG_DIR|g; \
+         s|__HOME__|$HOME|g; \
+         s|__EXTRA_PATH__|${LOOP_EXTRA_PATH:-/opt/homebrew/bin:/usr/local/bin}|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/restart-scanner-if-stale.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <!-- Check every 5 minutes whether the scanner heartbeat is fresh -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,144 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — scanner liveness heartbeat (issue #413).
+#
+# Verifies that run_once() touches $HEARTBEAT_FILE on every tick so the
+# external watchdog (restart-scanner-if-stale.sh) can detect a silently
+# wedged scanner.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+    export LOOP_EXTRA_PATH=""
+
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/logs/scanner-test.log"
+    touch "$LOG_FILE"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+    LOOP_JOBS_ENQUEUE=0
+
+    # Override functions that would require real infrastructure
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    loop_list_slugs() { printf ''; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat file written on every tick
+# ---------------------------------------------------------------------------
+
+@test "run_once: creates heartbeat file on first tick" {
+    HEARTBEAT_FILE="$BATS_TMPDIR/logs/scanner-heartbeat"
+    rm -f "$HEARTBEAT_FILE"
+
+    run_once
+
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: heartbeat file mtime advances between ticks" {
+    # stat -f%m is macOS-specific; skip if unavailable.
+    if ! stat -f%m "$LOG_FILE" 2>/dev/null; then
+        skip "stat -f%m not available on this platform"
+    fi
+
+    HEARTBEAT_FILE="$BATS_TMPDIR/logs/scanner-heartbeat"
+    rm -f "$HEARTBEAT_FILE"
+
+    run_once
+
+    [ -f "$HEARTBEAT_FILE" ]
+    local mtime1
+    mtime1=$(stat -f%m "$HEARTBEAT_FILE")
+
+    sleep 1
+
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "$HEARTBEAT_FILE")
+
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once: heartbeat path uses LOOP_LOG_DIR" {
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    rm -f "$HEARTBEAT_FILE"
+
+    run_once
+
+    [ -f "$LOOP_LOG_DIR/scanner-heartbeat" ]
+}
+
+# ---------------------------------------------------------------------------
+# restart-scanner-if-stale.sh — staleness detection
+# ---------------------------------------------------------------------------
+
+@test "restart-scanner-if-stale: exits 0 when heartbeat is fresh" {
+    local hb="$BATS_TMPDIR/logs/scanner-heartbeat"
+    touch "$hb"
+
+    LOOP_SCANNER_STALE_THRESHOLD=900 \
+    LOOP_LOG_DIR="$BATS_TMPDIR/logs" \
+    run "$REPO_ROOT/scanner/restart-scanner-if-stale.sh" --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ok: heartbeat age="* ]]
+}
+
+@test "restart-scanner-if-stale: exits 0 when heartbeat file missing (first start)" {
+    rm -f "$BATS_TMPDIR/logs/scanner-heartbeat"
+
+    LOOP_LOG_DIR="$BATS_TMPDIR/logs" \
+    run "$REPO_ROOT/scanner/restart-scanner-if-stale.sh" --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"heartbeat file missing"* ]]
+}
+
+@test "restart-scanner-if-stale: detects stale heartbeat and logs restart in dry-run" {
+    local hb="$BATS_TMPDIR/logs/scanner-heartbeat"
+    touch -t 197001010000 "$hb"   # epoch 0 — definitely stale
+
+    LOOP_SCANNER_STALE_THRESHOLD=60 \
+    LOOP_LOG_DIR="$BATS_TMPDIR/logs" \
+    run "$REPO_ROOT/scanner/restart-scanner-if-stale.sh" --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"stale"* ]]
+    [[ "$output" == *"DRY-RUN"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`**
- Added `HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"` variable
- At the start of every `run_once()` tick: touch the heartbeat file so the external watchdog can detect a silently wedged scanner (alive PID, no tick activity)
- Added log-file writability check at tick start: if `LOG_FILE` exists but is not writable (filesystem read-only, disk full, post-rotation inode mismatch without SIGHUP), exit 1 so launchd restarts us cleanly

**`scanner/restart-scanner-if-stale.sh`** (new)
- Watchdog script to be run every 5 minutes via launchd or cron
- Reads heartbeat file mtime; if age ≥ `LOOP_SCANNER_STALE_THRESHOLD` (default 900 s = 3 × poll interval), kills the wedged scanner PID — launchd auto-restarts via `KeepAlive=true`
- Falls back to `launchctl kickstart` when PID is no longer alive
- Supports `--dry-run` for safe testing

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new)
- launchd plist template for the watchdog; fires every 5 minutes (`StartInterval=300`)

**`tests/scanner-heartbeat.bats`** (new)
- 6 tests: heartbeat file created on first tick, mtime advances between ticks, path uses LOOP_LOG_DIR; watchdog exits cleanly when heartbeat is fresh, when file is missing (first start), and logs restart intent when stale

## Test Plan

- All 6 new bats tests pass
- `bash -n` and `shellcheck -S warning` pass on all modified/new shell scripts
- No personal identifiers introduced
- Manual: simulate wedge with `kill -STOP $SCANNER_PID`; watchdog should restart within 15 min (3 missed ticks)