### PR TITLE
[LOOP-413] scanner: heartbeat file + stale-process watchdog

### DIFF
--- a/scanner/restart-scanner-if-stale.sh
+++ b/scanner/restart-scanner-if-stale.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# restart-scanner-if-stale.sh — scanner liveness watchdog.
+#
+# Reads ${LOOP_LOG_DIR}/scanner-heartbeat (written every tick by scanner.sh).
+# If the file's mtime is older than STALE_THRESHOLD_SECONDS, the scanner is
+# considered silently wedged: kill it and let launchd/cron restart it.
+#
+# Designed to run every 5 minutes via launchd StartInterval or cron.
+# Does nothing on --dry-run (print decision without acting).
+#
+# Usage:
+#   restart-scanner-if-stale.sh
+#   restart-scanner-if-stale.sh --dry-run
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=../lib/env.sh
+source "$LOOP_ROOT/lib/env.sh"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20; exit 0 ;;
+        *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+    esac
+done
+
+HEARTBEAT_FILE="${LOOP_LOG_DIR}/scanner-heartbeat"
+# Default: 2 × poll interval (2 × 300s = 600s). Override via env var.
+POLL_INTERVAL="${LOOP_SCANNER_INTERVAL:-300}"
+STALE_THRESHOLD="${LOOP_SCANNER_STALE_THRESHOLD:-$(( POLL_INTERVAL * 2 ))}"
+LOCK_FILE="/tmp/loop-scanner.lock"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [scanner-watchdog] $*"; }
+
+# age_seconds <file>  — portable mtime age in seconds (macOS + Linux).
+age_seconds() {
+    local file="$1"
+    local mtime
+    mtime=$(stat -f%m "$file" 2>/dev/null) \
+        || mtime=$(stat -c%Y "$file" 2>/dev/null) \
+        || { echo 0; return 1; }
+    echo $(( $(date +%s) - mtime ))
+}
+
+if [ ! -f "$HEARTBEAT_FILE" ]; then
+    log "heartbeat file missing — scanner may not have started yet; skipping"
+    exit 0
+fi
+
+age=$(age_seconds "$HEARTBEAT_FILE") || age=0
+
+if [ "$age" -lt "$STALE_THRESHOLD" ]; then
+    log "scanner healthy (heartbeat age=${age}s < threshold=${STALE_THRESHOLD}s)"
+    exit 0
+fi
+
+log "WARN: scanner heartbeat stale (age=${age}s >= threshold=${STALE_THRESHOLD}s)"
+
+if $DRY_RUN; then
+    log "DRY-RUN: would kill scanner and let launchd/cron restart it"
+    exit 0
+fi
+
+# Kill all processes whose lock file PID is alive.
+if [ -f "$LOCK_FILE" ]; then
+    local_pid=$(cat "$LOCK_FILE" 2>/dev/null || true)
+    if [ -n "$local_pid" ] && kill -0 "$local_pid" 2>/dev/null; then
+        log "killing wedged scanner PID $local_pid"
+        kill "$local_pid" 2>/dev/null || true
+        sleep 2
+        # Force-kill if it didn't respond.
+        if kill -0 "$local_pid" 2>/dev/null; then
+            log "SIGKILL PID $local_pid"
+            kill -9 "$local_pid" 2>/dev/null || true
+        fi
+        rm -f "$LOCK_FILE"
+    fi
+fi
+
+# On macOS, kick launchd to restart the scanner.
+if command -v launchctl >/dev/null 2>&1; then
+    if launchctl list com.user.loop-scanner >/dev/null 2>&1; then
+        log "kickstarting com.user.loop-scanner via launchd"
+        launchctl kickstart -k "gui/$(id -u)/com.user.loop-scanner" 2>/dev/null \
+            || launchctl start com.user.loop-scanner 2>/dev/null || true
+        exit 0
+    fi
+fi
+
+# On Linux (or when launchd is not managing the scanner), log only.
+# The operator is responsible for configuring cron or systemd to restart.
+log "scanner killed; restart it via your process manager (launchd/cron/systemd)"

