### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — detects wedged scanner and kills it so
+    # launchd restarts it. Runs every 5 min on its own cadence.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — detect a wedged scanner and restart it.
+#
+# The scanner writes ${LOOP_LOG_DIR}/scanner-heartbeat on every tick.
+# This watchdog checks that file's mtime. If it hasn't been updated in
+# 2 × POLL_INTERVAL seconds, the scanner is considered wedged: we kill
+# the PID recorded in /tmp/loop-scanner.lock and let launchd (KeepAlive)
+# or cron restart it automatically.
+#
+# Designed to run every 5 min via launchd (macOS) or cron (Linux).
+# Safe to run concurrently with the scanner — it only acts when the
+# heartbeat is provably stale.
+#
+# Usage:
+#   scanner-watchdog.sh            # check once, exit
+#   scanner-watchdog.sh --dry-run  # report verdict without killing
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+LOCK_FILE="/tmp/loop-scanner.lock"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 ))
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+now=$(date +%s)
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file missing — scanner may not have started yet (${HEARTBEAT_FILE})"
+    exit 0
+fi
+
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+age=$(( now - mtime ))
+
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner healthy (heartbeat ${age}s old)"
+    exit 0
+fi
+
+log "STALE: heartbeat ${age}s old (>${STALE_THRESHOLD}s) — scanner appears wedged"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID from $LOCK_FILE and let launchd/cron restart it"
+    exit 0
+fi
+
+if [ ! -f "$LOCK_FILE" ]; then
+    log "lock file missing — scanner not running, launchd/cron will restart it"
+    exit 0
+fi
+
+scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || echo "")
+if [ -z "$scanner_pid" ]; then
+    log "WARN: lock file empty, removing it"
+    rm -f "$LOCK_FILE"
+    exit 0
+fi
+
+if ! kill -0 "$scanner_pid" 2>/dev/null; then
+    log "scanner PID $scanner_pid already dead — removing stale lock"
+    rm -f "$LOCK_FILE"
+    exit 0
+fi
+
+log "killing wedged scanner PID $scanner_pid — launchd/cron will restart it"
+kill "$scanner_pid" 2>/dev/null || true
+
+# Remove the lock file so launchd's restarted process can acquire it immediately
+# rather than waiting to detect the stale PID on its own.
+sleep 2
+if [ -f "$LOCK_FILE" ]; then
+    current_pid=$(cat "$LOCK_FILE" 2>/dev/null || echo "")
+    if [ "$current_pid" = "$scanner_pid" ]; then
+        rm -f "$LOCK_FILE"
+        log "removed stale lock for PID $scanner_pid"
+    fi
+fi
+
+log "restart triggered"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -776,6 +776,8 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Heartbeat — updated every tick so scanner-watchdog can detect a wedged process.
+    $DRY_RUN || touch "${LOOP_LOG_DIR}/scanner-heartbeat"
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <!-- Check scanner liveness every 5 minutes -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verify scanner writes a heartbeat file every tick.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export LOOP_EXTRA_PATH=""
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Expose mock-gh.sh as gh.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    # Source scanner.sh function definitions (same strategy as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-hb-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    STAGE_AGE_DIR="$BATS_TMPDIR/stage-age"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR" "$STAGE_AGE_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+    LOOP_JOBS_ENQUEUE=0
+
+    log() { :; }
+    dispatch_direct() { :; }
+    loop_list_slugs() { echo ""; }
+    scan_project() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" "$BATS_TMPDIR/stage-age" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-hb-src.sh" 2>/dev/null || true
+}
+
+@test "run_once: heartbeat file is created on first tick" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    [ ! -f "$hb" ]   # not present before
+    run_once
+    [ -f "$hb" ]
+}
+
+@test "run_once: heartbeat file mtime is updated on each tick" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb")
+    sleep 1
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb")
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once: heartbeat file not written in dry-run mode" {
+    DRY_RUN=true
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    run_once
+    [ ! -f "$hb" ]
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`** — write `${LOOP_LOG_DIR}/scanner-heartbeat` on every tick via `touch`. Skipped in `--dry-run` mode. One line added to `run_once`.

**`scanner/scanner-watchdog.sh`** (new) — runs every 5 min via launchd/cron. Reads the heartbeat file mtime; if `now - mtime > 2 × POLL_INTERVAL` (default 10 min), considers the scanner wedged, kills its PID from `/tmp/loop-scanner.lock`, and removes the stale lock so launchd's `KeepAlive` restart can acquire it immediately. Includes `--dry-run` flag.

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new) — `StartInterval=300`, no `KeepAlive` (one-shot per interval), uses standard `__LOOP_ROOT__`/`__LOG_DIR__`/`__HOME__`/`__EXTRA_PATH__` substitution tokens.

**`install.sh`** — registers the watchdog in both `bootstrap_register_launchd` (macOS) and `bootstrap_register_cron` (Linux). Idempotent — skips if already registered.

**`tests/scanner-heartbeat.bats`** (new) — 3 bats tests:
- heartbeat file created on first tick
- heartbeat mtime updated on subsequent ticks
- heartbeat not written in dry-run mode

## Test Plan

- Bats: `bats tests/scanner-heartbeat.bats` → 3/3 pass
- Manual: `kill -STOP $SCANNER_PID` → watchdog fires within 10 min, kills the stopped PID, launchd restarts scanner
- Manual: `scanner-watchdog.sh --dry-run` → prints verdict without killing
- Syntax: `bash -n` + `shellcheck -S warning` → clean