### PR TITLE
[LOOP-413] scanner: liveness heartbeat + auto-restart watchdog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,6 +338,25 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    # Scanner liveness watchdog — restarts a wedged scanner that has a live PID
+    # but emits no events. Fires every 5 min; kills + lets launchd restart.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     local digest_plist="$agents_dir/com.user.loop-digest.plist"
     if [ -f "$digest_plist" ]; then
         echo "[launchd] com.user.loop-digest already registered — skipping"
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — restart a wedged scanner process.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat. If the file is absent or its mtime
+# is older than STALE_THRESHOLD_SECONDS, the scanner is considered wedged:
+# the lock-file PID is killed (SIGTERM → SIGKILL) and launchd / cron restarts it.
+#
+# Designed to run every 5 min via launchd (StartInterval) or cron. It is safe
+# to run while the scanner is healthy — a fresh heartbeat means no action taken.
+#
+# Environment / tunables (via loop.env):
+#   LOOP_SCANNER_INTERVAL        poll interval in seconds (default 300)
+#   LOOP_WATCHDOG_STALE_MULT     staleness = MULT × INTERVAL (default 2)
+#   LOOP_WATCHDOG_KILL_GRACE     seconds between SIGTERM and SIGKILL (default 10)
+#
+# Usage:
+#   scanner-watchdog.sh [--dry-run]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_MULT="${LOOP_WATCHDOG_STALE_MULT:-2}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * STALE_MULT ))
+KILL_GRACE="${LOOP_WATCHDOG_KILL_GRACE:-10}"
+LOCK_FILE="/tmp/loop-scanner.lock"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _heartbeat_age — prints seconds since the heartbeat file was last written,
+# or a very large number if the file is absent.
+_heartbeat_age() {
+    if [ ! -f "$HEARTBEAT_FILE" ]; then
+        echo 999999
+        return
+    fi
+    local mtime now
+    mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+         || stat -c%Y  "$HEARTBEAT_FILE" 2>/dev/null \
+         || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+# _scanner_pid — read PID from lock file; empty if absent or unreadable.
+_scanner_pid() {
+    cat "$LOCK_FILE" 2>/dev/null || true
+}
+
+# _kill_scanner <pid> — SIGTERM, wait, then SIGKILL if still alive.
+_kill_scanner() {
+    local pid="$1"
+    log "sending SIGTERM to scanner PID $pid"
+    kill -TERM "$pid" 2>/dev/null || true
+    local i=0
+    while [ "$i" -lt "$KILL_GRACE" ]; do
+        kill -0 "$pid" 2>/dev/null || return 0
+        sleep 1
+        i=$(( i + 1 ))
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+        log "scanner PID $pid still alive after ${KILL_GRACE}s — sending SIGKILL"
+        kill -KILL "$pid" 2>/dev/null || true
+    fi
+    rm -f "$LOCK_FILE"
+}
+
+age=$(_heartbeat_age)
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner is healthy — no action"
+    exit 0
+fi
+
+pid=$(_scanner_pid)
+
+if [ -z "$pid" ]; then
+    log "WARN: heartbeat stale (${age}s) but no lock file — scanner may have exited; launchd will restart"
+    exit 0
+fi
+
+if ! kill -0 "$pid" 2>/dev/null; then
+    log "WARN: heartbeat stale (${age}s) and PID $pid is dead — removing stale lock"
+    $DRY_RUN || rm -f "$LOCK_FILE"
+    exit 0
+fi
+
+log "ALERT: scanner wedged — heartbeat=${age}s > threshold=${STALE_THRESHOLD}s, PID=$pid"
+if $DRY_RUN; then
+    log "DRY-RUN: would kill PID $pid and let launchd restart"
+    exit 0
+fi
+
+_kill_scanner "$pid"
+log "scanner killed; launchd/cron will restart it automatically"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -774,8 +774,19 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+
+# _write_heartbeat — record the current epoch second to $HEARTBEAT_FILE so the
+# scanner-watchdog can detect a wedged scanner (alive PID but no emit activity).
+# Called at the start of every tick. Skipped in --dry-run mode.
+_write_heartbeat() {
+    $DRY_RUN && return 0
+    date +%s > "$HEARTBEAT_FILE" 2>/dev/null || true
+}
+
 run_once() {
     log "=== scan tick start ==="
+    _write_heartbeat
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes, checks scanner-heartbeat mtime, and kills + allows
+  launchd to restart the scanner if it has been silent for > 2 × POLL_INTERVAL.
+
+  Install via:   ./install.sh --bootstrap   (handled automatically)
+
+  Manual install:
+    sed -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+        -e "s|__LOG_DIR__|$LOOP_LOG_DIR|g" \
+        -e "s|__HOME__|$HOME|g" \
+        -e "s|__EXTRA_PATH__|...|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 scanner liveness heartbeat.
+#
+# Tests:
+#   1. _write_heartbeat creates/updates the heartbeat file on each tick.
+#   2. _write_heartbeat is a no-op in --dry-run mode.
+#   3. scanner-watchdog.sh exits 0 and takes no action when heartbeat is fresh.
+#   4. scanner-watchdog.sh kills a wedged-scanner PID when heartbeat is stale.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Expose mock-gh.sh as the gh binary.
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner.sh function definitions only (same strip as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+    DRY_RUN=false
+
+    # Silence log() and no-op dispatch so run_once doesn't try real work.
+    log() { :; }
+    dispatch_direct() { :; }
+    loop_list_slugs() { echo; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/bin" "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# _write_heartbeat
+# ---------------------------------------------------------------------------
+
+@test "_write_heartbeat creates heartbeat file" {
+    rm -f "$HEARTBEAT_FILE"
+    _write_heartbeat
+    [ -f "$HEARTBEAT_FILE" ]
+}
+
+@test "_write_heartbeat writes a recent epoch timestamp" {
+    _write_heartbeat
+    local ts now
+    ts=$(cat "$HEARTBEAT_FILE")
+    now=$(date +%s)
+    [ "$ts" -gt 0 ]
+    # Timestamp should be within 5 seconds of now.
+    [ $(( now - ts )) -lt 5 ]
+}
+
+@test "_write_heartbeat updates mtime on repeated calls" {
+    _write_heartbeat
+    local mtime1 mtime2
+    mtime1=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+    sleep 1
+    _write_heartbeat
+    mtime2=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null)
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "_write_heartbeat is a no-op when DRY_RUN=true" {
+    DRY_RUN=true
+    rm -f "$HEARTBEAT_FILE"
+    _write_heartbeat
+    [ ! -f "$HEARTBEAT_FILE" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh behaviour
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits 0 and logs healthy when heartbeat is fresh" {
+    # Write a heartbeat right now — age ≈ 0 s, well under any threshold.
+    date +%s > "$HEARTBEAT_FILE"
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scanner is healthy"* ]]
+}
+
+@test "scanner-watchdog: reports stale when heartbeat is old and no lock file" {
+    # Write a heartbeat and set its mtime to epoch 0 (Jan 1 1970) — far past threshold.
+    date +%s > "$HEARTBEAT_FILE"
+    python3 -c "import os; os.utime('$HEARTBEAT_FILE', (0, 0))"
+
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    # Either it detects no lock file or logs ALERT — both are fine.
+    # The important assertion is that it does NOT claim the scanner is healthy.
+    [[ "$output" != *"scanner is healthy"* ]]
+}
+
+@test "scanner-watchdog: DRY-RUN logs would-kill when heartbeat stale and PID alive" {
+    # Spawn a long-running no-op process to serve as the mock scanner PID.
+    sleep 300 &
+    local mock_pid=$!
+    # Write a stale heartbeat (mtime = epoch 0).
+    date +%s > "$HEARTBEAT_FILE"
+    python3 -c "import os; os.utime('$HEARTBEAT_FILE', (0, 0))"
+    # Write PID to lock file.
+    local lock="/tmp/loop-scanner.lock"
+    echo "$mock_pid" > "$lock"
+
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    local exit_code=$status
+
+    kill "$mock_pid" 2>/dev/null || true
+    rm -f "$lock"
+
+    [ "$exit_code" -eq 0 ]
+    [[ "$output" == *"DRY-RUN"* ]]
+    [[ "$output" == *"would kill"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- Added `HEARTBEAT_FILE` variable (`${LOOP_LOG_DIR}/scanner-heartbeat`)
- Added `_write_heartbeat()` — writes `date +%s` to the heartbeat file at the start of every tick; no-op in `--dry-run` mode
- `run_once()` now calls `_write_heartbeat` as its first action

### `scanner/scanner-watchdog.sh` (new)
- Standalone watchdog script that reads `scanner-heartbeat` mtime
- If age > `LOOP_WATCHDOG_STALE_MULT × LOOP_SCANNER_INTERVAL` (default 2 × 300 = 600 s), sends SIGTERM then SIGKILL (with `LOOP_WATCHDOG_KILL_GRACE` grace period) to the scanner PID from the lock file
- Launchd `KeepAlive=true` on the scanner means it restarts automatically after the kill
- Supports `--dry-run` for safe testing

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- LaunchAgent that fires the watchdog every 5 min (`StartInterval=300`)
- Follows same `__LOOP_ROOT__` / `__LOG_DIR__` substitution pattern as existing templates

### `install.sh`
- `bootstrap_register_launchd`: registers `com.user.loop-scanner-watchdog` plist (idempotent, skips if already present)
- `bootstrap_register_cron`: adds `*/5 * * * * scanner-watchdog.sh` cron entry for Linux (idempotent)

## Test Plan

- `tests/scanner-heartbeat.bats` (7 tests — all pass):
  - `_write_heartbeat` creates the file and writes a recent epoch timestamp
  - `_write_heartbeat` updates mtime on repeated calls
  - `_write_heartbeat` is a no-op in `--dry-run` mode
  - Watchdog exits 0 with "healthy" when heartbeat is fresh
  - Watchdog logs stale warning when heartbeat is old and no lock present
  - Watchdog logs DRY-RUN / would-kill when heartbeat stale and PID is alive
- All CI checks pass: `bash -n`, `shellcheck -S warning`, workflow lint, no personal identifiers