--- a/scanner/scanner.sh
+++ b/scanner/scanner.sh
@@ -776,6 +776,9 @@ scan_project() {
 
 run_once() {
     log "=== scan tick start ==="
+    # Heartbeat — updated every tick so the scanner watchdog can detect
+    # a silently wedged process (alive PID but zero emit activity).
+    $DRY_RUN || touch "${LOOP_LOG_DIR}/scanner-heartbeat" 2>/dev/null || true
     $DRY_RUN || _sweep_stale_locks
     if [[ "${LOOP_JOBS_ENQUEUE:-1}" == "1" ]] && ! $DRY_RUN; then
         jobs_init_schema 2>/dev/null \

--- a/templates/launchd/com.user.loop-scanner-watchdog.plist.template
+++ b/templates/launchd/com.user.loop-scanner-watchdog.plist.template
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  loop-scanner-watchdog launchd template.
+
+  Fires every 5 minutes. Reads ${LOOP_LOG_DIR}/scanner-heartbeat written by
+  scanner.sh on each tick. If the heartbeat is older than
+  LOOP_SCANNER_STALE_THRESHOLD seconds (default: 2 × poll interval = 600s),
+  the watchdog kills the wedged scanner process and lets launchd restart it
+  via the com.user.loop-scanner KeepAlive plist.
+
+  Install:
+    sed "s|__LOOP_ROOT__|$(cd "$(dirname "$0")/../.." && pwd)|g; \
+         s|__LOG_DIR__|$LOOP_LOG_DIR|g; \
+         s|__HOME__|$HOME|g; \
+         s|__EXTRA_PATH__|${LOOP_EXTRA_PATH:-/opt/homebrew/bin:/usr/local/bin}|g" \
+        templates/launchd/com.user.loop-scanner-watchdog.plist.template \
+        > ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+    rm ~/Library/LaunchAgents/com.user.loop-scanner-watchdog.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.loop-scanner-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__LOOP_ROOT__/scanner/restart-scanner-if-stale.sh</string>
+    </array>
+    <!-- Run every 5 minutes -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/loop-scanner-watchdog.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__EXTRA_PATH__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/scanner-heartbeat.bats
+++ b/tests/scanner-heartbeat.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+# tests/scanner-heartbeat.bats — verifies heartbeat file is updated on every tick.
+#
+# Sourcing strategy mirrors tests/scanner.bats: awk strips the acquire_lock call
+# and the argument-parsing for..done block so we can source function definitions
+# into the test scope without starting the daemon loop.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+    mkdir -p "$BATS_TMPDIR/bin"
+    export LOOP_LOG_DIR="$BATS_TMPDIR/logs"
+    mkdir -p "$LOOP_LOG_DIR"
+
+    export LOOP_EXTRA_PATH="$BATS_TMPDIR/bin"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    # Minimal mock gh so env.sh and config.sh don't fail.
+    cat > "$BATS_TMPDIR/bin/gh" <<'MOCK'
+#!/usr/bin/env bash
+exit 0
+MOCK
+    chmod +x "$BATS_TMPDIR/bin/gh"
+
+    # Source scanner function definitions (stop before acquire_lock).
+    local _src="$BATS_TMPDIR/scanner-src.sh"
+    {
+        printf "LOOP_ROOT='%s'\n" "$REPO_ROOT"
+        awk '
+            /^SCRIPT_DIR=/           { next }
+            /^LOOP_ROOT=/            { next }
+            /^for arg in "\$@"; do$/ { skip=1; print "DRY_RUN=false"; print "ONCE=false"; next }
+            skip && /^done$/         { skip=0; next }
+            skip                     { next }
+            /^acquire_lock$/         { exit }
+            { print }
+        ' "$REPO_ROOT/scanner/scanner.sh"
+    } > "$_src"
+    # shellcheck disable=SC1090
+    source "$_src"
+    export PATH="$BATS_TMPDIR/bin:$PATH"
+
+    # Override paths so run_once does not try to load real projects.
+    DEDUP_DIR="$BATS_TMPDIR/dedup"
+    LOG_FILE="$BATS_TMPDIR/scanner-test.log"
+    STAGE_AGE_DIR="$BATS_TMPDIR/stage-age"
+    mkdir -p "$DEDUP_DIR" "$STAGE_AGE_DIR"
+
+    DRY_RUN=false
+    LOOP_DISPATCH_MODE=direct
+    BOBA_EVENT_CLIENT=""
+
+    # Stub out functions that require real GitHub or project config.
+    log() { :; }
+    dispatch_direct() { :; }
+    _sweep_stale_locks() { :; }
+    jobs_init_schema() { :; }
+    loop_list_slugs() { echo ""; }
+    LOOP_JOBS_ENQUEUE=0
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/bin" "$BATS_TMPDIR/dedup" \
+           "$BATS_TMPDIR/logs" "$BATS_TMPDIR/stage-age" \
+           "$BATS_TMPDIR/scanner-test.log" \
+           "$BATS_TMPDIR/scanner-src.sh" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# heartbeat
+# ---------------------------------------------------------------------------
+
+@test "run_once: creates scanner-heartbeat file on first tick" {
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+    run_once
+    [ -f "$LOOP_LOG_DIR/scanner-heartbeat" ]
+}
+
+@test "run_once: updates scanner-heartbeat mtime on subsequent ticks" {
+    # Create an old heartbeat file.
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+    touch -t "$(date -v-1H '+%Y%m%d%H%M.%S' 2>/dev/null || date -d '1 hour ago' '+%Y%m%d%H%M.%S')" \
+        "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null || touch "$LOOP_LOG_DIR/scanner-heartbeat"
+
+    local before
+    before=$(stat -f%m "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null \
+        || stat -c%Y "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null)
+
+    sleep 1
+    run_once
+
+    local after
+    after=$(stat -f%m "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null \
+        || stat -c%Y "$LOOP_LOG_DIR/scanner-heartbeat" 2>/dev/null)
+
+    [ "$after" -gt "$before" ]
+}
+
+@test "run_once: does not create scanner-heartbeat when DRY_RUN=true" {
+    DRY_RUN=true
+    rm -f "$LOOP_LOG_DIR/scanner-heartbeat"
+    run_once
+    [ ! -f "$LOOP_LOG_DIR/scanner-heartbeat" ]
+}


### PR DESCRIPTION
Closes #413

## Changes

### `scanner/scanner.sh`
- Added a `touch "${LOOP_LOG_DIR}/scanner-heartbeat"` call at the top of `run_once()` (skipped in `--dry-run` mode). Every tick updates the file mtime, giving the watchdog a reliable liveness signal without adding any external dependencies.

### `scanner/restart-scanner-if-stale.sh` (new)
- Reads the heartbeat file mtime. If the age exceeds `LOOP_SCANNER_STALE_THRESHOLD` (default: `2 × LOOP_SCANNER_INTERVAL` = 600 s), it kills the wedged scanner PID (SIGTERM → SIGKILL) and, on macOS, fires `launchctl kickstart` to restart it immediately via the existing `KeepAlive` plist.
- On Linux / non-launchd environments, the script kills the process and logs a restart prompt (cron or systemd handles the restart).
- Supports `--dry-run` flag that reports the stale state without acting.

### `templates/launchd/com.user.loop-scanner-watchdog.plist.template` (new)
- macOS launchd plist that runs `restart-scanner-if-stale.sh` every 5 minutes (`StartInterval=300`). Installed alongside the scanner plist; uses the same `__LOOP_ROOT__` / `__LOG_DIR__` / `__HOME__` / `__EXTRA_PATH__` substitution pattern as the other Loop plists.

### `tests/scanner-heartbeat.bats` (new)
Three bats tests covering the acceptance criterion from the issue:
1. Heartbeat file is created on the first tick.
2. Heartbeat mtime is updated on subsequent ticks.
3. Heartbeat file is **not** written when `DRY_RUN=true`.

## Test Plan
- Run `bats tests/scanner-heartbeat.bats` — all 3 tests pass.
- Manual smoke: `./scanner/scanner.sh --once` → confirm `${LOOP_LOG_DIR}/scanner-heartbeat` exists and has a recent mtime.
- Stale simulation: `kill -STOP $SCANNER_PID`, wait for watchdog interval, verify watchdog kills and launchd restarts the scanner within 5 minutes.
- `bash -n` and `shellcheck -S warning` clean on all modified/new scripts.