### PR TITLE
[LOOP-413] scanner: heartbeat file + watchdog auto-restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,25 @@ bootstrap_register_launchd() {
             echo "[launchd] WARNING: could not load com.user.loop-digest (check Console.app)" >&2
         fi
     fi
+
+    # Scanner liveness watchdog — fires every 5 min, kills wedged scanner so
+    # launchd restarts it. Complements the KeepAlive scanner plist.
+    local scanner_watchdog_plist="$agents_dir/com.user.loop-scanner-watchdog.plist"
+    if [ -f "$scanner_watchdog_plist" ]; then
+        echo "[launchd] com.user.loop-scanner-watchdog already registered — skipping"
+    else
+        sed \
+            -e "s|__LOOP_ROOT__|$LOOP_ROOT|g" \
+            -e "s|__LOG_DIR__|$log_dir|g" \
+            -e "s|__HOME__|$HOME|g" \
+            -e "s|__EXTRA_PATH__|$extra_path|g" \
+            "$template_dir/com.user.loop-scanner-watchdog.plist.template" > "$scanner_watchdog_plist"
+        if launchctl load "$scanner_watchdog_plist" 2>/dev/null; then
+            echo "[launchd] com.user.loop-scanner-watchdog loaded (every 5 min)"
+        else
+            echo "[launchd] WARNING: could not load com.user.loop-scanner-watchdog (check Console.app)" >&2
+        fi
+    fi
 }
 
 # Register scanner + reconciler via crontab (Linux). Idempotent: skips if marker present.
