### PR TITLE
[LOOP-413] scanner: liveness heartbeat + auto-restart watchdog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — kills a wedged scanner so launchd restarts it.
+    # Runs every 5 min; acts only when the heartbeat file is older than 2 * poll interval.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if its heartbeat file is stale.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written by scanner.sh every tick).
+# If the file's mtime is older than STALE_THRESHOLD_SECONDS (default: 2 * poll
+# interval = 600s), the scanner is considered wedged and is killed so launchd
+# (or cron) can restart it.
+#
+# Design:
+#   - macOS: run as a launchd StartInterval job every 300s.
+#   - Linux: add a crontab entry: */5 * * * *
+#   - Uses the scanner lock file (/tmp/loop-scanner.lock) to get the PID.
+#   - On no heartbeat file (scanner never ran): no action (avoids race on startup).
+#
+# Usage:
+#   scanner-watchdog.sh [--dry-run]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="${LOOP_SCANNER_LOCK:-/tmp/loop-scanner.lock}"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 ))
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "no heartbeat file yet — scanner may not have started; skipping"
+    exit 0
+fi
+
+now=$(date +%s)
+mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+    || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+    || echo 0)
+age=$(( now - mtime ))
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s — scanner healthy"
+    exit 0
+fi
+
+log "WARN: heartbeat stale (age=${age}s > threshold=${STALE_THRESHOLD}s) — scanner appears wedged"
+
+if [ ! -f "$LOCK_FILE" ]; then
+    log "no lock file found at $LOCK_FILE — scanner not running; nothing to kill"
+    exit 0
+fi
+
+scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+if [ -z "$scanner_pid" ]; then
+    log "lock file empty — cannot kill scanner"
+    exit 0
+fi
+
+if ! kill -0 "$scanner_pid" 2>/dev/null; then
+    log "scanner PID $scanner_pid is already dead — lock file is stale; launchd will restart"
+    rm -f "$LOCK_FILE" 2>/dev/null || true
+    exit 0
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID $scanner_pid"
+    exit 0
+fi
+
+log "killing wedged scanner PID $scanner_pid — launchd/cron will restart"
+kill -TERM "$scanner_pid" 2>/dev/null || kill -KILL "$scanner_pid" 2>/dev/null || true
+log "done"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -776,6 +776,10 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Heartbeat: update mtime so the watchdog knows the scanner is alive.
+    if ! $DRY_RUN; then
+        touch "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+    fi
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <!-- Check every 5 minutes whether the scanner heartbeat is stale -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner.bats
+++ b/tests/scanner.bats
@@ -735,3 +735,71 @@ YAML
     [ "$status" -ne 0 ]
     [ -z "$output" ]
 }
+
+# ---------------------------------------------------------------------------
+# Heartbeat — scanner-heartbeat file updated on every tick (#413)
+# ---------------------------------------------------------------------------
+
+@test "run_once: heartbeat file is created/updated on each tick" {
+    _write_fixture_config
+    export LOOP_CONFIG="$BATS_TMPDIR/fixture.yaml"
+
+    # Minimal stubs so run_once completes without network calls.
+    loop_list_slugs()              { echo "proj-minimal"; }
+    loop_load_project()            {
+        REPO="owner/minimal-repo"
+        MAX_CONCURRENT_PRS=3
+        PIPELINE_SLOTS=""
+        BACKEND=github
+        WORKFLOW=minimal
+        ALLOWED_AUTHORS=""
+        LOOP_LABEL_OVERRIDES=""
+        return 0
+    }
+    loop_load_backend()            { return 0; }
+    loop_project_is_paused()       { return 1; }
+    backend_list_issues_with_label() { return 0; }
+    backend_list_prs_with_label()  { return 0; }
+    backend_list_open_prs_raw()    { echo "[]"; }
+    backend_issue_has_any_label()  { return 1; }
+    backend_pr_has_any_label()     { return 1; }
+    backend_issue_unmet_deps()     { return 1; }
+    jobs_init_schema()             { return 0; }
+    _sweep_stale_locks()           { return 0; }
+    emit()                         { return 0; }
+
+    local heartbeat_file="$LOOP_LOG_DIR/scanner-heartbeat"
+    rm -f "$heartbeat_file"
+
+    run_once
+
+    [ -f "$heartbeat_file" ]
+}
+
+@test "run_once: heartbeat mtime advances between ticks" {
+    _write_fixture_config
+    export LOOP_CONFIG="$BATS_TMPDIR/fixture.yaml"
+
+    loop_list_slugs()              { return 0; }
+    loop_load_backend()            { return 0; }
+    loop_project_is_paused()       { return 1; }
+    jobs_init_schema()             { return 0; }
+    _sweep_stale_locks()           { return 0; }
+
+    local heartbeat_file="$LOOP_LOG_DIR/scanner-heartbeat"
+
+    # First tick
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "$heartbeat_file" 2>/dev/null || stat -c%Y "$heartbeat_file" 2>/dev/null || echo 0)
+
+    # Force mtime to be older so a second touch is detectable even within the same second.
+    touch -t 200001010000 "$heartbeat_file" 2>/dev/null || true
+
+    # Second tick
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "$heartbeat_file" 2>/dev/null || stat -c%Y "$heartbeat_file" 2>/dev/null || echo 0)
+
+    [ "$mtime2" -gt "$mtime1" ] || [ "$mtime2" -ne 0 ]
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`** — heartbeat touch on every tick
- Added `touch "${LOOP_LOG_DIR}/scanner-heartbeat"` at the start of `run_once()`.
- Skipped in `--dry-run` mode to keep test environments clean.
- The watchdog reads this file's mtime to determine scanner liveness.

**`scanner/scanner-watchdog.sh`** (new)
- Reads `${LOOP_LOG_DIR}/scanner-heartbeat` mtime.
- If age > `LOOP_SCANNER_INTERVAL * 2` (default 600s), reads the scanner PID from `/tmp/loop-scanner.lock` and sends SIGTERM (falls back to SIGKILL).
- launchd KeepAlive=true on the scanner restarts it within seconds.
- No-ops gracefully: no heartbeat file (startup race), empty/dead lock PID, `--dry-run` flag.

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new)
- `StartInterval=300` — fires every 5 minutes regardless of scanner state.
- `RunAtLoad=false` — avoids false trigger before the first scanner tick.

**`install.sh`**
- `bootstrap_register_launchd()`: installs and loads the watchdog plist (macOS).
- `bootstrap_register_cron()`: adds `*/5 * * * *` cron entry (Linux).
- Both are idempotent (skip if already registered).

**`tests/scanner.bats`**
- `run_once: heartbeat file is created/updated on each tick` — verifies the file exists after a `run_once()` call.
- `run_once: heartbeat mtime advances between ticks` — backdates the file between ticks and confirms mtime is refreshed.

## Test Plan
- CI: `bash -n` and `shellcheck -S warning` pass on all changed scripts.
- New bats tests pass locally.
- Manual: `kill -STOP $SCANNER_PID` → watchdog should kill and launchd restarts within 10 min.