### PR TITLE
[LOOP-413] scanner: liveness heartbeat + watchdog auto-restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,6 +338,23 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     local digest_plist="$agents_dir/com.user.loop-digest.plist"
     if [ -f "$digest_plist" ]; then
         echo "[launchd] com.user.loop-digest already registered — skipping"
@@ -361,8 +378,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +401,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart the scanner if it has not emitted a heartbeat tick recently.
+#
+# The scanner writes ${LOOP_LOG_DIR}/scanner-heartbeat on every tick. This script
+# checks that file's mtime; if it is older than STALE_THRESHOLD seconds the scanner
+# is considered silently wedged and is restarted via launchctl (macOS) or a direct
+# kill + re-exec (Linux/fallback).
+#
+# Designed to run every 5 minutes via launchd (macOS) or cron (Linux).
+# No-ops when --dry-run is passed; only logs what it would do.
+#
+# Usage:
+#   scanner-watchdog.sh          # check and restart if stale
+#   scanner-watchdog.sh --dry-run
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+# Restart if heartbeat is older than 2× poll interval (default 10 min).
+STALE_THRESHOLD="${LOOP_SCANNER_WATCHDOG_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+LOCK_FILE="/tmp/loop-scanner.lock"
+HB_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -15
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _mtime <file> — print the file's modification time as a Unix timestamp.
+_mtime() {
+    stat -f%m "$1" 2>/dev/null \
+        || stat -c%Y "$1" 2>/dev/null \
+        || echo 0
+}
+
+log "check (threshold=${STALE_THRESHOLD}s dry=${DRY_RUN})"
+
+# If the heartbeat file does not exist yet the scanner may not have completed
+# its first tick; give it one full poll interval before alarming.
+if [ ! -f "$HB_FILE" ]; then
+    log "heartbeat file absent — scanner may be starting up; skipping restart"
+    exit 0
+fi
+
+age=$(( $(date +%s) - $(_mtime "$HB_FILE") ))
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is healthy"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat stale (${age}s > ${STALE_THRESHOLD}s) — restarting"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would restart scanner"
+    exit 0
+fi
+
+# Kill existing scanner process (if any) so launchd/cron can restart it.
+if [ -f "$LOCK_FILE" ]; then
+    local_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    if [ -n "$local_pid" ] && kill -0 "$local_pid" 2>/dev/null; then
+        log "killing stale scanner PID $local_pid"
+        kill "$local_pid" 2>/dev/null || true
+        sleep 2
+    fi
+    rm -f "$LOCK_FILE" 2>/dev/null || true
+fi
+
+# On macOS, ask launchd to restart the service (respects KeepAlive).
+if [ "$(uname -s)" = "Darwin" ]; then
+    if launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null; then
+        log "launchd kickstart sent"
+    else
+        log "launchd kickstart failed — launchd will auto-restart via KeepAlive"
+    fi
+else
+    # Linux: removing the lock file is enough; cron will start a new instance
+    # on the next 5-minute tick. Log the gap so operators can investigate.
+    log "lock removed — cron will restart scanner on next tick"
+fi

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -774,7 +774,28 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+_scanner_heartbeat() {
+    # Write current timestamp to the heartbeat file so the watchdog can detect
+    # a silently-wedged scanner (alive PID, no tick activity).
+    local hb_file="${LOOP_LOG_DIR}/scanner-heartbeat"
+    $DRY_RUN && return 0
+    printf '%s\n' "$(date '+%Y-%m-%d %H:%M:%S')" > "$hb_file" 2>/dev/null || true
+}
+
+# _scanner_check_log_fd — if the log file exists but is not writable, exit so
+# launchd restarts us and reopens a fresh fd against the current inode.
+# A missing file is normal on first startup; only an unwritable existing file
+# indicates a broken fd state worth recovering from.
+_scanner_check_log_fd() {
+    [ -n "${LOG_FILE:-}" ] || return 0
+    if [ -e "$LOG_FILE" ] && [ ! -w "$LOG_FILE" ]; then
+        exit 1
+    fi
+}
+
 run_once() {
+    _scanner_check_log_fd
+    _scanner_heartbeat
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes and restarts the scanner if its heartbeat file
+  (${LOOP_LOG_DIR}/scanner-heartbeat) has not been updated within
+  2x the poll interval (default 10 minutes). Complements the scanner's
+  KeepAlive plist by catching the "alive PID, no activity" failure mode.
+
+  Install via: ./install.sh --bootstrap
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verify scanner writes a heartbeat file on every tick.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    unset GH_MOCK_OUTPUT GH_MOCK_EXIT GH_MOCK_LOG
+
+    export LOOP_EXTRA_PATH=""
+    local _src="$BATS_TMPDIR/scanner-hb-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    log() { :; }
+    dispatch_direct() { :; }
+
+    # Minimal stubs so run_once/scan_project do not hit real backends.
+    loop_list_slugs()              { echo ""; }
+    jobs_init_schema()             { return 0; }
+    _sweep_stale_locks()           { return 0; }
+    LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-hb-src.sh" 2>/dev/null || true
+}
+
+@test "heartbeat file is created by run_once" {
+    run_once
+    [ -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+@test "heartbeat file contains a timestamp" {
+    run_once
+    local content
+    content=$(cat "${LOOP_LOG_DIR}/scanner-heartbeat")
+    # Expect a non-empty string that looks like a date.
+    [ -n "$content" ]
+    [[ "$content" == *"-"* ]]
+}
+
+@test "heartbeat file mtime is updated on each run_once call" {
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+             || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+             || echo 0)
+    # Ensure at least 1 second passes so mtime can differ.
+    sleep 1
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+             || stat -c%Y "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null \
+             || echo 0)
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "heartbeat file is NOT written in dry-run mode" {
+    DRY_RUN=true
+    run_once
+    [ ! -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}
+
+@test "_scanner_heartbeat: writes file to LOOP_LOG_DIR" {
+    _scanner_heartbeat
+    [ -f "${LOOP_LOG_DIR}/scanner-heartbeat" ]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- Added `_scanner_heartbeat()`: writes the current timestamp to `${LOOP_LOG_DIR}/scanner-heartbeat` at the start of every tick. Skipped in `--dry-run` mode. This file is the signal the watchdog reads to determine liveness.
- Added `_scanner_check_log_fd()`: exits with code 1 if the log file exists but is not writable (broken fd state). Missing file is allowed — normal on first startup. Exiting triggers launchd/cron to restart and reopen a fresh fd.
- `run_once()` now calls both helpers before the tick body.

### `scanner/scanner-watchdog.sh` (new)
- Reads the heartbeat file mtime; if age > `LOOP_SCANNER_WATCHDOG_THRESHOLD` (default 2× poll interval = 10 min), kills the scanner PID and uses `launchctl kickstart` on macOS (or removes the lock file on Linux) so the scanner restarts.
- Designed to run every 5 minutes via launchd or cron.
- No-ops cleanly with `--dry-run`.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- `StartInterval=300` (5 min), logs to `loop-scanner-watchdog.log`.

### `install.sh`
- `bootstrap_register_launchd`: registers `com.user.loop-scanner-watchdog`.
- `bootstrap_register_cron`: adds `*/5` cron entry for the watchdog.

### `tests/scanner-heartbeat.bats` (new)
- Verifies heartbeat file is created by `run_once`.
- Verifies heartbeat file contains a timestamp.
- Verifies mtime is updated on successive calls.
- Verifies heartbeat is suppressed in dry-run mode.
- Directly tests `_scanner_heartbeat`.

## Test Plan
- All 5 new bats tests pass: `bats tests/scanner-heartbeat.bats`
- No regressions in existing scanner tests (pre-existing failures on main are unchanged)
- Syntax: `bash -n` + `shellcheck -S warning` on all scripts: clean
- Personal-identifiers grep: clean
- Manual: `kill -STOP $SCANNER_PID` → watchdog fires within 10 min and restarts