@@ -361,8 +380,10 @@ bootstrap_register_cron() {
     local log_dir="$1"
     local scanner_marker="# loop-scanner"
     local reconciler_marker="# loop-reconciler"
+    local watchdog_marker="# loop-scanner-watchdog"
     local scanner_entry="*/5 * * * * $LOOP_ROOT/scanner/scanner.sh --once >> $log_dir/loop-scanner.log 2>&1 $scanner_marker"
     local reconciler_entry="*/15 * * * * $LOOP_ROOT/scanner/reconciler.sh >> $log_dir/loop-reconciler.log 2>&1 $reconciler_marker"
+    local watchdog_entry="*/5 * * * * $LOOP_ROOT/scanner/watchdog.sh >> $log_dir/loop-scanner-watchdog.log 2>&1 $watchdog_marker"
 
     local current_cron new_cron updated=false
     current_cron=$(crontab -l 2>/dev/null || true)
@@ -382,6 +403,14 @@ bootstrap_register_cron() {
         new_cron="${new_cron}"$'\n'"$reconciler_entry"
         updated=true
         echo "[cron] Added reconciler (*/15 min)"
+    fi
+
+    if echo "$current_cron" | grep -qF "$watchdog_marker"; then
+        echo "[cron] scanner-watchdog entry already exists — skipping"
+    else
+        new_cron="${new_cron}"$'\n'"$watchdog_entry"
+        updated=true
+        echo "[cron] Added scanner-watchdog (*/5 min)"
     fi
 
     if $updated; then

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -776,6 +776,9 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Liveness heartbeat: touched every tick so the scanner watchdog can detect
+    # a wedged process (alive PID but no forward progress) and restart it.
+    $DRY_RUN || touch "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/scanner/watchdog.sh
+++ b/scanner/watchdog.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# watchdog.sh — Scanner liveness watchdog.
+#
+# Runs every 5 minutes (via launchd on macOS, cron on Linux).
+# Reads the scanner heartbeat file written each tick by scanner.sh.
+# If the heartbeat is older than 2 × LOOP_SCANNER_INTERVAL seconds
+# (default: 2 × 300 = 600s = 10 min), the scanner is considered wedged
+# and its lock-file PID is killed so launchd/cron restarts it.
+#
+# Usage:
+#   watchdog.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+LOG_FILE="${LOOP_LOG_DIR}/loop-scanner-watchdog.log"
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+SCANNER_LOCK="/tmp/loop-scanner.lock"
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD=$(( POLL_INTERVAL * 2 ))
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*" | tee -a "$LOG_FILE"; }
+
+mkdir -p "$LOOP_LOG_DIR"
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file absent — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+now=$(date +%s)
+hb_mtime=$(stat -f%m "$HEARTBEAT_FILE" 2>/dev/null || stat -c%Y "$HEARTBEAT_FILE" 2>/dev/null || echo 0)
+age=$(( now - hb_mtime ))
+
+log "heartbeat age=${age}s threshold=${STALE_THRESHOLD}s"
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    exit 0
+fi
+
+log "ALERT: scanner heartbeat stale (${age}s > ${STALE_THRESHOLD}s) — attempting restart"
+
+if [ ! -f "$SCANNER_LOCK" ]; then
+    log "no lock file at $SCANNER_LOCK — scanner not running; nothing to kill"
+    exit 0
+fi
+
+pid=$(cat "$SCANNER_LOCK" 2>/dev/null || true)
+if [ -z "$pid" ]; then
+    log "lock file empty — removing stale lock"
+    rm -f "$SCANNER_LOCK"
+    exit 0
+fi
+
+if ! kill -0 "$pid" 2>/dev/null; then
+    log "scanner PID $pid already gone — removing stale lock"
+    rm -f "$SCANNER_LOCK"
+    exit 0
+fi
+
+log "killing wedged scanner PID $pid"
+kill "$pid" 2>/dev/null || true
+sleep 2
+if kill -0 "$pid" 2>/dev/null; then
+    log "PID $pid still alive after SIGTERM — sending SIGKILL"
+    kill -9 "$pid" 2>/dev/null || true
+fi
+rm -f "$SCANNER_LOCK"
+log "scanner restarted (launchd/cron will respawn)"

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/watchdog.sh</string>
+    </array>
+    <!-- Run every 5 minutes: checks heartbeat and restarts scanner if stale -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — coverage for #413 scanner liveness heartbeat.
+#
+# Verifies:
+#  1. scanner.sh touches scanner-heartbeat on every run_once() call.
+#  2. watchdog.sh exits 0 when heartbeat is fresh.
+#  3. watchdog.sh kills the scanner PID and removes the lock when heartbeat is stale.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    # Minimal env required by env.sh sourcing in watchdog.sh.
+    export LOOP_EXTRA_PATH=""
+    export LOOP_SCANNER_INTERVAL=300
+
+    # Source scanner function definitions only (same pattern as scanner.bats).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    mkdir -p "$DEDUP_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { :; }
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/logs" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/scanner-src.sh" "$BATS_TMPDIR/scanner-test.log" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# heartbeat file
+# ---------------------------------------------------------------------------
+
+@test "run_once: creates scanner-heartbeat file on first tick" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    [ ! -f "$hb" ]
+    run_once
+    [ -f "$hb" ]
+}
+
+@test "run_once: updates scanner-heartbeat mtime on each tick" {
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    run_once
+    local mtime1
+    mtime1=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb")
+    # Force mtime to look old.
+    touch -t 200001010000 "$hb"
+    local mtime_old
+    mtime_old=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb")
+    [ "$mtime_old" -lt "$mtime1" ]
+    run_once
+    local mtime2
+    mtime2=$(stat -f%m "$hb" 2>/dev/null || stat -c%Y "$hb")
+    [ "$mtime2" -gt "$mtime_old" ]
+}
+
+@test "run_once: does NOT create heartbeat when DRY_RUN=true" {
+    DRY_RUN=true
+    local hb="$LOOP_LOG_DIR/scanner-heartbeat"
+    [ ! -f "$hb" ]
+    run_once
+    [ ! -f "$hb" ]
+}
+
+# ---------------------------------------------------------------------------
+# watchdog.sh behaviour
+# ---------------------------------------------------------------------------
+
+@test "watchdog.sh: exits 0 silently when heartbeat file is absent" {
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+    run bash "$REPO_ROOT/scanner/watchdog.sh"
+    [ "$status" -eq 0 ]
+}
+
+@test "watchdog.sh: exits 0 when heartbeat is fresh" {
+    touch "$LOOP_LOG_DIR/scanner-heartbeat"
+    run bash "$REPO_ROOT/scanner/watchdog.sh"
+    [ "$status" -eq 0 ]
+    # No kill action should have been logged.
+    if [ -f "$LOOP_LOG_DIR/loop-scanner-watchdog.log" ]; then
+        run grep -c "ALERT" "$LOOP_LOG_DIR/loop-scanner-watchdog.log"
+        [ "$output" = "0" ]
+    fi
+}
+
+@test "watchdog.sh: kills scanner PID and removes lock when heartbeat is stale" {
+    # Write a stale heartbeat (2000-01-01).
+    touch -t 200001010000 "$LOOP_LOG_DIR/scanner-heartbeat"
+
+    # Spin up a real process to act as the "wedged scanner".
+    sleep 60 &
+    local fake_pid=$!
+
+    # Write a lock file pointing at the fake scanner PID.
+    echo "$fake_pid" > /tmp/loop-scanner.lock
+
+    run bash "$REPO_ROOT/scanner/watchdog.sh"
+    [ "$status" -eq 0 ]
+
+    # Lock file must be gone.
+    [ ! -f /tmp/loop-scanner.lock ]
+
+    # Process must be dead.
+    ! kill -0 "$fake_pid" 2>/dev/null
+
+    # Log must mention the kill.
+    grep -q "killing wedged scanner" "$LOOP_LOG_DIR/loop-scanner-watchdog.log"
+}


### PR DESCRIPTION
Closes #413

## Changes

**`scanner/scanner.sh`** — touches `${LOOP_LOG_DIR}/scanner-heartbeat` at the top of every `run_once()` tick (skipped in `--dry-run` mode). This is the liveness signal used by the watchdog.

**`scanner/watchdog.sh`** (new) — runs every 5 minutes via launchd/cron. Reads the heartbeat mtime; if older than `2 × LOOP_SCANNER_INTERVAL` seconds (default 10 min), kills the scanner PID from `/tmp/loop-scanner.lock` and removes the lock so launchd/cron can restart the scanner immediately. Handles the edge cases: absent heartbeat (scanner not started yet), absent lock, stale/empty lock, already-dead PID.

**`templates/launchd/com.user.loop-scanner-watchdog.plist.template`** (new) — launchd plist template for the watchdog; uses `StartInterval=300` (every 5 min). Same placeholder substitution pattern as all other Loop launchd templates.

**`install.sh`** — `bootstrap_register_launchd()` now registers `com.user.loop-scanner-watchdog`; `bootstrap_register_cron()` now adds a `*/5` cron entry for the watchdog on Linux. Both are idempotent (skip if already registered).

**`tests/scanner-heartbeat.bats`** (new) — 6 tests covering: heartbeat created on first tick, mtime updated each tick, heartbeat skipped in dry-run mode, watchdog no-op on fresh/absent heartbeat, watchdog kills wedged PID + removes lock on stale heartbeat.

## Test Plan
- All 6 new bats tests pass locally (`bats tests/scanner-heartbeat.bats`)
- `bash -n` syntax check passes on all changed scripts
- `shellcheck -S warning` passes with no warnings
- No personal identifiers in committed files
- Manual verification: `kill -STOP $SCANNER_PID` → watchdog should restart within 10 min (2 × 300s interval)