### PR TITLE
[LOOP-413] scanner: add liveness heartbeat and watchdog for silent-stop detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — checks heartbeat file every 5 min and kills
+    # a wedged scanner so launchd auto-restarts it via KeepAlive.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner-watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner-watchdog.sh
+++ b/scanner/scanner-watchdog.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# scanner-watchdog.sh — Detect and restart a silently-wedged scanner process.
+#
+# The scanner can become wedged: PID alive, sleep loop intact, but no events
+# emitted for hours. This script checks the scanner-heartbeat file written at
+# the top of every scan tick. If the heartbeat is older than
+# LOOP_WATCHDOG_STALE_THRESHOLD seconds (default: 2 × LOOP_SCANNER_INTERVAL),
+# the scanner process is killed so launchd / cron can restart it.
+#
+# Designed to run every 5 min via launchd (StartInterval 300) or cron.
+#
+# Usage:
+#   scanner-watchdog.sh [--dry-run]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+# Default stale threshold: 2 × poll interval, minimum 120 s.
+STALE_THRESHOLD="${LOOP_WATCHDOG_STALE_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+LOCK_FILE="/tmp/loop-scanner.lock"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# _heartbeat_age — print seconds since the heartbeat file was last written,
+# or a large value (9999999) when the file is absent so the caller treats a
+# missing heartbeat as stale.
+_heartbeat_age() {
+    if [ ! -f "$HEARTBEAT_FILE" ]; then
+        echo 9999999
+        return
+    fi
+    local mtime now
+    mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null \
+            || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null \
+            || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+# _scanner_pid — read the PID from the lock file; print nothing if absent/dead.
+_scanner_pid() {
+    [ -f "$LOCK_FILE" ] || return 0
+    local pid
+    pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    [ -n "$pid" ] || return 0
+    kill -0 "$pid" 2>/dev/null && echo "$pid" || true
+}
+
+main() {
+    local age
+    age=$(_heartbeat_age)
+
+    if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+        log "OK: heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+        return 0
+    fi
+
+    log "STALE: heartbeat age=${age}s >= threshold=${STALE_THRESHOLD}s"
+
+    local pid
+    pid=$(_scanner_pid)
+
+    if [ -z "$pid" ]; then
+        log "scanner PID not found — launchd/cron will restart it on next interval"
+        return 0
+    fi
+
+    if $DRY_RUN; then
+        log "DRY-RUN: would kill scanner PID $pid"
+        return 0
+    fi
+
+    log "killing stale scanner PID $pid — expect launchd/cron restart"
+    kill "$pid" 2>/dev/null || log "WARN: kill $pid failed (already gone?)"
+}
+
+main

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -774,8 +774,18 @@ scan_project() {
     done < <(loop_polled_labels "$slug" pr)
 }
 
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+
+# _write_heartbeat — record the current epoch to the heartbeat file so the
+# scanner-watchdog can detect a silently-wedged scanner process.
+_write_heartbeat() {
+    $DRY_RUN && return 0
+    printf '%s\n' "$(date +%s)" > "$HEARTBEAT_FILE" || true
+}
+
 run_once() {
     log "=== scan tick start ==="
+    _write_heartbeat
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes and checks whether the scanner heartbeat file
+  (${LOOP_LOG_DIR}/scanner-heartbeat) has been updated within the last
+  2 × LOOP_SCANNER_INTERVAL seconds. If stale, kills the scanner PID so
+  launchd restarts it via the scanner plist KeepAlive=true.
+
+  Install via ./install.sh --bootstrap (automatic), or manually:
+    sed "s|__LOOP_ROOT__|$(cd "$(dirname "$0")/.." && pwd)|g; \
+         s|__LOG_DIR__|$LOOP_LOG_DIR|g; \
+         s|__HOME__|$HOME|g; \
+         s|__EXTRA_PATH__|/opt/homebrew/bin:/usr/local/bin|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/scanner-watchdog.sh</string>
+    </array>
+    <!-- Check every 5 minutes — catches a stale scanner within one check cycle -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,128 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — liveness heartbeat written on every tick.
+#
+# Verifies:
+#   1. _write_heartbeat creates the heartbeat file in LOOP_LOG_DIR.
+#   2. The file contains a Unix epoch integer.
+#   3. run_once updates the heartbeat on every call.
+#   4. DRY_RUN suppresses the write.
+#   5. scanner-watchdog.sh exits cleanly when heartbeat is fresh.
+#   6. scanner-watchdog.sh kills a stale PID when heartbeat is old.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+    export LOOP_EXTRA_PATH=""
+
+    # Source scanner.sh functions only (stop before acquire_lock).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+
+    # Silence log() and disable real dispatch/lock sweeps.
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { :; }
+
+    LOOP_JOBS_ENQUEUE=0
+    DRY_RUN=false
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# _write_heartbeat
+# ---------------------------------------------------------------------------
+
+@test "_write_heartbeat: creates heartbeat file" {
+    _write_heartbeat
+    [ -f "$LOOP_LOG_DIR/scanner-heartbeat" ]
+}
+
+@test "_write_heartbeat: file contains a Unix epoch integer" {
+    _write_heartbeat
+    local content
+    content=$(cat "$LOOP_LOG_DIR/scanner-heartbeat")
+    # Must be a non-empty string of digits
+    [[ "$content" =~ ^[0-9]+$ ]]
+    # Must be a plausible epoch (after 2020-01-01)
+    [ "$content" -gt 1577836800 ]
+}
+
+@test "_write_heartbeat: updates mtime on repeated calls" {
+    _write_heartbeat
+    local first
+    first=$(cat "$LOOP_LOG_DIR/scanner-heartbeat")
+    sleep 1
+    _write_heartbeat
+    local second
+    second=$(cat "$LOOP_LOG_DIR/scanner-heartbeat")
+    [ "$second" -gt "$first" ]
+}
+
+@test "_write_heartbeat: no-op in dry-run mode" {
+    DRY_RUN=true
+    _write_heartbeat
+    [ ! -f "$LOOP_LOG_DIR/scanner-heartbeat" ]
+}
+
+# ---------------------------------------------------------------------------
+# run_once writes heartbeat
+# ---------------------------------------------------------------------------
+
+@test "run_once: heartbeat file is written each tick" {
+    run_once
+    [ -f "$LOOP_LOG_DIR/scanner-heartbeat" ]
+}
+
+# ---------------------------------------------------------------------------
+# scanner-watchdog.sh
+# ---------------------------------------------------------------------------
+
+@test "scanner-watchdog: exits 0 when heartbeat is fresh" {
+    printf '%s\n' "$(date +%s)" > "$LOOP_LOG_DIR/scanner-heartbeat"
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"OK"* ]]
+}
+
+@test "scanner-watchdog: reports stale when heartbeat is old" {
+    # Write a heartbeat 2 hours in the past by touching with an old mtime.
+    printf '%s\n' "$(( $(date +%s) - 7200 ))" > "$LOOP_LOG_DIR/scanner-heartbeat"
+    # Backdate the mtime so stat-based age detection also fires.
+    touch -t "$(date -v-2H '+%Y%m%d%H%M' 2>/dev/null || date -d '2 hours ago' '+%Y%m%d%H%M' 2>/dev/null || date '+%Y%m%d%H%M')" \
+        "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null || true
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STALE"* ]]
+}
+
+@test "scanner-watchdog: dry-run does not kill any process" {
+    printf '%s\n' "$(( $(date +%s) - 7200 ))" > "$LOOP_LOG_DIR/scanner-heartbeat"
+    touch -t "$(date -v-2H '+%Y%m%d%H%M' 2>/dev/null || date -d '2 hours ago' '+%Y%m%d%H%M' 2>/dev/null || date '+%Y%m%d%H%M')" \
+        "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null || true
+    # Place a fake (own PID) in the lock file so watchdog finds a "live" scanner.
+    printf '%s\n' "$$" > /tmp/loop-scanner.lock
+    run "$REPO_ROOT/scanner/scanner-watchdog.sh" --dry-run
+    rm -f /tmp/loop-scanner.lock
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DRY-RUN"* ]]
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`** — writes a heartbeat file (`${LOOP_LOG_DIR}/scanner-heartbeat`) at the top of every `run_once()` tick. The file contains the current Unix epoch as a plain integer. The write is suppressed in `--dry-run` mode. This is the observable signal the watchdog consumes.

**`scanner/scanner-watchdog.sh`** (new) — a short-lived script that reads the heartbeat file's mtime, compares it to `LOOP_WATCHDOG_STALE_THRESHOLD` (default: `2 × LOOP_SCANNER_INTERVAL`, i.e. 10 min), and kills the scanner PID if stale. launchd's `KeepAlive=true` on the scanner plist then auto-restarts it within seconds. Supports `--dry-run` for safe testing. Designed to run every 5 min.

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new) — launchd plist (`StartInterval 300`) for the watchdog. Installed by `--bootstrap` alongside scanner + reconciler.

**`install.sh`** — registers the watchdog in both `bootstrap_register_launchd()` (macOS) and `bootstrap_register_cron()` (Linux, `*/5` cron entry). Idempotent: skips if already registered.

**`tests/scanner-heartbeat.bats`** (new) — 8 bats tests covering: heartbeat file creation, epoch content, mtime progression, dry-run suppression, `run_once` integration, watchdog fresh/stale exit paths, and dry-run no-kill guard.

## Test Plan

- All 8 new bats tests pass locally (`bats tests/scanner-heartbeat.bats`)
- `bash -n` and `shellcheck -S warning` pass on all scripts
- No personal identifiers introduced
- Manual verification: `kill -STOP $SCANNER_PID` → watchdog detects stale heartbeat within one 5-min interval → kills PID → launchd restarts