### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog auto-restart on silent-stop

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -316,6 +316,27 @@ bootstrap_register_launchd() {
         fi
     fi
 
+    # Scanner liveness watchdog — kills and restarts the scanner if its heartbeat
+    # file is stale (age > LOOP_SCANNER_STALE_THRESHOLD, default 600s). Fires
+    # every 5 min so a silently-wedged scanner is detected and restarted within
+    # one check interval.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
+
     # PR auto-rework watchdog — labels stale loop-authored PRs needs-rework so
     # the dev-rework handler picks them up. Independent of scanner; runs every
     # 15 min on its own cadence. Only acts on PRs whose author is in the
@@ -361,8 +382,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scripts/restart-scanner-if-stale.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +405,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -775,6 +775,19 @@ scan_project() {
 }
 
 run_once() {
+    # Stdout file integrity: if LOG_FILE is not writable (e.g., after log rotation
+    # where launchd holds a stale FD), try to reopen it; exit if that fails so
+    # launchd restarts the scanner cleanly.
+    if [ -n "${LOG_FILE:-}" ] && [ ! -w "$LOG_FILE" ]; then
+        exec 1>>"$LOG_FILE" 2>>"$LOG_FILE" || exit 1
+    fi
+
+    # Heartbeat: touch a sentinel file every tick so the scanner watchdog can
+    # detect a silently-wedged scanner (alive PID, no log output for hours).
+    if ! $DRY_RUN; then
+        touch "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
+    fi
+
     log "=== scan tick start ==="
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then

--- a/scripts/restart-scanner-if-stale.sh
+++ b/scripts/restart-scanner-if-stale.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# restart-scanner-if-stale.sh — Liveness watchdog for the Loop scanner.
+#
+# Fires every 5 min via launchd (macOS) or cron (Linux).
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat mtime; if the file is older than
+# LOOP_SCANNER_STALE_THRESHOLD (default 600s = 2 × default poll_interval),
+# kills the scanner process and lets launchd (KeepAlive=true) restart it.
+#
+# On Linux (no launchd), kills the scanner PID outright; cron re-launches it
+# on the next 5-min tick.
+#
+# Usage: restart-scanner-if-stale.sh [--dry-run]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+STALE_THRESHOLD="${LOOP_SCANNER_STALE_THRESHOLD:-600}"
+SCANNER_LOCK="/tmp/loop-scanner.lock"
+DRY_RUN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+            exit 0
+            ;;
+        *) echo "unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file absent — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+_file_age_seconds() {
+    local f="$1"
+    local mtime now
+    mtime=$(stat -f%m "$f" 2>/dev/null || stat -c%Y "$f" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+age=$(_file_age_seconds "$HEARTBEAT_FILE")
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner healthy (heartbeat age=${age}s threshold=${STALE_THRESHOLD}s)"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat stale (age=${age}s > threshold=${STALE_THRESHOLD}s) — restarting"
+
+scanner_pid=""
+if [ -f "$SCANNER_LOCK" ]; then
+    scanner_pid=$(cat "$SCANNER_LOCK" 2>/dev/null || true)
+fi
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner PID=${scanner_pid:-unknown} and trigger restart"
+    exit 0
+fi
+
+if [ -n "$scanner_pid" ] && kill -0 "$scanner_pid" 2>/dev/null; then
+    log "sending SIGTERM to stale scanner PID $scanner_pid"
+    kill -TERM "$scanner_pid" 2>/dev/null || true
+    sleep 3
+    if kill -0 "$scanner_pid" 2>/dev/null; then
+        log "scanner did not exit after SIGTERM — sending SIGKILL"
+        kill -KILL "$scanner_pid" 2>/dev/null || true
+    fi
+fi
+rm -f "$SCANNER_LOCK"
+
+if command -v launchctl >/dev/null 2>&1; then
+    log "restarting via launchctl kickstart"
+    launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null \
+        || log "WARN: launchctl kickstart failed — launchd will restart scanner on next exit"
+else
+    log "no launchctl — cron will restart scanner on next 5-min tick"
+fi

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 min; restarts the scanner if its heartbeat file is stale
+  (age > LOOP_SCANNER_STALE_THRESHOLD, default 600s = 2 * poll_interval).
+
+  Install (LOOP_ROOT and LOOP_LOG_DIR must be set):
+    sed -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+        -e "s|__LOG_DIR__|$LOOP_LOG_DIR|g" \
+        -e "s|__HOME__|$HOME|g" \
+        -e "s|__EXTRA_PATH__|$LOOP_EXTRA_PATH|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scripts/restart-scanner-if-stale.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — heartbeat file liveness (#413).
+#
+# Verifies that run_once() touches ${LOOP_LOG_DIR}/scanner-heartbeat on every
+# tick, enabling the scanner watchdog to detect a silently-wedged scanner.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    mkdir -p "$BATS_TMPDIR/bin"
+    ln -sf "$BATS_TEST_DIRNAME/test_helper/mock-gh.sh" "$BATS_TMPDIR/bin/gh"
+    chmod +x "$BATS_TMPDIR/bin/gh"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export LOOP_EXTRA_PATH=""
+
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { printf ''; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+@test "run_once: creates scanner-heartbeat file on first tick" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    [ ! -f "$hb" ]
+    run_once
+    [ -f "$hb" ]
+}
+
+@test "run_once: updates scanner-heartbeat mtime on each tick" {
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb")
+    # Sleep 1 second so mtime can advance.
+    sleep 1
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb")
+    [ "$mtime2" -ge "$mtime1" ]
+}
+
+@test "run_once: skips heartbeat in dry-run mode" {
+    DRY_RUN=true
+    local hb="${LOOP_LOG_DIR}/scanner-heartbeat"
+    run_once
+    [ ! -f "$hb" ]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- **Heartbeat file**: `run_once()` now calls `touch ${LOOP_LOG_DIR}/scanner-heartbeat` at the start of every tick (skipped in `--dry-run` mode). The watchdog reads this file's mtime to detect a silently-wedged scanner.
- **Stdout integrity check**: at the top of each tick, if `$LOG_FILE` is not writable, re-exec stdout/stderr against the file path; exits if that fails so launchd (KeepAlive=true) restarts cleanly. Complements the existing SIGHUP log-reopen trap.

### `scripts/restart-scanner-if-stale.sh` (new)
- Reads `${LOOP_LOG_DIR}/scanner-heartbeat` mtime.
- If age > `LOOP_SCANNER_STALE_THRESHOLD` (default 600s = 2 × poll_interval), sends SIGTERM to the scanner PID from the lock file, waits 3s, SIGKILL if still alive, then `launchctl kickstart` on macOS (launchd restarts it) or exits on Linux (cron re-launches on next 5-min tick).
- Supports `--dry-run` for safe testing.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- Fires `restart-scanner-if-stale.sh` every 300s (5 min).
- Registered automatically by `install.sh --bootstrap` on macOS.

### `install.sh`
- `bootstrap_register_launchd()`: registers `com.user.loop-scanner-watchdog` plist (idempotent).
- `bootstrap_register_cron()`: adds `*/5 * * * *` cron entry for `restart-scanner-if-stale.sh` on Linux (idempotent).

### `tests/scanner-heartbeat.bats` (new)
- 3 bats tests: heartbeat file is created on first tick, mtime advances on subsequent ticks, heartbeat is skipped in dry-run mode.

## Test Plan
- [ ] Bats: `bats tests/scanner-heartbeat.bats` — all 3 pass
- [ ] Manual (macOS): `kill -STOP $SCANNER_PID` to simulate wedge; within 10 min the watchdog should kill + restart; check `loop-scanner-watchdog.log`
- [ ] `scripts/restart-scanner-if-stale.sh --dry-run` logs "scanner healthy" when heartbeat is fresh
- [ ] `LOOP_SCANNER_STALE_THRESHOLD=5 scripts/restart-scanner-if-stale.sh --dry-run` after touching heartbeat > 5s ago logs "WARN: scanner heartbeat stale"