### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,26 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — kills a wedged scanner so launchd restarts it.
+    # Runs every 5 min; acts only when the scanner heartbeat is older than
+    # 2 × LOOP_SCANNER_INTERVAL (default: 10 min).
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +381,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local scanner_watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local scanner_watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $scanner_watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +404,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$scanner_watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$scanner_watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — Restart the scanner if its heartbeat goes stale.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written by scanner.sh every tick).
+# If the file is absent or older than STALE_THRESHOLD_SECONDS, kills any running
+# scanner and lets launchd / cron restart it.
+#
+# Designed to run every 5 minutes via launchd (macOS) or cron (Linux).
+#
+# Flags:
+#   --dry-run  Print what would happen without taking action
+#
+# Env vars:
+#   LOOP_SCANNER_INTERVAL   Scanner poll interval in seconds (default 300)
+#   LOOP_WATCHDOG_MULTIPLIER  Stale = interval × multiplier (default 2)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+MULTIPLIER="${LOOP_WATCHDOG_MULTIPLIER:-2}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * MULTIPLIER ))
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+LOCK_FILE="/tmp/loop-scanner.lock"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+now=$(date +%s)
+
+# Determine heartbeat age.
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    # No heartbeat file — scanner may never have run or was fully replaced.
+    # Treat as infinitely stale only if the lock file is also old (scanner running but silent).
+    if [ ! -f "$LOCK_FILE" ]; then
+        log "heartbeat absent and no lock file — scanner is not running; skipping"
+        exit 0
+    fi
+    heartbeat_age=$(( STALE_THRESHOLD + 1 ))
+    log "heartbeat absent but lock file exists — treating age as stale (${heartbeat_age}s)"
+else
+    mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+        || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+        || echo 0)
+    heartbeat_age=$(( now - mtime ))
+    log "heartbeat age=${heartbeat_age}s threshold=${STALE_THRESHOLD}s"
+fi
+
+if [ "$heartbeat_age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is healthy — no action needed"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat stale (${heartbeat_age}s >= ${STALE_THRESHOLD}s threshold)"
+
+# Identify scanner PID from lock file.
+scanner_pid=""
+if [ -f "$LOCK_FILE" ]; then
+    scanner_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+fi
+
+if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+    if $DRY_RUN; then
+        log "DRY-RUN: would kill scanner PID $scanner_pid"
+    else
+        log "killing wedged scanner PID $scanner_pid"
+        kill "$scanner_pid" 2>/dev/null || kill -9 "$scanner_pid" 2>/dev/null || true
+        rm -f "$LOCK_FILE"
+        log "scanner killed; launchd/cron will restart it"
+    fi
+else
+    log "WARN: no live scanner PID found in lock file (lock=${LOCK_FILE})"
+    if ! $DRY_RUN; then
+        rm -f "$LOCK_FILE"
+        log "stale lock removed; scanner will restart on next launchd/cron tick"
+    fi
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -29,6 +29,7 @@ source "$LOOP_ROOT/lib/jobs.sh"
 
 LOCK_FILE="/tmp/loop-scanner.lock"
 LOG_FILE="${LOOP_LOG_DIR}/loop-scanner.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
 POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
 BOBA_EVENT_CLIENT="${LOOP_EVENT_CLIENT:-}"
 HANDLER_TIMEOUT="${LOOP_HANDLER_TIMEOUT:-7200}"
@@ -776,6 +777,8 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Heartbeat: write current timestamp so the watchdog can detect a wedged scanner.
+    $DRY_RUN || date +%s > "$HEARTBEAT_FILE" 2>/dev/null || true
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <!-- Run every 5 minutes to detect a stale scanner heartbeat -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — heartbeat file written on every scanner tick.
+#
+# Loads scanner.sh function definitions (same awk-strip technique as scanner.bats),
+# then verifies that run_once writes a Unix timestamp to $HEARTBEAT_FILE.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+
+    local _src="$BATS_TMPDIR/scanner-hb-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    HEARTBEAT_FILE="$LOOP_LOG_DIR/scanner-heartbeat"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    log()           { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema()   { :; }
+    loop_list_slugs()    { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/scanner-test.log" "$BATS_TMPDIR/scanner-hb-src.sh" 2>/dev/null || true
+}
+
+@test "run_once: heartbeat file is created on first tick" {
+    rm -f "$HEARTBEAT_FILE"
+    run_once
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "run_once: heartbeat file contains a Unix timestamp" {
+    rm -f "$HEARTBEAT_FILE"
+    run_once
+    local ts
+    ts=$(cat "$HEARTBEAT_FILE")
+    # Must be a positive integer and within the last 10 seconds
+    [[ "$ts" =~ ^[0-9]+$ ]]
+    local now
+    now=$(date +%s)
+    [ "$(( now - ts ))" -lt 10 ]
+}
+
+@test "run_once: heartbeat file mtime is updated on each tick" {
+    rm -f "$HEARTBEAT_FILE"
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+        || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+        || echo 0)
+
+    sleep 1
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+        || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+        || echo 0)
+
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once: heartbeat file is NOT written in dry-run mode" {
+    rm -f "$HEARTBEAT_FILE"
+    DRY_RUN=true
+    run_once
+    [ ! -f "$HEARTBEAT_FILE" ]
+}


### PR DESCRIPTION
Closes #413

## Changes

### scanner/scanner.sh
- Added `HEARTBEAT_FILE` variable (`${LOOP_LOG_DIR}/scanner-heartbeat`)
- `run_once()` writes the current Unix timestamp to the heartbeat file at the top of each tick (skipped in `--dry-run` mode)

### scanner/scanner-watchdog.sh (new)
- Reads the heartbeat file mtime; if absent or older than `LOOP_SCANNER_INTERVAL × LOOP_WATCHDOG_MULTIPLIER` (default: 2 × 300s = 10 min), kills the wedged scanner PID from the lock file and removes the lock so launchd/cron restarts it cleanly
- Falls back gracefully when the heartbeat file doesn't exist yet (checks for a live lock file before acting)
- Supports `--dry-run` mode for safe testing

### templates/launchd/com.user.loop-scanner-watchdog.plist.template (new)
- Runs `scanner-watchdog.sh` every 5 minutes via launchd on macOS

### install.sh
- `bootstrap_register_launchd()`: registers `com.user.loop-scanner-watchdog` plist (macOS)
- `bootstrap_register_cron()`: adds `scanner-watchdog.sh` cron entry every 5 min (Linux)

### tests/scanner-heartbeat.bats (new)
- 4 bats tests: heartbeat file is created on first tick, contains a valid Unix timestamp, has its mtime updated on each subsequent tick, and is NOT written in dry-run mode

## Test Plan
- All new bats tests pass: `bats tests/scanner-heartbeat.bats` → 4/4 ok
- `bash -n` and `shellcheck -S warning` pass on all scripts
- No personal identifiers detected
- Manual: simulate wedge with `kill -STOP $SCANNER_PID`; watchdog should kill and remove lock within one 5-min tick, letting launchd restart the scanner